### PR TITLE
Update metrics on transfer/owner change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [#808](https://github.com/opendatateam/udata/pull/808)
 - Fix user default metrics not being set [migration]
   [#809](https://github.com/opendatateam/udata/pull/809)
+- Fix metric update after transfer
+  [#810](https://github.com/opendatateam/udata/pull/810)
 
 ## 1.0.3 (2017-02-21)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -12,9 +12,7 @@ from mongoengine.fields import DateTimeField
 from werkzeug import cached_property
 
 from udata.frontend.markdown import mdstrip
-from udata.models import (
-    db, WithMetrics, BadgeMixin, SpatialCoverage, OwnedByQuerySet
-)
+from udata.models import db, WithMetrics, BadgeMixin, SpatialCoverage
 from udata.i18n import lazy_gettext as _
 from udata.utils import hash_url
 
@@ -107,7 +105,7 @@ class License(db.Document):
         return self.title
 
 
-class DatasetQuerySet(OwnedByQuerySet):
+class DatasetQuerySet(db.OwnedQuerySet):
     def visible(self):
         return self(private__ne=True, resources__0__exists=True, deleted=None)
 
@@ -236,7 +234,7 @@ class Resource(ResourceMixin, WithMetrics, db.EmbeddedDocument):
     on_deleted = signal('Resource.on_deleted')
 
 
-class Dataset(WithMetrics, BadgeMixin, db.Document):
+class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
     created_at = DateTimeField(verbose_name=_('Creation date'),
                                default=datetime.now, required=True)
     last_modified = DateTimeField(verbose_name=_('Last modification date'),
@@ -251,9 +249,6 @@ class Dataset(WithMetrics, BadgeMixin, db.Document):
     resources = db.ListField(db.EmbeddedDocumentField(Resource))
 
     private = db.BooleanField()
-    owner = db.ReferenceField('User', reverse_delete_rule=db.NULLIFY)
-    organization = db.ReferenceField('Organization',
-                                     reverse_delete_rule=db.NULLIFY)
     frequency = db.StringField(choices=UPDATE_FREQUENCIES.keys())
     frequency_date = db.DateTimeField(verbose_name=_('Future date of update'))
     temporal_coverage = db.EmbeddedDocumentField(db.DateRange)
@@ -276,14 +271,12 @@ class Dataset(WithMetrics, BadgeMixin, db.Document):
     }
 
     meta = {
-        'allow_inheritance': True,
         'indexes': [
             '-created_at',
             'slug',
-            'organization',
             'resources.id',
             'resources.urlhash',
-        ],
+        ] + db.Owned.meta['indexes'],
         'ordering': ['-created_at'],
         'queryset_class': DatasetQuerySet,
     }
@@ -560,19 +553,16 @@ pre_save.connect(Dataset.pre_save, sender=Dataset)
 post_save.connect(Dataset.post_save, sender=Dataset)
 
 
-class CommunityResource(ResourceMixin, WithMetrics, db.Document):
+class CommunityResource(ResourceMixin, WithMetrics, db.Owned, db.Document):
     '''
     Local file, remote file or API added by the community of the users to the
     original dataset
     '''
     dataset = db.ReferenceField(Dataset)
-    owner = db.ReferenceField('User', reverse_delete_rule=db.NULLIFY)
-    organization = db.ReferenceField(
-        'Organization', reverse_delete_rule=db.NULLIFY)
 
     meta = {
         'ordering': ['-created_at'],
-        'queryset_class': OwnedByQuerySet,
+        'queryset_class': db.OwnedQuerySet,
     }
 
     @property

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -9,7 +9,7 @@ from werkzeug import cached_property
 from udata.core.storages import images, default_image_basename
 from udata.frontend.markdown import mdstrip
 from udata.i18n import lazy_gettext as _
-from udata.models import db, BadgeMixin, WithMetrics, OwnedByQuerySet
+from udata.models import db, BadgeMixin, WithMetrics
 from udata.utils import hash_url
 
 __all__ = ('Reuse', 'REUSE_TYPES')
@@ -31,7 +31,7 @@ IMAGE_SIZES = [100, 50, 25]
 IMAGE_MAX_SIZE = 800
 
 
-class ReuseQuerySet(OwnedByQuerySet):
+class ReuseQuerySet(db.OwnedQuerySet):
     def visible(self):
         return self(private__ne=True, datasets__0__exists=True, deleted=None)
 
@@ -41,7 +41,7 @@ class ReuseQuerySet(OwnedByQuerySet):
                     db.Q(deleted__ne=None))
 
 
-class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Document):
+class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Owned, db.Document):
     title = db.StringField(required=True)
     slug = db.SlugField(
         max_length=255, required=True, populate_from='title', update=True)
