### PR TITLE
Ensure unknown parameters are ignored

### DIFF
--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -32,7 +32,14 @@ class SearchQuery(FacetedSearch):
         self.extract_sort(params)
         self.extract_pagination(params)
         q = params.pop('q', '')
+
+        params = self.clean_parameters(params)
+
         super(SearchQuery, self).__init__(q, params)
+
+    def clean_parameters(self, params):
+        '''Only keep known parameters'''
+        return {k: v for k, v in params.items() if k in self.adapter.facets}
 
     def extract_sort(self, params):
         '''Extract and build sort query from parameters'''

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -197,6 +197,11 @@ class SearchQueryTest(SearchTestMixin, SearchTestCase):
             {'description.raw': 'asc'},
         ])
 
+    def test_ignore_unkown_parameters(self):
+        '''Should ignore unknown parameters'''
+        # Should not raise any exception
+        search.search_for(FakeSearch, unknown='whatever')
+
     def test_custom_scoring(self):
         '''Search should handle field boosting'''
         class FakeBoostedSearch(FakeSearch):


### PR DESCRIPTION
This PRs ensure not search-related parameters in query doesn't make it crash.