### PR TITLE
Make the allowed extensions list configurable (fix #732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Themes are now entrypoint-based [#829](https://github.com/opendatateam/udata/pull/829).
   There is also a new [theming documention](https://udata.readthedocs.io/en/stable/creating-theme/).
 - Images are now optimized and you can force rerendering using the `udata images render` command.
+- Allowed files extensions are now configurable via the `ALLOWED_RESOURCES_EXTENSIONS` setting
+  and both admin and API will have the same behavior
+  [#833](https://github.com/opendatateam/udata/pull/833).
 
 ## 1.0.5 (2017-03-27)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -66,6 +66,32 @@ The enabled theme name.
 
 The duration used for templates' cache, in minutes.
 
+### ALLOWED_RESOURCES_EXTENSIONS
+
+**default**:
+```python
+[
+    # Base
+    'csv', 'txt', 'json', 'pdf', 'xml', 'rdf', 'rtf', 'xsd',
+    # OpenOffice
+    'ods', 'odt', 'odp', 'odg',
+    # Microsoft Office
+    'xls', 'xlsx', 'doc', 'docx', 'pps', 'ppt',
+    # Archives
+    'tar', 'gz', 'tgz', 'rar', 'zip', '7z', 'xz', 'bz2',
+    # Images
+    'jpeg', 'jpg', 'jpe', 'gif', 'png', 'dwg', 'svg', 'tiff', 'ecw', 'svgz', 'jp2',
+    # Geo
+    'shp', 'kml', 'kmz', 'gpx', 'shx', 'ovr', 'geojson',
+    # Meteorology
+    'grib2',
+    # Misc
+    'dbf', 'prj', 'sql', 'epub', 'sbn', 'sbx', 'cpg', 'lyr', 'owl',
+]
+```
+
+This is the allowed resources extensions list that user can upload.
+
 ## Territories configuration
 
 ### ACTIVATE_TERRITORIES
@@ -74,7 +100,6 @@ The duration used for templates' cache, in minutes.
 
 Whether you want to activate pages and API related to territories.
 Don't forget to set the `HANDLED_LEVELS` setting too.
-
 
 ### HANDLED_LEVELS
 
@@ -88,7 +113,6 @@ a given territory. You have to set the smallest territory level first:
 ```python
 HANDLED_LEVELS = ('fr/town', 'fr/county', 'fr/region', 'country')
 ```
-
 
 ## ElasticSearch configuration
 

--- a/js/models/allowedExtensions.js
+++ b/js/models/allowedExtensions.js
@@ -1,0 +1,11 @@
+import {List} from 'models/base';
+
+export class AllowedExtensions extends List {
+    constructor(options) {
+        super(options);
+        this.$options.ns = 'datasets';
+        this.$options.fetch = 'allowed_extensions';
+    }
+}
+
+export default new AllowedExtensions().fetch();

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -9,6 +9,7 @@ from functools import wraps
 from flask import (
     current_app, g, request, url_for, json, make_response, redirect, Blueprint
 )
+from flask_fs import UnauthorizedFileType
 from flask_restplus import Api, Resource, inputs, cors
 
 from udata import search, theme, tracking
@@ -207,6 +208,18 @@ def handle_permission_denied(error):
 def handle_value_error(error):
     '''A generic value error'''
     return {'message': str(error)}, 400
+
+
+@api.errorhandler(UnauthorizedFileType)
+@api.marshal_with(default_error, code=400)
+def handle_unauthorized_file_type(error):
+    '''Error occuring when the user try to upload a non-allowed file type'''
+    url = url_for('api.allowed_extensions', _external=True)
+    msg = (
+        'This file type is not allowed.'
+        'The allowed file type list is available at {url}'
+    ).format(url=url)
+    return {'message': msg}, 400
 
 
 @apidoc.route('/api/')

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 import os
 from datetime import datetime
 
-from flask import request
+from flask import request, current_app
 from flask_security import current_user
 
 from werkzeug.datastructures import FileStorage
@@ -505,6 +505,15 @@ class FrequenciesAPI(API):
         '''List all available frequencies'''
         return [{'id': id, 'label': label}
                 for id, label in UPDATE_FREQUENCIES.items()]
+
+
+@ns.route('/extensions/', endpoint='allowed_extensions')
+class AllowedExtensionsAPI(API):
+    @api.doc('allowed_extensions')
+    @api.response(200, 'Success', [str])
+    def get(self):
+        '''List all allowed resources extensions'''
+        return current_app.config['ALLOWED_RESOURCES_EXTENSIONS']
 
 
 checkurl_parser = api.parser()

--- a/udata/core/storages/__init__.py
+++ b/udata/core/storages/__init__.py
@@ -4,9 +4,18 @@ from __future__ import unicode_literals
 from datetime import date
 from uuid import uuid4
 
+from flask import current_app
+
 import flask_fs as fs
 
 AUTHORIZED_TYPES = fs.AllExcept(fs.SCRIPTS + fs.EXECUTABLES)
+
+
+class ConfigurableAuthorizedTypes(object):
+    def __contains__(self, value):
+        return value in current_app.config['ALLOWED_RESOURCES_EXTENSIONS']
+
+CONFIGURABLE_AUTHORIZED_TYPES = ConfigurableAuthorizedTypes()
 
 
 def tmp_upload_to():
@@ -14,7 +23,7 @@ def tmp_upload_to():
     isodate = date.today().isoformat()
     return '/'.join((isodate, uuid))
 
-resources = fs.Storage('resources', AUTHORIZED_TYPES)
+resources = fs.Storage('resources', CONFIGURABLE_AUTHORIZED_TYPES)
 avatars = fs.Storage('avatars', fs.IMAGES)
 logos = fs.Storage('logos', fs.IMAGES)
 images = fs.Storage('images', fs.IMAGES)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -148,6 +148,26 @@ class Defaults(object):
     # Optimize uploaded images
     FS_IMAGES_OPTIMIZE = True
 
+    # Default resources extensions whitelist
+    ALLOWED_RESOURCES_EXTENSIONS = [
+        # Base
+        'csv', 'txt', 'json', 'pdf', 'xml', 'rdf', 'rtf', 'xsd',
+        # OpenOffice
+        'ods', 'odt', 'odp', 'odg',
+        # Microsoft Office
+        'xls', 'xlsx', 'doc', 'docx', 'pps', 'ppt',
+        # Archives
+        'tar', 'gz', 'tgz', 'rar', 'zip', '7z', 'xz', 'bz2',
+        # Images
+        'jpeg', 'jpg', 'jpe', 'gif', 'png', 'dwg', 'svg', 'tiff', 'ecw', 'svgz', 'jp2',
+        # Geo
+        'shp', 'kml', 'kmz', 'gpx', 'shx', 'ovr', 'geojson',
+        # Meteorology
+        'grib2',
+        # Misc
+        'dbf', 'prj', 'sql', 'epub', 'sbn', 'sbx', 'cpg', 'lyr', 'owl',
+    ]
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -887,6 +887,14 @@ class DatasetReferencesAPITest(APITestCase):
         self.assert200(response)
         self.assertEqual(len(response.json), len(UPDATE_FREQUENCIES))
 
+    def test_dataset_allowed_resources_extensions(self):
+        '''It should fetch the resources allowed extensions list from the API'''
+        extensions = ['csv', 'json', 'xml']
+        self.app.config['ALLOWED_RESOURCES_EXTENSIONS'] = extensions
+        response = self.get(url_for('api.allowed_extensions'))
+        self.assert200(response)
+        self.assertEqual(response.json, extensions)
+
 
 class CommunityResourceAPITest(APITestCase):
 

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -65,6 +65,22 @@ class TestStorageUtils(TestCase):
         self.assertIsNone(utils.mime('test'))
 
 
+class TestConfigurableAllowedExtensions(TestCase):
+    def test_has_default(self):
+        self.assertIn('csv', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertIn('xml', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertIn('json', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertNotIn('exe', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertNotIn('bat', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+
+    def test_with_config(self):
+        self.app.config['ALLOWED_RESOURCES_EXTENSIONS'] = ['csv', 'json']
+        self.assertIn('csv', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertIn('json', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertNotIn('xml', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertNotIn('exe', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+        self.assertNotIn('bat', storages.CONFIGURABLE_AUTHORIZED_TYPES)
+
 class StorageTestMixin(object):
     def create_app(self):
         app = super(StorageTestMixin, self).create_app()


### PR DESCRIPTION
This PR make the allowed extensions list configurable through the `ALLOWED_RESOURCES_EXTENSIONS` setting.
This make the admin file uploader prevent uploading these files AND it prevent these files from manually being uploaded through the API.

It also fixes some file upload bugs:
- properly displays upload errors in the admin
- do not behave like it succeed on upload error in the admin
- unauthorized file type is properly handled as error 400 with a json response in the API