### PR TITLE
Transform udata_version jinja global into reusable package_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix assets packaging for production [#763](https://github.com/opendatateam/udata/pull/763) [#765](https://github.com/opendatateam/udata/pull/765)
+- Transform `udata_version` jinja global into a reusable (by themes) `package_version` [#768](https://github.com/opendatateam/udata/pull/768)
 
 ## 1.0.1 (2017-02-16)
 

--- a/udata/frontend/helpers.py
+++ b/udata/frontend/helpers.py
@@ -25,8 +25,8 @@ log = logging.getLogger(__name__)
 
 
 @front.app_template_global()
-def udata_version():
-    return pkg_resources.get_distribution('udata').version
+def package_version(name):
+    return pkg_resources.get_distribution(name).version
 
 
 @front.app_template_global()
@@ -39,7 +39,7 @@ def static_global(filename, _burst=True, **kwargs):
     if current_app.config['DEBUG'] or current_app.config['TESTING']:
         burst = time()
     else:
-        burst = udata_version()
+        burst = package_version('udata')
     if _burst:
         kwargs['_'] = burst
     return url_for('static', filename=filename, **kwargs)

--- a/udata/templates/footer.html
+++ b/udata/templates/footer.html
@@ -1,12 +1,12 @@
 {# Cache footer for 24h #}
-{% cache 86400, 'footer', udata_version() %}
+{% cache 86400, 'footer', package_version('udata') %}
 <footer>
   <div class="container">
     <div class="row">
       <div class="col-lg-12">
         <p>
           <a href="https://github.com/opendatateam/udata/">UData</a>
-          <a href="https://udata.readthedocs.io/en/latest/changelog/">v{{ udata_version() }}</a>
+          <a href="https://pypi.python.org/pypi/udata/{{ package_version('udata') }}/">v{{ package_version('udata') }}</a>
           - Copyright &copy; Opendata Team {{ now()|dateformat(format='yyyy') }}
         </p>
       </div>

--- a/udata/theme.py
+++ b/udata/theme.py
@@ -29,6 +29,7 @@ def get_current_theme():
         g.theme.configure()
     return g.theme
 
+
 current = LocalProxy(get_current_theme)
 
 


### PR DESCRIPTION
This PR allows theme to use package versions in templates (and so allows to perform deep linking to deployed packages)