### PR TITLE
Display the correct number of followers in the reuses list (fixes #20)

### DIFF
--- a/udata/core/site/metrics.py
+++ b/udata/core/site/metrics.py
@@ -140,7 +140,7 @@ class MaxReuseDatasetsMetric(SiteMetric):
     def get_value(self):
         reuse = (Reuse.objects(metrics__datasets__gt=0).visible()
                  .order_by('-metrics.datasets').first())
-        return reuse.metrics.get('datasets', 0)
+        return reuse.metrics['datasets'] if reuse else 0
 
 MaxReuseDatasetsMetric.connect(Reuse.on_create, Reuse.on_update)
 
@@ -153,7 +153,7 @@ class MaxReuseFollowersMetric(SiteMetric):
     def get_value(self):
         reuse = (Reuse.objects(metrics__followers__gt=0).visible()
                  .order_by('-metrics.followers').first())
-        return reuse.metrics.get('followers', 0)
+        return reuse.metrics['followers'] if reuse else 0
 
 MaxReuseFollowersMetric.connect(on_follow, on_unfollow)
 
@@ -166,7 +166,7 @@ class MaxOrgFollowersMetric(SiteMetric):
     def get_value(self):
         org = (Organization.objects(metrics__followers__gt=0).visible()
                .order_by('-metrics.followers').first())
-        return org.metrics.get('followers', 0)
+        return org.metrics['followers'] if org else 0
 
 MaxOrgFollowersMetric.connect(Organization.on_create, Organization.on_update,
                               on_follow, on_unfollow)
@@ -180,10 +180,8 @@ class MaxOrgReusesMetric(SiteMetric):
     def get_value(self):
         org = (Organization.objects(metrics__reuses__gt=0).visible()
                .order_by('-metrics.reuses').first())
-        if org:
-            return org.metrics.get('reuses', 0)
-        else:
-            return 0
+        return org.metrics['reuses'] if org else 0
+
 
 MaxOrgReusesMetric.connect(Dataset.on_create, Dataset.on_update)
 
@@ -196,7 +194,7 @@ class MaxOrgDatasetsMetric(SiteMetric):
     def get_value(self):
         org = (Organization.objects(metrics__datasets__gt=0).visible()
                .order_by('-metrics.datasets').first())
-        return org.metrics.get('datasets', 0)
+        return org.metrics['datasets'] if org else 0
 
 MaxOrgDatasetsMetric.connect(Organization.on_create, Organization.on_update,
                              Reuse.on_create, Reuse.on_update)

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -87,6 +87,12 @@ def populate_slug(instance, field):
                      not field.update):
         return value
 
+    # This can happen when serializing an object which does not contain
+    # the properties used to generate the slug. Typically, when such
+    # an object is passed to one of the Celery workers (see issue #20).
+    if value is None:
+        return
+
     if field.lower_case:
         value = value.lower()
 

--- a/udata/templates/reuse/search-result.html
+++ b/udata/templates/reuse/search-result.html
@@ -31,7 +31,7 @@
                 <a class="btn btn-xs" v-tooltip tooltip-placement="top"
                     title="{{ _('Number of stars') }}">
                     <span class="fa fa-star fa-fw"></span>
-                    {{ ngettext('%(num)s star', '%(num)s stars', reuse.metrics.stars or 0) }}
+                    {{ ngettext('%(num)s star', '%(num)s stars', reuse.metrics.followers or 0) }}
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
This PR aims at solving #20, which is easy to reproduce in a dev environment.

There were actually several problems:
1. There was an obvious bug in the template search-result.html.
2. There were also some bugs in metrics.py, which occured probably only in the dev environment.
3. When clicking on the 'Follow' button, a POST request was sent to the server, which crashed, in slug_fields.py, which prevented the metrics from being updated.

