### PR TITLE
Use upstream Sifter lib and activate nesting

### DIFF
--- a/js/models/base.js
+++ b/js/models/base.js
@@ -213,7 +213,7 @@ export class List extends Base {
      * Populate the data view (filtered and sorted)
      */
     populate() {
-        const options = {};
+        const options = {nesting: true};
         const sifter = new Sifter(this.items);
 
         if (this.$options.search) {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "respond.js": "^1.4.2",
     "script-loader": "^0.6.1",
     "selectize": "^0.12.1",
-    "sifter": "noirbizarre/sifter.js#nested-properties-built",
+    "sifter": "0.5.1",
     "sortablejs": "^1.4.2",
     "source-sans-pro": "^2.0.10",
     "spin.js": "^2.3.2",


### PR DESCRIPTION
This PR fix the build by using the upstream Sifter.js with nesting (was a patched version but upstream patch has been accepted)