### PR TITLE
DB tuning on GenericReferenceField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix badges trying to use API too early
   [#799](https://github.com/opendatateam/udata/pull/799)
+- Some minor tuning on generic references
+  [#801](https://github.com/opendatateam/udata/pull/801)
 
 ## 1.0.3 (2017-02-21)
 

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -144,8 +144,8 @@ class DiscussionsAPI(API):
             discussions = discussions(closed=None)
         elif args['closed'] is True:
             discussions = discussions(closed__ne=None)
-        return (discussions.order_by(args['sort'])
-                           .paginate(args['page'], args['page_size']))
+        discussions = discussions.order_by(args['sort'])
+        return discussions.paginate(args['page'], args['page_size'])
 
     @api.secure
     @api.doc('create_discussion')

--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -28,9 +28,9 @@ class Discussion(db.Document):
         'indexes': [
             'user',
             'subject',
-            'created'
+            '-created'
         ],
-        'ordering': ['created'],
+        'ordering': ['-created'],
     }
 
     def person_involved(self, person):

--- a/udata/core/issues/api.py
+++ b/udata/core/issues/api.py
@@ -129,8 +129,8 @@ class IssuesAPI(API):
             issues = issues(closed=None)
         elif args['closed'] is True:
             issues = issues(closed__ne=None)
-        return (issues.order_by(args['sort'])
-                      .paginate(args['page'], args['page_size']))
+        issues = issues.order_by(args['sort'])
+        return issues.paginate(args['page'], args['page_size'])
 
     @api.secure
     @api.doc('create_issue')

--- a/udata/core/issues/models.py
+++ b/udata/core/issues/models.py
@@ -30,7 +30,7 @@ class Issue(db.Document):
         'indexes': [
             'user',
             'subject',
-            'created'
+            '-created'
         ],
-        'ordering': ['created'],
+        'ordering': ['-created'],
     }

--- a/udata/migrations/2017-02-23-references-indexes.js
+++ b/udata/migrations/2017-02-23-references-indexes.js
@@ -1,0 +1,13 @@
+/*
+ * Manually created indexes that can't be expressed with mongoengine
+ */
+
+// Index on discussion.subject.id with and without default order
+db.discussion.createIndex({'subject._ref.$id': 1});
+db.discussion.createIndex({'subject._ref.$id': 1, 'created': -1});
+print('Created missing indexes on db.discussion');
+
+// Index on issue.subject.id with and without default order
+db.issue.createIndex({'subject._ref.$id': 1});
+db.issue.createIndex({'subject._ref.$id': 1, 'created': -1});
+print('Created missing indexes on db.issue');


### PR DESCRIPTION
This PR apply some little tuning on disucssions and issues retrieval:
- optimize the DB query when filtering on a single ID
- ensure indexes and default order match the one provided as default from the API
- manualy create the indexes that monoengine can't express (`subject.id`)