### PR TITLE
Improve Croquemort error handling

### DIFF
--- a/udata/core/dataset/croquemort.py
+++ b/udata/core/dataset/croquemort.py
@@ -11,6 +11,8 @@ log = logging.getLogger(__name__)
 # We are waiting 3 sec for the connexion and 9 for the response.
 TIMEOUT = (3.1, 9.1)
 
+DEFAULT_DELAY = 5
+DEFAULT_RETRY = 10
 CONNECTION_ERROR_MSG = 'Unable to reach the URL checker'
 
 ERROR_LOG_MSG = 'Unable to connect to croquemort'
@@ -26,8 +28,8 @@ def check_url(url, group=None):
     if CROQUEMORT is None:
         return {'error': 'Check server not configured.'}, {}
     check_url = '{url}/check/one'.format(url=CROQUEMORT['url'])
-    delay = CROQUEMORT['delay']
-    retry = CROQUEMORT['retry']
+    delay = CROQUEMORT.get('delay', DEFAULT_DELAY)
+    retry = CROQUEMORT.get('retry', DEFAULT_RETRY)
     params = {'url': url, 'group': group}
     try:
         response = requests.post(check_url,

--- a/udata/core/dataset/croquemort.py
+++ b/udata/core/dataset/croquemort.py
@@ -33,10 +33,10 @@ def check_url(url, group=None):
         response = requests.post(check_url,
                                  data=json.dumps(params),
                                  timeout=TIMEOUT)
-    except requests.ConnectionError:
+    except requests.RequestException:
         log.error(ERROR_LOG_MSG, exc_info=True)
         return {}, 503
-    except requests.ConnectTimeout:
+    except requests.Timeout:
         log.error(TIMEOUT_LOG_MSG, exc_info=True)
         return {}, 503
     url_hash = response.json()['url-hash']
@@ -44,11 +44,11 @@ def check_url(url, group=None):
         url=CROQUEMORT['url'], url_hash=url_hash)
     try:
         response = requests.get(retrieve_url, params=params, timeout=TIMEOUT)
-    except requests.ConnectionError:
-        log.error(ERROR_LOG_MSG, exc_info=True)
-        return {}, 503
-    except requests.ConnectTimeout:
+    except requests.Timeout:
         log.error(TIMEOUT_LOG_MSG, exc_info=True)
+        return {}, 503
+    except requests.RequestException:
+        log.error(ERROR_LOG_MSG, exc_info=True)
         return {}, 503
     attempts = 0
     while response.status_code == 404 or 'status' not in response.json():
@@ -60,11 +60,11 @@ def check_url(url, group=None):
             response = requests.get(retrieve_url,
                                     params=params,
                                     timeout=TIMEOUT)
-        except requests.ConnectionError:
-            log.error(ERROR_LOG_MSG, exc_info=True)
-            return {}, 503
-        except requests.ConnectTimeout:
+        except requests.Timeout:
             log.error(TIMEOUT_LOG_MSG, exc_info=True)
+            return {}, 503
+        except requests.RequestException:
+            log.error(ERROR_LOG_MSG, exc_info=True)
             return {}, 503
         time.sleep(delay)
         attempts += 1
@@ -84,11 +84,11 @@ def check_url_from_cache(url, group=None):
         response = requests.get(retrieve_url,
                                 params={'url': url, 'group': group},
                                 timeout=TIMEOUT)
-    except requests.ConnectionError:
-        log.error(ERROR_LOG_MSG, exc_info=True)
-        return {'error': CONNECTION_ERROR_MSG}, {}
-    except requests.ConnectTimeout:
+    except requests.Timeout:
         log.error(TIMEOUT_LOG_MSG, exc_info=True)
+        return {'error': CONNECTION_ERROR_MSG}, {}
+    except requests.RequestException:
+        log.error(ERROR_LOG_MSG, exc_info=True)
         return {'error': CONNECTION_ERROR_MSG}, {}
     if response.status_code == 404:
         return {'error': 'URL {url} not found'.format(url=url)}, {}
@@ -109,11 +109,11 @@ def check_url_from_group(group):
         response = requests.get(retrieve_url,
                                 params={'group': group},
                                 timeout=TIMEOUT)
-    except requests.ConnectionError:
-        log.error(ERROR_LOG_MSG, exc_info=True)
-        return {'error': CONNECTION_ERROR_MSG}, {}
-    except requests.ConnectTimeout:
+    except requests.Timeout:
         log.error(TIMEOUT_LOG_MSG, exc_info=True)
+        return {'error': CONNECTION_ERROR_MSG}, {}
+    except requests.RequestException:
+        log.error(ERROR_LOG_MSG, exc_info=True)
         return {'error': CONNECTION_ERROR_MSG}, {}
     if response.status_code == 404:
         return {'error': 'Group {group} not found'.format(group=group)}, {}

--- a/udata/core/dataset/croquemort.py
+++ b/udata/core/dataset/croquemort.py
@@ -35,11 +35,11 @@ def check_url(url, group=None):
         response = requests.post(check_url,
                                  data=json.dumps(params),
                                  timeout=TIMEOUT)
