### PR TITLE
Added some meta[name=robots] markup to handler crawlers behavior (fix #771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Properly raise 400 error on transfer API in case of bad subject or recipient
   [#784](https://github.com/opendatateam/udata/pull/784)
 - Fix broken OEmbed rendering [#783](https://github.com/opendatateam/udata/issues/783)
+- Improve crawlers behavior by adding some `meta[name=robots]` on pages requiring it
+  [#777](https://github.com/opendatateam/udata/pull/777)
 
 ## 1.0.1 (2017-02-16)
 

--- a/udata/templates/admin.html
+++ b/udata/templates/admin.html
@@ -6,6 +6,7 @@
             'title': _('Admin'),
             'description': 'Administration',
             'keywords': ['administration'],
+            'robots': 'noindex',
         }) }}
         <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport' />
         <link href="{{ static('common.css') }}" rel="stylesheet">

--- a/udata/templates/dataset/list.html
+++ b/udata/templates/dataset/list.html
@@ -4,6 +4,13 @@
 
 {% set toolbar_class='search-toolbar' %}
 
+{% set meta = {
+    'title': _('Datasets'),
+    'description': _("%(site)s dataset search", site=config['SITE_TITLE']),
+    'keywords': [_('search'), _('datasets')],
+    'robots': 'noindex',
+} %}
+
 {% block extra_js %}
 <script src="{{ static('search.js') }}"></script>
 {% endblock %}

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -8,8 +8,10 @@
 <title>{{ title }} - {{ current_site.title }}</title>
 <meta property="og:title" content="{{ title }} - {{ current_site.title }}" />
 <link rel="author" href="{{ config.SITE_AUTHOR_URL }}" />
-{% if config.DISALLOW_INDEXING %}<meta name="robots" content="noindex,nofollow" />{% endif %}
 <meta name="description" content="{{ description }}" />
+{% if config.DISALLOW_INDEXING %}<meta name="robots" content="noindex,nofollow" />
+{% elif meta.robots %}<meta name="robots" content="{{ meta.robots }}" />
+{% endif %}
 <meta property="og:description" content="{{ description }}" />
 <meta property="og:image" content="{{ image }}" />
 <meta name="keywords" content="{{ ', '.join(current_site.keywords + keywords) }}" />

--- a/udata/templates/macros/paginator.html
+++ b/udata/templates/macros/paginator.html
@@ -5,27 +5,27 @@
 <div class="text-center">
     <ul class="pagination">
         <li {% if p.page == 1 %}class="disabled"{% endif %}>
-            <a href="{{ url_rewrite(page=1) }}" title="{% trans %}First page{% endtrans %}">
+            <a href="{{ url_rewrite(page=1) }}" title="{% trans %}First page{% endtrans %}" rel="nofollow">
                 &laquo;
             </a>
         </li>
         <li {% if p.page == 1 %}class="disabled"{% endif %}>
-            <a href="{{ url_rewrite(page=p.page - 1) }}" title="{% trans %}Previous page{% endtrans %}">
+            <a href="{{ url_rewrite(page=p.page - 1) }}" title="{% trans %}Previous page{% endtrans %}" rel="nofollow">
                 &lsaquo;
             </a>
         </li>
         {% for num_page in range(start, end + 1) %}
         <li {% if num_page == p.page %}class="active"{% endif %}>
-            <a href="{{ url_rewrite(page=num_page) }}">{{ num_page }}</a>
+            <a href="{{ url_rewrite(page=num_page) }}" rel="nofollow">{{ num_page }}</a>
         </li>
         {% endfor %}
         <li {% if p.page == p.pages %}class="disabled"{% endif %}>
-            <a href="{{ url_rewrite(page=p.page + 1) }}" title="{% trans %}Next page{% endtrans %}">
+            <a href="{{ url_rewrite(page=p.page + 1) }}" title="{% trans %}Next page{% endtrans %}" rel="nofollow">
                 &rsaquo;
             </a>
         </li>
         <li {% if p.page == p.pages %}class="disabled"{% endif %}>
-            <a href="{{ url_rewrite(page=p.pages) }}" title="{% trans %}Last page{% endtrans %}">
+            <a href="{{ url_rewrite(page=p.pages) }}" title="{% trans %}Last page{% endtrans %}" rel="nofollow">
                 &raquo;
             </a>
         </li>

