### PR TITLE
Flask Mongoengine WTForms update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Upgrade to Flask-Mongoengine 0.9.2, Flask-WTF 0.14.2, mongoengine 0.11.0.
 
 ## 1.0.4 (2017-03-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Upgrade to Flask-Mongoengine 0.9.2, Flask-WTF 0.14.2, mongoengine 0.11.0.
+  [#812](https://github.com/opendatateam/udata/pull/812)
 
 ## 1.0.4 (2017-03-01)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -23,7 +23,7 @@ Flask-Script==2.0.5
 Flask-Security==1.7.5
 Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 Flask==0.12
 html2text==2016.9.19
 lxml==3.7.3

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -39,7 +39,7 @@ redis==2.10.5
 requests==2.13.0
 unicodecsv==0.14.1
 voluptuous==0.9.3
-wtforms-json==0.2.10
+wtforms-json==0.3.0
 wtforms==2.1
 xmltodict==0.10.2
 geojson>=1.3.1

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -15,7 +15,7 @@ flask-fs==0.2.1
 Flask-Gravatar==0.4.2
 Flask-Login==0.3.2
 Flask-Mail==0.9.1
-flask-mongoengine==0.8.0
+flask-mongoengine==0.9.2
 Flask-Navigation==0.2.0
 Flask-OAuthlib==0.9.3
 flask-restplus==0.10.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -27,7 +27,7 @@ Flask-WTF==0.12
 Flask==0.12
 html2text==2016.9.19
 lxml==3.7.3
-mongoengine==0.10.6
+mongoengine==0.11.0
 msgpack-python==0.4.8
 pillow==4.0.0
 bcrypt==3.1.3

--- a/udata/app.py
+++ b/udata/app.py
@@ -15,7 +15,7 @@ from flask import (
 )
 from flask_caching import Cache
 
-from flask_wtf.csrf import CsrfProtect
+from flask_wtf.csrf import CSRFProtect
 from flask_navigation import Navigation
 from speaklater import is_lazy_string
 from werkzeug.contrib.fixers import ProxyFix
@@ -27,7 +27,7 @@ ROOT_DIR = abspath(join(dirname(__file__)))
 log = logging.getLogger(__name__)
 
 cache = Cache()
-csrf = CsrfProtect()
+csrf = CSRFProtect()
 nav = Navigation()
 
 

--- a/udata/commands/db.py
+++ b/udata/commands/db.py
@@ -9,8 +9,7 @@ from pkg_resources import resource_isdir, resource_listdir, resource_string
 from flask import current_app
 
 from pymongo.errors import PyMongoError, OperationFailure
-from flask_mongoengine.connection import get_db
-from flask_mongoengine.connection import DEFAULT_CONNECTION_NAME
+from mongoengine.connection import get_db
 
 from udata.commands import submanager, green, yellow, cyan, purple, red
 
@@ -72,13 +71,13 @@ DATE_FORMAT = '%Y-%m-%d %H:%M'
 
 def get_migration(plugin, filename):
     '''Get an existing migration record if exists'''
-    db = get_db(DEFAULT_CONNECTION_NAME)
+    db = get_db()
     return db.migrations.find_one({'plugin': plugin, 'filename': filename})
 
 
 def execute_migration(plugin, filename, script, dryrun=False):
     '''Execute and record a migration'''
-    db = get_db(DEFAULT_CONNECTION_NAME)
+    db = get_db()
     js = SCRIPT_WRAPPER.format(script)
     lines = script.splitlines()
     success = True
@@ -102,7 +101,7 @@ def execute_migration(plugin, filename, script, dryrun=False):
 
 def record_migration(plugin, filename, script, **kwargs):
     '''Only record a migration without applying it'''
-    db = get_db(DEFAULT_CONNECTION_NAME)
+    db = get_db()
     db.eval(RECORD_WRAPPER, plugin, filename, script)
     return True
 
@@ -172,7 +171,7 @@ def unrecord(plugin, filename):
     migration = get_migration(plugin, filename)
     if migration:
         log.info('Removing migration %s:%s', plugin, filename)
-        db = get_db(DEFAULT_CONNECTION_NAME)
+        db = get_db()
         db.eval(UNRECORD_WRAPPER, migration['_id'])
     else:
         log.error('Migration not found %s:%s', plugin, filename)

--- a/udata/core/jobs/forms.py
+++ b/udata/core/jobs/forms.py
@@ -10,11 +10,11 @@ from .models import PeriodicTask
 class CrontabForm(ModelForm):
     model_class = PeriodicTask.Crontab
 
-    minute = fields.StringField(default='*')
-    hour = fields.StringField(default='*')
-    day_of_week = fields.StringField(default='*')
-    day_of_month = fields.StringField(default='*')
-    month_of_year = fields.StringField(default='*')
+    minute = fields.Field(default='*')
+    hour = fields.Field(default='*')
+    day_of_week = fields.Field(default='*')
+    day_of_month = fields.Field(default='*')
+    month_of_year = fields.Field(default='*')
 
 
 class IntervalForm(ModelForm):

--- a/udata/core/spatial/forms.py
+++ b/udata/core/spatial/forms.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from udata.forms import widgets, ModelForm, validators
-from udata.forms.fields import ModelList, StringField, SelectField, FormField
+from udata.forms.fields import ModelList, Field, SelectField, FormField
 from udata.i18n import lazy_gettext as _
 
 from .models import GeoZone, SpatialCoverage, spatial_granularities
@@ -27,12 +27,12 @@ class ZonesAutocompleter(widgets.TextInput):
         return super(ZonesAutocompleter, self).__call__(field, **kwargs)
 
 
-class ZonesField(ModelList, StringField):
+class ZonesField(ModelList, Field):
     model = GeoZone
     widget = ZonesAutocompleter()
 
 
-class GeomField(StringField):
+class GeomField(Field):
     def process_formdata(self, valuelist):
         if valuelist:
             value = valuelist[0]

--- a/udata/core/spatial/tests/test_fields.py
+++ b/udata/core/spatial/tests/test_fields.py
@@ -45,7 +45,7 @@ class SpatialCoverageFieldTest(TestCase):
         geom = faker.multipolygon()
 
         fake = Fake(spatial=SpatialCoverage(geom=geom))
-        form = FakeForm(None, fake)
+        form = FakeForm(None, obj=fake)
         self.assertEqual(form.spatial.geom.data, geom)
 
     def test_initial_zones(self):
@@ -53,7 +53,7 @@ class SpatialCoverageFieldTest(TestCase):
         zones = [GeoZoneFactory() for _ in range(3)]
 
         fake = Fake(spatial=SpatialCoverage(zones=zones))
-        form = FakeForm(None, fake)
+        form = FakeForm(None, obj=fake)
         self.assertEqual(
             form.spatial.zones._value(), ','.join([z.id for z in zones]))
 
@@ -224,7 +224,7 @@ class SpatialCoverageFieldTest(TestCase):
         zone = GeoZoneFactory()
         data = MultiDict({'spatial-zones': zone.id})
 
-        form = FakeForm(data, fake)
+        form = FakeForm(data, obj=fake)
 
         form.validate()
         self.assertEqual(form.errors, {})
@@ -245,7 +245,7 @@ class SpatialCoverageFieldTest(TestCase):
 
         data = MultiDict({'spatial-granularity': granularity})
 
-        form = FakeForm(data, fake)
+        form = FakeForm(data, obj=fake)
 
         form.validate()
         self.assertEqual(form.errors, {})
@@ -279,7 +279,7 @@ class SpatialCoverageFieldTest(TestCase):
         form = FakeForm(MultiDict({
             'spatial-zones': str(zone.id),
             'spatial-granularity': faker.spatial_granularity()
-        }), fake)
+        }), obj=fake)
 
         form.validate()
         self.assertEqual(form.errors, {})

