### PR TITLE
Restablish bottom margin on site search

### DIFF
--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -189,10 +189,6 @@ export default {
 .site-search {
     position: relative;
 
-    .form-group {
-        margin-bottom: 0;
-    }
-
     .result-group {
         position: relative;
     }


### PR DESCRIPTION
This PR fix the missing space under the site search field on mobile layout.

Initialy identified here etalab/udata-gouvfr#149