### PR TITLE
Add Accept and Content-Type to allowed headers (CORS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Allow `Content-Type` and `Accept` in cors preflight headers
+  [#857](https://github.com/opendatateam/udata/pull/857)
 
 ## 1.0.7 (2017-04-07)
 

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -39,6 +39,8 @@ HEADER_API_KEY = 'X-API-KEY'
 PREFLIGHT_HEADERS = (
     HEADER_API_KEY,
     'X-Fields',
+    'Content-Type',
+    'Accept',
 )
 
 


### PR DESCRIPTION
Content-Type is required for _pre-flight mode_.