--- a/udata/forms/__init__.py
+++ b/udata/forms/__init__.py
@@ -8,7 +8,7 @@ wtforms_json.init()
 from flask_mongoengine.wtf import model_form  # noqa
 
 from flask_mongoengine.wtf.models import ModelForm as MEModelForm  # noqa
-from flask_wtf import Form as WTForm  # noqa
+from flask_wtf import FlaskForm  # noqa
 
 from udata import i18n  # noqa
 
@@ -22,7 +22,7 @@ class CommonFormMixin(object):
         super(CommonFormMixin, self).process(formdata, obj, data, **kwargs)
 
 
-class Form(CommonFormMixin, WTForm):
+class Form(CommonFormMixin, FlaskForm):
     pass
 
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -23,8 +23,6 @@ from udata.i18n import lazy_gettext as _
 from udata import tags
 from udata.utils import to_iso_date, get_by
 
-# _ = lambda s: s
-
 
 class FieldHelper(object):
     def __init__(self, *args, **kwargs):
@@ -96,14 +94,13 @@ class RolesField(FieldHelper, fields.StringField):
 
 
 class DateTimeField(Field, fields.DateTimeField):
-
     def process_formdata(self, valuelist):
         if valuelist:
             dt = valuelist[0]
             self.data = parse(dt) if isinstance(dt, basestring) else dt
 
 