@@ -59,9 +59,6 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Document):
     # badges = db.ListField(db.EmbeddedDocumentField(ReuseBadge))
 
     private = db.BooleanField()
-    owner = db.ReferenceField('User', reverse_delete_rule=db.NULLIFY)
-    organization = db.ReferenceField(
-        'Organization', reverse_delete_rule=db.NULLIFY)
 
     ext = db.MapField(db.GenericEmbeddedDocumentField())
     extras = db.ExtrasField()
@@ -77,8 +74,7 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Document):
     __badges__ = {}
 
     meta = {
-        'allow_inheritance': True,
-        'indexes': ['-created_at', 'owner', 'urlhash'],
+        'indexes': ['-created_at', 'urlhash'] + db.Owned.meta['indexes'],
         'ordering': ['-created_at'],
         'queryset_class': ReuseQuerySet,
     }

--- a/udata/features/transfer/actions.py
+++ b/udata/features/transfer/actions.py
@@ -46,10 +46,8 @@ def accept_transfer(transfer, comment=None):
     recipient = transfer.recipient
     if isinstance(recipient, Organization):
         subject.organization = recipient
-        subject.owner = None
     elif isinstance(recipient, User):
         subject.owner = recipient
-        subject.organization = None
 
     subject.save()
 

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -3,19 +3,13 @@ from __future__ import unicode_literals
 import importlib
 import logging
 
-from collections import Iterable
-
 from bson import ObjectId, DBRef
-from flask_mongoengine import (
-    MongoEngine, MongoEngineSessionInterface, Document, BaseQuerySet
-)
+from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 from mongoengine.base import TopLevelDocumentMetaclass, get_document
 from mongoengine.errors import ValidationError
 from mongoengine.signals import pre_save, post_save
 
 from flask_fs.mongo import FileField, ImageField
-
-from udata.utils import Paginable
 
 from .badges_field import BadgesField
 from .taglist_field import TagListField
@@ -23,6 +17,9 @@ from .datetime_fields import DateField, DateRange, Datetimed
 from .extras_fields import ExtrasField, Extra
 from .slug_fields import SlugField
 from .uuid_fields import AutoUUIDField
+from .owned import Owned, OwnedQuerySet
+from .queryset import UDataQuerySet
+from .document import UDataDocument, DomainModel
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +46,8 @@ class UDataMongoEngine(MongoEngine):
         self.ValidationError = ValidationError
         self.ObjectId = ObjectId
         self.DBRef = DBRef
+        self.Owned = Owned
+        self.OwnedQuerySet = OwnedQuerySet
         self.post_save = post_save
         self.pre_save = pre_save
 
@@ -74,134 +73,8 @@ class UDataMongoEngine(MongoEngine):
             raise ValueError(message)
 
 
