### PR TITLE
Improve images handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - drop Handlebars dependency
 - Themes are now entrypoint-based [#829](https://github.com/opendatateam/udata/pull/829).
   There is also a new [theming documention](https://udata.readthedocs.io/en/stable/creating-theme/).
+- Images are now optimized and you can force rerendering using the `udata images render` command.
 
 ## 1.0.5 (2017-03-27)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -11,7 +11,7 @@ factory-boy==2.8.1
 Faker==0.7.10
 Flask-BabelEx==0.9.3
 Flask-Caching==1.2.0
-flask-fs==0.2.1
+flask-fs==0.3.0
 Flask-Gravatar==0.4.2
 Flask-Login==0.4.0
 Flask-Mail==0.9.1

--- a/udata/commands/images.py
+++ b/udata/commands/images.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+from collections import Counter
+
+from udata.commands import submanager, green, cyan, white
+from udata.core.organization.models import Organization
+from udata.core.post.models import Post
+from udata.core.reuse.models import Reuse
+from udata.core.user.models import User
+
+log = logging.getLogger(__name__)
+
+
+m = submanager(
+    'images',
+    help='Images related operations',
+    description='Handle all images related operations and maintenance'
+)
+
+
+def render_or_skip(obj, attr):
+    try:
+        getattr(obj, attr).rerender()
+        obj.save()
+        return 1
+    except Exception as e:
+        log.warning('Skipped "%s": %e(%s)', obj, e.__class__.__name__, e)
+        return 0
+
+
+@m.command
+def render():
+    '''Force (re)rendering stored images'''
+    print(cyan('Rendering images'))
+
+    count = Counter()
+    total = Counter()
+
+    organizations = Organization.objects(logo__exists=True)
+    total['orgs'] = organizations.count()
+    print(white('Processing {0} organizations logos'.format(total['orgs'])))
+    for org in organizations:
+        count['orgs'] += render_or_skip(org, 'logo')
+
+    users = User.objects(avatar__exists=True)
+    total['users'] = users.count()
+    print(white('Processing {0} user avatars'.format(total['users'])))
+    for user in users:
+        count['users'] += render_or_skip(user, 'avatar')
+
+    posts = Post.objects(image__exists=True)
+    total['posts'] = posts.count()
+    print(white('Processing {0} post images'.format(total['posts'])))
+    for post in posts:
+        count['posts'] += render_or_skip(post, 'image')
+
+    reuses = Reuse.objects(image__exists=True)
+    total['reuses'] = reuses.count()
+    print(white('Processing {0} reuse images'.format(total['reuses'])))
+    for reuse in reuses:
+        count['reuses'] += render_or_skip(reuse, 'image')
+
+    print(white('Summary:'))
+    print('''
+    Organization logos: {count[orgs]}/{total[orgs]}
+    User avatars: {count[users]}/{total[users]}
+    Post images: {count[posts]}/{total[posts]}
+    Reuse images: {count[reuses]}/{total[reuses]}
+    '''.format(count=count, total=total))
+    print(green('Images rendered'))

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -145,6 +145,9 @@ class Defaults(object):
 
     DELETE_ME = True
 
+    # Optimize uploaded images
+    FS_IMAGES_OPTIMIZE = True
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/tests/forms/test_image_field.py
+++ b/udata/tests/forms/test_image_field.py
@@ -77,7 +77,7 @@ class ImageFieldTest(DBTestMixin, FSTestMixin, TestCase):
             doc.image.save(img, 'image.jpg')
         doc.save()
         form = self.F(None, obj=doc)
-        self.assertEqual(form.image.filename.data, 'image.jpg')
+        self.assertEqual(form.image.filename.data, 'image.png')
         self.assertEqual(form.image.bbox.data, None)
 
     def test_with_image_and_bbox(self):
@@ -86,7 +86,7 @@ class ImageFieldTest(DBTestMixin, FSTestMixin, TestCase):
             doc.thumbnail.save(img, 'image.jpg', bbox=[10, 10, 100, 100])
         doc.save()
         form = self.F(None, obj=doc)
-        self.assertEqual(form.thumbnail.filename.data, 'image.jpg')
+        self.assertEqual(form.thumbnail.filename.data, 'image.png')
         self.assertEqual(form.thumbnail.bbox.data, [10, 10, 100, 100])
 
     def test_post_new(self):


### PR DESCRIPTION
This PR supersedes #815 and:
- activate images optimization by default
- add a `images render` command to force (re)rendering of stored images