-class UUIDField(Field, fields.HiddenField):
+class UUIDField(HiddenField):
     def process_formdata(self, valuelist):
         if valuelist:
             try:

--- a/udata/models/queryset.py
+++ b/udata/models/queryset.py
@@ -39,8 +39,8 @@ class DBPaginator(Paginable):
 
 
 class UDataQuerySet(BaseQuerySet):
-    def paginate(self, page, per_page, error_out=True):
-        result = super(UDataQuerySet, self).paginate(page, per_page, error_out)
+    def paginate(self, page, per_page, **kwargs):
+        result = super(UDataQuerySet, self).paginate(page, per_page)
         return DBPaginator(result)
 
     def bulk_list(self, ids):

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -92,7 +92,7 @@ def init_app(app):
 
     from udata.models import db
     with app.app_context():
-        default_url = 'mongodb://{0}:{1}'.format(*db.connection.client.address)
+        default_url = 'mongodb://{0}:{1}'.format(*db.connection.address)
     app.config.setdefault('CELERY_MONGODB_SCHEDULER_URL', default_url)
 
     celery.conf.update(app.config)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -178,7 +178,7 @@ class DBTestMixin(object):
         '''Clear the database'''
         super(DBTestMixin, self).tearDown()
         db_name = self.app.config['MONGODB_DB']
-        db.connection.client.drop_database(db_name)
+        db.connection.drop_database(db_name)
 
 
 class SearchTestMixin(DBTestMixin):

--- a/udata/tests/forms/test_current_user_field.py
+++ b/udata/tests/forms/test_current_user_field.py
@@ -43,7 +43,7 @@ class CurrentUserFieldTest(TestCase):
         login_user(user)
         ownable = Ownable(owner=user)
 
-        form = OwnableForm(None, ownable)
+        form = OwnableForm(None, obj=ownable)
         self.assertEqual(form.owner.data, user)
 
     def test_with_valid_user_self(self):

--- a/udata/tests/forms/test_daterange_field.py
+++ b/udata/tests/forms/test_daterange_field.py
@@ -38,7 +38,7 @@ class DateRangeFieldTest(TestCase):
                           end=date.today())
 
         fake = Fake(daterange=dr)
-        form = FakeForm(None, fake)
+        form = FakeForm(None, obj=fake)
         expected = ' - '.join([to_iso_date(dr.start), to_iso_date(dr.end)])
         self.assertEqual(form.daterange._value(), expected)
 

--- a/udata/tests/forms/test_image_field.py
+++ b/udata/tests/forms/test_image_field.py
@@ -65,7 +65,7 @@ class ImageFieldTest(DBTestMixin, FSTestMixin, TestCase):
 
     def test_with_unbound_image(self):
         doc = self.D()
-        form = self.F(None, doc)
+        form = self.F(None, obj=doc)
         self.assertEqual(form.image.filename.data, None)
         self.assertEqual(form.image.bbox.data, None)
 
@@ -77,7 +77,7 @@ class ImageFieldTest(DBTestMixin, FSTestMixin, TestCase):
         with open(self.data('image.png')) as img:
             doc.image.save(img, 'image.jpg')
         doc.save()