When the problem 3 occurs, I have the following traces in the standard output:
```
ERROR: Exception on /api/1/reuses/57ff416b82412f3ecd7495f7/followers/ [POST]
  | Traceback (most recent call last):
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
  |     rv = self.dispatch_request()
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
  |     return self.view_functions[rule.endpoint](**req.view_args)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/flask_restplus/cors.py", line 38, in wrapped_function
  |     resp = make_response(f(*args, **kwargs))
  |   File "/home/jpnoel/udata/udata/api/__init__.py", line 92, in wrapper
  |     return func(*args, **kwargs)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/flask_restplus/api.py", line 309, in wrapper
  |     resp = resource(*args, **kwargs)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/flask/views.py", line 84, in view
  |     return self.dispatch_request(*args, **kwargs)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/flask_restplus/resource.py", line 44, in dispatch_request
  |     resp = meth(*args, **kwargs)
  |   File "/home/jpnoel/udata/udata/api/__init__.py", line 83, in wrapper
  |     return func(*args, **kwargs)
  |   File "/home/jpnoel/udata/udata/core/followers/api.py", line 60, in post
  |     follower=current_user.id, following=model, until=None)
  |   File "/home/jpnoel/udata/udata/models/__init__.py", line 141, in get_or_create
  |     doc.save(write_concern=write_concern)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/mongoengine/document.py", line 403, in save
  |     signals.post_save.send(self.__class__, document=self, created=created)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/blinker/base.py", line 267, in send
  |     for receiver in self.receivers_for(sender)]
  |   File "/home/jpnoel/udata/udata/core/followers/models.py", line 48, in emit_new_follower
  |     on_follow.send(document)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/blinker/base.py", line 267, in send
  |     for receiver in self.receivers_for(sender)]
  |   File "/home/jpnoel/udata/udata/core/followers/metrics.py", line 21, in callback
  |     new_class(follow.following).trigger_update()
  |   File "/home/jpnoel/udata/udata/core/metrics/__init__.py", line 115, in trigger_update
  |     self.need_update.send(self)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/blinker/base.py", line 267, in send
  |     for receiver in self.receivers_for(sender)]
  |   File "/home/jpnoel/udata/udata/core/metrics/__init__.py", line 23, in update_on_demand
  |     update_metric.delay(metric)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/celery/app/task.py", line 461, in delay
  |     return self.apply_async(args, kwargs)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/celery/app/task.py", line 573, in apply_async
  |     **dict(self._get_exec_options(), **options)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/celery/app/base.py", line 354, in send_task
  |     reply_to=reply_to or self.oid, **options
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/celery/app/amqp.py", line 310, in publish_task
  |     **kwargs
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/messaging.py", line 165, in publish
  |     compression, headers)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/messaging.py", line 241, in _prepare
  |     body) = dumps(body, serializer=serializer)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/serialization.py", line 164, in dumps
  |     payload = encoder(data)
  |   File "/usr/lib/python2.7/contextlib.py", line 35, in __exit__
  |     self.gen.throw(type, value, traceback)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/serialization.py", line 59, in _reraise_errors
  |     reraise(wrapper, wrapper(exc), sys.exc_info()[2])
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/serialization.py", line 55, in _reraise_errors
  |     yield
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/serialization.py", line 164, in dumps
  |     payload = encoder(data)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/kombu/serialization.py", line 356, in pickle_dumps
  |     return dumper(obj, protocol=pickle_protocol)
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/mongoengine/base/document.py", line 195, in __getstate__
  |     data['_data'] = self.to_mongo()
  |   File "/home/jpnoel/.virtualenvs/udata/local/lib/python2.7/site-packages/mongoengine/base/document.py", line 345, in to_mongo
  |     value = field.generate()
  |   File "/home/jpnoel/udata/udata/models/slug_fields.py", line 44, in generate
  |     return populate_slug(self.instance, self)
  |   File "/home/jpnoel/udata/udata/models/slug_fields.py", line 91, in populate_slug
  |     value = value.lower()
  | EncodeError: 'NoneType' object has no attribute 'lower'
```

To fix the problem 3, I must remove the `only('id')` part in followers/api.py.

But this is not really satisfactory, indeed:

- I do not exactly understand the problem 3, even if it seems to be related to the serialization, when sending a message to the celery worker to update the metrics 
- [This test ](https://github.com/opendatateam/udata/blob/dev/udata/tests/api/test_reuses_api.py#L217) should fail without the modification on followers/api.py, but it does not.