### PR TITLE
Improve Swagger Api lazy handling

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -9,7 +9,6 @@ import 'raven';
 // ES6 environment
 import 'babel-polyfill';
 
-import $ from 'jquery';
 import 'bootstrap';
 
 import Vue from 'vue';
@@ -31,6 +30,6 @@ Vue.use(require('plugins/tooltips'));
 Vue.use(require('plugins/outside'));
 
 
-$(API).on('built', function() {
+API.onReady(function() {
     router.start(require('admin.vue'), '#app');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -14,7 +14,6 @@ import 'bootstrap';
 import Vue from 'vue';
 import config from 'config';
 import router from 'admin.routes';
-import API from 'api';
 
 // Ensure retrocompatibily for 0.12.2 replace behavior
 Vue.options.replace = false;
@@ -29,7 +28,4 @@ Vue.use(require('plugins/scroll-to'));
 Vue.use(require('plugins/tooltips'));
 Vue.use(require('plugins/outside'));
 
-
-API.onReady(function() {
-    router.start(require('admin.vue'), '#app');
-});
+router.start(require('admin.vue'), '#app');

--- a/js/api.js
+++ b/js/api.js
@@ -44,7 +44,9 @@ const API = new SwaggerClient({
     url: config.api_specs,
     useJQuery: true,
     success: function() {
-        $(this).trigger('built');
+        this.readyCallbacks.forEach(callback => {
+            callback(this);
+        });
     },
     progress: function(msg) {
         log.debug(msg);
@@ -54,6 +56,8 @@ const API = new SwaggerClient({
     }
 });
 
+API.readyCallbacks = [];
+
 /**
  * Resolve a definition from a $ref
  * @param  {String} $ref The reference string
@@ -62,6 +66,15 @@ const API = new SwaggerClient({
 API.resolve = function($ref) {
     const def = $ref.split('#')[1].replace('/definitions/', '');
     return this.definitions[def];
+};
+
+/**
+ * Register a callback to be called when API is ready.
+ * The callback should have the following signature: function(API)
+ * @param  {Function} callback A callback to call when API is ready.
+ */
+API.onReady = function(callback) {
+    this.readyCallbacks.push(callback);
 };
 
 export default API;

--- a/js/api.js
+++ b/js/api.js
@@ -43,12 +43,12 @@ const API = new SwaggerClient({
     debug: config.debug,
     url: config.api_specs,
     useJQuery: true,
-    success: function() {
+    success() {
         this.readyCallbacks.forEach(callback => {
             callback(this);
         });
     },
-    progress: function(msg) {
+    progress(msg) {
         log.debug(msg);
     },
     authorizations: {

--- a/js/api.js
+++ b/js/api.js
@@ -74,7 +74,13 @@ API.resolve = function($ref) {
  * @param  {Function} callback A callback to call when API is ready.
  */
 API.onReady = function(callback) {
-    this.readyCallbacks.push(callback);
+    if (this.ready && this.isBuilt) {
+        // API is already ready, call the callback immediately
+        callback(this);
+    } else {
+        // Register the callback for later call
+        this.readyCallbacks.push(callback);
+    }
 };
 
 export default API;

--- a/js/front/dashboard.js
+++ b/js/front/dashboard.js
@@ -1,7 +1,6 @@
 // ES6 environment
 import 'front/bootstrap';
 
-import $ from 'jquery';
 import Vue from 'vue';
 import API from 'api';
 
@@ -11,7 +10,7 @@ import DashboardGraphs from 'components/dashboard/graphs.vue';
 // Ensure retrocompatibily for 0.12.2 replace behavior
 Vue.options.replace = false;
 
-$(API).on('built', function() {
+API.onReady(function() {
     new Vue({
         components: {ActivityTimeline, DashboardGraphs}
     });

--- a/js/front/dashboard.js
+++ b/js/front/dashboard.js
@@ -2,7 +2,6 @@
 import 'front/bootstrap';
 
 import Vue from 'vue';
-import API from 'api';
 
 import ActivityTimeline from 'components/activities/timeline.vue';
 import DashboardGraphs from 'components/dashboard/graphs.vue';
@@ -10,8 +9,7 @@ import DashboardGraphs from 'components/dashboard/graphs.vue';
 // Ensure retrocompatibily for 0.12.2 replace behavior
 Vue.options.replace = false;
 
-API.onReady(function() {
-    new Vue({
-        components: {ActivityTimeline, DashboardGraphs}
-    });
+new Vue({
+    el: 'body',
+    components: {ActivityTimeline, DashboardGraphs}
 });

--- a/js/front/organization/index.js
+++ b/js/front/organization/index.js
@@ -19,61 +19,55 @@ import Tab from 'components/tab';
 
 import MembershipRequest from './membership-request.vue';
 
-// TODO: simplify Swagger API handling for front views
-import API from 'api';
-
-
-API.onReady(function() {
-    new Vue({
-        el: 'body',
-        components: {FollowButton, Tab, tabset, ActivityTimeline, DashboardGraphs},
-        data() {
-            return {
-                followersVisible: false,
-                // Current tab index
-                currentTab: 0,
-            };
-        },
-        methods: {
-            /**
-            * Display the membership request modal
-            */
-            requestMembership(url) {
-                if (Auth.need_user(i18n._('You need to be logged in to request membership to an organization'))) {
-                    return new Vue({
-                        mixins: [MembershipRequest],
-                        el: this.$els.modal,
-                        replace: false, // Needed while all components are not migrated to replace: true behavior
-                        parent: this,
-                        propsData: {url}
-                    });
-                }
-            },
-            showFollowers() {
-                this.followersVisible = true;
-            }
-        },
-        ready() {
-            log.debug('Organization display page');
-
-            // Restore tab from hash
-            if (location.hash !== '') {
-                this.$refs.tabs.$children.some((tab, index) => {
-                    if (`#${tab.id}` === location.hash) {
-                        this.currentTab = index;
-                        return true;
-                    }
+new Vue({
+    el: 'body',
+    components: {FollowButton, Tab, tabset, ActivityTimeline, DashboardGraphs},
+    data() {
+        return {
+            followersVisible: false,
+            // Current tab index
+            currentTab: 0,
+        };
+    },
+    methods: {
+        /**
+        * Display the membership request modal
+        */
+        requestMembership(url) {
+            if (Auth.need_user(i18n._('You need to be logged in to request membership to an organization'))) {
+                return new Vue({
+                    mixins: [MembershipRequest],
+                    el: this.$els.modal,
+                    replace: false, // Needed while all components are not migrated to replace: true behavior
+                    parent: this,
+                    propsData: {url}
                 });
             }
         },
-        watch: {
-            /**
-            * Set current tab ID as location hash
-            * @param  {Number} index The new tab index
-            */
-            currentTab(index) {
-                location.hash = this.$refs.tabs.$children[index].id;
-            }
+        showFollowers() {
+            this.followersVisible = true;
         }
-    });
+    },
+    ready() {
+        log.debug('Organization display page');
+
+        // Restore tab from hash
+        if (location.hash !== '') {
+            this.$refs.tabs.$children.some((tab, index) => {
+                if (`#${tab.id}` === location.hash) {
+                    this.currentTab = index;
+                    return true;
+                }
+            });
+        }
+    },
+    watch: {
+        /**
+        * Set current tab ID as location hash
+        * @param  {Number} index The new tab index
+        */
+        currentTab(index) {
+            location.hash = this.$refs.tabs.$children[index].id;
+        }
+    }
 });

--- a/js/front/organization/index.js
+++ b/js/front/organization/index.js
@@ -23,7 +23,7 @@ import MembershipRequest from './membership-request.vue';
 import API from 'api';
 
 
-$(API).on('built', function() {
+API.onReady(function() {
     new Vue({
         el: 'body',
         components: {FollowButton, Tab, tabset, ActivityTimeline, DashboardGraphs},

--- a/js/front/user.js
+++ b/js/front/user.js
@@ -13,41 +13,35 @@ import FollowButton from 'components/buttons/follow.vue';
 import ActivityTimeline from 'components/activities/timeline.vue';
 import Tab from 'components/tab';
 
-// TODO: simplify Swagger API handling for front views
-import API from 'api';
+new Vue({
+    el: 'body',
+    components: {FollowButton, Tab, tabset, ActivityTimeline},
+    data() {
+        return {
+            // Current tab index
+            currentTab: 0,
+        };
+    },
+    ready() {
+        log.debug('User display page');
 
-API.onReady(function() {
-    new Vue({
-        el: 'body',
-        components: {FollowButton, Tab, tabset, ActivityTimeline},
-        data() {
-            return {
-                // Current tab index
-                currentTab: 0,
-                // API,
-            };
-        },
-        ready() {
-            log.debug('User display page');
-
-            // Restore tab from hash
-            if (location.hash !== '') {
-                this.$refs.tabs.$children.some((tab, index) => {
-                    if (`#${tab.id}` === location.hash) {
-                        this.currentTab = index;
-                        return true;
-                    }
-                });
-            }
-        },
-        watch: {
-            /**
-            * Set current tab ID as location hash
-            * @param  {Number} index The new tab index
-            */
-            currentTab(index) {
-                location.hash = this.$refs.tabs.$children[index].id;
-            },
+        // Restore tab from hash
+        if (location.hash !== '') {
+            this.$refs.tabs.$children.some((tab, index) => {
+                if (`#${tab.id}` === location.hash) {
+                    this.currentTab = index;
+                    return true;
+                }
+            });
         }
-    });
+    },
+    watch: {
+        /**
+        * Set current tab ID as location hash
+        * @param  {Number} index The new tab index
+        */
+        currentTab(index) {
+            location.hash = this.$refs.tabs.$children[index].id;
+        },
+    }
 });

--- a/js/front/user.js
+++ b/js/front/user.js
@@ -16,10 +16,7 @@ import Tab from 'components/tab';
 // TODO: simplify Swagger API handling for front views
 import API from 'api';
 
-// Legacy depedencies soon to be dropped
-import $ from 'jquery';
-
-$(API).on('built', function() {
+API.onReady(function() {
     new Vue({
         el: 'body',
         components: {FollowButton, Tab, tabset, ActivityTimeline},

--- a/js/models/base.js
+++ b/js/models/base.js
@@ -101,9 +101,7 @@ export class Base {
      */
     $api(endpoint, data, on_success, on_error = () => {}) {
         API.onReady(() => {
-            const parts = endpoint.split('.');
-            const namespace = parts[0];
-            const method = parts[1];
+            const [namespace, method] = endpoint.split('.');
             const operation = API[namespace][method];
 
             if (this.$options.mask && !('X-Fields' in data)) {
@@ -159,8 +157,7 @@ export class Model extends Base {
     on_fetched(data) {
         for (const prop in data.obj) {
             if (data.obj.hasOwnProperty(prop)) {
-                const value = data.obj[prop];
-                this._set(prop, value);
+                this._set(prop, data.obj[prop]);
             }
         }
         this.$emit('updated');

--- a/js/models/validator.js
+++ b/js/models/validator.js
@@ -1,24 +1,26 @@
 import API from 'api';
-import moment from 'moment'
+import moment from 'moment';
 import tv4 from 'tv4';
 import Vue from 'vue';
 
+API.onReady(function() {
+    for (const key of Object.keys(API.definitions)) {
+        const schema = API.definitions[key];
+        tv4.addSchema('#/definitions/' + key, schema);
+    }
+});
 
-for (let key of Object.keys(API.definitions)) {
-    let schema = API.definitions[key];
-    tv4.addSchema('#/definitions/' + key, schema);
-}
 
 tv4.addFormat({
-    date: function(data, schema) {
-        var m = moment(data, 'YYYY-MM-DD'),
-            flags = m.parsingFlags();
+    date: function(data) {
+        const m = moment(data, 'YYYY-MM-DD');
+        const flags = m.parsingFlags();
 
         if (!m.isValid() || (flags.unusedInput + flags.unusedTokens).length) {
             return Vue._('Unsupported ISO-8601 date format');
         }
     },
-    'date-time': function(data, schema) {
+    'date-time': function(data) {
         if (!moment(data, moment.ISO_8601).isValid()) {
             return Vue._('Unsupported ISO-8601 date-time format');
         }


### PR DESCRIPTION
This PR:
- drop jquery event for ready status
- remove the need to wait API being ready on views initialization
- ensure models empty models are correctly set on API ready
- ensure API calls wait for API being ready

This PR is built on #512 