### PR TITLE
Upgrade to latest flake8

### DIFF
--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -1,3 +1,2 @@
 flake8==3.0.4
-flake8-respect-noqa
 coverage==4.2


### PR DESCRIPTION
This PR includes #584 but drop flake8-respect-noqa as it not needed anymore (noqa support has been integrated into flake8).
As a consequence #585  is not needed anymore.