### PR TITLE
Fix js/models/geogranularities double export default

### DIFF
--- a/js/models/geogranularities.js
+++ b/js/models/geogranularities.js
@@ -1,14 +1,13 @@
 import {List} from 'models/base';
-import log from 'logger';
 
 
-export default class GeoGranularity extends List {
+export class GeoGranularity extends List {
     constructor(options) {
         super(options);
         this.$options.ns = 'spatial';
         this.$options.fetch = 'spatial_granularities';
     }
-};
+}
 
-export var granularities = new GeoGranularity().fetch();
+export const granularities = new GeoGranularity().fetch();
 export default granularities;


### PR DESCRIPTION
This PR fix double "export default" in `js/models/geogranularities`
(Was breaking admin)