-        form = self.F(None, doc)
+        form = self.F(None, obj=doc)
         self.assertEqual(form.image.filename.data, 'image.jpg')
         self.assertEqual(form.image.bbox.data, None)
 
@@ -86,7 +86,7 @@ class ImageFieldTest(DBTestMixin, FSTestMixin, TestCase):
         with open(self.data('image.png')) as img:
             doc.thumbnail.save(img, 'image.jpg', bbox=[10, 10, 100, 100])
         doc.save()
-        form = self.F(None, doc)
+        form = self.F(None, obj=doc)
         self.assertEqual(form.thumbnail.filename.data, 'image.jpg')
         self.assertEqual(form.thumbnail.bbox.data, [10, 10, 100, 100])
 

--- a/udata/tests/forms/test_image_field.py
+++ b/udata/tests/forms/test_image_field.py
@@ -11,7 +11,6 @@ import flask_fs as fs
 from udata.models import db
 from udata.forms import Form
 from udata.forms.fields import ImageField
-from udata.frontend.helpers import placeholder
 from udata.tests import DBTestMixin, FSTestMixin, TestCase
 from udata.core.storages import tmp
 from udata.core.storages.views import blueprint

--- a/udata/tests/forms/test_model_list_field.py
+++ b/udata/tests/forms/test_model_list_field.py
@@ -18,7 +18,7 @@ class Fake(db.Document):
     nested = db.ListField(db.ReferenceField(Nested))
 
 
-class NestedListField(fields.ModelList, fields.StringField):
+class NestedListField(fields.ModelList, fields.Field):
     model = Nested
 
 

--- a/udata/tests/forms/test_publish_as_field.py
+++ b/udata/tests/forms/test_publish_as_field.py
@@ -61,7 +61,7 @@ class PublishFieldTest(TestCase):
         user = UserFactory()
         ownable = Ownable(owner=user)
 
-        form = OwnableForm(None, ownable)
+        form = OwnableForm(None, obj=ownable)
         self.assertEqual(form.owner.data, user)
         self.assertIsNone(form.organization.data)
 
@@ -70,7 +70,7 @@ class PublishFieldTest(TestCase):
         org = OrganizationFactory()
         ownable = Ownable(organization=org)
 
-        form = OwnableForm(None, ownable)
+        form = OwnableForm(None, obj=ownable)
         self.assertIsNone(form.owner.data)
         self.assertEqual(form.organization.data, org)
 
@@ -82,7 +82,7 @@ class PublishFieldTest(TestCase):
 
         login_user(user)
 
-        form = OwnableForm(None, ownable)
+        form = OwnableForm(None, obj=ownable)
         self.assertIsNone(form.owner.data)
         self.assertEqual(form.organization.data, org)
 
@@ -219,7 +219,7 @@ class PublishFieldTest(TestCase):
 
         form = OwnableForm(MultiDict({
             'organization': str(neworg.id)
-        }), ownable)
+        }), obj=ownable)
 
         self.assertEqual(form.organization.data, neworg)
 
@@ -240,7 +240,7 @@ class PublishFieldTest(TestCase):
 
         form = OwnableForm(MultiDict({
             'organization': str(neworg.id)
-        }), ownable)
+        }), obj=ownable)
 
         self.assertEqual(form.organization.data, neworg)
 
@@ -292,7 +292,7 @@ class PublishFieldTest(TestCase):
 
         form = OwnableForm(MultiDict({
             'organization': str(org.id)
-        }), ownable)
+        }), obj=ownable)
 
         self.assertTrue(form.validate())
         self.assertEqual(form.errors, {})
@@ -311,7 +311,7 @@ class PublishFieldTest(TestCase):
 
         form = OwnableForm(MultiDict({
             'owner': str(user.id)
-        }), ownable)
+        }), obj=ownable)
 
         self.assertEqual(form.owner.data, user)
         self.assertEqual(form.organization.data, org)
@@ -336,7 +336,7 @@ class PublishFieldTest(TestCase):
 
         form = OwnableForm(MultiDict({
             'organization': str(org.id)
-        }), ownable)
+        }), obj=ownable)
 
         self.assertEqual(form.owner.data, user)
         self.assertEqual(form.organization.data, org)
