### PR TITLE
Fix modals properties

### DIFF
--- a/js/components/badges/modal.vue
+++ b/js/components/badges/modal.vue
@@ -41,34 +41,34 @@
 <script>
 import API from 'api';
 import {badges} from 'models/badges';
+import Modal from 'components/modal.vue';
 
 export default {
-    name: 'BadgesModal',
-    components: {
-        modal: require('components/modal.vue')
+    components: {Modal},
+    props: {
+        subject: Object
     },
-    data: function() {
+    data() {
         return {
             selected: [],
             initial: [],
-            subject: null,
             badges: {},
             added: {},
             removed: {}
         };
     },
     computed: {
-        hasBadges: function() {
+        hasBadges() {
             return Object.keys(this.badges).length > 0;
         },
-        hasModifications: function() {
+        hasModifications() {
             return (this.selected.length !== this.initial.length)
                 || this.selected.some((badge) => {
                     return this.initial.indexOf(badge) < 0;
                 });
         }
     },
-    compiled: function() {
+    compiled() {
         this.badges = badges.available(this.subject);
 
         if (this.subject.hasOwnProperty('badges')) {
@@ -80,8 +80,8 @@ export default {
         }
     },
     methods: {
-        confirm: function() {
-            let to_add = this.selected.filter((badge) => {
+        confirm() {
+            const to_add = this.selected.filter((badge) => {
                         return this.initial.indexOf(badge) < 0;
                     }),
                 to_remove = this.initial.filter((badge) => {
@@ -105,8 +105,8 @@ export default {
                 });
             });
         },
-        checkAllDone: function() {
-            let allAdded = Object.keys(this.added).every((key) => {
+        checkAllDone() {
+            const allAdded = Object.keys(this.added).every((key) => {
                     return this.added[key];
                 }),
                 allRemoved = Object.keys(this.removed).every((key) => {
@@ -118,7 +118,7 @@ export default {
                 this.$emit('badges:modified');
             }
         },
-        toggle: function(badge) {
+        toggle(badge) {
             if (this.selected.indexOf(badge) >= 0) {
                 this.selected.$remove(badge);
             } else {

--- a/js/components/dataset/delete-modal.vue
+++ b/js/components/dataset/delete-modal.vue
@@ -27,18 +27,15 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        modal: require('components/modal.vue')
-    },
-    data: function() {
-        return {
-            dataset: {}
-        };
+    components: {Modal},
+    props: {
+        dataset: Object,
     },
     methods: {
-        confirm: function() {
+        confirm() {
             API.datasets.delete_dataset({dataset: this.dataset.id},
                 (response) => {
                     this.dataset.fetch();

--- a/js/components/harvest/delete-modal.vue
+++ b/js/components/harvest/delete-modal.vue
@@ -27,18 +27,15 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        'modal': require('components/modal.vue')
-    },
-    data: function() {
-        return {
-            source: {}
-        };
+    components: {Modal},
+    props:  {
+        source: Object
     },
     methods: {
-        confirm: function() {
+        confirm() {
             API.harvest.delete_harvest_source({ident: this.source.id},
                 (response) => {
                     this.source.fetch();

--- a/js/components/harvest/item.vue
+++ b/js/components/harvest/item.vue
@@ -55,21 +55,19 @@
 <script>
 import {STATUS_CLASSES, STATUS_I18N} from 'models/harvest/item';
 
+import Modal from 'components/modal.vue';
+import DatasetCard from 'components/dataset/card.vue';
+
 export default {
-    name: 'JobItemModal',
-    components: {
-        'modal': require('components/modal.vue'),
-        'dataset-card': require('components/dataset/card.vue')
-    },
-    props: ['item'],
-    data: function() {
-        return {};
+    components: {Modal, DatasetCard},
+    props: {
+        item: Object,
     },
     filters: {
-        statusClass: function(value) {
+        statusClass(value) {
             return STATUS_CLASSES[value];
         },
-        statusI18n: function(value) {
+        statusI18n(value) {
             return STATUS_I18N[value];
         }
     }

--- a/js/components/harvest/validation-modal.vue
+++ b/js/components/harvest/validation-modal.vue
@@ -33,25 +33,26 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        modal: require('components/modal.vue')
+    components: {Modal},
+    props: {
+        source: Object,
     },
-    data: function() {
+    data() {
         return {
-            source: {},
             comment: null
         };
     },
     methods: {
-        validate: function() {
+        validate() {
             this.perform_validation('accepted');
         },
-        reject: function() {
+        reject() {
             this.perform_validation('refused');
         },
-        perform_validation: function(state) {
+        perform_validation(state) {
             if (state === 'refused' && !this.comment) {
                 this.$els.group.className.replace('has-success', '');
                 if (!this.$els.group.className.indexOf('has-error') >= 0) {

--- a/js/components/organization/delete-modal.vue
+++ b/js/components/organization/delete-modal.vue
@@ -27,18 +27,15 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        modal: require('components/modal.vue')
-    },
-    data: function() {
-        return {
-            organization: {}
-        };
+    components: {Modal},
+    props: {
+        organization: Object
     },
     methods: {
-        confirm: function() {
+        confirm() {
             API.organizations.delete_organization(
                 {org: this.organization.id},
                 (response) => {

--- a/js/components/reuse/delete-modal.vue
+++ b/js/components/reuse/delete-modal.vue
@@ -27,18 +27,15 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        modal: require('components/modal.vue')
-    },
-    data: function() {
-        return {
-            reuse: {}
-        };
+    components: {Modal},
+    props: {
+        reuse: Object
     },
     methods: {
-        confirm: function() {
+        confirm() {
             API.reuses.delete_reuse({reuse: this.reuse.id},
                 (response) => {
                     this.reuse.fetch();

--- a/js/components/transfer/request-modal.vue
+++ b/js/components/transfer/request-modal.vue
@@ -72,22 +72,23 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
+import OrgFilter from 'components/organization/card-filter.vue';
+import UserFilter from 'components/user/card-filter.vue';
+import OrgCard from 'components/organization/card.vue';
+import UserCard from 'components/user/card.vue';
+import DatasetCard from 'components/dataset/card.vue';
+import ReuseCard from 'components/reuse/card.vue';
 
 export default {
-    components: {
-        'modal': require('components/modal.vue'),
-        'org-filter': require('components/organization/card-filter.vue'),
-        'user-filter': require('components/user/card-filter.vue'),
-        'org-card': require('components/organization/card.vue'),
-        'user-card': require('components/user/card.vue'),
-        'dataset-card': require('components/dataset/card.vue'),
-        'reuse-card': require('components/reuse/card.vue')
+    components: {Modal, OrgFilter, UserFilter, OrgCard, UserCard, DatasetCard, ReuseCard},
+    props: {
+        subject: Object,
     },
-    data: function() {
+    data() {
         return {
             type: null,
             recipient: null,
-            subject: null,
             comment: null
         };
     },
@@ -100,7 +101,7 @@ export default {
         }
     },
     methods: {
-        confirm: function() {
+        confirm() {
             API.transfer.request_transfer({
                 payload: {
                     subject: {

--- a/js/components/transfer/response-modal.vue
+++ b/js/components/transfer/response-modal.vue
@@ -73,24 +73,25 @@
 <script>
 import API from 'api';
 import Vue from 'vue';
+import Modal from 'components/modal.vue';
+import OrgCard from 'components/organization/card.vue';
+import UserCard from 'components/user/card.vue';
+import DatasetCard from 'components/dataset/card.vue';
+import ReuseCard from 'components/reuse/card.vue';
 
 export default {
-    components: {
-        'modal': require('components/modal.vue'),
-        'org-card': require('components/organization/card.vue'),
-        'user-card': require('components/user/card.vue'),
-        'dataset-card': require('components/dataset/card.vue'),
-        'reuse-card': require('components/reuse/card.vue')
+    components: {Modal, OrgCard, UserCard, DatasetCard, ReuseCard},
+    props: {
+        transferid: String,
     },
-    data: function() {
+    data() {
         return {
-            transferid: null,
             transfer: {},
             comment: null
         };
     },
     methods: {
-        respond: function(response) {
+        respond(response) {
             API.transfer.respond_to_transfer({
                 id: this.transferid,
                 payload: {
@@ -107,7 +108,7 @@ export default {
             });
         }
     },
-    ready: function() {
+    ready() {
         API.transfer.get_transfer({id: this.transferid}, (response) => {
             this.transfer = response.obj;
             this.$emit('transfer:loaded');

--- a/js/components/user/delete-me-modal.vue
+++ b/js/components/user/delete-me-modal.vue
@@ -30,11 +30,10 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        modal: require('components/modal.vue')
-    },
+    components: {Modal},
     methods: {
         confirm() {
             API.me.delete_me(

--- a/js/components/user/delete-user-modal.vue
+++ b/js/components/user/delete-user-modal.vue
@@ -31,15 +31,12 @@
 
 <script>
 import API from 'api';
+import Modal from 'components/modal.vue';
 
 export default {
-    components: {
-        modal: require('components/modal.vue')
-    },
-    data() {
-        return {
-            user: {}
-        };
+    components: {Modal},
+    props: {
+        user: Object,
     },
     methods: {
         confirm() {

--- a/js/views/reuse.vue
+++ b/js/views/reuse.vue
@@ -2,10 +2,10 @@
 <layout :title="reuse.title || ''" :subtitle="_('Reuse')"
     :actions="actions" :badges="badges" :page="reuse.page || ''">
     <div class="row">
-        <sbox class="col-lg-4 col-xs-6" v-for="b in boxes"
+        <small-box class="col-lg-4 col-xs-6" v-for="b in boxes"
             :value="b.value" :label="b.label" :color="b.color"
             :icon="b.icon" :target="b.target">
-        </sbox>
+        </small-box>
     </div>
     <div class="row">
         <reuse-details :reuse="reuse" class="col-xs-12 col-md-6"></reuse-details>
@@ -21,11 +21,11 @@
 
     <div class="row">
         <issue-list id="issues-widget" class="col-xs-12 col-md-6" :issues="issues"></issue-list>
-        <discussions id="discussions-widget" class="col-xs-12 col-md-6" :discussions="discussions"></discussions>
+        <discussion-list id="discussions-widget" class="col-xs-12 col-md-6" :discussions="discussions"></discussion-list>
     </div>
 
     <div class="row">
-        <followers id="followers-widget" class="col-xs-12" :followers="followers"></followers>
+        <follower-list id="followers-widget" class="col-xs-12" :followers="followers"></follower-list>
     </div>
 </layout>
 </template>
@@ -40,15 +40,19 @@ import Issues from 'models/issues';
 import Discussions from 'models/discussions';
 import mask from 'models/mask';
 // Widgets
+import Chart from 'components/charts/widget.vue';
 import DatasetCards from 'components/dataset/card-list.vue';
 import DiscussionList from 'components/discussions/list.vue';
+import FollowerList from 'components/follow/list.vue';
 import IssueList from 'components/issues/list.vue';
 import Layout from 'components/layout.vue';
+import ReuseDetails from 'components/reuse/details.vue';
+import SmallBox from 'components/containers/small-box.vue';
 
 const MASK = `datasets{${mask(DatasetCards.MASK)}},*`;
 
 export default {
-    name: 'ReuseView',
+    components: {SmallBox, Chart, ReuseDetails, FollowerList, DiscussionList, IssueList, DatasetCards, Layout},
     data() {
         const actions = [{
                 label: this._('Edit'),
@@ -118,16 +122,6 @@ export default {
                 target: '#traffic'
             }];
         }
-    },
-    components: {
-        sbox: require('components/containers/small-box.vue'),
-        chart: require('components/charts/widget.vue'),
-        'reuse-details': require('components/reuse/details.vue'),
-        followers: require('components/follow/list.vue'),
-        DiscussionList,
-        IssueList,
-        DatasetCards,
-        Layout
     },
     events: {
         'dataset-card-list:submit': function(ids) {


### PR DESCRIPTION
This PR fix modals data that should be properties.

This bug is (positive) side-effect of #725 

Same fix than #747 and 744 (ie. use `props` instead of `data` when required).

Touched files have been linted/ES6ified