### PR TITLE
Properly handle deleted datasets and reuses on home

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -307,6 +307,8 @@ class Dataset(WithMetrics, BadgeMixin, db.Document):
             cls.on_create.send(document)
         else:
             cls.on_update.send(document)
+        if document.deleted:
+            cls.on_delete.send(document)
 
     def clean(self):
         super(Dataset, self).clean()

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -6,9 +6,9 @@ from elasticsearch_dsl import (
 )
 
 from udata.i18n import lazy_gettext as _
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 from udata.models import (
-    Dataset, Organization, License, User, GeoZone, CERTIFIED
+    Dataset, Organization, License, User, GeoZone
 )
 from udata.search import (
     ModelSearchAdapter, i18n_analyzer, metrics_mapping_for, register,

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -7,7 +7,7 @@ from werkzeug.contrib.atom import AtomFeed
 from udata.frontend.views import DetailView, SearchView
 from udata.i18n import I18nBlueprint, lazy_gettext as _
 from udata.models import Dataset, Discussion, Follow, Reuse, CommunityResource
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 from udata.sitemap import sitemap
 from udata.utils import get_by
 

--- a/udata/core/metrics/api.py
+++ b/udata/core/metrics/api.py
@@ -9,7 +9,7 @@ from flask_restplus.inputs import boolean
 from udata.api import api, API, fields
 from udata.models import Metrics
 
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 
 
 metrics_fields = api.model('Metric', {

--- a/udata/core/organization/search.py
+++ b/udata/core/organization/search.py
@@ -7,7 +7,7 @@ from udata.i18n import lazy_gettext as _
 from udata import search
 from udata.search.fields import TermsFacet, RangeFacet
 from udata.models import Organization
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 from udata.search.analysis import simple
 
 from . import metrics  # noqa: Metrics are need for the mapping

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -105,6 +105,8 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Document):
             cls.on_create.send(document)
         else:
             cls.on_update.send(document)
+        if document.deleted:
+            cls.on_delete.send(document)
 
     def url_for(self, *args, **kwargs):
         return url_for('reuses.show', reuse=self, *args, **kwargs)

--- a/udata/core/reuse/search.py
+++ b/udata/core/reuse/search.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from elasticsearch_dsl import Boolean, Completion, Date,  Object, String
 
 from udata.i18n import lazy_gettext as _
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 from udata.models import (
     Reuse, Organization, Dataset, User, REUSE_TYPES
 )

--- a/udata/core/site/models.py
+++ b/udata/core/site/models.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from flask import g, current_app
+from werkzeug.local import LocalProxy
+
 from udata.models import db, WithMetrics
+from udata.core.dataset.models import Dataset
+from udata.core.reuse.models import Reuse
 
 
 __all__ = ('Site', 'SiteSettings')
@@ -11,8 +16,8 @@ DEFAULT_FEED_SIZE = 20
 
 
 class SiteSettings(db.EmbeddedDocument):
-    home_datasets = db.ListField(db.ReferenceField('Dataset'))
-    home_reuses = db.ListField(db.ReferenceField('Reuse'))
+    home_datasets = db.ListField(db.ReferenceField(Dataset))
+    home_reuses = db.ListField(db.ReferenceField(Reuse))
 
 
 class Site(WithMetrics, db.Document):
@@ -23,3 +28,30 @@ class Site(WithMetrics, db.Document):
     configs = db.DictField()
     themes = db.DictField()
     settings = db.EmbeddedDocumentField(SiteSettings, default=SiteSettings)
+
+
+def get_current_site():
+    if getattr(g, 'site', None) is None:
+        site_id = current_app.config['SITE_ID']
+        g.site, _ = Site.objects.get_or_create(id=site_id, defaults={
+            'title': current_app.config.get('SITE_TITLE'),
+            'keywords': current_app.config.get('SITE_KEYWORDS', []),
+        })
+    return g.site
+
+
+current_site = LocalProxy(get_current_site)
+
+
+@Dataset.on_delete.connect
+def remove_from_home_datasets(dataset):
+    if dataset in current_site.settings.home_datasets:
+        current_site.settings.home_datasets.remove(dataset)
+        current_site.save()
+
+
+@Reuse.on_delete.connect
+def remove_from_home_reuses(reuse):
+    if reuse in current_site.settings.home_reuses:
+        current_site.settings.home_reuses.remove(reuse)
+        current_site.save()

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -1,38 +1,24 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import g, request, current_app, send_from_directory, Blueprint
+from flask import request, current_app, send_from_directory, Blueprint
 from werkzeug.contrib.atom import AtomFeed
-from werkzeug.local import LocalProxy
 
 from udata import search, theme
 from udata.frontend import csv
 from udata.frontend.views import DetailView
 from udata.i18n import I18nBlueprint, lazy_gettext as _
-from udata.models import (
-    Dataset, Activity, Site, Reuse, Organization, Post
-)
+from udata.models import Dataset, Activity, Reuse, Organization, Post
 from udata.utils import multi_to_dict
 from udata.core.dataset.csv import ResourcesCsvAdapter
 from udata.core.organization.csv import OrganizationCsvAdapter
 from udata.core.reuse.csv import ReuseCsvAdapter
 from udata.sitemap import sitemap
 
+from .models import current_site
+
 noI18n = Blueprint('noI18n', __name__)
 blueprint = I18nBlueprint('site', __name__)
-
-
-def get_current_site():
-    if getattr(g, 'site', None) is None:
-        site_id = current_app.config['SITE_ID']
-        g.site, _ = Site.objects.get_or_create(id=site_id, defaults={
-            'title': current_app.config.get('SITE_TITLE'),
-            'keywords': current_app.config.get('SITE_KEYWORDS', []),
-        })
-    return g.site
-
-
-current_site = LocalProxy(get_current_site)
 
 
 @blueprint.app_context_processor

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -252,3 +252,9 @@ class DatasetModelTest(TestCase, DBTestMixin):
         for oldFreq, newFreq in LEGACY_FREQUENCIES.items():
             dataset = DatasetFactory(frequency=oldFreq)
             self.assertEqual(dataset.frequency, newFreq)
+
+    def test_send_on_delete(self):
+        dataset = DatasetFactory()
+        with self.assert_emit(Dataset.on_delete):
+            dataset.deleted = datetime.now()
+            dataset.save()

--- a/udata/tests/reuse/test_reuse_model.py
+++ b/udata/tests/reuse/test_reuse_model.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
+from datetime import datetime
+
 from udata.models import Reuse
 
 from udata.core.organization.factories import OrganizationFactory
@@ -53,3 +55,9 @@ class ReuseModelTest(TestCase, DBTestMixin):
         reuse = ReuseFactory(owner=user, tags=tags)
         self.assertEqual(len(reuse.tags), 2)
         self.assertEqual(reuse.tags[1], 'this-is-a-tag')
+
+    def test_send_on_delete(self):
+        reuse = ReuseFactory()
+        with self.assert_emit(Reuse.on_delete):
+            reuse.deleted = datetime.now()
+            reuse.save()

--- a/udata/tests/site/test_site_api.py
+++ b/udata/tests/site/test_site_api.py
@@ -7,7 +7,7 @@ from flask import url_for
 
 from udata.core.site.models import Site
 from udata.core.site.metrics import SiteMetric
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 from udata.core.site.factories import SiteFactory
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.reuse.factories import VisibleReuseFactory

--- a/udata/tests/site/test_site_model.py
+++ b/udata/tests/site/test_site_model.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.site.models import current_site
+from udata.core.reuse.factories import ReuseFactory
+
+from udata.tests import TestCase, DBTestMixin
+
+
+class SiteModelTest(DBTestMixin, TestCase):
+    def test_delete_home_dataset(self):
+        '''Should pull home datasets on deletion'''
+        current_site.settings.home_datasets = DatasetFactory.create_batch(3)
+        current_site.save()
+
+        dataset = current_site.settings.home_datasets[1]
+        dataset.deleted = datetime.now()
+        dataset.save()
+
+        current_site.reload()
+        home_datasets = [d.id for d in current_site.settings.home_datasets]
+        self.assertEqual(len(home_datasets), 2)
+        self.assertNotIn(dataset.id, home_datasets)
+
+    def test_delete_home_reuse(self):
+        '''Should pull home reuses on deletion'''
+        current_site.settings.home_reuses = ReuseFactory.create_batch(3)
+        current_site.save()
+
+        reuse = current_site.settings.home_reuses[1]
+        reuse.deleted = datetime.now()
+        reuse.save()
+
+        current_site.reload()
+        home_reuses = [r.id for r in current_site.settings.home_reuses]
+        self.assertEqual(len(home_reuses), 2)
+        self.assertNotIn(reuse.id, home_reuses)

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -12,7 +12,7 @@ from udata.models import Badge, Site, PUBLIC_SERVICE
 
 from udata.core.dataset.factories import DatasetFactory, ResourceFactory
 from udata.core.organization.factories import OrganizationFactory
-from udata.core.site.views import current_site
+from udata.core.site.models import current_site
 from udata.core.reuse.factories import ReuseFactory
 from udata.tests.frontend import FrontTestCase
 

--- a/udata/theme.py
+++ b/udata/theme.py
@@ -57,7 +57,7 @@ class ConfigurableTheme(Theme):
 
     @property
     def site(self):
-        from udata.core.site.views import current_site
+        from udata.core.site.models import current_site
         return current_site
 
     @property


### PR DESCRIPTION
This PR ensures:
- deleted datasets or reuses are not displayed on the home page
- datasets and reuses dispatch the proper `on_delete` signal when flagged as deleted
- deleted datasets or reuses are pulled from home featured

Should fix #731 