### PR TITLE
Packaging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ uData
 [![Python Requirements Status][requires-io-badge]][requires-io-url]
 [![JavaScript Dependencies Status][david-dm-badge]][david-dm-url]
 [![JavaScript Development Dependencies Status][david-dm-dev-badge]][david-dm-dev-url]
-[![Join the chat at https://gitter.im/etalab/udata][gitter-badge]][gitter-url]
+[![Join the chat at https://gitter.im/opendatateam/udata][gitter-badge]][gitter-url]
 
 Customizable and skinnable social platform dedicated to (open)data.
 
@@ -13,11 +13,11 @@ The [full documentation](http://udata.readthedocs.org/) is hosted on Read the Do
 
 [circleci-url]: https://circleci.com/gh/opendatateam/udata
 [circleci-badge]: https://circleci.com/gh/opendatateam/udata.svg?style=shield
-[requires-io-url]: https://requires.io/github/etalab/udata/requirements/?branch=master
-[requires-io-badge]: https://requires.io/github/etalab/udata/requirements.png?branch=master
+[requires-io-url]: https://requires.io/github/opendatateam/udata/requirements/?branch=master
+[requires-io-badge]: https://requires.io/github/opendatateam/udata/requirements.png?branch=master
 [david-dm-url]: https://david-dm.org/opendatateam/udata
 [david-dm-badge]: https://img.shields.io/david/opendatateam/udata.svg
 [david-dm-dev-url]: https://david-dm.org/opendatateam/udata#info=devDependencies
 [david-dm-dev-badge]: https://david-dm.org/opendatateam/udata/dev-status.svg
 [gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
-[gitter-url]: https://gitter.im/etalab/udata
+[gitter-url]: https://gitter.im/opendatateam/udata

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,5 @@
-# Current (in progress)
+# Changelog
+
+## Current (in progress)
 
 - First published version

--- a/setup.py
+++ b/setup.py
@@ -7,36 +7,82 @@ from os.path import join, dirname
 
 from setuptools import setup, find_packages
 
-RE_REQUIREMENT = re.compile(r'^\s*-r\s*(?P<filename>.*)$')
-
-PYPI_CLEANDOC_FILTERS = (
-    # Remove badges lines
-    (r'\n.*travis-.*', ''),
-    (r'\n.*requires-.*', ''),
-    (r'\n.*david-dm.*', ''),
-    (r'\n.*gitter-.*', ''),
-    (r'\n.*coveralls-.*', ''),
-    # Transform links
-    (r'\[(.+)\]\[(.+)\]', '`\g<1> <\g<2>_>`_'),
-    (r'\[(.+)\]:\s*(.+)\s*', '.. _\g<1>: \g<2>'),
-    (r'\[(.+)\]\((.+)\)', '`\g<1> <\g<2>>`_'),
-)
-
 ROOT = dirname(__file__)
 
+RE_REQUIREMENT = re.compile(r'^\s*-r\s*(?P<filename>.*)$')
 
-def clean_doc(filename):
-    """Load markdown file and sanitize it for PyPI restructuredtext.
+RE_MD_CODE_BLOCK = re.compile(r'```(?P<language>\w+)?\n(?P<lines>.*?)```', re.S)
+RE_SELF_LINK = re.compile(r'\[(.*?)\]\[\]')
+RE_LINK_TO_URL = re.compile(r'\[(?P<text>.*?)\]\((?P<url>.*?)\)')
+RE_LINK_TO_REF = re.compile(r'\[(?P<text>.*?)\]\[(?P<ref>.*?)\]')
+RE_LINK_REF = re.compile(r'^\[(?P<key>[^!].*?)\]:\s*(?P<url>.*)$', re.M)
+RE_BADGE = re.compile(r'^\[\!\[(?P<text>.*?)\]\[(?P<badge>.*?)\]\]\[(?P<target>.*?)\]$', re.M)
+RE_TITLE = re.compile(r'^(?P<level>#+)\s*(?P<title>.*)$', re.M)
 
+BADGES_TO_KEEP = ['gitter-badge']
+
+RST_TITLE_LEVELS = ['=', '-', '*']
+
+RST_BADGE = '''\
+.. image:: {badge}
+    :target: {target}
+    :alt: {text}
+'''
+
+def md2pypi(filename):
+    '''
+    Load .md (markdown) file and sanitize it for PyPI.
     Remove unsupported github tags:
-     - various badges
+     - code-block directive
+     - travis ci build badges
+    '''
+    content = open(filename).read()
 
-    Transform markdown links into restructuredtext
-    """
-    content = open(join(ROOT, filename)).read()
-    for regex, replacement in PYPI_CLEANDOC_FILTERS:
-        content = re.sub(regex, replacement, content)
+    for match in RE_MD_CODE_BLOCK.finditer(content):
+        rst_block = '\n'.join(
+            ['.. code-block:: {language}'.format(**match.groupdict()), ''] +
+            ['    {0}'.format(l) for l in match.group('lines').split('\n')] +
+            ['']
+        )
+        content = content.replace(match.group(0), rst_block)
+
+    refs = dict(RE_LINK_REF.findall(content))
+    content = RE_LINK_REF.sub('.. _\g<key>: \g<url>', content)
+    content = RE_SELF_LINK.sub('`\g<1>`_', content)
+    content = RE_LINK_TO_URL.sub('`\g<text> <\g<url>>`_', content)
+
+    for match in RE_BADGE.finditer(content):
+        if match.group('badge') not in BADGES_TO_KEEP:
+            content = content.replace(match.group(0), '')
+        else:
+            params = match.groupdict()
+            params['badge'] = refs[match.group('badge')]
+            params['target'] = refs[match.group('target')]
+            content = content.replace(match.group(0),
+                                      RST_BADGE.format(**params))
+    # Must occur after badges
+    for match in RE_LINK_TO_REF.finditer(content):
+        content = content.replace(match.group(0), '`{text} <{url}>`_'.format(
+            text=match.group('text'),
+            url=refs[match.group('ref')]
+        ))
+
+    for match in RE_TITLE.finditer(content):
+        underchar = RST_TITLE_LEVELS[len(match.group('level'))]
+        title = match.group('title')
+        underline = underchar * len(title)
+
+        full_title = '\n'.join((title, underline))
+        content = content.replace(match.group(0), full_title)
+
     return content
+
+
+long_description = '\n'.join((
+    md2pypi('README.md'),
+    md2pypi('CHANGELOG.md'),
+    ''
+))
 
 
 def pip(filename):
@@ -54,28 +100,20 @@ def pip(filename):
     return requirements
 
 
-def dependency_links(filename):
-    return [line.strip()
-            for line in open(join(ROOT, 'requirements', filename))
-            if '://' in line]
-
 install_requires = pip('install.pip')
 tests_require = pip('test.pip')
-readme_md = clean_doc('README.md')
 
 setup(
     name='udata',
     version=__import__('udata').__version__,
     description=__import__('udata').__description__,
-    long_description=readme_md,
-    url='https://github.com/etalab/udata',
-    download_url='http://pypi.python.org/pypi/udata',
-    author='Axel Haustant',
-    author_email='axel@data.gouv.fr',
+    long_description=long_description,
+    url='https://github.com/opendatateam/udata',
+    author='Opendata Team',
+    author_email='opendatateam@data.gouv.fr',
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
-    dependency_links=dependency_links('install.pip'),
     tests_require=tests_require,
     extras_require={
         'test': tests_require,


### PR DESCRIPTION
This PR:

- fixes some URLs and emails `README.md` and `setup.py`
- remove the deprecated `download_url` and `dependency_links`
- ensure proper md to rst conversion of the PyPI long description
- add the changelog to PyPI long description
- add the missing changelog title