### PR TITLE
Proper producer logo display on dataset page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix bad stored (community) resources URLs [migration]
   [#882](https://github.com/opendatateam/udata/issues/882)
+- Proper producer logo display on dataset pages
 
 ## 1.0.9 (2017-04-23)
 

--- a/udata/templates/organization/sidebar-producer.html
+++ b/udata/templates/organization/sidebar-producer.html
@@ -1,8 +1,7 @@
 <a href="{{ url_for('organizations.show', org=organization, _external=True) }}"
    title="{{ organization.name }}">
-    <img src="{{ organization.logo(150)|placeholder('organization') }}"
-        alt="{{ organization.name }}" class="organization-logo producer"
-        width="150" height="150"/>
+    <img src="{{ organization.logo|placeholder('organization') }}"
+        alt="{{ organization.name }}" class="organization-logo producer"/>
 </a>
 <div class="caption text-left">
 {% if organization.description %}


### PR DESCRIPTION
Before:
![screenshot-www data dev 2017-04-28 09-26-37](https://cloud.githubusercontent.com/assets/15725/25610788/dfd69c02-2f24-11e7-9c04-8b71a3edd286.png)
![screenshot-www data dev 2017-04-28 09-26-57](https://cloud.githubusercontent.com/assets/15725/25610790/dff10704-2f24-11e7-8f8a-2bc2dce02332.png)
![screenshot-www data dev 2017-04-28 09-27-21](https://cloud.githubusercontent.com/assets/15725/25610789/dfd98fa2-2f24-11e7-825b-58b36c3c2dc2.png)

After:
![screenshot-www data dev 2017-04-28 09-28-57](https://cloud.githubusercontent.com/assets/15725/25610797/e6f431ca-2f24-11e7-949e-7d61673d6cdc.png)
![screenshot-www data dev 2017-04-28 09-29-21](https://cloud.githubusercontent.com/assets/15725/25610800/e71450f4-2f24-11e7-9a38-df91e8f240d3.png)
![screenshot-www data dev 2017-04-28 09-29-49](https://cloud.githubusercontent.com/assets/15725/25610799/e71328fa-2f24-11e7-8e35-9928dc7516f2.png)
