### PR TITLE
Organization page fixes

### DIFF
--- a/js/components/charts/widget.vue
+++ b/js/components/charts/widget.vue
@@ -125,15 +125,10 @@ export default {
     },
     computed: {
         series() {
-            const series = this.y.map((item) => {
-                return item.id;
-            });
+            const series = this.y.map(item => item.id);
             const raw = this.metrics.timeserie(series);
-            const data = {
-                labels: raw.map((item) => {
-                    return moment(item.date).format('L');
-                }),
-
+            return {
+                labels: raw.map(item => moment(item.date).format('L')),
                 datasets: this.y.map((serie, idx) => {
                     const dataset = {label: serie.label};
                     const color = serie.color || COLORS[idx];
@@ -143,14 +138,10 @@ export default {
                     // datasetpointStrokeColor: "#c1c7d1",
                     dataset.pointHighlightFill = '#fff';
                     dataset.pointHighlightStroke = color;
-                    dataset.data = raw.map((item) => {
-                        return item[serie.id];
-                    });
+                    dataset.data = raw.map(item => item[serie.id]);
                     return dataset;
                 })
             };
-
-            return data;
         }
     },
     components: {Box},

--- a/js/components/charts/widget.vue
+++ b/js/components/charts/widget.vue
@@ -27,6 +27,7 @@
 </style>
 
 <template>
+<div class="chart-widget">
     <box :title="title" :icon="icon"
         boxclass="box-solid"
         bodyclass="chart-responsive"
@@ -36,13 +37,15 @@
         </div>
         <div class="chart-legend" v-el:legend></div>
     </box>
+</div>
 </template>
 
 <script>
-import $ from 'jquery';
 import moment from 'moment';
 import Chart from 'chart.js';
 import 'Chart.StackedBar.js';
+
+import Box from 'components/containers/box.vue';
 
 /*
  * Set common global chart options
@@ -61,9 +64,11 @@ const AREA_OPTIONS = {
     scaleShowVerticalLines: true,
     bezierCurveTension: 0.3,
 };
-const LINE_OPTIONS = $.extend({}, AREA_OPTIONS, {
+
+const LINE_OPTIONS = Object.assign({}, AREA_OPTIONS, {
     datasetFill: false,
 });
+
 const BAR_OPTIONS = {
     scaleBeginAtZero: true,
     scaleShowGridLines: true,
@@ -75,9 +80,10 @@ const BAR_OPTIONS = {
     barDatasetSpacing: 1,
     datasetFill: false,
 };
-const STACKEDBAR_OPTIONS = $.extend({}, BAR_OPTIONS, {
+const STACKEDBAR_OPTIONS = Object.assign({}, BAR_OPTIONS, {
     scaleShowVerticalLines: false,
 });
+
 const COLORS = [
     '#a0d0e0',
     '#3c8dbc',
@@ -89,8 +95,7 @@ const COLORS = [
 
 
 export default {
-    name: 'chartjs-chart',
-    data: function() {
+    data() {
         return {
             chart: null,
             canvasHeight: null,
@@ -119,19 +124,19 @@ export default {
         }
     },
     computed: {
-        series: function() {
-            let series = this.y.map((item) => {
+        series() {
+            const series = this.y.map((item) => {
                 return item.id;
             });
-            let raw = this.metrics.timeserie(series);
-            let data = {
+            const raw = this.metrics.timeserie(series);
+            const data = {
                 labels: raw.map((item) => {
                     return moment(item.date).format('L');
                 }),
 
                 datasets: this.y.map((serie, idx) => {
-                    let dataset = {label: serie.label};
-                    let color = serie.color || COLORS[idx];
+                    const dataset = {label: serie.label};
+                    const color = serie.color || COLORS[idx];
                     dataset.fillColor = this.toRGBA(color, .5);
                     dataset.strokeColor = color;
                     dataset.pointColor = color;
@@ -148,62 +153,60 @@ export default {
             return data;
         }
     },
-    components: {
-        box: require('components/containers/box.vue')
-    },
-    ready: function() {
+    components: {Box},
+    ready() {
         this.canvasHeight = this.$els.container.clientHeight;
         this.buildChart();
         this.metrics.$on('updated', this.buildChart.bind(this));
     },
-    beforeDestroy: function() {
+    beforeDestroy() {
         this.cleanChart();
     },
     watch: {
-        'y': function(new_value, old_value) {
+        y(new_value, old_value) {
             if (new_value != old_value) {
                 this.buildChart();
             }
         }
     },
     methods: {
-        buildChart: function() {
+        buildChart() {
             if (!this.y || !this.metrics || !this.chartType) {
                 return;
             }
-            let factory = this['build' + this.chartType];
-            let ctx = this.$els.canvas.getContext('2d');
+            const factory = this['build' + this.chartType];
+            const ctx = this.$els.canvas.getContext('2d');
             this.cleanChart();
             ctx.canvas.height = this.canvasHeight;
             this.chart = factory(ctx);
             this.$els.legend.innerHTML = this.chart.generateLegend();
         },
-        buildArea: function(ctx) {
+        buildArea(ctx) {
             return new Chart(ctx).Line(this.series, AREA_OPTIONS);
         },
-        buildBar: function(ctx) {
+        buildBar(ctx) {
             return new Chart(ctx).Bar(this.series, BAR_OPTIONS);
         },
-        buildStackedBar: function(ctx) {
+        buildStackedBar(ctx) {
             return new Chart(ctx).StackedBar(this.series, STACKEDBAR_OPTIONS);
         },
-        buildLine: function(ctx) {
+        buildLine(ctx) {
             return new Chart(ctx).Line(this.series, LINE_OPTIONS);
         },
-        cleanChart: function() {
+        cleanChart() {
             if (this.chart) {
                 this.chart.destroy();
                 this.chart = null;
             }
         },
-        toRGBA: function(hex, opacity) {
+        toRGBA(hex, opacity) {
             // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
-            let shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+            const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
             hex = hex.replace(shorthandRegex, function(m, r, g, b) {
                 return r + r + g + g + b + b;
             });
 
-            let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+            const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
             return result ?
                 'rgba('
                     + parseInt(result[1], 16) + ','

--- a/js/components/containers/box.vue
+++ b/js/components/containers/box.vue
@@ -90,7 +90,6 @@
 
 <script>
 export default {
-    name: 'box-container',
     replace: true,
     props: {
         title: String,

--- a/js/components/dashboard/graphs.vue
+++ b/js/components/dashboard/graphs.vue
@@ -1,8 +1,5 @@
 <style lang="less">
 .graphs {
-    .small-boxes {
-        margin: 1em 0 0;
-    }
     .graphs-chart .box-title {
         margin-top: 0;
     }
@@ -10,24 +7,11 @@
 </style>
 <template>
 <div class="graphs">
-    <div v-if="metrics.loading" class="text-center"><span class="fa fa-4x fa-cog fa-spin"></span></div>
-    <div v-if="!metrics.loading" class="row small-boxes">
-        <small-box class="col-lg-4 col-xs-6" v-for="b in dataBoxes"
-            :value="b.value" :label="b.label" :color="b.color"
-            :icon="b.icon" :target="b.target">
-        </small-box>
-    </div>
-    <div class="row small-boxes">
-        <small-box class="col-lg-4 col-xs-6" v-for="b in communityBoxes"
-        :value="b.value" :label="b.label" :color="b.color"
-        :icon="b.icon" :target="b.target">
-    </small-box>
-    </div>
     <div class="row graphs-chart">
-        <chart class="col-xs-6" :title="_('Latest dataset uploads')"
+        <chart class="col-xs-12 col-sm-6" :title="_('Latest dataset uploads')"
         :metrics="metrics" icon="null"
         :y="dataDatasets" chart-type="Line"></chart>
-        <chart class="col-xs-6" :title="_('Latest reuse uploads')"
+        <chart class="col-xs-12 col-sm-6" :title="_('Latest reuse uploads')"
         :metrics="metrics" icon="null"
         :y="dataReuses" chart-type="Line"></chart>
     </div>
@@ -37,16 +21,13 @@
 <script>
 import Metrics from 'models/metrics';
 import moment from 'moment';
-import site from 'models/site';
-import SmallBox from 'components/containers/small-box.vue';
 import Chart from 'components/charts/widget.vue';
 
 export default {
-    components: {Chart, SmallBox},
+    components: {Chart},
     props: ['objectId'],
     data() {
         return {
-            site: site,
             metrics: new Metrics({
                 data: {
                     loading: true,
@@ -62,63 +43,19 @@ export default {
             }]
         };
     },
-    computed: {
-        dataBoxes() {
-            if (!this.$root.site || !this.$root.site.metrics) {
-                return [];
-            }
-            return [{
-                value: this.$root.site.metrics.datasets || 0,
-                label: this._('Datasets'),
-                icon: 'cubes',
-                color: 'aqua',
-            }, {
-                value: this.$root.site.metrics.resources || 0,
-                label: this._('Resources'),
-                icon: 'file-text-o',
-                color: 'maroon',
-            }, {
-                value: this.$root.site.metrics.reuses || 0,
-                label: this._('Reuses'),
-                icon: 'retweet',
-                color: 'green',
-            }];
-        },
-        communityBoxes() {
-            if (!this.$root.site.metrics) {
-                return [];
-            }
-            return [{
-                value: this.$root.site.metrics.users || 0,
-                label: this._('Users'),
-                icon: 'users',
-                color: 'yellow',
-            }, {
-                value: this.$root.site.metrics.organizations || 0,
-                label: this._('Organizations'),
-                icon: 'building',
-                color: 'purple',
-            }, {
-                value: this.$root.site.metrics.discussions || 0,
-                label: this._('Discussions'),
-                icon: 'comments',
-                color: 'teal',
-            }];
-        }
-    },
     watch: {
-        'site.id': function(id) {
+        objectId(id) {
             this.fetchMetrics();
         }
     },
-    attached: function() {
+    attached() {
         this.fetchMetrics();
     },
     methods: {
-        fetchMetrics: function() {
-            if (this.objectId || this.site.id) {
+        fetchMetrics() {
+            if (this.objectId) {
                 this.metrics.fetch({
-                    id: this.objectId || this.site.id,
+                    id: this.objectId,
                     start: moment().subtract(12, 'days').format('YYYY-MM-DD'),
                     end: moment().format('YYYY-MM-DD'),
                     cumulative: false

--- a/js/components/dashboard/graphs.vue
+++ b/js/components/dashboard/graphs.vue
@@ -1,7 +1,30 @@
 <style lang="less">
+/**
+ * Style fixes: this component is meant to be used outside admin
+ */
 .graphs {
-    .graphs-chart .box-title {
-        margin-top: 0;
+    .graphs-chart {
+        .box-title {
+            margin-top: 0;
+            text-align: center;
+        }
+
+        .box > .overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+
+            > .fa {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                margin-left: -15px;
+                margin-top: -15px;
+                font-size: 30px;
+            }
+        }
     }
 }
 </style>

--- a/js/front/dashboard.js
+++ b/js/front/dashboard.js
@@ -3,9 +3,8 @@ import 'front/bootstrap';
 
 import Vue from 'vue';
 
-import site from 'models/site';
-
 import ActivityTimeline from 'components/activities/timeline.vue';
+import SmallBox from 'components/containers/small-box.vue';
 import DashboardGraphs from 'components/dashboard/graphs.vue';
 
 // Ensure retrocompatibily for 0.12.2 replace behavior
@@ -14,8 +13,5 @@ Vue.options.replace = false;
 
 new Vue({
     el: 'body',
-    components: {ActivityTimeline, DashboardGraphs},
-    data() {
-        return {site};
-    }
+    components: {ActivityTimeline, DashboardGraphs, SmallBox},
 });

--- a/js/front/organization/index.js
+++ b/js/front/organization/index.js
@@ -17,11 +17,17 @@ import ActivityTimeline from 'components/activities/timeline.vue';
 import DashboardGraphs from 'components/dashboard/graphs.vue';
 import Tab from 'components/tab';
 
+import SmallBox from 'components/containers/small-box.vue';
+
 import MembershipRequest from './membership-request.vue';
+
+// Ensure retrocompatibily for 0.12.2 replace behavior
+Vue.options.replace = false;
+
 
 new Vue({
     el: 'body',
-    components: {FollowButton, Tab, tabset, ActivityTimeline, DashboardGraphs},
+    components: {FollowButton, Tab, tabset, ActivityTimeline, DashboardGraphs, SmallBox},
     data() {
         return {
             followersVisible: false,

--- a/udata/templates/organization/dashboard.html
+++ b/udata/templates/organization/dashboard.html
@@ -14,10 +14,24 @@
 {% endblock %}
 
 {% block main_content %}
-<dashboard-graphs object-id="{{ org.id }}">
-    {# Load spinner until JS is ready #}
-    <div class="text-center"><span class="fa fa-4x fa-cog fa-spin"></span></div>
-</dashboard-graphs>
+{# Load spinner until JS is ready #}
+<div v-if="false" class="text-center"><span class="fa fa-4x fa-cog fa-spin"></span></div>
+{# Boxes definitions: (label, metric, icon, color) #}
+{% set boxes = [
+    (_('Datasets'), 'datasets', 'cubes', 'aqua'),
+    (_('Reuses'), 'reuses', 'retweet', 'green'),
+    (_('Followers'), 'followers', 'users', 'purple'),
+] %}
+<div class="row">
+    {% for (label, metric, icon, color) in boxes %}
+    <small-box class="col-lg-4 col-md-4 col-xs-6"
+        value="{{org.metrics[metric]}}" label="{{label}}" color="{{color}}"
+        icon="{{icon}}">
+    </small-box>
+    {% endfor %}
+</div>
+
+<dashboard-graphs object-id="{{ org.id }}"></dashboard-graphs>
 {% endblock %}
 
 {% block after_content %}

--- a/udata/templates/organization/display_base.html
+++ b/udata/templates/organization/display_base.html
@@ -148,20 +148,13 @@
                 </a>
                 {% endif %}
 
-                <button type="button"
-                    class="btn btn-primary btn-follow btn-block btn-sm icon-left {% if is_following(org) %}active{% endif %}"
-                    v-tooltip tooltip-placement="left"
-                    data-api-url="{{ url_for('api.organization_followers', id=org.id|string) }}"
-                    {% if is_following(org) %}
-                    title="{{ _('Unfollow') }}">
-                    <span class="glyphicon glyphicon-eye-close"></span>
-                    {{ _('Unfollow') }}
-                    {% else %}
-                    title="{{ _("I'll be informed about this organization news") }}">
-                    <span class="glyphicon glyphicon-eye-open"></span>
-                    {{ _('Follow') }}
-                    {% endif %}
-                </button>
+                <follow-button with-label classes="btn-primary btn-block btn-sm btn-left"
+                    class="btn-block"  {# Necessary until Vue.config.replace can be reverted to true #}
+                    {% if is_following(org) %}following{% endif %}
+                    url="{{ url_for('api.organization_followers', id=org.id|string) }}"
+                    tooltip="{{ _('I\'ll be informed about this organization news') }}"
+                    >
+                </follow-button>
             </aside>
         </div>
 

--- a/udata/templates/site/dashboard.html
+++ b/udata/templates/site/dashboard.html
@@ -15,13 +15,30 @@
 {% endblock %}
 
 {% block content %}
-<section>
+{# Boxes definitions: (label, metric, icon, color) #}
+{% set boxes = [
+    (_('Datasets'), 'datasets', 'cubes', 'aqua'),
+    (_('Resources'), 'resources', 'file-text-o', 'maroon'),
+    (_('Reuses'), 'reuses', 'retweet', 'green'),
+    (_('Users'), 'users', 'users', 'yellow'),
+    (_('Organizations'), 'organizations', 'building', 'purple'),
+    (_('Discussions'), 'discussions', 'comments', 'teal'),
+] %}
+<section class="default">
     <div class="container">
         <div class="row">
-            <dashboard-graphs class="col-sm-12">
-                {# Load spinner until JS is ready #}
-                <div class="text-center"><span class="fa fa-4x fa-cog fa-spin"></span></div>
-            </dashboard-graphs>
+            {# Load spinner until JS is ready #}
+            <div v-if="false" class="col-xs-12 text-center"><span class="fa fa-4x fa-cog fa-spin"></span></div>
+            {% for (label, metric, icon, color) in boxes %}
+            <small-box class="col-lg-4 col-md-4 col-xs-6"
+                value="{{current_site.metrics[metric]}}" label="{{label}}" color="{{color}}"
+                icon="{{icon}}">
+            </small-box>
+            {% endfor %}
+        </div>
+
+        <div class="row">
+            <dashboard-graphs class="col-xs-12"  object-id="{{ current_site.id }}"></dashboard-graphs>
         </div>
     </div>
 </section>


### PR DESCRIPTION
This PR provides multiple fixes on organization page:
- use the `follow-button` widget instead of the legacy one (which is broken)
- use already available server-side metrics for boxes (fix rendering on organization dashboard and speedup rendering on site dashboard)
- drop useless jQuery requirement
- fix replacement behavior on small boxes
- fix the charts spinner rendering and center the title