### PR TITLE
Fix Factory Boy requirement

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -7,6 +7,7 @@ chardet==2.3.0
 CommonMark==0.7.2
 elasticsearch==2.3.0
 elasticsearch-dsl==2.1.0
+factory-boy==2.7.0
 fake-factory==0.5.7
 Flask-BabelEx==0.9.3
 Flask-Caching==1.0.1

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -8,7 +8,7 @@ CommonMark==0.7.2
 elasticsearch==2.3.0
 elasticsearch-dsl==2.1.0
 factory-boy==2.7.0
-fake-factory==0.5.7
+Faker==0.7.3
 Flask-BabelEx==0.9.3
 Flask-Caching==1.0.1
 flask-fs==0.2.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,4 @@
 Flask-Testing==0.6.1
-factory-boy==2.7.0
 mock==2.0.0
 nose>=1.3.7
 rednose>=1.2.1


### PR DESCRIPTION
Factory Boy is now an install requirement for the fixture command.

Also upgrade to fake-factory to Faker 0.7.3 (has been renamed in PyPI)