### PR TITLE
Pin OAuthlib 1.1.2

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -43,3 +43,7 @@ geojson>=1.3.1
 
 # Pin this until flask-restplus works with 0.3.4
 Flask-RESTful==0.3.3
+
+# Pin OAuthlib until https://github.com/idan/oauthlib/issues/433
+# and https://github.com/idan/oauthlib/issues/359 are fixed
+oauthlib==1.1.2


### PR DESCRIPTION
Pin OAuthlib to avoid https://github.com/idan/oauthlib/issues/433 (and https://github.com/idan/oauthlib/issues/359)

(Maybe solved by upgrading to Flask-OAuthlib 0.9.3)