### PR TITLE
Ensure empty form field value is treated as undefined

### DIFF
--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -43,6 +43,31 @@ function empty_schema() {
     return {properties: {}, required: []};
 }
 
+/**
+ * Input type which are text or formated text
+ */
+const TEXT_INPUTS = [
+    'color',
+    'date',
+    'datetime',
+    'datetime-local',
+    'email',
+    'hidden',
+    'month',
+    'range',
+    'search',
+    'tel',
+    'text',
+    'time',
+    'url',
+    'week',
+];
+
+/**
+ * Form tags that should be considered as text
+ */
+const TEXT_TAGS = ['select', 'textarea'];
+
 
 export default {
     name: 'base-form',
@@ -168,7 +193,7 @@ export default {
 
             Array.prototype.map.call(elements, function(el) {
                 let value;
-                if (el.tagName.toLowerCase() === 'select') {
+                if (TEXT_TAGS.includes(el.tagName.toLowerCase()) || TEXT_INPUTS.includes(el.type)) {
                     value = el.value || undefined;
                 } else if (el.type === 'checkbox') {
                     value = el.checked;

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -45,6 +45,8 @@ function empty_schema() {
 
 /**
  * Input type which are text or formated text
+ *
+ * See: https://www.w3.org/TR/html5/forms.html#attr-input-type
  */
 const TEXT_INPUTS = [
     'color',
@@ -193,7 +195,7 @@ export default {
 
             Array.prototype.map.call(elements, function(el) {
                 let value;
-                if (TEXT_TAGS.includes(el.tagName.toLowerCase()) || TEXT_INPUTS.includes(el.type)) {
+                if (TEXT_TAGS.includes(el.tagName.toLowerCase()) || TEXT_INPUTS.includes(el.type.toLowerCase())) {
                     value = el.value || undefined;
                 } else if (el.type === 'checkbox') {
                     value = el.checked;

--- a/specs/components/form/base.specs.js
+++ b/specs/components/form/base.specs.js
@@ -204,9 +204,9 @@ describe('Common Form features', function() {
             ];
 
             expect(this.vm.serialize()).to.eql({
-                input: '',
+                input: undefined,
                 checkbox: false,
-                textarea: '',
+                textarea: undefined,
                 select: 'b',
             });
         });
@@ -296,8 +296,8 @@ describe('Common Form features', function() {
 
                 expect(this.vm.serialize()).to.eql({
                     nested: {
-                        a: '',
-                        b: ''
+                        a: undefined,
+                        b: undefined
                     }
                 });
             });


### PR DESCRIPTION
Ensure empty string is treated as an empty value in form serialization (and so does not break form validation)