### PR TITLE
Harvesters admin fixes and improvements (first pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
     - allows use of hot components reloading.
 - Pure Vue.js modals. Fix the default membership role. Added contribute modal.
   [#873](https://github.com/opendatateam/udata/pull/873)
+- Lot of fixes and improvements on Harvest admin UI
+  [#817](https://github.com/opendatateam/udata/pull/817):
+    - harvester edition fixed (and missing API added)
+    - harvester deletion fixed
+    - harvester listing is now paginated
+    - more detailed harvesters widgets
+    - ensure harvest source are owned by a user or an organization, not both [migration]
 
 ## 1.0.9 (2017-04-23)
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -9,6 +9,9 @@ import 'raven';
 // ES6 environment
 import 'babel-polyfill';
 
+// DOM polyfills
+import 'dom-polyfills';
+
 import 'bootstrap';
 
 import Vue from 'vue';

--- a/js/components/datatable/cells/avatar.vue
+++ b/js/components/datatable/cells/avatar.vue
@@ -11,17 +11,15 @@
 </template>
 
 <script>
-import $ from 'jquery';
 import placeholders from 'helpers/placeholders';
 
 export default {
-    name: 'datatable-cell-avatar',
-    attached: function() {
+    attached() {
         // Dirty hack to fix class on field/td iteration
-        $(this.$el).closest('td').addClass('avatar-cell');
+        this.$el.closest('td').classList.add('avatar-cell');
     },
     computed: {
-        src: function() {
+        src() {
             if (this.value) {
                 return this.value;
             } else if (this.field.placeholder) {

--- a/js/components/harvest/source-form.vue
+++ b/js/components/harvest/source-form.vue
@@ -14,7 +14,7 @@ export default {
             }
         }
     },
-    data: function() {
+    data() {
         return {
             fields: [{
                 id: 'name',
@@ -39,10 +39,10 @@ export default {
         vform: require('components/form/vertical-form.vue')
     },
     methods: {
-        serialize: function() {
+        serialize() {
             return this.$refs.form.serialize();
         },
-        validate: function() {
+        validate() {
             return this.$refs.form.validate();
         }
     }

--- a/js/components/harvest/source-form.vue
+++ b/js/components/harvest/source-form.vue
@@ -5,6 +5,7 @@
 <script>
 import HarvestSource from 'models/harvest/source';
 
+
 export default {
     props: {
         source: {

--- a/js/components/harvest/source.vue
+++ b/js/components/harvest/source.vue
@@ -22,13 +22,12 @@ import Datatable from 'components/datatable/widget.vue';
 import HarvestJobs from 'models/harvest/jobs';
 
 export default {
-    name: 'harvest-jobs-widget',
     components: {Datatable},
     props: {
         source: Object,
         current: null
     },
-    data: function() {
+    data() {
         return {
             title: this._('Jobs'),
             jobs: new HarvestJobs({query: {page_size: 10}}),

--- a/js/components/harvest/sources.vue
+++ b/js/components/harvest/sources.vue
@@ -10,22 +10,20 @@
 import {Model} from 'models/base';
 import HarvestSources from 'models/harvest/sources';
 import {STATUS_CLASSES, STATUS_I18N} from 'models/harvest/job';
+import Datatable from 'components/datatable/widget.vue';
 
-const MASK = ['id', 'name', 'owner', 'last_job{status}', 'organization'];
+const MASK = ['id', 'name', 'owner', 'last_job{status,ended}', 'organization'];
 
 export default {
     MASK,
-    name: 'harvesters-widget',
-    components: {
-        datatable: require('components/datatable/widget.vue')
-    },
+    components: {Datatable},
     props: {
         owner: {
             type: Model,
-            default: function() {return {};}
+            default: () => {}
         }
     },
-    data: function() {
+    data() {
         return {
             title: this._('Harvesters'),
             sources: new HarvestSources({mask: MASK}),
@@ -41,7 +39,7 @@ export default {
                 sort: 'last_job.status',
                 type: 'label',
                 width: 100,
-                label_type: function(status) {
+                label_type(status) {
                     if (!status) return 'default';
                     return STATUS_CLASSES[status];
                 },
@@ -49,6 +47,13 @@ export default {
                     if (!status) return this._('No job yet');
                     return STATUS_I18N[status];
                 }
+            }, {
+                label: this._('Last run'),
+                key: 'last_job.ended',
+                sort: 'last_job.ended',
+                align: 'left',
+                type: 'timeago',
+                width: 120
             }]
         };
     },
@@ -57,7 +62,7 @@ export default {
             this.$go('/harvester/' + harvester.id + '/');
         }
     },
-    ready: function() {
+    ready() {
         if (this.owner instanceof Model) {
             // Only fetch if binding occured and object is already fetched, else wait for watch
             if (this.owner.id) {

--- a/js/dom-polyfills.js
+++ b/js/dom-polyfills.js
@@ -1,0 +1,14 @@
+// closest polyfill
+// taken from https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+if (window.Element && !Element.prototype.closest) {
+    Element.prototype.closest = function(s) {
+        const matches = (this.document || this.ownerDocument).querySelectorAll(s);
+        let i;
+        let el = this;
+        do {
+            i = matches.length;
+            while (--i >= 0 && matches.item(i) !== el) {};
+        } while ((i < 0) && (el = el.parentElement));
+        return el;
+    };
+}

--- a/js/models/harvest/source.js
+++ b/js/models/harvest/source.js
@@ -1,8 +1,21 @@
 import {Model} from 'models/base';
+import {_} from 'i18n';
 import log from 'logger';
 
+export const VALIDATION_STATUS_CLASSES = {
+    'pending': 'default',
+    'accepted': 'success',
+    'refused': 'danger',
+};
 
-export default class HarvestSource extends Model {
+export const VALIDATION_STATUS_I18N = {
+    'pending': _('Pending'),
+    'accepted': _('Accepted'),
+    'refused': _('Refused'),
+};
+
+
+export class HarvestSource extends Model {
     fetch(ident) {
         ident = ident || this.id || this.slug;
         this.loading = true;
@@ -34,3 +47,5 @@ export default class HarvestSource extends Model {
         }, on_success, on_error);
     }
 }
+
+export default HarvestSource;

--- a/js/models/harvest/source.js
+++ b/js/models/harvest/source.js
@@ -18,11 +18,19 @@ export default class HarvestSource extends Model {
     }
 
     /**
-     * Create or update the given dataset.
+     * Create or update the given harvest source.
      */
     save() {
-        var ep = this.id ? 'harvest.update_harvest_source' : 'harvest.create_harvest_source';
+        const ep = this.id ? 'harvest.update_harvest_source' : 'harvest.create_harvest_source';
         this.loading = true;
         this.$api(ep, {payload: this}, this.on_fetched);
     }
-};
+
+    update(data, on_success, on_error) {
+        this.loading = true;
+        this.$api('harvest.update_harvest_source', {
+            ident: this.id,
+            payload: data
+        }, on_success, on_error);
+    }
+}

--- a/js/models/harvest/sources.js
+++ b/js/models/harvest/sources.js
@@ -1,8 +1,7 @@
-import {List} from 'models/base';
-import log from 'logger';
+import {ModelPage} from 'models/base';
 
 
-export default class HarvestSources extends List {
+export default class HarvestSourcePage extends ModelPage {
     constructor(options) {
         super(options);
         this.$options.ns = 'harvest';

--- a/js/views/harvester-edit.vue
+++ b/js/views/harvester-edit.vue
@@ -23,7 +23,7 @@ import ItemModal from 'components/harvest/item.vue';
 import Preview from 'components/harvest/preview.vue';
 
 export default {
-    data: function() {
+    data() {
         return {
             source: new HarvestSource(),
         };

--- a/js/views/system.vue
+++ b/js/views/system.vue
@@ -1,7 +1,7 @@
 <template>
 <layout :title="_('System')">
     <div class="row">
-        <harvesters-widget class="col-xs-12 col-md-6"></harvesters-widget>
+        <harvesters-widget class="col-xs-12"></harvesters-widget>
         <jobs-widget class="col-xs-12 col-md-6"></jobs-widget>
         <oauth-widget class="col-xs-12 col-md-6"></oauth-widget>
     </div>
@@ -10,14 +10,11 @@
 
 <script>
 import Layout from 'components/layout.vue';
+import HarvestersWidget from 'components/harvest/sources.vue';
+import JobsWidget from 'components/system/jobs.vue';
+import OauthWidget from 'components/system/oauth.vue';
 
 export default {
-    name: 'SystemView',
-    components: {
-        'harvesters-widget': require('components/harvest/sources.vue'),
-        'jobs-widget': require('components/system/jobs.vue'),
-        'oauth-widget': require('components/system/oauth.vue'),
-        Layout
-    }
+    components: {HarvestersWidget, JobsWidget, OauthWidget, Layout}
 };
 </script>

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -115,7 +115,6 @@ class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
     deleted = db.DateTimeField()
 
     meta = {
-        'allow_inheritance': True,
         'indexes': ['-created_at', 'slug'],
         'ordering': ['-created_at'],
         'queryset_class': OrganizationQuerySet,

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -90,7 +90,6 @@ class User(WithMetrics, UserMixin, db.Document):
     on_delete = Signal()
 
     meta = {
-        'allow_inheritance': True,
         'indexes': ['-created_at', 'slug', 'apikey'],
         'ordering': ['-created_at']
     }

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -71,6 +71,15 @@ def create_source(name, url, backend,
     return source
 
 
+def update_source(ident, data):
+    '''Update an harvest source'''
+    print(data)
+    source = get_source(ident)
+    source.modify(**data)
+    signals.harvest_source_updated.send(source)
+    return source
+
+
 def validate_source(ident, comment=None):
     '''Validate a source for automatic harvesting'''
     source = get_source(ident)

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -22,18 +22,31 @@ from .tasks import harvest
 
 log = logging.getLogger(__name__)
 
+DEFAULT_PAGE_SIZE = 10
+
 
 def list_backends():
     '''List all available backends'''
     return backends.get_all().values()
 
 
-def list_sources(owner=None):
-    '''List all harvest sources'''
+def _sources_queryset(owner=None):
     sources = HarvestSource.objects.visible()
     if owner:
-        return list(sources.owned_by(owner))
-    return list(sources)
+        sources = sources.owned_by(owner)
+    return sources
+
+
+def list_sources(owner=None):
+    '''List all harvest sources'''
+    return list(_sources_queryset(owner=owner))
+
+
+def paginate_sources(owner=None, page=1, page_size=DEFAULT_PAGE_SIZE):
+    '''Paginate harvest sources'''
+    sources = _sources_queryset(owner=owner)
+    page = max(page or 1, 1)
+    return sources.paginate(page, page_size)
 
 
 def get_source(ident):
@@ -73,7 +86,6 @@ def create_source(name, url, backend,
 
 def update_source(ident, data):
     '''Update an harvest source'''
-    print(data)
     source = get_source(ident)
     source.modify(**data)
     signals.harvest_source_updated.send(source)

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -113,6 +113,9 @@ source_fields = api.model('HarvestSource', {
     'deleted': fields.ISODateTime(description='The source deletion date'),
 })
 
+source_page_fields = api.model('HarvestSourcePage',
+                               fields.pager(source_fields))
+
 backend_fields = api.model('HarvestBackend', {
     'id': fields.String(description='The backend identifier'),
     'label': fields.String(description='The backend display name')
@@ -138,7 +141,7 @@ preview_job_fields = api.clone('HarvestJobPreview', job_fields, {
                          description='The job collected items'),
 })
 
-source_parser = api.parser()
+source_parser = api.page_parser()
 source_parser.add_argument('owner', type=str, location='args',
                            help='The organization or user ID to filter on')
 
@@ -146,11 +149,13 @@ source_parser.add_argument('owner', type=str, location='args',
 @ns.route('/sources/', endpoint='harvest_sources')
 class SourcesAPI(API):
     @api.doc('list_harvest_sources', parser=source_parser)
-    @api.marshal_list_with(source_fields)
+    @api.marshal_list_with(source_page_fields)
     def get(self):
         '''List all harvest sources'''
         args = source_parser.parse_args()
-        return actions.list_sources(args.get('owner'))
+        return actions.paginate_sources(args.get('owner'),
+                                        page=args['page'],
+                                        page_size=args['page_size'])
 
     @api.doc('create_harvest_source')
     @api.secure

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -175,6 +175,17 @@ class SourceAPI(API):
         return actions.get_source(ident)
 
     @api.secure
+    @api.doc('update_harvest_source')
+    @api.expect(source_fields)
+    @api.marshal_with(source_fields)
+    def put(self, ident):
+        '''Create a new harvests source'''
+        source = actions.get_source(ident)
+        form = api.validate(HarvestSourceForm, source)
+        source = actions.update_source(ident, form.data)
+        return source
+
+    @api.secure
     @api.doc('delete_harvest_source')
     @api.marshal_with(source_fields)
     def delete(self, ident):

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -127,7 +127,7 @@ class HarvestSource(db.Owned, db.Document):
         'indexes': [
             '-created_at',
             'slug',
-            'deleted',
+            ('deleted', '-created_at'),
         ] + db.Owned.meta['indexes'],
         'ordering': ['-created_at'],
         'queryset_class': HarvestSourceQuerySet,
@@ -144,3 +144,12 @@ class HarvestJob(db.Document):
     errors = db.ListField(db.EmbeddedDocumentField(HarvestError))
     items = db.ListField(db.EmbeddedDocumentField(HarvestItem))
     source = db.ReferenceField(HarvestSource, reverse_delete_rule=db.NULLIFY)
+
+    meta = {
+        'indexes': [
+            '-created',
+            'source',
+            ('source', '-created')
+        ],
+        'ordering': ['-created'],
+    }

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -114,7 +114,7 @@ class HarvestSource(db.Owned, db.Document):
 
     @classmethod
     def get(cls, ident):
-        return cls.objects(slug=ident).first() or cls.objects.get(id=ident)
+        return cls.objects(slug=ident).first() or cls.objects.get(pk=ident)
 
     def get_last_job(self):
         return HarvestJob.objects(source=self).order_by('-created').first()

--- a/udata/harvest/signals.py
+++ b/udata/harvest/signals.py
@@ -12,6 +12,9 @@ ns = Namespace()
 #: Sent when a new HarvestSource is created
 harvest_source_created = ns.signal('harvest:source-created')
 
+#: Sent when a HarvestSource is updated
+harvest_source_updated = ns.signal('harvest:source-updated')
+
 #: Sent when a HarvestSource is deleted
 harvest_source_deleted = ns.signal('harvest:source-deleted')
 

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -15,7 +15,7 @@ from udata.tests import TestCase, DBTestMixin
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.user.factories import UserFactory
 from udata.core.dataset.factories import DatasetFactory
-from udata.utils import faker
+from udata.utils import faker, Paginable
 
 from .factories import (
     HarvestSourceFactory, HarvestJobFactory,
@@ -89,6 +89,30 @@ class HarvestActionsTest(DBTestMixin, TestCase):
 
         for source in sources:
             self.assertIn(source, result)
+
+    def test_paginate_sources(self):
+        result = actions.paginate_sources()
+        self.assertIsInstance(result, Paginable)
+        self.assertEqual(result.page, 1)
+        self.assertEqual(result.page_size, actions.DEFAULT_PAGE_SIZE)
+        self.assertEqual(result.total, 0)
+        self.assertEqual(len(result.objects), 0)
+
+        HarvestSourceFactory.create_batch(3)
+
+        result = actions.paginate_sources(page_size=2)
+        self.assertIsInstance(result, Paginable)
+        self.assertEqual(result.page, 1)
+        self.assertEqual(result.page_size, 2)
+        self.assertEqual(result.total, 3)
+        self.assertEqual(len(result.objects), 2)
+
+        result = actions.paginate_sources(page=2, page_size=2)
+        self.assertIsInstance(result, Paginable)
+        self.assertEqual(result.page, 2)
+        self.assertEqual(result.page_size, 2)
+        self.assertEqual(result.total, 3)
+        self.assertEqual(len(result.objects), 1)
 
     def test_create_source(self):
         source_url = faker.url()

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -112,6 +112,19 @@ class HarvestActionsTest(DBTestMixin, TestCase):
         self.assertIsNone(source.validation.by)
         self.assertIsNone(source.validation.comment)
 
+    def test_update_source(self):
+        source = HarvestSourceFactory()
+        data = source.to_dict()
+        new_url = faker.url()
+        data['url'] = new_url
+
+        with self.assert_emit(signals.harvest_source_updated):
+            source = actions.update_source(source.id, data)
+
+        self.assertEqual(source.url, new_url)
+        source.reload()
+        self.assertEqual(source.url, new_url)
+
     @patch('udata.harvest.actions.launch')
     def test_validate_source(self, mock):
         source = HarvestSourceFactory()

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -112,6 +112,25 @@ class HarvestAPITest(APITestCase):
 
         self.assert403(response)
 
+    def test_update_source(self):
+        '''It should update a source'''
+        user = self.login()
+        source = HarvestSourceFactory(owner=user)
+        new_url = faker.url()
+        data = {
+            'name': source.name,
+            'description': source.description,
+            'url': new_url,
+            'backend': 'factory',
+        }
+        api_url = url_for('api.harvest_source', ident=str(source.id))
+        response = self.put(api_url, data)
+
+        self.assert200(response)
+
+        source = response.json
+        self.assertEqual(source['url'], new_url)
+
     def test_validate_source(self):
         '''It should allow to validate a source if admin'''
         self.login(AdminFactory())

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -37,7 +37,7 @@ class HarvestAPITest(APITestCase):
 
         response = self.get(url_for('api.harvest_sources'))
         self.assert200(response)
-        self.assertEqual(len(response.json), len(sources))
+        self.assertEqual(len(response.json['data']), len(sources))
 
     def test_list_sources_for_owner(self):
         owner = UserFactory()
@@ -48,7 +48,7 @@ class HarvestAPITest(APITestCase):
         response = self.get(url)
         self.assert200(response)
 
-        self.assertEqual(len(response.json), len(sources))
+        self.assertEqual(len(response.json['data']), len(sources))
 
     def test_list_sources_for_org(self):
         org = OrganizationFactory()
@@ -58,7 +58,7 @@ class HarvestAPITest(APITestCase):
         response = self.get(url_for('api.harvest_sources', owner=str(org.id)))
         self.assert200(response)
 
-        self.assertEqual(len(response.json), len(sources))
+        self.assertEqual(len(response.json['data']), len(sources))
 
     def test_create_source_with_owner(self):
         '''It should create and attach a new source to an owner'''

--- a/udata/migrations/2017-03-06-fix-harvesters-owners.js
+++ b/udata/migrations/2017-03-06-fix-harvesters-owners.js
@@ -1,0 +1,10 @@
+/*
+ * Remove harvest sources owner when there is an orgnization
+ */
+const result = db.harvest_source.update(
+    {owner: {$exists: true}, organization: {$exists: true}},
+    {$unset: {owner: true}},
+    {multi: true}
+);
+
+print(`Updated ${result.nModified} harvest source(s) with both owner and organization`);

--- a/udata/models/document.py
+++ b/udata/models/document.py
@@ -27,13 +27,17 @@ class UDataDocument(Document):
     }
 
     def to_dict(self, exclude=None):
+        id_field = self._meta['id_field']
         excluded_keys = set(exclude or [])
+        excluded_keys.add('_id')
         excluded_keys.add('_cls')
-        return dict((
+        data = dict((
             (key, serialize(value))
             for key, value in self.to_mongo().items()
             if key not in excluded_keys
         ))
+        data[id_field] = getattr(self, id_field)
+        return data
 
 
 class DomainModel(UDataDocument):


### PR DESCRIPTION
This PR fixes most of the harvesters admin views:
- fix edition (API was also missing)
- fix deletion
- remove owner on harvesters owned by an organization (migration)

There is also some improvements, mostly on the harvester listing:
- is now paginated, wider
- display more details (implementation, owner, last run, validation status...)

![screenshot-www data dev 2017-03-06 10-34-46](https://cloud.githubusercontent.com/assets/15725/23604299/b192b89c-0258-11e7-91d5-47a54e5af303.png)

![screenshot-www data dev 2017-03-06 11-54-18](https://cloud.githubusercontent.com/assets/15725/23607570/8dacee40-0265-11e7-8414-13a98b903d18.png)

Fixes/changes included that can be extracted into a separate PR:
- Remove jQuery dependency on avatar cell component (and add a `closest()` polyfill): 1c69d87
- Fix `Document.to_dict()` ID handling (required for update): 38c2aa5
- Some Minor models improvements (inheritance and indexing): 30ca20c