-    except requests.RequestException:
-        log.error(ERROR_LOG_MSG, exc_info=True)
-        return {}, 503
     except requests.Timeout:
         log.error(TIMEOUT_LOG_MSG, exc_info=True)
+        return {}, 503
+    except requests.RequestException:
+        log.error(ERROR_LOG_MSG, exc_info=True)
         return {}, 503
     url_hash = response.json()['url-hash']
     retrieve_url = '{url}/url/{url_hash}'.format(

--- a/udata/tests/api/test_url_api.py
+++ b/udata/tests/api/test_url_api.py
@@ -1,40 +1,98 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import unittest
+
+import json
+
+import httpretty
 
 from flask import url_for
 
-from . import APITestCase
+
+from udata.tests.api import APITestCase
+from udata.tests.factories import faker
+
+from udata.settings import Testing
+
+CROQUEMORT_URL = 'http://check.test'
+CHECK_ONE_URL = CROQUEMORT_URL + '/check/one'
+METADATA_URL = CROQUEMORT_URL + '/url'
+
+
+def metadata_factory(url, status, content_type=None):
+    return json.dumps({
+      'etag': '',
+      'url': url,
+      'content-length': faker.pyint(),
+      'content-disposition': '',
+      'content-md5': faker.md5(),
+      'content-location': '',
+      'expires': faker.iso8601(),
+      'status': str(status),
+      'updated': faker.iso8601(),
+      'last-modified': faker.iso8601(),
+      'content-encoding': 'gzip',
+      'content-type': content_type or faker.mime_type()
+    })
+
+
+class CheckUrlSettings(Testing):
+    CROQUEMORT = {'url': CROQUEMORT_URL}
 
 
 class CheckUrlAPITest(APITestCase):
+    settings = CheckUrlSettings
 
-    def setUp(self):
-        super(CheckUrlAPITest, self).setUp()
-        # If you set up a Croquemort URL, don't forget to clean up the
-        # Redis database after each test. Otherwise the test against the
-        # delayed URL will not pass (existing entry already fetched).
-        self.CROQUEMORT = self.app.config.get('CROQUEMORT')
-        if self.CROQUEMORT is None:
-            raise unittest.SkipTest
+    # def setUp(self):
+    #     super(CheckUrlAPITest, self).setUp()
+    #     self.config_backup = self.app.config.get('CROQUEMORT')
+    #     self.croquemort_url = 'http://check.test'
+    #     self.app.config['CROQUEMORT'] = {'url': self.croquemort_url}
+    #
+    # def tearDown(self):
+    #     self.app.config['CROQUEMORT'] = self.config_backup
 
+    @httpretty.activate
     def test_returned_metadata(self):
-        url = 'https://www.data.gouv.fr/fr/'
+        url = faker.uri()
+        url_hash = 'abcdef'
+        content_type = 'text/html; charset=utf-8'
+        httpretty.register_uri(httpretty.POST, CHECK_ONE_URL,
+                               body=json.dumps({'url-hash': url_hash}),
+                               content_type='application/json')
+        httpretty.register_uri(httpretty.GET, METADATA_URL + '/' + url_hash,
+                               body=metadata_factory(url, 200,
+                                                     content_type=content_type),
+                               content_type='application/json')
         response = self.get(url_for('api.checkurl'), qs={'url': url})
         self.assert200(response)
         self.assertEqual(response.json['status'], '200')
         self.assertEqual(response.json['url'], url)
-        self.assertEqual(response.json['content-type'],
-                         'text/html; charset=utf-8')
+        self.assertEqual(response.json['content-type'], content_type)
 
+    @httpretty.activate
     def test_invalid_url(self):
-        url = 'https://bad.data.gouv.fr/'
+        url = faker.uri()
+        url_hash = 'abcdef'
+        httpretty.register_uri(httpretty.POST, CHECK_ONE_URL,
+                               body=json.dumps({'url-hash': url_hash}),
+                               content_type='application/json')
+        httpretty.register_uri(httpretty.GET, METADATA_URL + '/' + url_hash,
+                               body=metadata_factory(url, 503),
+                               content_type='application/json')
         response = self.get(url_for('api.checkurl'), qs={'url': url})
         self.assertStatus(response, 500)
         self.assertEqual(response.json['status'], '503')
 
+    @httpretty.activate
     def test_delayed_url(self):
-        url = 'http://httpbin.org/delay/10'
+        url = faker.uri()
+        url_hash = 'abcdef'
+        httpretty.register_uri(httpretty.POST, CHECK_ONE_URL,
+                               body=json.dumps({'url-hash': url_hash}),
+                               content_type='application/json')
+        httpretty.register_uri(httpretty.GET, METADATA_URL + '/' + url_hash,
+                               body=metadata_factory(url, 502),
+                               content_type='application/json')
         response = self.get(url_for('api.checkurl'), qs={'url': url})
         self.assertStatus(response, 502)
         self.assertEqual(


### PR DESCRIPTION
This PR improve Croquemort error handling:
- catch more exceptions (and ensure these exception exists in all requests versions)
- ensures timeout is handled with a specific message (before any other error)
- adds tests for these cases
- ensure tests are always run