-def serialize(value):
-    if hasattr(value, 'to_dict'):
-        return value.to_dict()
-    elif isinstance(value, Iterable) and not isinstance(value, basestring):
-        return [serialize(val) for val in value]
-    else:
-        return value
-
-
-class DBPaginator(Paginable):
-    '''A simple paginable implementation'''
-    def __init__(self, queryset):
-        self.queryset = queryset
-
-    def __iter__(self):
-        return iter(self.queryset.items)
-
-    def __len__(self):
-        return len(self.queryset.items)
-
-    @property
-    def page(self):
-        return self.queryset.page
-
-    @property
-    def page_size(self):
-        return self.queryset.per_page
-
-    @property
-    def total(self):
-        return self.queryset.total
-
-    @property
-    def objects(self):
-        return self.queryset.items
-
-
-class UDataQuerySet(BaseQuerySet):
-    def paginate(self, page, per_page, error_out=True):
-        result = super(UDataQuerySet, self).paginate(page, per_page, error_out)
-        return DBPaginator(result)
-
-    def bulk_list(self, ids):
-        data = self.in_bulk(ids)
-        return [data[id] for id in ids]
-
-    def get_or_create(self, write_concern=None, auto_save=True,
-                      *q_objs, **query):
-        """Retrieve unique object or create, if it doesn't exist.
-
-        Returns a tuple of ``(object, created)``, where ``object`` is
-        the retrieved or created object and ``created`` is a boolean
-        specifying whether a new object was created.
-
-        Taken back from:
-
-        https://github.com/MongoEngine/mongoengine/
-        pull/1029/files#diff-05c70acbd0634d6d05e4a6e3a9b7d66b
-        """
-        defaults = query.pop('defaults', {})
-        try:
-            doc = self.get(*q_objs, **query)
-            return doc, False
-        except self._document.DoesNotExist:
-            query.update(defaults)
-            doc = self._document(**query)
-
-            if auto_save:
-                doc.save(write_concern=write_concern)
-            return doc, True
-
-    def generic_in(self, **kwargs):
-        '''Bypass buggy GenericReferenceField querying issue'''
-        query = {}
-        for key, value in kwargs.items():
-            if not value:
-                continue
-            # Optimize query for when there is only one value
-            if isinstance(value, (list, tuple)) and len(value) == 1:
-                value = value[0]
-            if isinstance(value, (list, tuple)):
-                if all(isinstance(v, basestring) for v in value):
-                    ids = [ObjectId(v) for v in value]
-                    query['{0}._ref.$id'.format(key)] = {'$in': ids}
-                elif all(isinstance(v, DBRef) for v in value):
-                    query['{0}._ref'.format(key)] = {'$in': value}
-                elif all(isinstance(v, ObjectId) for v in value):
-                    query['{0}._ref.$id'.format(key)] = {'$in': value}
-            elif isinstance(value, ObjectId):
-                query['{0}._ref.$id'.format(key)] = value
-            elif isinstance(value, basestring):
-                query['{0}._ref.$id'.format(key)] = ObjectId(value)
-            else:
-                self.error('expect a list of string, ObjectId or DBRef')
-        return self(__raw__=query)
-
-
-class UDataDocument(Document):
-    meta = {
-        'abstract': True,
-        'queryset_class': UDataQuerySet,
-    }
-
-    def to_dict(self, exclude=None):
-        excluded_keys = set(exclude or [])
-        excluded_keys.add('_cls')
-        return dict((
-            (key, serialize(value))
-            for key, value in self.to_mongo().items()
-            if key not in excluded_keys
-        ))
-
-
-class DomainModel(UDataDocument):
-    '''Placeholder for inheritance'''
-    pass
-
-
 db = UDataMongoEngine()
 session_interface = MongoEngineSessionInterface(db)
-
-
-class OwnedByQuerySet(db.BaseQuerySet):
-    def owned_by(self, *owners):
-        qs = db.Q()
-        for owner in owners:
-            qs |= db.Q(owner=owner) | db.Q(organization=owner)
-        return self(qs)
 
 
 # Load all core models and mixins

--- a/udata/models/document.py
+++ b/udata/models/document.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+from collections import Iterable
+
+from flask_mongoengine import Document
+
+from .queryset import UDataQuerySet
+
+log = logging.getLogger(__name__)
+
+
+def serialize(value):
+    if hasattr(value, 'to_dict'):
+        return value.to_dict()
+    elif isinstance(value, Iterable) and not isinstance(value, basestring):
+        return [serialize(val) for val in value]
+    else:
+        return value
+
+
+class UDataDocument(Document):
+    meta = {
+        'abstract': True,
+        'queryset_class': UDataQuerySet,
+    }
+
+    def to_dict(self, exclude=None):
+        excluded_keys = set(exclude or [])
+        excluded_keys.add('_cls')
+        return dict((
+            (key, serialize(value))
+            for key, value in self.to_mongo().items()
+            if key not in excluded_keys
+        ))
+
+
+class DomainModel(UDataDocument):
+    '''Placeholder for inheritance'''
+    pass

