### PR TITLE
Upgrade to CommonMark 0.7.2

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -4,7 +4,7 @@ blinker==1.4
 celery==3.1.23
 celerybeat-mongo==0.0.10
 chardet
-CommonMark==0.6.4
+CommonMark==0.7.2
 elasticsearch>=1.0.0,<2.0.0
 Flask-BabelEx==0.9.3
 Flask-Cache==0.13.1


### PR DESCRIPTION
This PR upgrade CommonMark to latest version on master branch fixing a bunch of bug, including [this line in particular](https://github.com/rtfd/CommonMark-py/commit/252d1911b8af8a24f6e0538b6399837a6814722a#diff-ab22872980c053082795809e4d0a14feL705) (which caused a data.gouv.fr outage).