### PR TITLE
Fix share popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix JavaScript locales handling [#786](https://github.com/opendatateam/udata/pull/786)
 - Optimize images sizes for territory placeholders [#788](https://github.com/opendatateam/udata/issues/788)
+- Fix share popover in production build [#793](https://github.com/opendatateam/udata/pull/793)
 
 ## 1.0.2 (2017-02-20)
 

--- a/js/components/buttons/share.vue
+++ b/js/components/buttons/share.vue
@@ -2,7 +2,7 @@
 <button type="button" class="btn btn-primary btn-share" :title="_('Share')" v-tooltip
     v-popover popover-large :popover-title="_('Share')">
     <span class="fa fa-share-alt"></span>
-    <div class="btn-group btn-group-lg" slot="content" v-popover-content>
+    <div class="btn-group btn-group-lg" data-popover-content>
         <a class="btn btn-link" title="Google+" @click="click"
             href="https://plus.google.com/share?url={{url|encode}}" target="_blank">
             <span class="fa fa-2x fa-google-plus"></span>

--- a/js/plugins/tooltips.js
+++ b/js/plugins/tooltips.js
@@ -93,6 +93,12 @@ export function install(Vue) {
                 }
             }, popover));
 
+            // Transclude child content if found
+            const content = this.el.querySelector('[data-popover-content]');
+            if (content) {
+                this.popover.content = content;
+            }
+
             switch(this.trigger) {
                 case 'hover':
                     this._mouseenterHandler = this.el.addEventListener('mouseenter', this.showPopover.bind(this));
@@ -140,38 +146,6 @@ export function install(Vue) {
             popoverTitle(value) {
                 this.popover.title = value;
             },
-        }
-    });
-
-    /**
-     * Attach a popover on the element.
-     */
-    Vue.directive('popover-content', {
-        /**
-         * Transclude the popover content into the popover
-         */
-        bind() {
-            const popover = this.findPopover();
-            if (!popover) {
-                log.error('popover-content need a parent popover directive');
-                return;
-            }
-            popover.content = this.el;
-        },
-        /**
-         * Find the closest parent node with a popover directive.
-         * @return {Vue} The target popover component
-         */
-        findPopover() {
-            let el = this.el;
-            while (el.parentElement) {
-                el = el.parentElement;
-                if (el._vue_directives) {
-                    for (const directive of el._vue_directives) {
-                        if (directive.name === 'popover') return directive.popover;
-                    }
-                }
-            }
         }
     });
 }


### PR DESCRIPTION
Currently the share popover is broken on the production build:

![screenshot-next data gouv fr 2017-02-20 23-17-13](https://cloud.githubusercontent.com/assets/15725/23162141/19895a7c-f82d-11e6-94dd-90acca7d0589.png)

This PR refactor a little bit the `popover` transclusion to work in production mode.

This current implementation was relying on Vue.js debug symbols (ie. `_vue_directives` attribute on elements).

The gain is double:
- one directive deleted
- now rely on native `querySelector`