### PR TITLE
Daterange picker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fixes error display in forms [#830](https://github.com/opendatateam/udata/pull/830)
+- Fixes date range picker dates validation [#830](https://github.com/opendatateam/udata/pull/830)
 
 ## 1.0.4 (2017-03-01)
 

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -165,7 +165,7 @@ export default {
                 }
             },
             errorPlacement(error, element) {
-                $(element).closest('.form-group,.field-wrapper').children('div').append(error);
+                $(element).closest('.form-group,.field-wrapper').append(error);
             }
         });
         this.$broadcast('form:ready');

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -34,7 +34,7 @@ $.extend($.validator.messages, {
  *  Rule for depend dates, should be greater that param.
  */
 $.validator.addMethod('dateGreaterThan', function(value, element, param) {
-    const start = moment($(param).val());
+    const start = moment(document.getElementById(param).value);
     return this.optional(element) || moment(value).isAfter(start);
 }, $.validator.format(_('Date should be after start date')));
 

--- a/js/components/form/daterange-picker.vue
+++ b/js/components/form/daterange-picker.vue
@@ -96,7 +96,7 @@ export default {
     ready() {
         // Perform all validations on end field because performing on start field unhighlight.
         $(this.$els.endHidden).rules('add', {
-            dateGreaterThan: '#' + this.$els.startHidden.id,
+            dateGreaterThan: this.$els.startHidden.id,
             required: (el) => {
                 return (this.$els.startHidden.value && !this.$els.endHidden.value) || (this.$els.endHidden.value && !this.$els.startHidden.value);
             },


### PR DESCRIPTION
This PR fixes:
- the broken error display on form fields
- the `dateGreatherThan` rule handling with dot in identifiers

![screenshot-www data gouv fr 2017-03-27 20-18-14](https://cloud.githubusercontent.com/assets/15725/24371261/9624188e-132a-11e7-85e7-408233386af1.png)
