### PR TITLE
Optimized imgs for territories placeholders, fix #788

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix JavaScript locales handling [#786](https://github.com/opendatateam/udata/pull/786)
+- Optimize images sizes for territory placeholders [#788](https://github.com/opendatateam/udata/issues/788)
 
 ## 1.0.2 (2017-02-20)
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -320,7 +320,7 @@
                     <div class="panel-body">
                         <h3>{{ _('Territories')}}</h3>
                         {% for territory in dataset.spatial.handled_zones %}
-                            <img src="{{ territory.logo_url(external=True) or theme_static('img/placeholder_territory.png') }}" alt="{{ territory.name }}" class="float-left" width="13px" /> <a href="{{ territory.url }}" title="{{ territory.name }}">{{ territory.name }}</a>{% if not loop.last %}, {% endif %}
+                            <img src="{{ territory.logo_url(external=True) or theme_static('img/placeholder_territory_mini.png') }}" alt="{{ territory.name }}" class="float-left" width="13px" /> <a href="{{ territory.url }}" title="{{ territory.name }}">{{ territory.name }}</a>{% if not loop.last %}, {% endif %}
                         {% endfor %}
                     </div>
                 </div>

--- a/udata/templates/territories/county.html
+++ b/udata/templates/territories/county.html
@@ -40,7 +40,7 @@
                     <ul class="list-unstyled territories-list">
                         {% for town in territory.children[:8] %}
                             <li>
-                                <img src="{{ town.logo_url(external=True) or theme_static('img/placeholder_territory.png', external=True) }}" alt="{{ town.name }}" class="float-left" width="13px" />
+                                <img src="{{ town.logo_url(external=True) or theme_static('img/placeholder_territory_mini.png', external=True) }}" alt="{{ town.name }}" class="float-left" width="13px" />
                                 <a href="{{ town.url }}"> {{ town.name }}</a>
                             </li>
                         {% endfor %}

--- a/udata/templates/territories/region.html
+++ b/udata/templates/territories/region.html
@@ -53,7 +53,7 @@
                     <ul class="list-unstyled territories-list">
                         {% for county in territory.children[:8] %}
                             <li>
-                                <img src="{{ county.logo_url(external=True) or theme_static('img/placeholder_territory.png', external=True) }}" alt="{{ county.name }}" class="float-left" width="13px" />
+                                <img src="{{ county.logo_url(external=True) or theme_static('img/placeholder_territory_mini.png', external=True) }}" alt="{{ county.name }}" class="float-left" width="13px" />
                                 <a href="{{ county.url }}"> {{ county.name }}</a>
                             </li>
                         {% endfor %}

--- a/udata/templates/territories/search-result.html
+++ b/udata/templates/territories/search-result.html
@@ -1,11 +1,11 @@
 {% cache cache_duration, 'territory-search-result', territory.id, g.lang_code %}
-{% set logo=territory.logo_url() or theme_static('img/placeholder_territory.png') %}
+{% set logo=territory.logo_url() or theme_static('img/placeholder_territory_medium.png') %}
 <li class="search-result territory-result">
     <a href="{{ territory.url }}" title="{{ territory.name }}">
         <div class="result-logo pull-left">
             <img alt="{{ territory.name }}"
                 src="{{ logo }}"
-                width="70" height="70">
+                width="64" height="70">
         </div>
         <div class="result-body ellipsis-dot">
             <h4 class="result-title">{{ territory.html_title|safe }}</h4>


### PR DESCRIPTION
See gouvfr counterpart: https://github.com/etalab/udata-gouvfr/pull/158