### PR TITLE
User metric fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#801](https://github.com/opendatateam/udata/pull/801)
 - Cleanup factories
   [#808](https://github.com/opendatateam/udata/pull/808)
+- Fix user default metrics not being set [migration]
+  [#809](https://github.com/opendatateam/udata/pull/809)
 
 ## 1.0.3 (2017-02-21)
 

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -42,7 +42,7 @@ class UserSettings(db.EmbeddedDocument):
     prefered_language = db.StringField()
 
 
-class User(db.Document, WithMetrics, UserMixin):
+class User(WithMetrics, UserMixin, db.Document):
     slug = db.SlugField(
         max_length=255, required=True, populate_from='fullname')
     email = db.StringField(max_length=255, required=True, unique=True)

--- a/udata/migrations/2017-02-25-missing-user-metrics.js
+++ b/udata/migrations/2017-02-25-missing-user-metrics.js
@@ -1,0 +1,26 @@
+/*
+ * Set default metric values on users
+ */
+
+const DEFAULT_METRICS = {
+    'datasets': 0,
+    'reuses': 0,
+    'following': 0,
+    'followers': 0,
+};
+
+var count = 0;
+const users = db.user.find({$or: [
+    {'metrics.datasets': {$exists: false}},
+    {'metrics.reuses': {$exists: false}},
+    {'metrics.following': {$exists: false}},
+    {'metrics.followers': {$exists: false}},
+]});
+
+users.forEach(function(user) {
+    user.metrics = Object.assign({}, DEFAULT_METRICS, users.metrics || {});
+    db.user.save(user);
+    count++;
+});
+
+print(`Updated ${count} user(s) missing metrics`);

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -19,6 +19,7 @@ from udata.core.issues.factories import IssueFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.user.factories import UserFactory
+from udata.i18n import _
 from udata.utils import faker
 
 from . import APITestCase
@@ -31,7 +32,7 @@ class MeAPITest(APITestCase):
         self.login()
         response = self.get(url_for('api.me'))
         self.assert200(response)
-        # self.assertEqual(response.json['email'], self.user.email)
+        self.assertEqual(response.json['email'], self.user.email)
         self.assertEqual(response.json['first_name'], self.user.first_name)
         self.assertEqual(response.json['roles'], [])
 
@@ -368,7 +369,7 @@ class MeAPITest(APITestCase):
             response = self.delete(url_for('api.me'))
         self.assertEqual(len(mails), 1)
         self.assertEqual(mails[0].send_to, set([user.email]))
-        self.assertEqual(mails[0].subject, 'Account deletion')
+        self.assertEqual(mails[0].subject, _('Account deletion'))
         self.assert204(response)
 
         user.reload()


### PR DESCRIPTION
This PR fix user metrics not being initialized and some other undetected bugs and provides default metrics for existing users (migration).

Also fix a local dependant test on Me API
