### PR TITLE
Ensure db.resolve_model only throw ValueError (fix #772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix assets packaging for production [#763](https://github.com/opendatateam/udata/pull/763) [#765](https://github.com/opendatateam/udata/pull/765)
 - Transform `udata_version` jinja global into a reusable (by themes) `package_version` [#768](https://github.com/opendatateam/udata/pull/768)
 - Ensure topics datasets and reuses can display event with a topic parameter [#769](https://github.com/opendatateam/udata/pull/769)
+- Raise a `400 Bad Request` when a bad `class` attribute is provided to the API
+  (for entry point not using forms). [#772](https://github.com/opendatateam/udata/issues/772)
 
 ## 1.0.1 (2017-02-16)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -382,11 +382,10 @@ class ModelField(Field):
                     message = _('Expect both class and identifier')
                     raise validators.ValidationError(message)
 
-            try:
-                model = db.resolve_model(specs['class'])
-            except db.NotRegistered:
-                message = _('{0} does not exists').format(specs['class'])
-                raise validators.ValidationError(message)
+            # No try/except required
+            # In case of error, ValueError is raised
+            # and is properly handled as form validation error
+            model = db.resolve_model(specs['class'])
 
             try:
                 self.data = model.objects.only('id').get(id=clean_oid(specs, model))

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -56,7 +56,7 @@ class UDataMongoEngine(MongoEngine):
         '''
         Resolve a model given a name or dict with `class` entry.
 
-        Conventions are resolved too: DatasetFull will resolve as Dataset
+        :raises ValueError: model specification is wrong or does not exists
         '''
         if not model:
             raise ValueError('Unsupported model specifications')
@@ -67,7 +67,11 @@ class UDataMongoEngine(MongoEngine):
         else:
             raise ValueError('Unsupported model specifications')
 
-        return get_document(classname)
+        try:
+            return get_document(classname)
+        except self.NotRegistered:
+            message = '{0} does not exists'.format(classname)
+            raise ValueError(message)
 
 
 def serialize(value):

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -327,11 +327,11 @@ class ModelResolutionTest(DBTestMixin, TestCase):
         self.assertEqual(db.resolve_model({'class': 'Dataset'}), Dataset)
 
     def test_raise_if_not_found(self):
-        with self.assertRaises(db.NotRegistered):
+        with self.assertRaises(ValueError):
             db.resolve_model('NotFound')
 
     def test_raise_if_not_a_document(self):
-        with self.assertRaises(db.NotRegistered):
+        with self.assertRaises(ValueError):
             db.resolve_model('UDataMongoEngine')
 
     def test_raise_if_none(self):


### PR DESCRIPTION
See #772 

This PR ensures that APIs calling directly `db.resolve_model` without using a form will raise a 400 instead of a 500 (and preserve existing and tested behavior on forms)