### PR TITLE
Fix JS locales handling by reverting to the old behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix JavaScript locales handling [#786](https://github.com/opendatateam/udata/pull/786)
 
 ## 1.0.2 (2017-02-20)
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -12,10 +12,7 @@ export const lang = config.lang;
 const resources = {};
 
 resources[lang] = {};
-// Force split and async loading of locale (and so remove them from common.js)
-require.ensure([], function() {
-  resources[lang][NAMESPACE] = require('locales/' + NAMESPACE + '.' + lang + '.json');
-});
+resources[lang][NAMESPACE] = require('locales/' + NAMESPACE + '.' + lang + '.json');
 
 moment.locale(lang);
 i18next.init({


### PR DESCRIPTION
Right now, i18n in JavaScript doesn't works asynchronously.
This PR revert to the previous behavior (locales packaged into common.js)