### PR TITLE
Factorize Leaflet config and switch to CartoDB positron

### DIFF
--- a/js/components/widgets/map.vue
+++ b/js/components/widgets/map.vue
@@ -42,18 +42,10 @@
 </template>
 
 <script>
+import config from 'config';
 import L from 'leaflet';
 
-const ATTRIBUTIONS = [
-        '&copy;',
-        '<a href="http://openstreetmap.org">OpenStreetMap</a>',
-        '/',
-        '<a href="http://open.mapquest.com/">MapQuest</a>'
-    ].join(' '),
-    TILES_PREFIX = location.protocol === 'https:' ? '//otile{s}-s' : '//otile{s}',
-    TILES_URL = TILES_PREFIX + '.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png',
-    TILES_CONFIG = {subdomains: '1234', attribution: ATTRIBUTIONS},
-    INITIAL_SETTINGS = {center: [42, 2.4], zoom: 4, zoomControl: false};
+const INITIAL_SETTINGS = {center: [42, 2.4], zoom: 4, zoomControl: false};
 
 export default {
     props: {
@@ -85,7 +77,7 @@ export default {
         }
 
 
-        L.tileLayer(TILES_URL, TILES_CONFIG).addTo(this.map);
+        L.tileLayer(config.tiles_url, config.tiles_config).addTo(this.map);
     },
     watch: {
         'geojson': function(json) {

--- a/js/config.js
+++ b/js/config.js
@@ -120,6 +120,32 @@ export const notify_in = _meta('notify-in');
  */
 export const is_territory_enabled = _jsonMeta('territory-enabled');
 
+/**
+ * Detect HiDPI screens
+ */
+export const hidpi = (window.devicePixelRatio > 1 || (
+    window.matchMedia
+    && window.matchMedia('(-webkit-min-device-pixel-ratio: 1.25),(min-resolution: 120dpi)').matches)
+);
+
+/**
+ * Attributions for map tiles
+ */
+export const tiles_attributions = '&copy;' + [
+    '<a href="http://openstreetmap.org/copyright">OpenStreetMap</a>',
+    '<a href="https://cartodb.com/attributions">CartoDB</a>'
+].join('/');
+
+/**
+ * Map tiles URL
+ */
+export const tiles_url = `https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}${hidpi ? '@2x' : ''}.png`;
+
+/**
+ * Leaflet base config
+ */
+export const tiles_config = {subdomains: 'abcd', attribution: tiles_attributions};
+
 
 export default {
     user,
@@ -137,4 +163,8 @@ export default {
     notify_in,
     check_urls,
     is_territory_enabled,
+    hidpi,
+    tiles_attributions,
+    tiles_url,
+    tiles_config,
 };

--- a/js/dashboard/map.js
+++ b/js/dashboard/map.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import $ from 'jquery';
 import API from 'api.light';
 import log from 'logger';
@@ -18,16 +19,7 @@ const DEFAULTS = {
         }
     },
     LEVELS_URL = '/spatial/levels',
-    COVERAGE_URL = '/spatial/coverage/{level}',
-    ATTRIBUTIONS = [
-        '&copy;',
-        '<a href="http://openstreetmap.org">OpenStreetMap</a>',
-        '/',
-        '<a href="http://open.mapquest.com/">MapQuest</a>'
-    ].join(' '),
-    TILES_PREFIX = location.protocol === 'https:' ? '//otile{s}-s' : '//otile{s}',
-    TILES_URL = TILES_PREFIX + '.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png',
-    TILES_CONFIG = {subdomains: '1234', attribution: ATTRIBUTIONS};
+    COVERAGE_URL = '/spatial/coverage/{level}';
 
 
 if (!window.Spinner) { // Fix for leaflet.spin
@@ -77,7 +69,7 @@ export default class CoverageMap {
             return level;
         });
 
-        L.tileLayer(TILES_URL, TILES_CONFIG).addTo(this.map);
+        L.tileLayer(config.tiles_url, config.tiles_config).addTo(this.map);
 
         L.control.layers(layers, null, {collapsed: false}).addTo(this.map);
         this.map.on('baselayerchange', (ev) => {

--- a/js/dataset/display.js
+++ b/js/dataset/display.js
@@ -132,16 +132,6 @@ function loadJson(map, layer, data) {
 
 function load_coverage_map() {
     const $el = $('#coverage-map');
-    const ATTRIBUTIONS = [
-            '&copy;',
-            '<a href="http://openstreetmap.org">OpenStreetMap</a>',
-            '/',
-            '<a href="http://open.mapquest.com/">MapQuest</a>'
-        ].join(' ');
-    const TILES_PREFIX = location.protocol === 'https:' ? '//otile{s}-s' : '//otile{s}';
-    const TILES_URL = TILES_PREFIX + '.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png';
-    const TILES_CONFIG = {subdomains: '1234', attribution: ATTRIBUTIONS};
-    let map;
     let layer;
 
     if (!$el.length) {
@@ -159,7 +149,7 @@ function load_coverage_map() {
     // Disable tap handler, if present.
     if (map.tap) map.tap.disable();
 
-    L.tileLayer(TILES_URL, TILES_CONFIG).addTo(map);
+    L.tileLayer(config.tiles_url, config.tiles_config).addTo(map);
 
     layer = L.geoJson(null, {
         onEachFeature: function(feature, layer) {


### PR DESCRIPTION
Given that MapQuest [ends free tiles support](http://devblog.mapquest.com/2016/06/15/modernization-of-mapquest-results-in-changes-to-open-tile-access/), this pull request switch to [CartoDB Positron](https://carto.com/location-data-services/basemaps/).

In the same time, Leaflet base configuration is factorized into config and support for hidpi tiles has been added.