### PR TITLE
Drop title limits when only slug is indexed (fix #676)

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -239,9 +239,9 @@ class Dataset(WithMetrics, BadgeMixin, db.Document):
                                default=datetime.now, required=True)
     last_modified = DateTimeField(verbose_name=_('Last modification date'),
                                   default=datetime.now, required=True)
-    title = db.StringField(max_length=255, required=True)
-    slug = db.SlugField(
-        max_length=255, required=True, populate_from='title', update=True)
+    title = db.StringField(required=True)
+    slug = db.SlugField(max_length=255, required=True,
+                        populate_from='title', update=True)
     description = db.StringField(required=True, default='')
     license = db.ReferenceField('License')
 

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -93,7 +93,7 @@ class OrganizationQuerySet(db.BaseQuerySet):
 
 
 class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
-    name = db.StringField(max_length=255, required=True)
+    name = db.StringField(required=True)
     acronym = db.StringField(max_length=128)
     slug = db.SlugField(
         max_length=255, required=True, populate_from='name', update=True)

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -42,7 +42,7 @@ class ReuseQuerySet(OwnedByQuerySet):
 
 
 class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Document):
-    title = db.StringField(max_length=255, required=True)
+    title = db.StringField(required=True)
     slug = db.SlugField(
         max_length=255, required=True, populate_from='title', update=True)
     description = db.StringField(required=True)

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -10,7 +10,7 @@ __all__ = ('Topic', )
 
 
 class Topic(db.Document):
-    name = db.StringField(max_length=255, required=True)
+    name = db.StringField(required=True)
     slug = db.SlugField(
         max_length=255, required=True, populate_from='name', update=True)
     description = db.StringField()

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -22,7 +22,7 @@ class UUIDAsIdTester(db.Document):
 
 class SlugTester(db.Document):
     title = db.StringField()
-    slug = db.SlugField(populate_from='title')
+    slug = db.SlugField(populate_from='title', max_length=1000)
     meta = {
         'allow_inheritance': True,
     }
@@ -152,6 +152,13 @@ class SlugFieldTest(DBTestMixin, TestCase):
         obj = SlugTester.objects.create(title='title')
         inherited = InheritedSlugTester.objects.create(title='title')
         self.assertNotEqual(obj.slug, inherited.slug)
+
+    def test_crop(self):
+        '''SlugField should truncate itself on save if not set'''
+        obj = SlugTester(title='x' * (SlugTester.slug.max_length + 1))
+        obj.save()
+        self.assertEqual(len(obj.title), SlugTester.slug.max_length + 1)
+        self.assertEqual(len(obj.slug), SlugTester.slug.max_length)
 
 
 class DateFieldTest(DBTestMixin, TestCase):


### PR DESCRIPTION
Slug truncation was already here, only added a test to ensure it works.
Slug are still limited to 255 to avoid very very long URLs