### PR TITLE
Add .jp2 as allowed file extension

### DIFF
--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -77,7 +77,7 @@ export default {
                     // Archives
                     'tar', 'gz', 'tgz', 'rar', 'zip', '7z', 'xz', 'bz2',
                     // Images
-                    'jpeg', 'jpg', 'jpe', 'gif', 'png', 'dwg', 'svg', 'tiff', 'ecw', 'svgz',
+                    'jpeg', 'jpg', 'jpe', 'gif', 'png', 'dwg', 'svg', 'tiff', 'ecw', 'svgz', 'jp2',
                     // Geo
                     'shp', 'kml', 'kmz', 'gpx', 'shx', 'ovr', 'geojson',
                     // Meteorology


### PR DESCRIPTION
A common file format for large geospatial raster data (in our case Luxembourg orthoimagery)