### PR TITLE
Make spatial completion ponderation f(level, population) with priority on level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [#809](https://github.com/opendatateam/udata/pull/809)
 - Fix metric update after transfer
   [#810](https://github.com/opendatateam/udata/pull/810)
+- Improve spatial completion ponderation (spatial zones reindexation required)
+  [#811](https://github.com/opendatateam/udata/pull/811)
 
 ## 1.0.3 (2017-02-21)
 


### PR DESCRIPTION
This PR try to enhance spatial completion for zones with short name and few population (or no population data available) by taking in account administrative level and area.
The algorithm gives priority to the administrative level and then optionally to the population.
It could be enhanced with the area too which is also available.