### PR TITLE
Fix webpack --watch calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "assets:watch": "webpack -c -d  --progress --watch",
+    "assets:watch": "webpack --progress --watch",
     "assets:build": "webpack -p --progress",
-    "widgets:watch": "webpack -d -c --progress --watch --config webpack.config.widgets.js",
+    "widgets:watch": "webpack --progress --watch --config webpack.config.widgets.js",
     "widgets:build": "webpack -p --progress --config webpack.config.widgets.js",
     "build": "npm run assets:build && npm run widgets:build",
     "test": "npm run test:unit",


### PR DESCRIPTION
Remove `-d` option since it breaks incremental builds.
`-c` doesn't exist anymore.