### PR TITLE
Ensure cached admin levels are callable from workers and command line (fix #778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Ensure topics datasets and reuses can display event with a topic parameter [#769](https://github.com/opendatateam/udata/pull/769)
 - Raise a `400 Bad Request` when a bad `class` attribute is provided to the API
   (for entry point not using forms). [#772](https://github.com/opendatateam/udata/issues/772)
+- Fix datasets with spatial coverage not being indexed [#778](https://github.com/opendatateam/udata/issues/778)
 
 ## 1.0.1 (2017-02-16)
 

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -201,7 +201,7 @@ spatial_granularities = LocalProxy(
     lambda: get_spatial_granularities(get_locale()))
 
 
-@cache.cached(timeout=50)
+@cache.cached(timeout=50, key_prefix='admin_levels')
 def get_spatial_admin_levels():
     return dict((l.id, l.admin_level) for l in GeoLevel.objects)
 


### PR DESCRIPTION
This PR ensure `admin_levels` cache can be accessed from works or commandline.
(simply provide a cache-key as described in the [documentation](https://pythonhosted.org/Flask-Caching/#caching-other-functions).