### PR TITLE
Huge performance improvement on notifications querying

### DIFF
--- a/udata/core/discussions/actions.py
+++ b/udata/core/discussions/actions.py
@@ -14,8 +14,8 @@ def discussions_for(user, only_open=True):
 
     :param bool only_open: whether to include closed discussions or not.
     '''
-    datasets = Dataset.objects.owned_by(user.id, *user.organizations)
-    reuses = Reuse.objects.owned_by(user.id, *user.organizations)
+    datasets = Dataset.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
+    reuses = Reuse.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
 
     qs = Discussion.objects(subject__in=list(datasets) + list(reuses))
     if only_open:

--- a/udata/core/discussions/actions.py
+++ b/udata/core/discussions/actions.py
@@ -14,6 +14,8 @@ def discussions_for(user, only_open=True):
 
     :param bool only_open: whether to include closed discussions or not.
     '''
+    # Only fetch required fields for discussion filtering (id and slug)
+    # Greatly improve performances and memory usage
     datasets = Dataset.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
     reuses = Reuse.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
 

--- a/udata/core/discussions/notifications.py
+++ b/udata/core/discussions/notifications.py
@@ -16,10 +16,12 @@ def discussions_notifications(user):
     '''Notify user about open discussions'''
     notifications = []
 
-    # Only fetch required attributes
+    # Only fetch required fields for notification serialization
+    # Greatly improve performances and memory usage
     qs = discussions_for(user).only('id', 'created', 'title', 'subject')
 
     # Do not dereference subject (so it's a DBRef)