--- a/udata/models/owned.py
+++ b/udata/models/owned.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+from blinker import signal
+from mongoengine import NULLIFY, Q, pre_save, post_save
+from mongoengine.fields import ReferenceField
+
+from .queryset import UDataQuerySet
+
+log = logging.getLogger(__name__)
+
+
+class OwnedQuerySet(UDataQuerySet):
+    def owned_by(self, *owners):
+        qs = Q()
+        for owner in owners:
+            qs |= Q(owner=owner) | Q(organization=owner)
+        return self(qs)
+
+
+class Owned(object):
+    '''
+    A mixin to factorize owning behvaior between users and organizations.
+    '''
+    owner = ReferenceField('User', reverse_delete_rule=NULLIFY)
+    organization = ReferenceField('Organization', reverse_delete_rule=NULLIFY)
+
+    on_owner_change = signal('Owned.on_owner_change')
+
+    meta = {
+        'indexes': [
+            'owner',
+            'organization',
+        ],
+        'queryset_class': OwnedQuerySet,
+    }
+
+
+def owned_pre_save(sender, document, **kwargs):
+    '''
+    Owned mongoengine.pre_save signal handler
+    Need to fetch original owner before the new one erase it.
+    '''
+    if not isinstance(document, Owned):
+        return
+    changed_fields = getattr(document, '_changed_fields', [])
+    if 'organization' in changed_fields:
+        if document.owner:
+            # Change from owner to organization
+            document._previous_owner = document.owner
+            document.owner = None
+        else:
+            # Change from org to another
+            # Need to fetch previous value in base
+            original = sender.objects.only('organization').get(pk=document.pk)
+            document._previous_owner = original.organization
+    elif 'owner' in changed_fields:
+        if document.organization:
+            # Change from organization to owner
+            document._previous_owner = document.organization
+            document.organization = None
+        else:
+            # Change from owner to another
+            # Need to fetch previous value in base
+            original = sender.objects.only('owner').get(pk=document.pk)
+            document._previous_owner = original.owner
+
+
+def owned_post_save(sender, document, **kwargs):
+    '''
+    Owned mongoengine.post_save signal handler
+    Dispatch the `Owned.on_owner_change` signal
+    once the document has been saved including the previous owner.
+
+    The signal handler should have the following signature:
+    ``def handler(document, previous)``
+    '''
+    if isinstance(document, Owned) and hasattr(document, '_previous_owner'):
+        Owned.on_owner_change.send(document, previous=document._previous_owner)
+
+
+pre_save.connect(owned_pre_save)
+post_save.connect(owned_post_save)

