### PR TITLE
Fix the communautary resource modal

### DIFF
--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -9,9 +9,6 @@ import config from 'config';
 import log from 'logger';
 import Velocity from 'velocity-animate';
 
-// Plugins
-import ScrollTo from 'plugins/scroll-to';
-
 // Components
 import AddReuseModal from './add-reuse-modal.vue';
 import DetailsModal from './details-modal.vue';
@@ -82,21 +79,24 @@ new Vue({
             const dataset = JSON.parse(document.querySelector(selector).text)
             dataset.resources = dataset.distribution;
             delete dataset.distribution;
+            dataset.communityResources = dataset.contributedDistribution;
+            delete dataset.contributedDistribution;
             dataset.keywords = dataset.keywords.split(',').map(keyword => keyword.trim());
             return dataset;
         },
 
         /**
-         * Display a resource in a modal
+         * Display a resource or a community ressource in a modal
          */
-        showResource(id, e) {
+        showResource(id, e, isCommunity) {
             // Ensure edit button work
             if ([e.target, e.target.parentNode].some((el) => {el.classList.contains('btn-edit');})) {
                 return;
             }
             e.preventDefault();
-            const resource = this.dataset.resources.find(resource => resource['@id'] === id);
-            this.$modal(ResourceModal, {resource: resource});
+            const attr = isCommunity ? 'communityResources' : 'resources';
+            const resource = this.dataset[attr].find(resource => resource['@id'] === id);
+            this.$modal(ResourceModal, {resource});
         },
 
         /**

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -514,7 +514,10 @@ class Dataset(WithMetrics, BadgeMixin, db.Document):
             'name': self.title,
             'keywords': ','.join(self.tags),
             'distribution': [resource.json_ld for resource in self.resources],
-            # This value is not standard
+            # Theses values are not standard
+            'contributedDistribution': [
+                resource.json_ld for resource in self.community_resources
+            ],
             'extras': [self.get_json_ld_extra(*item)
                        for item in self.extras.items()],
         }

--- a/udata/templates/dataset/resource/list-item.html
+++ b/udata/templates/dataset/resource/list-item.html
@@ -1,7 +1,7 @@
 {% set resource_format = resource.format|trim|lower or 'data' %}
 <div id="resource-{{resource.id}}" class="list-group-item"
     data-checkurl="{{ url_for('api.checkurl') }}"
-    @click="showResource('{{resource.id}}', $event)">
+    @click="showResource('{{resource.id}}', $event, {{ resource.owner is defined|tojson }})">
     <div class="format-label pull-left ellipsis-dot" v-tooltip tooltip-placement="left">
         <span data-format="{{ resource_format }}">
             {{ resource_format }}

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -8,7 +8,8 @@ import feedparser
 from flask import url_for
 
 from udata.core.dataset.factories import (
-    ResourceFactory, DatasetFactory, LicenseFactory, CommunityResourceFactory
+    ResourceFactory, DatasetFactory, LicenseFactory, CommunityResourceFactory,
+    VisibleDatasetFactory
 )
 from udata.core.user.factories import UserFactory
 from udata.core.organization.factories import OrganizationFactory
@@ -55,6 +56,13 @@ class DatasetBlueprintTest(FrontTestCase):
 
     def test_render_display(self):
         '''It should render the dataset page'''
+        dataset = VisibleDatasetFactory()
+        url = url_for('datasets.show', dataset=dataset)
+        response = self.get(url)
+        self.assert200(response)
+
+    def test_json_ld(self):
+        '''It should render a json-ld markup into the dataset page'''
         resource = ResourceFactory(format='png',
                                    description='* Title 1\n* Title 2',
                                    metrics={'views': 10})
@@ -65,6 +73,12 @@ class DatasetBlueprintTest(FrontTestCase):
                                  description='a&éèëù$£',
                                  owner=UserFactory(),
                                  extras={'foo': 'bar'})
+        community_resource = CommunityResourceFactory(
+            dataset=dataset,
+            format='csv',
+            description='* Title 1\n* Title 2',
+            metrics={'views': 42})
+
         url = url_for('datasets.show', dataset=dataset)
         response = self.get(url)
         self.assert200(response)
@@ -82,32 +96,63 @@ class DatasetBlueprintTest(FrontTestCase):
         self.assertEquals(json_ld['name'], dataset.title)
         self.assertEquals(json_ld['keywords'], 'bar,foo')
         self.assertEquals(len(json_ld['distribution']), 1)
-        for json_ld_resource in json_ld['distribution']:
-            self.assertEquals(json_ld_resource['@type'], 'DataDownload')
-            self.assertEquals(json_ld_resource['@id'], str(resource.id))
-            self.assertEquals(json_ld_resource['url'], resource.latest)
-            self.assertEquals(json_ld_resource['name'], resource.title)
-            self.assertEquals(json_ld_resource['contentUrl'], resource.url)
-            self.assertEquals(json_ld_resource['dateCreated'][:16],
-                              resource.created_at.isoformat()[:16])
-            self.assertEquals(json_ld_resource['dateModified'][:16],
-                              resource.modified.isoformat()[:16])
-            self.assertEquals(json_ld_resource['datePublished'][:16],
-                              resource.published.isoformat()[:16])
-            self.assertEquals(json_ld_resource['encodingFormat'], 'png')
-            self.assertEquals(json_ld_resource['contentSize'],
-                              resource.filesize)
-            self.assertEquals(json_ld_resource['fileFormat'], resource.mime)
-            self.assertEquals(json_ld_resource['description'],
-                              'Title 1 Title 2')
-            self.assertEquals(json_ld_resource['interactionStatistic'],
-                              {
-                                  '@type': 'InteractionCounter',
-                                  'interactionType': {
-                                      '@type': 'DownloadAction',
-                                  },
-                                  'userInteractionCount': 10,
-                              })
+
+        json_ld_resource = json_ld['distribution'][0]
+        self.assertEquals(json_ld_resource['@type'], 'DataDownload')
+        self.assertEquals(json_ld_resource['@id'], str(resource.id))
+        self.assertEquals(json_ld_resource['url'], resource.latest)
+        self.assertEquals(json_ld_resource['name'], resource.title)
+        self.assertEquals(json_ld_resource['contentUrl'], resource.url)
+        self.assertEquals(json_ld_resource['dateCreated'][:16],
+                          resource.created_at.isoformat()[:16])
+        self.assertEquals(json_ld_resource['dateModified'][:16],
+                          resource.modified.isoformat()[:16])
+        self.assertEquals(json_ld_resource['datePublished'][:16],
+                          resource.published.isoformat()[:16])
+        self.assertEquals(json_ld_resource['encodingFormat'], 'png')
+        self.assertEquals(json_ld_resource['contentSize'],
+                          resource.filesize)
+        self.assertEquals(json_ld_resource['fileFormat'], resource.mime)
+        self.assertEquals(json_ld_resource['description'],
+                          'Title 1 Title 2')
+        self.assertEquals(json_ld_resource['interactionStatistic'],
+                          {
+                              '@type': 'InteractionCounter',
+                              'interactionType': {
+                                  '@type': 'DownloadAction',
+                              },
+                              'userInteractionCount': 10,
+                          })
+
+        self.assertEquals(len(json_ld['contributedDistribution']), 1)
+        json_ld_resource = json_ld['contributedDistribution'][0]
+        self.assertEquals(json_ld_resource['@type'], 'DataDownload')
+        self.assertEquals(json_ld_resource['@id'], str(community_resource.id))
+        self.assertEquals(json_ld_resource['url'], community_resource.latest)
+        self.assertEquals(json_ld_resource['name'], community_resource.title)
+        self.assertEquals(json_ld_resource['contentUrl'],
+                          community_resource.url)
+        self.assertEquals(json_ld_resource['dateCreated'][:16],
+                          community_resource.created_at.isoformat()[:16])
+        self.assertEquals(json_ld_resource['dateModified'][:16],
+                          community_resource.modified.isoformat()[:16])
+        self.assertEquals(json_ld_resource['datePublished'][:16],
+                          community_resource.published.isoformat()[:16])
+        self.assertEquals(json_ld_resource['encodingFormat'],
+                          community_resource.format)
+        self.assertEquals(json_ld_resource['contentSize'],
+                          community_resource.filesize)
+        self.assertEquals(json_ld_resource['fileFormat'],
+                          community_resource.mime)
+        self.assertEquals(json_ld_resource['description'], 'Title 1 Title 2')
+        self.assertEquals(json_ld_resource['interactionStatistic'], {
+            '@type': 'InteractionCounter',
+            'interactionType': {
+                '@type': 'DownloadAction',
+            },
+            'userInteractionCount': 42,
+        })
+
         self.assertEquals(json_ld['extras'],
                           [{
                               '@type': 'http://schema.org/PropertyValue',


### PR DESCRIPTION
The communautary resource modal was missing for 2 reasons:
- metadata weren't exposed into json-ld (added to the non standard contributedDitribution to fix that)
- it wasn't handled at all client-side