### PR TITLE
Prevent redirect on front discussions fetch (fix #795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Default values are properly displayed on dataset form
   [#745](https://github.com/opendatateam/udata/issues/745)
+- Prevent a redirect on discussion fetch
+  [#795](https://github.com/opendatateam/udata/issues/795)
 
 ## 1.0.5 (2017-03-27)
 

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -78,7 +78,7 @@ export default {
         }
     },
     ready() {
-        this.$api.get('discussions', {for: this.subjectId}).then(response => {
+        this.$api.get('discussions/', {for: this.subjectId}).then(response => {
             this.discussions = response.data;
             if (document.location.hash) {
                 this.$nextTick(() => { // Wait for data to be binded


### PR DESCRIPTION
Prevent 301 redirect due to missing trailing slash on discussions fetch.
See #795 