@@ -357,7 +357,7 @@ class PublishFieldTest(TestCase):
         org = OrganizationFactory(members=[Member(user=user, role='editor')])
         ownable = Ownable(organization=org)
 
-        form = OwnableForm(MultiDict({}), ownable)
+        form = OwnableForm(MultiDict({}), obj=ownable)
 
         self.assertEqual(form.organization.data, org)
 
@@ -374,7 +374,7 @@ class PublishFieldTest(TestCase):
         user = UserFactory()
         ownable = Ownable(owner=user)
 
-        form = OwnableForm(MultiDict({}), ownable)
+        form = OwnableForm(MultiDict({}), obj=ownable)
 
         self.assertEqual(form.owner.data, user)
 

--- a/udata/tests/forms/test_uuid_field.py
+++ b/udata/tests/forms/test_uuid_field.py
@@ -35,7 +35,7 @@ class UUIDFieldTest(TestCase):
         Fake, FakeForm = self.factory()
 
         fake = Fake(id=uuid.uuid4())
-        form = FakeForm(None, fake)
+        form = FakeForm(None, obj=fake)
         self.assertEqual(form.id._value(), str(fake.id))
 
     def test_with_valid_uuid_string(self):

--- a/udata/tests/forms/test_uuid_field.py
+++ b/udata/tests/forms/test_uuid_field.py
@@ -24,7 +24,6 @@ class UUIDFieldTest(TestCase):
         Fake, FakeForm = self.factory()
 
         form = FakeForm()
-        self.assertEqual(form.id._value(), '')
         self.assertEqual(form.id.data, None)
 
         fake = Fake()
@@ -36,7 +35,7 @@ class UUIDFieldTest(TestCase):
 
         fake = Fake(id=uuid.uuid4())
         form = FakeForm(None, obj=fake)
-        self.assertEqual(form.id._value(), str(fake.id))
+        self.assertEqual(form.id.data, fake.id)
 
     def test_with_valid_uuid_string(self):
         Fake, FakeForm = self.factory()

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -49,7 +49,7 @@ class DatetimedTester(db.Datetimed, db.Document):
     name = db.StringField()
 
 
-class AutoUUIDFieldTest(TestCase):
+class AutoUUIDFieldTest(DBTestMixin, TestCase):
     def test_auto_populate(self):
         '''AutoUUIDField should populate itself if not set'''
         obj = UUIDTester()
@@ -67,6 +67,19 @@ class AutoUUIDFieldTest(TestCase):
         self.assertIsNotNone(obj.id)
         self.assertIsInstance(obj.id, UUID)
         self.assertEqual(obj.pk, obj.id)
+
+    def test_query_as_uuid(self):
+        obj = UUIDAsIdTester.objects.create()
+        self.assertIsInstance(obj.id, UUID)
+        self.assertEqual(UUIDAsIdTester.objects.get(id=obj.id), obj)
+
+    def test_query_as_text(self):
+        obj = UUIDAsIdTester.objects.create()
+        self.assertEqual(UUIDAsIdTester.objects.get(id=str(obj.id)), obj)
+
+    def test_always_an_uuid(self):
+        obj = UUIDTester(uuid=str(uuid4()))
+        self.assertIsInstance(obj.uuid, UUID)
 
 
 class SlugFieldTest(DBTestMixin, TestCase):


### PR DESCRIPTION
This PR supersedes #586, #654, #682 and #767 because they were dependent upgrades.
These PR have been merged into this one and all required fixes/refactorings applied:
- `flask_wtf.Form` is now `flask_wtf.FlaskForm` and has a little signature change
- `flask_mongoengine` has a new connection manager
- `wtform-json` use `StringField` instead of the deprecated `TextField` which breaks every `StringField` instance (inherited or not) using default value (pending bug fix: kvesteri/wtforms-json#49), casting value to something else than a string or expected `None` as default

Consequence:
- make use of `mongoengine.get_db` instead of the removed `flask_mongoengine.connection.get_db`
- cleanup the form fields dependency tree: all fields expecting `None` as default/empty, inheriting from `StringField` but returning another type or using a default value now use `udata.forms.field.Field` as base class
- `Form(formdata, obj)` calls are now `Form(formdata, obj=obj)`