### PR TITLE
Handle theme assets cache burst (fix #761)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Raise a `400 Bad Request` when a bad `class` attribute is provided to the API
   (for entry point not using forms). [#772](https://github.com/opendatateam/udata/issues/772)
 - Fix datasets with spatial coverage not being indexed [#778](https://github.com/opendatateam/udata/issues/778)
+- Ensure theme assets cache is versionned (and flushed when necessary)
+  [#781](https://github.com/opendatateam/udata/pull/781)
 
 ## 1.0.1 (2017-02-16)
 

--- a/udata/theme.py
+++ b/udata/theme.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import imp
 import logging
+import pkg_resources
 
 from importlib import import_module
 from os.path import join, dirname, isdir, exists
@@ -52,6 +53,9 @@ def theme_static_with_version(ctx, filename, external=False):
         return url
     if current_app.config['DEBUG'] or current_app.config['TESTING']:
         burst = time()
+    elif current.pkg_version:
+        # If a package name is provided for versionning, use it
+        burst = pkg_resources.get_distribution(current.pkg_version).version
     else:
         burst = current.version
     return '?'.join((url, '_={0}'.format(burst)))
@@ -71,6 +75,8 @@ class ConfigurableTheme(Theme):
         if 'default' not in self.variants:
             self.variants.insert(0, 'default')
         self.context_processors = {}
+
+        self.pkg_version = self.info.get('pkg_version')
 
     @property
     def site(self):

--- a/udata/theme.py
+++ b/udata/theme.py
@@ -58,7 +58,7 @@ def theme_static_with_version(ctx, filename, external=False):
         burst = pkg_resources.get_distribution(current.pkg_version).version
     else:
         burst = current.version
-    return '?'.join((url, '_={0}'.format(burst)))
+    return '{url}?_={burst}'.format(url=url, burst=burst)
 
 
 class ConfigurableTheme(Theme):

--- a/udata/themes/default/info.json
+++ b/udata/themes/default/info.json
@@ -7,5 +7,6 @@
     "website": "http://data.gouv.fr",
     "license": "WTF",
     "version": "0.1.0",
+    "pkg_version": "udata",
     "doctype": "html5"
 }


### PR DESCRIPTION
This PR ensure theme assets have a proper cache burst which can be optionnaly extracted from the package version.