### PR TITLE
Flask login update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Upgrade to Flask-Mongoengine 0.9.2, Flask-WTF 0.14.2, mongoengine 0.11.0.
   [#812](https://github.com/opendatateam/udata/pull/812)
+- Upgrade to Flask-Login 0.4.0 and switch from Flask-Security to the latest
+  [Flask-Security-Fork](https://pypi.python.org/pypi/Flask-Security-Fork)
+  [#813](https://github.com/opendatateam/udata/pull/813)
 
 ## 1.0.4 (2017-03-01)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -20,7 +20,7 @@ Flask-Navigation==0.2.0
 Flask-OAuthlib==0.9.3
 flask-restplus==0.10.0
 Flask-Script==2.0.5
-Flask-Security==1.7.5
+Flask-Security-Fork==2.0.1
 Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
 Flask-WTF==0.14.2


### PR DESCRIPTION
This PR supersedes/includes #642 

- upgrade to flask-login 0.4.0
- switch from the unmaintained Flask-Security to the latest [Flask-Security-Fork](https://pypi.python.org/pypi/Flask-Security-Fork) which has been upgraded to support Flask-Login 0.4.0 and fixed some security issues