### PR TITLE
Resources permalink

### DIFF
--- a/js/front/dataset/resource-modal.vue
+++ b/js/front/dataset/resource-modal.vue
@@ -7,6 +7,8 @@
 
         <dl class="dl-horizontal dl-wide">
           <dt>{{ _('URL') }}</dt>
+          <dd><a :href="resource.contentUrl" @click="onClick">{{resource.contentUrl}}</a></dd>
+          <dt>{{ _('Permalink') }}</dt>
           <dd><a :href="resource.url" @click="onClick">{{resource.url}}</a></dd>
           <dt v-if="resource.encodingFormat">{{ _('Format') }}</dt>
           <dd v-if="resource.encodingFormat">{{resource.encodingFormat}}</dd>

--- a/js/front/dataset/resource-modal.vue
+++ b/js/front/dataset/resource-modal.vue
@@ -8,7 +8,7 @@
         <dl class="dl-horizontal dl-wide">
           <dt>{{ _('URL') }}</dt>
           <dd><a :href="resource.contentUrl" @click="onClick">{{resource.contentUrl}}</a></dd>
-          <dt>{{ _('Permalink') }}</dt>
+          <dt>{{ _('Latest URL') }}</dt>
           <dd><a :href="resource.url" @click="onClick">{{resource.url}}</a></dd>
           <dt v-if="resource.encodingFormat">{{ _('Format') }}</dt>
           <dd v-if="resource.encodingFormat">{{resource.encodingFormat}}</dd>

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -44,6 +44,10 @@ resource_fields = api.model('Resource', {
         required=True, enum=RESOURCE_TYPES.keys()),
     'format': fields.String(description='The resource format', required=True),
     'url': fields.String(description='The resource URL', required=True),
+    'permalink': fields.UrlFor('datasets.resource',
+                               lambda o: {'id': o.id},
+                               description='The resource permanent URL',
+                               readonly=True),
     'checksum': fields.Nested(
         checksum_fields, allow_null=True,
         description='A checksum to validate file validity'),

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -44,11 +44,11 @@ resource_fields = api.model('Resource', {
         required=True, enum=RESOURCE_TYPES.keys()),
     'format': fields.String(description='The resource format', required=True),
     'url': fields.String(description='The resource URL', required=True),
-    'permalink': fields.String(description='The permanent URL redirecting to '
-                               'the latest version of the resource. When the '
-                               'resource data is updated, the URL will '
-                               'change, the permalink won\'t.',
-                               readonly=True),
+    'latest': fields.String(description='The permanent URL redirecting to '
+                            'the latest version of the resource. When the '
+                            'resource data is updated, the URL will '
+                            'change, the latest URL won\'t.',
+                            readonly=True),
     'checksum': fields.Nested(
         checksum_fields, allow_null=True,
         description='A checksum to validate file validity'),

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -44,7 +44,8 @@ resource_fields = api.model('Resource', {
         required=True, enum=RESOURCE_TYPES.keys()),
     'format': fields.String(description='The resource format', required=True),
     'url': fields.String(description='The resource URL', required=True),
-    'permalink': fields.String(description='The resource permanent URL',
+    'permalink': fields.String(description='The resource permanent URL to '
+                               'the latest version (won\'t change on update)',
                                readonly=True),
     'checksum': fields.Nested(
         checksum_fields, allow_null=True,

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -44,9 +44,7 @@ resource_fields = api.model('Resource', {
         required=True, enum=RESOURCE_TYPES.keys()),
     'format': fields.String(description='The resource format', required=True),
     'url': fields.String(description='The resource URL', required=True),
-    'permalink': fields.UrlFor('datasets.resource',
-                               lambda o: {'id': o.id},
-                               description='The resource permanent URL',
+    'permalink': fields.String(description='The resource permanent URL',
                                readonly=True),
     'checksum': fields.Nested(
         checksum_fields, allow_null=True,

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -44,8 +44,10 @@ resource_fields = api.model('Resource', {
         required=True, enum=RESOURCE_TYPES.keys()),
     'format': fields.String(description='The resource format', required=True),
     'url': fields.String(description='The resource URL', required=True),
-    'permalink': fields.String(description='The resource permanent URL to '
-                               'the latest version (won\'t change on update)',
+    'permalink': fields.String(description='The permanent URL redirecting to '
+                               'the latest version of the resource. When the '
+                               'resource data is updated, the URL will '
+                               'change, the permalink won\'t.',
                                readonly=True),
     'checksum': fields.Nested(
         checksum_fields, allow_null=True,

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -157,7 +157,7 @@ class ResourceMixin(object):
         result = {
             '@type': 'DataDownload',
             '@id': str(self.id),
-            'url': self.url,
+            'url': url_for('datasets.resource', id=self.id, _external=True),
             'name': self.title or _('Nameless resource'),
             'contentUrl': self.url,
             'dateCreated': self.created_at.isoformat(),

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -156,7 +156,7 @@ class ResourceMixin(object):
         '''
         Permanent link to the latest version of this resource.
 
-        If this resource is updated and `url` change, this property won't.
+        If this resource is updated and `url` changes, this property won't.
         '''
         return url_for('datasets.resource', id=self.id, _external=True)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -153,6 +153,11 @@ class ResourceMixin(object):
 
     @property
     def permalink(self):
+        '''
+        Permanent link to the latest version of this resource.
+
+        If this resource is updated and `url` change, this property won't.
+        '''
         return url_for('datasets.resource', id=self.id, _external=True)
 
     @cached_property

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -152,7 +152,7 @@ class ResourceMixin(object):
         return self.check_availability(group=None)
 
     @property
-    def permalink(self):
+    def latest(self):
         '''
         Permanent link to the latest version of this resource.
 
@@ -166,7 +166,7 @@ class ResourceMixin(object):
         result = {
             '@type': 'DataDownload',
             '@id': str(self.id),
-            'url': self.permalink,
+            'url': self.latest,
             'name': self.title or _('Nameless resource'),
             'contentUrl': self.url,
             'dateCreated': self.created_at.isoformat(),

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -151,13 +151,17 @@ class ResourceMixin(object):
     def is_available(self):
         return self.check_availability(group=None)
 
+    @property
+    def permalink(self):
+        return url_for('datasets.resource', id=self.id, _external=True)
+
     @cached_property
     def json_ld(self):
 
         result = {
             '@type': 'DataDownload',
             '@id': str(self.id),
-            'url': url_for('datasets.resource', id=self.id, _external=True),
+            'url': self.permalink,
             'name': self.title or _('Nameless resource'),
             'contentUrl': self.url,
             'dateCreated': self.created_at.isoformat(),

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -6,7 +6,7 @@ from werkzeug.contrib.atom import AtomFeed
 
 from udata.frontend.views import DetailView, SearchView
 from udata.i18n import I18nBlueprint, lazy_gettext as _
-from udata.models import Dataset, Discussion, Follow, Reuse
+from udata.models import Dataset, Discussion, Follow, Reuse, CommunityResource
 from udata.core.site.views import current_site
 from udata.sitemap import sitemap
 from udata.utils import get_by
@@ -104,9 +104,13 @@ class DatasetFollowersView(DatasetView, DetailView):
         return context
 
 
-@blueprint.route('/<dataset:dataset>/r/<uuid:id>/', endpoint='resource')
-def resource_redirect(dataset, id):
-    resource = get_by(dataset.resources, 'id', id)
+@blueprint.route('/r/<uuid:id>', endpoint='resource')
+def resource_redirect(id):
+    dataset = Dataset.objects(resources__id=id).first()
+    if dataset:
+        resource = get_by(dataset.resources, 'id', id)
+    else:
+        resource = CommunityResource.objects(id=id).first()
     if not resource:
         abort(404)
     return redirect(resource.url)

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import abort, request, url_for, render_template
+from flask import abort, request, url_for, render_template, redirect
 from werkzeug.contrib.atom import AtomFeed
 
 from udata.frontend.views import DetailView, SearchView
@@ -9,6 +9,7 @@ from udata.i18n import I18nBlueprint, lazy_gettext as _
 from udata.models import Dataset, Discussion, Follow, Reuse
 from udata.core.site.views import current_site
 from udata.sitemap import sitemap
+from udata.utils import get_by
 
 from .search import DatasetSearch
 from .permissions import ResourceEditPermission, DatasetEditPermission
@@ -101,6 +102,14 @@ class DatasetFollowersView(DatasetView, DetailView):
         context['followers'] = (Follow.objects.followers(self.dataset)
                                               .order_by('follower.fullname'))
         return context
+
+
+@blueprint.route('/<dataset:dataset>/r/<uuid:id>/', endpoint='resource')
+def resource_redirect(dataset, id):
+    resource = get_by(dataset.resources, 'id', id)
+    if not resource:
+        abort(404)
+    return redirect(resource.url)
 
 
 @sitemap.register_generator

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -111,9 +111,7 @@ def resource_redirect(id):
         resource = get_by(dataset.resources, 'id', id)
     else:
         resource = CommunityResource.objects(id=id).first()
-    if not resource:
-        abort(404)
-    return redirect(resource.url)
+    return redirect(resource.url) if resource else abort(404)
 
 
 @sitemap.register_generator

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -106,6 +106,9 @@ class DatasetFollowersView(DatasetView, DetailView):
 
 @blueprint.route('/r/<uuid:id>', endpoint='resource')
 def resource_redirect(id):
+    '''
+    Redirect to the latest version of a resource given its identifier.
+    '''
     dataset = Dataset.objects(resources__id=id).first()
     if dataset:
         resource = get_by(dataset.resources, 'id', id)

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -141,16 +141,16 @@ class DatasetBlueprintTest(FrontTestCase):
         response = self.get(url_for('datasets.show', dataset='not-found'))
         self.assert404(response)
 
-    def test_resource_permalink(self):
+    def test_resource_latest_url(self):
         '''It should redirect to the real resource URL'''
         resource = ResourceFactory()
-        dataset = DatasetFactory(resources=[resource])
+        DatasetFactory(resources=[resource])
         response = self.get(url_for('datasets.resource',
                                     id=resource.id))
         self.assertStatus(response, 302)
         self.assertEqual(response.location, resource.url)
 
-    def test_community_resource_permalink(self):
+    def test_community_resource_latest_url(self):
         '''It should redirect to the real community resource URL'''
         resource = CommunityResourceFactory()
         response = self.get(url_for('datasets.resource',
@@ -158,7 +158,7 @@ class DatasetBlueprintTest(FrontTestCase):
         self.assertStatus(response, 302)
         self.assertEqual(response.location, resource.url)
 
-    def test_resource_permalink_404(self):
+    def test_resource_latest_url_404(self):
         '''It should return 404 if resource does not exists'''
         resource = ResourceFactory()
         response = self.get(url_for('datasets.resource',

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -7,9 +7,9 @@ import feedparser
 
 from flask import url_for
 
-from udata.core.dataset.factories import (ResourceFactory,
-                                          DatasetFactory,
-                                          LicenseFactory)
+from udata.core.dataset.factories import (
+    ResourceFactory, DatasetFactory, LicenseFactory, CommunityResourceFactory
+)
 from udata.core.user.factories import UserFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.models import Follow
@@ -146,7 +146,14 @@ class DatasetBlueprintTest(FrontTestCase):
         resource = ResourceFactory()
         dataset = DatasetFactory(resources=[resource])
         response = self.get(url_for('datasets.resource',
-                                    dataset=dataset,
+                                    id=resource.id))
+        self.assertStatus(response, 302)
+        self.assertEqual(response.location, resource.url)
+
+    def test_community_resource_permalink(self):
+        '''It should redirect to the real community resource URL'''
+        resource = CommunityResourceFactory()
+        response = self.get(url_for('datasets.resource',
                                     id=resource.id))
         self.assertStatus(response, 302)
         self.assertEqual(response.location, resource.url)
@@ -156,7 +163,6 @@ class DatasetBlueprintTest(FrontTestCase):
         resource = ResourceFactory()
         dataset = DatasetFactory()
         response = self.get(url_for('datasets.resource',
-                                    dataset=dataset,
                                     id=resource.id))
         self.assert404(response)
 

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -85,7 +85,7 @@ class DatasetBlueprintTest(FrontTestCase):
         for json_ld_resource in json_ld['distribution']:
             self.assertEquals(json_ld_resource['@type'], 'DataDownload')
             self.assertEquals(json_ld_resource['@id'], str(resource.id))
-            self.assertEquals(json_ld_resource['url'], resource.permalink)
+            self.assertEquals(json_ld_resource['url'], resource.latest)
             self.assertEquals(json_ld_resource['name'], resource.title)
             self.assertEquals(json_ld_resource['contentUrl'], resource.url)
             self.assertEquals(json_ld_resource['dateCreated'][:16],

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -85,7 +85,7 @@ class DatasetBlueprintTest(FrontTestCase):
         for json_ld_resource in json_ld['distribution']:
             self.assertEquals(json_ld_resource['@type'], 'DataDownload')
             self.assertEquals(json_ld_resource['@id'], str(resource.id))
-            self.assertEquals(json_ld_resource['url'], resource.url)
+            self.assertEquals(json_ld_resource['url'], resource.permalink)
             self.assertEquals(json_ld_resource['name'], resource.title)
             self.assertEquals(json_ld_resource['contentUrl'], resource.url)
             self.assertEquals(json_ld_resource['dateCreated'][:16],
@@ -161,7 +161,6 @@ class DatasetBlueprintTest(FrontTestCase):
     def test_resource_permalink_404(self):
         '''It should return 404 if resource does not exists'''
         resource = ResourceFactory()
-        dataset = DatasetFactory()
         response = self.get(url_for('datasets.resource',
                                     id=resource.id))
         self.assert404(response)

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from datetime import datetime
+
 import feedparser
 
 from flask import url_for
@@ -138,6 +139,25 @@ class DatasetBlueprintTest(FrontTestCase):
     def test_not_found(self):
         '''It should render the dataset page'''
         response = self.get(url_for('datasets.show', dataset='not-found'))
+        self.assert404(response)
+
+    def test_resource_permalink(self):
+        '''It should redirect to the real resource URL'''
+        resource = ResourceFactory()
+        dataset = DatasetFactory(resources=[resource])
+        response = self.get(url_for('datasets.resource',
+                                    dataset=dataset,
+                                    id=resource.id))
+        self.assertStatus(response, 302)
+        self.assertEqual(response.location, resource.url)
+
+    def test_resource_permalink_404(self):
+        '''It should return 404 if resource does not exists'''
+        resource = ResourceFactory()
+        dataset = DatasetFactory()
+        response = self.get(url_for('datasets.resource',
+                                    dataset=dataset,
+                                    id=resource.id))
         self.assert404(response)
 
     def test_recent_feed(self):


### PR DESCRIPTION
This PR adds permalinks to resources ie. an URL always redirecting to the latest version of a resource.

This URL is shown in the front resource details modal et in the `permalink` resource's API field.

In the distribution/resource JSON-LD, `url` is  the permalink whereas `contentUrl` is the direct link.