### PR TITLE
Last discussions fixes

### DIFF
--- a/js/components/discussions/thread-form.vue
+++ b/js/components/discussions/thread-form.vue
@@ -24,7 +24,8 @@ export default {
       return {
           // Flags to `true` when the form is in sending process. This prevents
           // duplicate POSTing.
-          sending: false
+          sending: false,
+          comment: ''
       }
   },
   methods: {

--- a/js/components/discussions/thread-form.vue
+++ b/js/components/discussions/thread-form.vue
@@ -37,7 +37,7 @@ export default {
           this.$api
           .post(`discussions/${this.discussionId}/`, {comment: this.comment})
           .then(response => {
-              this.$dispatch('discussion-load', response);
+              this.$dispatch('discussion:updated', response);
               this.comment = '';
               this.sending = false;
           })

--- a/js/components/discussions/thread-form.vue
+++ b/js/components/discussions/thread-form.vue
@@ -11,8 +11,6 @@
 </template>
 
 <script>
-import i18n from 'i18n';
-import Auth from 'auth';
 import log from 'logger';
 import Notify from 'notify';
 
@@ -30,9 +28,6 @@ export default {
   },
   methods: {
       submit() {
-          if (!Auth.need_user(i18n._('You need to be logged in to comment.'))) {
-              return;
-          }
           this.sending = true;
           this.$api
           .post(`discussions/${this.discussionId}/`, {comment: this.comment})
@@ -42,7 +37,7 @@ export default {
               this.sending = false;
           })
           .catch(err => {
-              const msg = i18n._('An error occured while submitting your comment')
+              const msg = this._('An error occured while submitting your comment')
               Notify.error(msg)
               log.error(err)
               this.sending = false;

--- a/js/components/discussions/thread-form.vue
+++ b/js/components/discussions/thread-form.vue
@@ -2,7 +2,7 @@
 <form role="form" class="clearfix animated" @submit.prevent="submit">
     <div class="form-group">
         <label for="comment-new-message">{{ _('Comment') }}</label>
-        <textarea id="comment-new-message" v-model="comment" class="form-control" rows="3" required></textarea>
+        <textarea v-el:textarea id="comment-new-message" v-model="comment" class="form-control" rows="3" required></textarea>
     </div>
     <button @click="submit" :disabled="this.sending || !this.comment" class="btn btn-primary btn-block pull-right submit-new-message">
         {{ _('Submit your comment') }}
@@ -27,6 +27,15 @@ export default {
       }
   },
   methods: {
+      /**
+       * Prefill the form and focus the comment area
+       */
+      prefill(comment) {
+          comment = comment || '';
+          this.comment = comment;
+          this.$els.textarea.setSelectionRange(comment.length, comment.length);
+          this.$els.textarea.focus();
+      },
       submit() {
           this.sending = true;
           this.$api
@@ -35,6 +44,7 @@ export default {
               this.$dispatch('discussion:updated', response);
               this.comment = '';
               this.sending = false;
+              document.location.href = `#discussion-${this.discussionId}-${response.discussion.length - 1}`;
           })
           .catch(err => {
               const msg = this._('An error occured while submitting your comment')

--- a/js/components/discussions/thread.vue
+++ b/js/components/discussions/thread.vue
@@ -1,8 +1,9 @@
 <template>
 <div>
-    <div class="list-group-item" :id="discussionIdAttr" @click="toggleDiscussions">
+    <div class="list-group-item" :id="discussionIdAttr" @click="toggleDiscussions"
+        :class="{expanded: detailed}">
         <div class="format-label pull-left">
-            <avatar :user="question.posted_by"></avatar>
+            <avatar :user="discussion.user"></avatar>
         </div>
         <span class="list-group-item-link">
             <a href="#{{ discussionIdAttr }}"><span class="fa fa-link"></span></a>
@@ -12,16 +13,16 @@
         </h4>
         <p class="list-group-item-text ellipsis open-discussion-thread list-group-message-number-{{ discussion.id }}">
             {{ _('Discussion started on {created} with {count} messages.',
-                 {created: createdDate, count: responses.length})
+                 {created: createdDate, count: discussion.discussion.length})
             }}
         </p>
     </div>
-    <div v-for="(index, response) in responses" id="{{ discussionIdAttr }}-{{ index }}"
+    <div v-for="(index, response) in discussion.discussion" id="{{ discussionIdAttr }}-{{ index }}"
         class="list-group-item list-group-indent animated discussion-messages-list"
-        :class="{'body-only': index == 0, 'hidden': !detailed}">
+        :class="{'body-only': index == 0}" v-show="detailed">
         <template v-if="index > 0">
             <div class="format-label pull-left">
-                {{ response.posted_by | display }}
+                <avatar :user="response.posted_by"></avatar>
             </div>
             <span class="list-group-item-link">
                 <a href="#{{ discussionIdAttr }}-{{ index }}"><span class="fa fa-link"></span></a>
@@ -33,16 +34,14 @@
     </div>
     <a v-if="!discussion.closed"
         class="list-group-item add new-comment list-group-indent animated"
-        :class="{hidden: formDisplayed || !detailed}"
-        @click="displayForm">
+        v-show="!formDisplayed && detailed" @click="displayForm">
         <div class="format-label pull-left">+</div>
         <h4 class="list-group-item-heading">
             {{ _('Add a comment') }}
         </h4>
     </a>
     <div class="list-group-item list-group-form list-group-indent animated"
-        id="{{ discussionIdAttr }}-{{ position }}"
-        :class="{hidden: !formDisplayed}">
+        id="{{ discussionIdAttr }}-{{ position }}" v-show="formDisplayed">
         <div class="format-label pull-left">
             {{ current_user | display }}
         </div>
@@ -80,23 +79,12 @@ export default {
         }
     },
     computed: {
-        question() {
-            return this.discussion.discussion[0];
-        },
-        responses() {
-            return this.discussion.discussion.splice(1);
-        },
         discussionIdAttr() {
             return `discussion-${this.discussion.id}`;
         },
         createdDate() {
             return moment(this.discussion.created).format('LL')
         }
-    },
-    ready() {
-        this.$on('discussion-load', discussion => {
-            this.discussion = discussion;
-        });
     },
     methods: {
         toggleDiscussions() {

--- a/js/components/discussions/thread.vue
+++ b/js/components/discussions/thread.vue
@@ -78,6 +78,13 @@ export default {
             formDisplayed: false,
         }
     },
+    events: {
+        'discussion:updated': function(discussion) {
+            // Hide the form on comment submitted
+            this.formDisplayed = false
+            return true; // Don't stop propagation
+        }
+    },
     computed: {
         discussionIdAttr() {
             return `discussion-${this.discussion.id}`;

--- a/js/components/discussions/thread.vue
+++ b/js/components/discussions/thread.vue
@@ -41,9 +41,9 @@
         </h4>
     </a>
     <div class="list-group-item list-group-form list-group-indent animated"
-        id="{{ discussionIdAttr }}-{{ position }}" v-show="formDisplayed">
+        id="{{ discussionIdAttr }}-{{ position }}" v-show="formDisplayed" v-if="currentUser">
         <div class="format-label pull-left">
-            {{ current_user | display }}
+            <avatar :user="currentUser"></avatar>
         </div>
         <span class="list-group-item-link">
             <a href="#{{ discussionIdAttr }}-{{ position }}"><span class="fa fa-link"></span></a>
@@ -61,6 +61,8 @@
 </template>
 
 <script>
+import Auth from 'auth';
+import config from 'config';
 import Avatar from 'components/avatar.vue';
 import ThreadForm from 'components/discussions/thread-form.vue';
 import moment from 'moment';
@@ -76,6 +78,7 @@ export default {
         return {
             detailed: false,
             formDisplayed: false,
+            currentUser: config.user,
         }
     },
     events: {
@@ -97,7 +100,13 @@ export default {
         toggleDiscussions() {
             this.detailed = !this.detailed;
         },
+        /**
+         * Display the comment form or triggers an authentication if required
+         */
         displayForm() {
+            if (!Auth.need_user(this._('You need to be logged in to comment.'))) {
+                return;
+            } 
             this.formDisplayed = true;
         }
     }

--- a/js/components/discussions/threads-form.vue
+++ b/js/components/discussions/threads-form.vue
@@ -13,7 +13,6 @@
 </template>
 
 <script>
-import i18n from 'i18n';
 import Auth from 'auth';
 import log from 'logger';
 import Notify from 'notify';
@@ -42,9 +41,6 @@ export default {
             this.$els.textarea.focus();
         },
         submit() {
-            if (!Auth.need_user(i18n._('You need to be logged in to comment.'))) {
-                return;
-            }
             const data = {
                 title: this.title,
                 comment: this.comment,
@@ -64,7 +60,7 @@ export default {
                 document.location.href = `#discussion-${response.id}`
             })
             .catch(err => {
-                const msg = i18n._('An error occured while submitting your comment');
+                const msg = this._('An error occured while submitting your comment');
                 Notify.error(msg);
                 log.error(err);
                 this.sending = false;

--- a/js/components/discussions/threads-form.vue
+++ b/js/components/discussions/threads-form.vue
@@ -57,7 +57,7 @@ export default {
             this.$api
             .post('discussions/', data)
             .then(response => {
-                this.$dispatch('discussions:created', response);
+                this.$dispatch('discussion:created', response);
                 this.title = '';
                 this.comment = '';
                 this.sending = false;

--- a/js/components/discussions/threads-form.vue
+++ b/js/components/discussions/threads-form.vue
@@ -35,8 +35,9 @@ export default {
          * Prefill the form and focus the comment area
          */
         prefill(title, comment) {
+            comment = comment || '';
+            this.comment = comment;
             this.title = title || '';
-            this.comment = comment || '';
             this.$els.textarea.setSelectionRange(comment.length, comment.length);
             this.$els.textarea.focus();
         },
@@ -57,7 +58,7 @@ export default {
                 this.title = '';
                 this.comment = '';
                 this.sending = false;
-                document.location.href = `#discussion-${response.id}`
+                document.location.href = `#discussion-${response.id}`;
             })
             .catch(err => {
                 const msg = this._('An error occured while submitting your comment');

--- a/js/components/discussions/threads-form.vue
+++ b/js/components/discussions/threads-form.vue
@@ -57,7 +57,7 @@ export default {
             this.$api
             .post('discussions/', data)
             .then(response => {
-                this.$dispatch('discussions-load', response);
+                this.$dispatch('discussions:created', response);
                 this.title = '';
                 this.comment = '';
                 this.sending = false;

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="list-group resources-list smaller">
-    <discussion-thread v-ref:threads v-for="discussion in discussions" :discussion="discussion">
+    <discussion-thread v-ref:threads v-for="discussion in discussions" :discussion="discussion" track-by="id">
     </discussion-thread>
     <a class="list-group-item add new-discussion" @click="displayForm" v-show="!formDisplayed">
         <div class="format-label pull-left">+</div>
@@ -43,16 +43,28 @@ export default {
         subjectClass: String
     },
     events: {
-        'discussions:created': function(discussion) {
+        /**
+         * Add the created discussion in the list and display it
+         * @type {Discussion} the newly created discussion
+         */
+        'discussion:created': function(discussion) {
             this.formDisplayed = false;
             this.discussions.unshift(discussion);
             this.$nextTick(() => {
-                // Scroll to new discussion when displayed
-                // and expand it
-                const $thread = this.threadFor(discussion);
+                // Scroll to new discussion when displayed and expand it
+                const $thread = this.$refs.threads.find($thread => $thread.discussion == discussion);
                 $thread.detailed = true;
                 this.$scrollTo($thread);
             });
+        },
+        /**
+         * Replace the updated discussion in the list
+         * @type {Discussion} the updated discussion
+         */
+        'discussion:updated': function(discussion) {
+            const index = this.discussions.indexOf(this.discussions.find(d => d.id == discussion.id));
+            // See: https://v1.vuejs.org/guide/list.html#Array-Change-Detection
+            this.discussions.$set(index, discussion);
         }
     },
     ready() {
@@ -75,14 +87,6 @@ export default {
                 this.$scrollTo(this.$els.form);
                 this.$refs.form.prefill(title, comment);
             })
-        },
-
-        /**
-         * Get the thread component for a given discussion
-         *
-         */
-        threadFor(discussion) {
-            return this.$refs.threads.find($thread => $thread.discussion == discussion);
         }
     }
 }

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -2,12 +2,9 @@
 <div class="list-group resources-list smaller">
     <discussion-thread v-for="discussion in discussions" :discussion="discussion">
     </discussion-thread>
-    <a class="list-group-item add new-discussion"
-        @click="displayForm" v-show="formDisplayed">
+    <a class="list-group-item add new-discussion" @click="displayForm" v-show="!formDisplayed">
         <div class="format-label pull-left">+</div>
-        <h4 class="list-group-item-heading">
-            {{ _('Start a new discussion') }}
-        </h4>
+        <h4 class="list-group-item-heading">{{ _('Start a new discussion') }}</h4>
     </a>
     <div class="list-group-item list-group-form list-group-form-discussion animated"
         v-show="formDisplayed" v-el:form>

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -42,14 +42,16 @@ export default {
         subjectId: String,
         subjectClass: String
     },
+    events: {
+        'discussions:created': function(discussion) {
+            this.formDisplayed = false;
+            this.discussions.unshift(discussion);
+        }
+    },
     ready() {
         this.$api.get('discussions', {for: this.subjectId}).then(response => {
             this.discussions = response.data;
         }).catch(log.error.bind(log));
-
-        this.$on('discussions-load', discussions => {
-            this.discussions.unshift(discussions);
-        });
     },
     methods: {
         displayForm() {

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="list-group resources-list smaller">
-    <discussion-thread v-for="discussion in discussions" :discussion="discussion">
+    <discussion-thread v-ref:threads v-for="discussion in discussions" :discussion="discussion">
     </discussion-thread>
     <a class="list-group-item add new-discussion" @click="displayForm" v-show="!formDisplayed">
         <div class="format-label pull-left">+</div>
@@ -46,6 +46,13 @@ export default {
         'discussions:created': function(discussion) {
             this.formDisplayed = false;
             this.discussions.unshift(discussion);
+            this.$nextTick(() => {
+                // Scroll to new discussion when displayed
+                // and expand it
+                const $thread = this.threadFor(discussion);
+                $thread.detailed = true;
+                this.$scrollTo($thread);
+            });
         }
     },
     ready() {
@@ -68,6 +75,14 @@ export default {
                 this.$scrollTo(this.$els.form);
                 this.$refs.form.prefill(title, comment);
             })
+        },
+
+        /**
+         * Get the thread component for a given discussion
+         *
+         */
+        threadFor(discussion) {
+            return this.$refs.threads.find($thread => $thread.discussion == discussion);
         }
     }
 }

--- a/js/config.js
+++ b/js/config.js
@@ -39,6 +39,7 @@ if (userEl) {
         slug: userEl.dataset.slug,
         first_name: userEl.dataset.first_name,
         last_name: userEl.dataset.last_name,
+        avatar: userEl.dataset.avatar,
         roles: userEl.dataset.roles.split(','),
     };
 }

--- a/js/front/bootstrap.js
+++ b/js/front/bootstrap.js
@@ -25,6 +25,7 @@ Vue.use(require('plugins/tooltips'));
 Vue.use(require('plugins/util'));
 Vue.use(require('plugins/location'));
 Vue.use(require('plugins/outside'));
+Vue.use(require('plugins/scroll-to'));
 
 // Site-wide components
 Vue.component('site-search', require('components/site-search.vue'));

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -30,15 +30,13 @@ function parseUrl(url) {
     return a;
 }
 
-Vue.use(require('plugins/scroll-to'));
-
 new Vue({
     el: 'body',
     components: {LeafletMap, ShareButton, FollowButton, DiscussionThreads, FeaturedButton},
     data() {
         const data = {
             dataset: this.extractDataset(),
-            userReuses: [],
+            userReuses: []
         };
         if (config.check_urls) {
             const port = location.port ? `:${location.port}` : '';

--- a/js/front/reuse.js
+++ b/js/front/reuse.js
@@ -10,16 +10,11 @@ import 'widgets/issues-btn';
 
 import Vue from 'vue';
 
-// Plugins
-import ScrollTo from 'plugins/scroll-to';
-
 // Components
 import FollowButton from 'components/buttons/follow.vue';
 import ShareButton from 'components/buttons/share.vue';
 import FeaturedButton from 'components/buttons/featured.vue';
 import DiscussionThreads from 'components/discussions/threads.vue';
-
-Vue.use(require('plugins/scroll-to'));
 
 new Vue({
     el: 'body',

--- a/less/udata/resource.less
+++ b/less/udata/resource.less
@@ -54,6 +54,10 @@
             }
         }
 
+        &.expanded {
+            border-bottom-color: #fafafa;
+        }
+
         &.body-only {
             margin-top: -@vspacing;
             border-color: #fafafa;

--- a/tasks.py
+++ b/tasks.py
@@ -21,7 +21,7 @@ STATIC_ASSETS_EXTS = (
     'jpg', 'gif'
 )
 STATIC_ASSETS_DIRS = (
-    'dataset', 'organization', 'post', 'reuse', 'site', 'topic', 'user'
+    'dataset', 'organization', 'post', 'reuse', 'site', 'topic', 'user', 'chunks',
 )
 
 

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -36,6 +36,7 @@
     data-first_name="{{ current_user.first_name }}"
     data-last_name="{{ current_user.last_name }}"
     data-roles="{{ current_user.roles|join(',') }}"
+    data-avatar="{{ current_user.avatar }}"
 />
 {% endif %}
 


### PR DESCRIPTION
This PR applies a lot of small fixes on the new discussion component:
- Fix the missing new discussion button
- Hide the form when the discussion has been created
- Focus (and expand) the newly created discussion after submit
- Display avatars in thread
- Fix missing first message
- Triggers auth earlier, when user the new comment or new discussion form instead of the submission (avoid loosing big messages on login)
- Fix some styling between the discussion header and the body
- Fix deep linking (on click and on load)
- Allows to close the comment and new discussion forms
- Removes some console warnings

(The first commit is not related and fixes the `clean` task)