--- a/udata/models/queryset.py
+++ b/udata/models/queryset.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+from bson import ObjectId, DBRef
+from flask_mongoengine import BaseQuerySet
+
+from udata.utils import Paginable
+
+log = logging.getLogger(__name__)
+
+
+class DBPaginator(Paginable):
+    '''A simple paginable implementation'''
+    def __init__(self, queryset):
+        self.queryset = queryset
+
+    def __iter__(self):
+        return iter(self.queryset.items)
+
+    def __len__(self):
+        return len(self.queryset.items)
+
+    @property
+    def page(self):
+        return self.queryset.page
+
+    @property
+    def page_size(self):
+        return self.queryset.per_page
+
+    @property
+    def total(self):
+        return self.queryset.total
+
+    @property
+    def objects(self):
+        return self.queryset.items
+
+
+class UDataQuerySet(BaseQuerySet):
+    def paginate(self, page, per_page, error_out=True):
+        result = super(UDataQuerySet, self).paginate(page, per_page, error_out)
+        return DBPaginator(result)
+
+    def bulk_list(self, ids):
+        data = self.in_bulk(ids)
+        return [data[id] for id in ids]
+
+    def get_or_create(self, write_concern=None, auto_save=True,
+                      *q_objs, **query):
+        """Retrieve unique object or create, if it doesn't exist.
+
+        Returns a tuple of ``(object, created)``, where ``object`` is
+        the retrieved or created object and ``created`` is a boolean
+        specifying whether a new object was created.
+
+        Taken back from:
+
+        https://github.com/MongoEngine/mongoengine/
+        pull/1029/files#diff-05c70acbd0634d6d05e4a6e3a9b7d66b
+        """
+        defaults = query.pop('defaults', {})
+        try:
+            doc = self.get(*q_objs, **query)
+            return doc, False
+        except self._document.DoesNotExist:
+            query.update(defaults)
+            doc = self._document(**query)
+
+            if auto_save:
+                doc.save(write_concern=write_concern)
+            return doc, True
+
+    def generic_in(self, **kwargs):
+        '''Bypass buggy GenericReferenceField querying issue'''
+        query = {}
+        for key, value in kwargs.items():
+            if not value:
+                continue
+            # Optimize query for when there is only one value
+            if isinstance(value, (list, tuple)) and len(value) == 1:
+                value = value[0]
+            if isinstance(value, (list, tuple)):
+                if all(isinstance(v, basestring) for v in value):
+                    ids = [ObjectId(v) for v in value]
+                    query['{0}._ref.$id'.format(key)] = {'$in': ids}
+                elif all(isinstance(v, DBRef) for v in value):
+                    query['{0}._ref'.format(key)] = {'$in': value}
+                elif all(isinstance(v, ObjectId) for v in value):
+                    query['{0}._ref.$id'.format(key)] = {'$in': value}
+            elif isinstance(value, ObjectId):
+                query['{0}._ref.$id'.format(key)] = value
+            elif isinstance(value, basestring):
+                query['{0}._ref.$id'.format(key)] = ObjectId(value)
+            else:
+                self.error('expect a list of string, ObjectId or DBRef')
+        return self(__raw__=query)

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -18,43 +18,6 @@ from .. import TestCase, DBTestMixin
 
 
 class DatasetModelTest(TestCase, DBTestMixin):
-    def test_owned_by_user(self):
-        user = UserFactory()
-        dataset = DatasetFactory(owner=user)
-        DatasetFactory(owner=UserFactory())
-
-        result = Dataset.objects.owned_by(user)
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], dataset)
-
-    def test_owned_by_org(self):
-        org = OrganizationFactory()
-        dataset = DatasetFactory(organization=org)
-        DatasetFactory(organization=OrganizationFactory())
-
-        result = Dataset.objects.owned_by(org)
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], dataset)
-
-    def test_owned_by_org_or_user(self):
-        user = UserFactory()
-        org = OrganizationFactory()
-        datasets = [DatasetFactory(owner=user),
-                    DatasetFactory(organization=org)]
-        excluded = [DatasetFactory(owner=UserFactory()),
-                    DatasetFactory(organization=OrganizationFactory())]
-
-        result = Dataset.objects.owned_by(org, user)
-
-        self.assertEqual(len(result), 2)
-        for dataset in result:
-            self.assertIn(dataset, datasets)
-
-        for dataset in excluded:
-            self.assertNotIn(dataset, result)
-
     def test_add_resource(self):
         user = UserFactory()
         dataset = DatasetFactory(owner=user)

