### PR TITLE
Pymongo connection string config errors

### DIFF
--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -92,8 +92,7 @@ def init_app(app):
 
     from udata.models import db
     with app.app_context():
-        default_url = 'mongodb://{host}:{port}'.format(
-            host=db.connection.host, port=db.connection.port)
+        default_url = 'mongodb://{0}:{1}'.format(*db.connection.client.address)
     app.config.setdefault('CELERY_MONGODB_SCHEDULER_URL', default_url)
 
     celery.conf.update(app.config)


### PR DESCRIPTION
Had error message when trying to start my dev instance using Procfile, where the workers didnt get the right mongodb connection info. 

````
09:31:07 beat.1          | celery beat v3.1.24 (Cipater) is starting.
09:31:07 beat.1          | Traceback (most recent call last):
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/bin/celery", line 11, in <module>
09:31:07 beat.1          |     sys.exit(main())
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/__main__.py", line 30, in main
09:31:07 beat.1          |     main()
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/celery.py", line 81, in main
09:31:07 beat.1          |     cmd.execute_from_commandline(argv)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/celery.py", line 793, in execute_from_commandline
09:31:07 beat.1          |     super(CeleryCommand, self).execute_from_commandline(argv)))
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/base.py", line 311, in execute_from_commandline
09:31:07 beat.1          |     return self.handle_argv(self.prog_name, argv[1:])
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/celery.py", line 785, in handle_argv
09:31:07 beat.1          |     return self.execute(command, argv)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/celery.py", line 717, in execute
09:31:07 beat.1          |     ).run_from_argv(self.prog_name, argv[1:], command=argv[0])
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/base.py", line 315, in run_from_argv
09:31:07 beat.1          |     sys.argv if argv is None else argv, command)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/base.py", line 377, in handle_argv
09:31:07 beat.1          |     return self(*args, **options)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/base.py", line 274, in __call__
09:31:07 beat.1          |     ret = self.run(*args, **kwargs)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/bin/beat.py", line 79, in run
09:31:07 beat.1          |     return beat().run()
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/apps/beat.py", line 83, in run
09:31:07 beat.1          |     self.start_scheduler()
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/apps/beat.py", line 104, in start_scheduler
09:31:07 beat.1          |     c.reset(self.startup_info(beat)))))
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/apps/beat.py", line 125, in startup_info
09:31:07 beat.1          |     scheduler = beat.get_scheduler(lazy=True)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/beat.py", line 507, in get_scheduler
09:31:07 beat.1          |     lazy=lazy)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celery/utils/imports.py", line 53, in instantiate
09:31:07 beat.1          |     return symbol_by_name(name)(*args, **kwargs)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/celerybeatmongo/schedulers.py", line 96, in __init__
09:31:07 beat.1          |     self._mongo = mongoengine.connect(db, host=current_app.conf.CELERY_MONGODB_SCHEDULER_URL)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/mongoengine/connection.py", line 192, in connect
09:31:07 beat.1          |     register_connection(alias, db, **kwargs)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/mongoengine/connection.py", line 66, in register_connection
09:31:07 beat.1          |     uri_dict = uri_parser.parse_uri(conn_host)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/pymongo/uri_parser.py", line 321, in parse_uri
09:31:07 beat.1          |     nodes = split_hosts(hosts, default_port=default_port)
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/pymongo/uri_parser.py", line 250, in split_hosts
09:31:07 beat.1          |     nodes.append(parse_host(entity, port))
09:31:07 beat.1          |   File "/home/wepa/dev.data.public.lu/venv/local/lib/python2.7/site-packages/pymongo/uri_parser.py", line 145, in parse_host
09:31:07 beat.1          |     % (port,))
09:31:07 beat.1          | ValueError: Port must be an integer between 0 and 65535: 27017']
````

This pull request fixes the error. It seems to me that the db.connection object has changed.