### PR TITLE
Dublin core frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ You have to re-initialize the index from scratch, not just use the `reindex` com
 
 ## New & Improved
 
+* 2016-12-20: Use all the [Dublin Core Frequencies](http://dublincore.org/groups/collections/frequency/)
+  plus some extra frequencies.
+
 * 2016-12-01: Add the possibility for a user to delete its account in the admin interface
 
 In some configurations, this feature should be deactivated, typically when
@@ -23,3 +26,13 @@ The addition of [fields masks](http://flask-restplus.readthedocs.io/en/stable/ma
 ## Fixes
 
 * 2016-11-29: Mark active users as confirmed [#619](https://github.com/opendatateam/udata/pull/618)
+
+## Deprecation
+
+Theses are deprecated and support will be removed in some feature release.
+See [Deprecation Policy](https://udata.readthedocs.io/versionning/#deprecation-policy).
+
+* Theses frequencies are deprecated for their Dublin Core counter part:
+    * `fortnighly` ⇨ `biweekly`
+    * `biannual` ⇨ `semiannual`
+    * `realtime` ⇨ `continuous`

--- a/docs/versionning.md
+++ b/docs/versionning.md
@@ -1,0 +1,13 @@
+# Versionning and deprecations
+
+## Versionning process
+
+**TODO**
+
+## Releasing
+
+**TODO**
+
+## Deprecation policy
+
+**TODO**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
     - Contributing:
         - Guide: contributing-guide.md
         - Governance: governance.md
+        - Versionning: versionning.md
     - Changelog: changelog.md
 
 markdown_extensions:

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -10,6 +10,7 @@ from udata.core.spatial.forms import SpatialCoverageField
 from .models import (
     Dataset, Resource, License, Checksum, CommunityResource,
     UPDATE_FREQUENCIES, DEFAULT_FREQUENCY, RESOURCE_TYPES, CHECKSUM_TYPES,
+    LEGACY_FREQUENCIES
 )
 
 __all__ = ('DatasetForm', 'ResourceForm', 'CommunityResourceForm')
@@ -60,6 +61,12 @@ class CommunityResourceForm(BaseResourceForm):
     organization = fields.PublishAsField(_('Publish as'))
 
 
+def map_legacy_frequencies(form, field):
+    ''' Map legacy frequencies to new ones'''
+    if field.data in LEGACY_FREQUENCIES:
+        field.data = LEGACY_FREQUENCIES[field.data]
+
+
 class DatasetForm(ModelForm):
     model_class = Dataset
 
@@ -74,6 +81,7 @@ class DatasetForm(ModelForm):
         _('Update frequency'),
         choices=UPDATE_FREQUENCIES.items(), default=DEFAULT_FREQUENCY,
         validators=[validators.optional()],
+        preprocessors=[map_legacy_frequencies],
         description=_('The frequency at which data are updated.'))
     frequency_date = fields.DateTimeField(_('Expected frequency date'))
     temporal_coverage = fields.DateRangeField(

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -23,26 +23,48 @@ from .croquemort import check_url_from_cache, check_url_from_group
 
 __all__ = (
     'License', 'Resource', 'Dataset', 'Checksum', 'CommunityResource',
-    'UPDATE_FREQUENCIES', 'RESOURCE_TYPES',
+    'UPDATE_FREQUENCIES', 'LEGACY_FREQUENCIES', 'RESOURCE_TYPES',
     'PIVOTAL_DATA', 'DEFAULT_LICENSE'
 )
 
-UPDATE_FREQUENCIES = {
-    'punctual': _('Punctual'),
-    'realtime': _('Real time'),
-    'daily': _('Daily'),
-    'weekly': _('Weekly'),
-    'fortnighly': _('Fortnighly'),
-    'monthly': _('Monthly'),
-    'bimonthly': _('Bimonthly'),
-    'quarterly': _('Quarterly'),
-    'biannual': _('Biannual'),
-    'annual': _('Annual'),
-    'biennial': _('Biennial'),
-    'triennial': _('Triennial'),
-    'quinquennial': _('Quinquennial'),
-    'unknown': _('Unknown'),
+#: Udata frequencies with their labels
+#:
+#: See: http://dublincore.org/groups/collections/frequency/
+UPDATE_FREQUENCIES = {                              # Dublin core equivalent
+    'punctual': _('Punctual'),                      # N/A
+    'continuous': _('Real time'),                   # freq:continuous
+    'hourly': _('Hourly'),                          # N/A
+    'fourTimesADay': _('Four times a day'),         # N/A
+    'threeTimesADay': _('Three times a day'),       # N/A
+    'semidaily': _('Semidaily'),                    # N/A
+    'daily': _('Daily'),                            # freq:daily
+    'fourTimesAWeek': _('Four times a week'),       # N/A
+    'threeTimesAWeek': _('Three times a week'),     # freq:threeTimesAWeek
+    'semiweekly': _('Semiweekly'),                  # freq:semiweekly
+    'weekly': _('Weekly'),                          # freq:weekly
+    'biweekly': _('Biweekly'),                      # freq:bimonthly
+    'semimonthly': _('Semimonthly'),                # freq:semimonthly
+    'threeTimesAMonth': _('Three times a month'),   # freq:threeTimesAMonth
+    'monthly': _('Monthly'),                        # freq:monthly
+    'bimonthly': _('Bimonthly'),                    # freq:bimonthly
+    'quarterly': _('Quarterly'),                    # freq:quarterly
+    'threeTimesAYear': _('Three times a year'),     # freq:threeTimesAYear
+    'semiannual': _('Biannual'),                    # freq:semiannual
+    'annual': _('Annual'),                          # freq:annual
+    'biennial': _('Biennial'),                      # freq:biennial
+    'triennial': _('Triennial'),                    # freq:triennial
+    'quinquennial': _('Quinquennial'),              # N/A
+    'irregular': _('Irregular'),                    # freq:irregular
+    'unknown': _('Unknown'),                        # N/A
 }
+
+#: Map legacy frequencies to currents
+LEGACY_FREQUENCIES = {
+    'fortnighly': 'biweekly',
+    'biannual': 'semiannual',
+    'realtime': 'continuous',
+}
+
 
 DEFAULT_FREQUENCY = 'unknown'
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -308,6 +308,11 @@ class Dataset(WithMetrics, BadgeMixin, db.Document):
         else:
             cls.on_update.send(document)
 
+    def clean(self):
+        super(Dataset, self).clean()
+        if self.frequency in LEGACY_FREQUENCIES:
+            self.frequency = LEGACY_FREQUENCIES[self.frequency]
+
     def url_for(self, *args, **kwargs):
         return url_for('datasets.show', dataset=self, *args, **kwargs)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -28,8 +28,9 @@ from udata.utils import to_iso_date, get_by
 
 class FieldHelper(object):
     def __init__(self, *args, **kwargs):
+        self._preprocessors = kwargs.pop('preprocessors', [])
         super(FieldHelper, self).__init__(*args, **kwargs)
-        self._form = kwargs['_form'] if '_form' in kwargs else None
+        self._form = kwargs.get('_form', None)
 
     @property
     def id(self):
@@ -51,6 +52,12 @@ class FieldHelper(object):
         if required is True:
             kwargs['required'] = required
         return super(FieldHelper, self).__call__(**kwargs)
+
+    def pre_validate(self, form):
+        '''Calls preprocessors before pre_validation'''
+        for preprocessor in self._preprocessors:
+            preprocessor(form, self)
+        super(FieldHelper, self).pre_validate(form)
 
 
 class Field(FieldHelper, WTField):

--- a/udata/migrations/2016-12-20-dublin-core-frequencies.js
+++ b/udata/migrations/2016-12-20-dublin-core-frequencies.js
@@ -1,0 +1,19 @@
+/*
+ * Map some old frequencies to new Dublin Core ones
+ */
+
+const FREQUENCIES = {
+    'fortnighly': 'biweekly',
+    'biannual': 'semiannual',
+    'realtime': 'continuous'
+};
+
+for (var old in FREQUENCIES) {
+    const result = db.dataset.update(
+        {frequency: old},
+        {$set: {frequency: FREQUENCIES[old]}},
+        {multi: true}
+    );
+
+    print(`Migrated ${result.nModified} dataset from '${old}' to '${FREQUENCIES[old]}' frequency`);
+}

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from flask import url_for
 
 from udata.models import (
-    CommunityResource, Dataset, Follow, Member, UPDATE_FREQUENCIES
+    CommunityResource, Dataset, Follow, Member, UPDATE_FREQUENCIES, LEGACY_FREQUENCIES
 )
 
 from . import APITestCase
@@ -255,6 +255,18 @@ class DatasetAPITest(APITestCase):
 
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.spatial.geom, SAMPLE_GEOM)
+
+    @attr('create')
+    def test_dataset_api_create_with_legacy_frequency(self):
+        '''It should create a dataset from the API with a legacy frequency'''
+        self.login()
+
+        for oldFreq, newFreq in LEGACY_FREQUENCIES.items():
+            data = DatasetFactory.attributes()
+            data['frequency'] = oldFreq
+            response = self.post(url_for('api.datasets'), data)
+            self.assert201(response)
+            self.assertEqual(response.json['frequency'], newFreq)
 
     @attr('update')
     def test_dataset_api_update(self):

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from mongoengine import post_save
 
-from udata.models import db, Dataset
+from udata.models import db, Dataset, LEGACY_FREQUENCIES
 from udata.core.dataset.factories import (
     ResourceFactory, DatasetFactory, CommunityResourceFactory
 )
@@ -243,8 +243,12 @@ class DatasetModelTest(TestCase, DBTestMixin):
             ])
 
     def test_tags_normalized(self):
-        user = UserFactory()
         tags = [' one another!', ' one another!', 'This IS a "tag"…']
-        dataset = DatasetFactory(owner=user, tags=tags)
+        dataset = DatasetFactory(tags=tags)
         self.assertEqual(len(dataset.tags), 2)
         self.assertEqual(dataset.tags[1], 'this-is-a-tag')
+
+    def test_legacy_frequencies(self):
+        for oldFreq, newFreq in LEGACY_FREQUENCIES.items():
+            dataset = DatasetFactory(frequency=oldFreq)
+            self.assertEqual(dataset.frequency, newFreq)


### PR DESCRIPTION
This PR:
- make use of [Dublin Core Frequencies](http://dublincore.org/groups/collections/frequency/) (fix #273)
- add some missing but requested frequencies (mostly between continuous and daily)
- ensure legacy frequencies are still handled and well mapped

To achieve the third point, it also allows form fields to perform data processing before validation (mostly because some fields perform validation in the `pre_validate` phase and using validators to transform data does not work in this case)