### PR TITLE
Fix common packaging

### DIFF
--- a/js/components/popover.vue
+++ b/js/components/popover.vue
@@ -9,7 +9,7 @@
 import log from 'logger';
 import TooltipMixin from 'mixins/tooltip';
 
-import { popover } from 'vue-strap'; // Needed for style
+import 'vue-strap/src/Popover.vue'; // Needed for style
 
 export default {
     mixins: [TooltipMixin],

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -1,7 +1,7 @@
-import {tab} from 'vue-strap';
+import Tab from 'vue-strap/src/Tab.vue';
 
 export default {
-    mixins: [tab],
+    mixins: [Tab],
     props: {
         id: String
     }

--- a/js/components/tooltip.vue
+++ b/js/components/tooltip.vue
@@ -9,7 +9,7 @@
 import log from 'logger';
 import TooltipMixin from 'mixins/tooltip';
 
-import { tooltip } from 'vue-strap'; // Needed for style
+import 'vue-strap/src/Tooltip.vue'; // Needed for style
 
 export default {
     mixins: [TooltipMixin],

--- a/js/front/organization/index.js
+++ b/js/front/organization/index.js
@@ -10,7 +10,7 @@ import i18n from 'i18n';
 
 import Vue from 'vue';
 
-import {tabset} from 'vue-strap';
+import Tabset from 'vue-strap/src/Tabset.vue';
 
 import FollowButton from 'components/buttons/follow.vue';
 import ActivityTimeline from 'components/activities/timeline.vue';
@@ -27,7 +27,7 @@ Vue.options.replace = false;
 
 new Vue({
     el: 'body',
-    components: {FollowButton, Tab, tabset, ActivityTimeline, DashboardGraphs, SmallBox},
+    components: {FollowButton, Tab, Tabset, ActivityTimeline, DashboardGraphs, SmallBox},
     data() {
         return {
             followersVisible: false,

--- a/js/front/user.js
+++ b/js/front/user.js
@@ -7,7 +7,7 @@ import log from 'logger';
 
 import Vue from 'vue';
 
-import {tabset} from 'vue-strap';
+import Tabset from 'vue-strap/src/Tabset.vue';
 
 import FollowButton from 'components/buttons/follow.vue';
 import ActivityTimeline from 'components/activities/timeline.vue';
@@ -15,7 +15,7 @@ import Tab from 'components/tab';
 
 new Vue({
     el: 'body',
-    components: {FollowButton, Tab, tabset, ActivityTimeline},
+    components: {FollowButton, Tab, Tabset, ActivityTimeline},
     data() {
         return {
             // Current tab index

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -12,7 +12,10 @@ export const lang = config.lang;
 const resources = {};
 
 resources[lang] = {};
-resources[lang][NAMESPACE] = require('locales/' + NAMESPACE + '.' + lang + '.json');
+// Force split and async loading of locale (and so remove them from common.js)
+require.ensure([], function() {
+  resources[lang][NAMESPACE] = require('locales/' + NAMESPACE + '.' + lang + '.json');
+});
 
 moment.locale(lang);
 i18next.init({

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "assets:watch": "webpack -c -d  --progress --watch",
-    "assets:build": "webpack -p --progress --config webpack.config.prod.js",
+    "assets:build": "webpack --progress --config webpack.config.prod.js",
     "widgets:watch": "webpack -c -d --progress --watch --config webpack.config.widgets.js",
     "widgets:build": "webpack -p --progress --config webpack.config.widgets.prod.js",
     "build": "npm run assets:build && npm run widgets:build",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,11 @@ module.exports = {
             {test: /\.json$/, loader: 'json-loader'},
             {test: /\.hbs$/, loader: hbs_loader},
             {test: /\.(woff|svg|ttf|eot|otf)([\?]?.*)$/, exclude: /img/, loader: 'file-loader?name=[name].[ext]'},
-            {test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader'},
+            {test: /\.js$/, loader: 'babel-loader', include: [
+                    path.resolve(__dirname, 'js'),
+                    path.resolve(__dirname, 'node_modules/vue-strap/src'),
+                ]
+            }
         ]
     },
     vue: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,25 +1,32 @@
 var webpack = require('webpack');
 var config = require('./webpack.config');
 
-config.plugins.push(new webpack.optimize.UglifyJsPlugin({
-    minimize: true,
-    output: {
-        comments: false,
-        screw_ie8: true
-    },
-    mangle: {
-        screw_ie8: true
-    },
-    compress: {
-        warnings: false,
-        screw_ie8: true
-    }
-}));
+config.plugins.push(
+    new webpack.DefinePlugin({
+        'process.env': {
+            NODE_ENV: '"production"'
+        }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+        minimize: true,
+        output: {
+            comments: false,
+            screw_ie8: true
+        },
+        mangle: {
+            screw_ie8: true,
+            keep_fnames: true
+        },
+        compress: {
+            warnings: false,
+            screw_ie8: true
+        }
+    }),
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.OccurenceOrderPlugin(true)
+);
 
 config.devtool = 'source-map';
-
-config.plugins.push(new webpack.optimize.DedupePlugin());
-config.plugins.push(new webpack.optimize.OccurenceOrderPlugin(true));
 
 /**
  * Image optimization.


### PR DESCRIPTION
This PR start to fix common.js packaging and side-effects and ensure:
- optimization plugins are loaded once with a non breaking configuration (`mangle.keep_fnames = true`)
- locales are not bundled into the common chunk
- vue-strap components are cherry picked instead of all being included into the common chunk

To reduce the size of the common chunk, we will have to:
- fix mangling (probably fixed with Vue.js 2.0 :/)
- ends the jQuery/Bootstrap(.js) drop