### PR TITLE
Ensure that the deep resource URL is checked, not the redirect link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#795](https://github.com/opendatateam/udata/issues/795)
 - API exposes both original and biggest thumbnail for organization logo, reuse image and user avatar
   [#824](https://github.com/opendatateam/udata/issues/824)
+- Restore the broken URL check feature
+  [#840](https://github.com/opendatateam/udata/issues/840)
 
 ## 1.0.5 (2017-03-27)
 

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -169,7 +169,7 @@ new Vue({
          * @param  {Object} resource A resource as extracted from JSON-LD
          */
         checkResource(resource) {
-            const url = parseUrl(resource.url);
+            const url = parseUrl(resource.contentUrl);
             const resource_el = document.querySelector(`#resource-${resource['@id']}`)
             const el = resource_el.querySelector('.format-label');
             const checkurl = resource_el.dataset.checkurl;


### PR DESCRIPTION
This PR fix a side effect introduced by the permanent redirect link on resource.