### PR TITLE
Use a raw html fallback on site search and factorize it into a macro

### DIFF
--- a/udata/templates/header.html
+++ b/udata/templates/header.html
@@ -1,3 +1,4 @@
+{% from theme('macros/search.html') import site_search with context %}
 <nav class="navbar navbar-default navbar-static-top">
   <div class="container">
     <div class="navbar-header">
@@ -12,9 +13,7 @@
     </div>
 
     <div class="col-sm-2 col-lg-3 nav navbar-nav search-bar" role="search">
-      <site-search  v-ref:search class="navbar-form"
-        placeholder="{{ _('Search') }}" action="{{ url_for('front.search') }}">
-      </site-search>
+      {{ site_search(class='navbar-form') }}
     </div>
 
     <ul class="nav navbar-nav collapse navbar-collapse collapse-on-search">

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -242,3 +242,24 @@
     {% endif %}
 </div>
 {% endmacro %}
+
+
+{# Display the site search component with raw html fallback #}
+{% set default_action = url_for('front.search') %}
+{% set default_placeholder = _('Search') %}
+{% macro site_search(action=default_action, placeholder=default_placeholder, territory=None, size=None, class=None) -%}
+<site-search v-ref:search action="{{ action }}" placeholder="{{ placeholder }}"
+    {% if class %}class="{{ class }}"{% endif %}
+    {% if size %}size="{{ size }}"{% endif %}
+    {% if territory %}territory-id="{{ territory.id }}"{% endif %}>
+    <form class="site-search{% if class %} {{ class }}{% endif %}" action="{{ action }}">
+        <div class="input-group {% if size %}input-group-{{ size }}{% endif%}">
+            <div class="input-group-btn">
+                <button class="btn" type="submit"><i class="fa fa-search"></i></button>
+            </div>
+            <label for="search" class="hidden">{{ placeholder }}</label>
+            <input id="search" name="q" type="search" class="form-control" placeholder="{{ placeholder }}" />
+        </div>
+    </form>
+</site-search>
+{%- endmacro %}


### PR DESCRIPTION
This PR adds a raw html fallback on site search avoiding flickering on component loading and allowing the search feature to work without JS.

Everything has been factorized into a reusable macro (for themes).