### PR TITLE
Mark active users as confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking Changes
 
-* 2016-05-11: Upgrade of ElasticSearch from 1.7 to 2.3 [#449](https://github.com/etalab/udata/pull/449)
+* 2016-05-11: Upgrade of ElasticSearch from 1.7 to 2.3 [#449](https://github.com/opendatateam/udata/pull/449)
 
 You have to re-initialize the index from scratch, not just use the `reindex` command given that ElasticSearch 2+ doesn't provide a way to [delete mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-mapping.html) anymore. The command is `udata search init` and may take some time given the amount of data you are dealing with.
 
@@ -15,6 +15,11 @@ there is an SSO in front of udata which may cause some inconsistencies. In
 that case, the configuration parameter DELETE_ME should be set to False (True
 by default).
 
-* 2016-05-12: Add fields masks to reduce API payloads [#451](https://github.com/etalab/udata/pull/451)
+* 2016-05-12: Add fields masks to reduce API payloads [#451](https://github.com/opendatateam/udata/pull/451)
 
 The addition of [fields masks](http://flask-restplus.readthedocs.io/en/stable/mask.html) in Flask-RESTPlus allows us to reduce the retrieved payload within the admin — especially for datasets — and results in a performances boost.
+
+
+## Fixes
+
+* 2016-11-29: Mark active users as confirmed [#619](https://github.com/opendatateam/udata/pull/618)

--- a/udata/migrations/2016-11-29-confirm-active-users.js
+++ b/udata/migrations/2016-11-29-confirm-active-users.js
@@ -1,0 +1,12 @@
+/*
+ * As email confirmation is required to be active
+ * this migration confirm all active users.
+ */
+
+var result = db.user.update(
+    {active: true, confirmed_at: {$exists: false}},
+    {$set: {confirmed_at: new Date()}}, // Use current date as effective confirmation happens now
+    {multi: true}
+);
+
+print(`Updated ${result.nModified} users`);


### PR DESCRIPTION
This PR add a migration marking already active users but without the `confirmed_at` attribute as confirmed