### PR TITLE
Remove style extraction for Vue components (fix #555, fix #710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@
     - lighter bootstrap style by importing only what's needed
     - make use of bootstrap and admin-lte variables (easier for theming)
     - proper separation between front and admin style
+- Drop `ExtractTextPlugin` on Vue components style:
+    - faster (re)compilation time
+    - resolves most compilation and missing style issues
+      [#555](https://github.com/opendatateam/udata/issues/555)
+      [#710](https://github.com/opendatateam/udata/issues/710)
+    - allows use of hot components reloading.
 
 
 ## 1.0.8 (2017-04-14)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,8 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const node_path = path.join(__dirname, 'node_modules');
 
-const css_loader = ExtractTextPlugin.extract('style', 'css?sourceMap');
-const less_loader = ExtractTextPlugin.extract('style', 'css?sourceMap!less?sourceMap=source-map-less-inline');
+const css_loader = ExtractTextPlugin.extract('vue-style?sourceMap', 'css?sourceMap');
+const less_loader = ExtractTextPlugin.extract('vue-style?sourceMap', 'css?sourceMap!less?sourceMap=source-map-less-inline');
 
 const languages = ['en', 'es', 'fr'];
 
@@ -60,8 +60,8 @@ module.exports = {
     },
     vue: {
         loaders: {
-            css: css_loader,
-            less: less_loader,
+            css: 'vue-style?sourceMap!css?sourceMap',
+            less: 'vue-style?sourceMap!css?sourceMap!less?sourceMap=source-map-less-inline',
             js: 'babel-loader'
         }
     },


### PR DESCRIPTION
This PR drops webpack `ExtractTextPlugin` on Vue components style:
- faster (re)compilation time
- resolves most compilation and missing style issues [#555](https://github.com/opendatateam/udata/issue/555) [#710](https://github.com/opendatateam/udata/issue/710)
- allows use of hot components reloading.
- reduce the amount of query for each display