--- a/udata/templates/organization/list.html
+++ b/udata/templates/organization/list.html
@@ -4,6 +4,13 @@
 
 {% set toolbar_class='search-toolbar' %}
 
+{% set meta = {
+    'title': _('Organizations'),
+    'description': _("%(site)s organization search", site=config['SITE_TITLE']),
+    'keywords': [_('search'), _('organizations')],
+    'robots': 'noindex',
+} %}
+
 {% block extra_js %}
 <script src="{{ static('search.js') }}"></script>
 {% endblock %}

--- a/udata/templates/reuse/list.html
+++ b/udata/templates/reuse/list.html
@@ -4,6 +4,13 @@
 
 {% set toolbar_class='search-toolbar' %}
 
+{% set meta = {
+    'title': _('Reuses'),
+    'description': _("%(site)s reuse search", site=config['SITE_TITLE']),
+    'keywords': [_('search'), _('reuses')],
+    'robots': 'noindex',
+} %}
+
 {% block extra_js %}
 <script src="{{ static('search.js') }}"></script>
 {% endblock %}

--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -8,6 +8,7 @@
     'title': _('Search'),
     'description': _("%(site)s search", site=config['SITE_TITLE']),
     'keywords': [_('search')],
+    'robots': 'noindex',
 } %}
 
 {% set bundle = 'search' %}

--- a/udata/templates/topic/datasets.html
+++ b/udata/templates/topic/datasets.html
@@ -3,6 +3,13 @@
 {% from theme('macros/paginator.html') import paginator with context %}
 {% import theme('macros/search.html') as s %}
 
+{% set meta = {
+    'title': _('%(topic)s datasets', topic=topic.name),
+    'description': _("%(site)s %(topic)s related datasets", site=config['SITE_TITLE'], topic=topic.name),
+    'keywords': [_('search'), _('datasets'), _('topic')] + topic.tags,
+    'robots': 'noindex',
+} %}
+
 {% set toolbar_class='search-toolbar' %}
 {% block breadcrumb %}
     <li>

--- a/udata/templates/topic/reuses.html
+++ b/udata/templates/topic/reuses.html
@@ -3,6 +3,13 @@
 {% from theme('macros/paginator.html') import paginator with context %}
 {% import theme('macros/search.html') as s %}
 
+{% set meta = {
+    'title': _('%(topic)s reuses', topic=topic.name),
+    'description': _("%(site)s %(topic)s related reuses", site=config['SITE_TITLE'], topic=topic.name),
+    'keywords': [_('search'), _('reuses'), _('topic')] + topic.tags,
+    'robots': 'noindex',
+} %}
+
 {% set toolbar_class='search-toolbar' %}
 {% block breadcrumb %}
     <li>

--- a/udata/templates/user/base.html
+++ b/udata/templates/user/base.html
@@ -3,11 +3,12 @@
 
 {% set bundle = 'user' %}
 
-{% block extra_head %}
-{{ super() }}
-<meta name="robots" content="noindex,follow">
-{% endblock %}
-
+{% set meta = {
+    'title': user.fullname,
+    'description': _("%(site)s %(username)s profile", site=config['SITE_TITLE'], username=user.fullname),
+    'keywords': [_('user'), _('profile')],
+    'robots': 'noindex',
+} %}
 
 {% block breadcrumb %}
     <li>{{ _('Users') }}</li>

--- a/udata/templates/user/list.html
+++ b/udata/templates/user/list.html
@@ -4,6 +4,13 @@
 
 {% set toolbar_class='search-toolbar' %}
 
+{% set meta = {
+    'title': _('Users'),
+    'description': _("%(site)s user search", site=config['SITE_TITLE']),
+    'keywords': [_('search'), _('users')],
+    'robots': 'noindex,nofollow',
+} %}
+
 {% block extra_js %}
 <script src="{{ static('search.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR adds support for an optionnal `meta[name=robots]` in templates
and define some nofollow/noindex on some pages to handle crawlers behavior:
- prevent pagination crawling
- prevent search results from being indexed but allows the first page of result to give some weight 
- prevent all user related pages to be indexed
- prevent admin from being indexed

As a side effect, some pages that where missing metadata (title, description...) gains at least a title and a description (for proper preview when sharing on social network)