--- a/udata/tests/test_owned.py
+++ b/udata/tests/test_owned.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from udata.core.organization.factories import OrganizationFactory
+from udata.core.organization.models import Organization
+from udata.core.user.factories import UserFactory
+from udata.core.user.models import User
+
+from udata.models import db
+
+from udata.tests import TestCase, DBTestMixin
+
+
+class Owned(db.Owned, db.Document):
+    name = db.StringField()
+
+
+class TestOwnedMixin(DBTestMixin, TestCase):
+    def test_fields(self):
+        self.assertIsInstance(Owned.owner, db.ReferenceField)
+        self.assertEqual(Owned.owner.document_type_obj, User)
+
+        self.assertIsInstance(Owned.organization, db.ReferenceField)
+        self.assertEqual(Owned.organization.document_type_obj, Organization)
+
+    def test_owner_changed_from_user_to_user(self):
+        first_owner = UserFactory()
+        second_owner = UserFactory()
+        owned = Owned.objects.create(owner=first_owner)
+
+        def handler(document, previous):
+            self.assertEqual(document, owned)
+            self.assertEqual(document.owner, second_owner)
+            self.assertIsNone(document.organization)
+            self.assertEqual(previous, first_owner)
+            handler.called = True
+
+        with Owned.on_owner_change.connected_to(handler):
+            owned.owner = second_owner
+            owned.save()
+
+        self.assertTrue(getattr(handler, 'called', False))
+
+    def test_owner_changed_from_user_to_org(self):
+        owner = UserFactory()
+        org = OrganizationFactory()
+        owned = Owned.objects.create(owner=owner)
+
+        def handler(document, previous):
+            self.assertEqual(document, owned)
+            self.assertIsNone(document.owner)
+            self.assertEqual(document.organization, org)
+            self.assertEqual(previous, owner)
+            handler.called = True
+
+        with Owned.on_owner_change.connected_to(handler):
+            owned.organization = org
+            owned.save()
+
+        self.assertTrue(getattr(handler, 'called', False))
+
+    def test_owner_changed_from_org_to_org(self):
+        first_org = OrganizationFactory()
+        second_org = OrganizationFactory()
+        owned = Owned.objects.create(organization=first_org)
+
+        def handler(document, previous):
+            self.assertEqual(document, owned)
+            self.assertIsNone(document.owner)
+            self.assertEqual(document.organization, second_org)
+            self.assertEqual(previous, first_org)
+            handler.called = True
+
+        with Owned.on_owner_change.connected_to(handler):
+            owned.organization = second_org
+            owned.save()
+
+        self.assertTrue(getattr(handler, 'called', False))
+
+    def test_owner_changed_from_org_to_user(self):
+        user = UserFactory()
+        org = OrganizationFactory()
+        owned = Owned.objects.create(organization=org)
+
+        def handler(document, previous):
+            self.assertEqual(document, owned)
+            self.assertEqual(document.owner, user)
+            self.assertIsNone(document.organization)
+            self.assertEqual(previous, org)
+            handler.called = True
+
+        with Owned.on_owner_change.connected_to(handler):
+            owned.owner = user
+            owned.save()
+
+        self.assertTrue(getattr(handler, 'called', False))
+
+
+class OwnedQuerysetTest(DBTestMixin, TestCase):
+    def test_queryset_type(self):
+        self.assertIsInstance(Owned.objects, db.OwnedQuerySet)
+
+    def test_owned_by_user(self):
+        user = UserFactory()
+        owned = Owned.objects.create(owner=user)
+        Owned.objects.create(owner=UserFactory())
+
+        result = Owned.objects.owned_by(user)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], owned)
+
+    def test_owned_by_org(self):
+        org = OrganizationFactory()
+        owned = Owned.objects.create(organization=org)
+        Owned.objects.create(organization=OrganizationFactory())
+
+        result = Owned.objects.owned_by(org)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], owned)
+
+    def test_owned_by_org_or_user(self):
+        user = UserFactory()
+        org = OrganizationFactory()
+        owneds = [Owned.objects.create(owner=user),
+                  Owned.objects.create(organization=org)]
+        excluded = [Owned.objects.create(owner=UserFactory()),
+                    Owned.objects.create(organization=OrganizationFactory())]
+
+        result = Owned.objects.owned_by(org, user)
+
+        self.assertEqual(len(result), 2)
+        for owned in result:
+            self.assertIn(owned, owneds)
+
+        for owned in excluded:
+            self.assertNotIn(owned, result)


### PR DESCRIPTION
This PR fix metrics not being updated after transfer for initial owner (organization or user):
- factorize the owning behavior into a tested mixin, ensuring all owned items have the same behavior and allowing to detect owner change
- split the big `models/__init__.py` into modules (`models/queryset.py`, `models/document.py`)
- test and fix transfer acceptation => fix metrics not being updated after transfer

Tests require #809 to pass