+    # Also improve performances and memory usage
     for discussion in qs.no_dereference():
         notifications.append((discussion.created, {
             'id': discussion.id,

--- a/udata/core/discussions/notifications.py
+++ b/udata/core/discussions/notifications.py
@@ -16,13 +16,17 @@ def discussions_notifications(user):
     '''Notify user about open discussions'''
     notifications = []
 
-    for discussion in discussions_for(user):
+    # Only fetch required attributes
+    qs = discussions_for(user).only('id', 'created', 'title', 'subject')
+
+    # Do not dereference subject (so it's a DBRef)
+    for discussion in qs.no_dereference():
         notifications.append((discussion.created, {
             'id': discussion.id,
             'title': discussion.title,
             'subject': {
-                'id': discussion.subject.id,
-                'type': discussion.subject.__class__.__name__.lower(),
+                'id': discussion.subject['_ref'].id,
+                'type': discussion.subject['_cls'].lower(),
             }
         }))
 

--- a/udata/core/issues/actions.py
+++ b/udata/core/issues/actions.py
@@ -14,6 +14,8 @@ def issues_for(user, only_open=True):
 
     :param bool only_open: whether to include closed issues or not.
     '''
+    # Only fetch required fields for issues filtering (id and slug)
+    # Greatly improve performances and memory usage
     datasets = Dataset.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
     reuses = Reuse.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
 

--- a/udata/core/issues/actions.py
+++ b/udata/core/issues/actions.py
@@ -14,8 +14,8 @@ def issues_for(user, only_open=True):
 
     :param bool only_open: whether to include closed issues or not.
     '''
-    datasets = Dataset.objects.owned_by(user.id, *user.organizations)
-    reuses = Reuse.objects.owned_by(user.id, *user.organizations)
+    datasets = Dataset.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
+    reuses = Reuse.objects.owned_by(user.id, *user.organizations).only('id', 'slug')
 
     qs = Issue.objects(subject__in=list(datasets) + list(reuses))
     if only_open:

--- a/udata/core/issues/notifications.py
+++ b/udata/core/issues/notifications.py
@@ -16,13 +16,17 @@ def issues_notifications(user):
     '''Notify user about open issues'''
     notifications = []
 
-    for issue in issues_for(user):
+    # Only fetch required attributes
+    qs = issues_for(user).only('id', 'title', 'created', 'subject')
+
+    # Do not dereference subject (so it's a DBRef)
+    for issue in qs.no_dereference():
         notifications.append((issue.created, {
             'id': issue.id,
             'title': issue.title,
             'subject': {
-                'id': issue.subject.id,
-                'type': issue.subject.__class__.__name__.lower(),
+                'id': issue.subject['_ref'].id,
+                'type': issue.subject['_cls'].lower(),
             }
         }))
 

--- a/udata/core/issues/notifications.py
+++ b/udata/core/issues/notifications.py
@@ -16,10 +16,12 @@ def issues_notifications(user):
     '''Notify user about open issues'''
     notifications = []
 
-    # Only fetch required attributes
+    # Only fetch required fields for notification serialization
+    # Greatly improve performances and memory usage
     qs = issues_for(user).only('id', 'title', 'created', 'subject')
 
     # Do not dereference subject (so it's a DBRef)
+    # Also improve performances and memory usage
     for issue in qs.no_dereference():
         notifications.append((issue.created, {
             'id': issue.id,

--- a/udata/features/transfer/notifications.py
+++ b/udata/features/transfer/notifications.py
@@ -17,10 +17,12 @@ def transfer_request_notifications(user):
     notifications = []
 
     qs = Transfer.objects(recipient__in=[user] + orgs, status='pending')
-    # Only fetch required attributes
+    # Only fetch required fields for notification serialization
+    # Greatly improve performances and memory usage
     qs = qs.only('id', 'created', 'subject')
 
     # Do not dereference subject (so it's a DBRef)
+    # Also improve performances and memory usage
     for transfer in qs.no_dereference():
         notifications.append((transfer.created, {
             'id': transfer.id,

--- a/udata/features/transfer/notifications.py
+++ b/udata/features/transfer/notifications.py
@@ -16,13 +16,17 @@ def transfer_request_notifications(user):
     orgs = [o for o in user.organizations if o.is_member(user)]
     notifications = []
 
-    for transfer in Transfer.objects(
-            recipient__in=[user] + orgs, status='pending'):
+    qs = Transfer.objects(recipient__in=[user] + orgs, status='pending')
+    # Only fetch required attributes
+    qs = qs.only('id', 'created', 'subject')
+
+    # Do not dereference subject (so it's a DBRef)
+    for transfer in qs.no_dereference():
         notifications.append((transfer.created, {
             'id': transfer.id,
             'subject': {
-                'class': transfer.subject.__class__.__name__.lower(),
-                'id': transfer.subject.id
+                'class': transfer.subject['_cls'].lower(),
+                'id': transfer.subject['_ref'].id
             }
         }))
 

--- a/udata/harvest/notifications.py
+++ b/udata/harvest/notifications.py
@@ -18,6 +18,8 @@ def validate_harvester_notifications(user):
 
     notifications = []
 
+    # Only fetch required fields for notification serialization
+    # Greatly improve performances and memory usage
     qs = HarvestSource.objects(validation__state=VALIDATION_PENDING)
     qs = qs.only('id', 'created_at', 'name')
 

--- a/udata/harvest/notifications.py
+++ b/udata/harvest/notifications.py
@@ -18,7 +18,10 @@ def validate_harvester_notifications(user):
 
     notifications = []
 
-    for source in HarvestSource.objects(validation__state=VALIDATION_PENDING):
+    qs = HarvestSource.objects(validation__state=VALIDATION_PENDING)
+    qs = qs.only('id', 'created_at', 'name')
+
+    for source in qs:
         notifications.append((source.created_at, {
             'id': source.id,
             'name': source.name,


### PR DESCRIPTION
This PR greatly improve performance and memory usage on notifications retrieval by:
- fetching only the required fields from MongoDB
- turning off GenericReferenceField dereferencing

The response time is divided by approximatively 5 on my computer (from more than 5 seconds to 800ms with an administrator account with 64 pending notifications).

The master branch need a different fix because of bc93fc233dde16753078e5d2eeafbfd398477024 being only on dev branch