### PR TITLE
Handle empty notes and metadata resource types in CKAN harvester (fix #886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix bad stored (community) resources URLs [migration]
   [#882](https://github.com/opendatateam/udata/issues/882)
 - Proper producer logo display on dataset pages
+- Fix CKAN harvester empty notes and `metadata` file type handling
 
 ## 1.0.9 (2017-04-23)
 

--- a/udata/harvest/backends/ckan.py
+++ b/udata/harvest/backends/ckan.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 RESOURCE_TYPES = ('file', 'file.upload', 'api', 'documentation',
                   'image', 'visualization')
 
-ALLOWED_RESOURCE_TYPES = ('file', 'file.upload', 'api')
+ALLOWED_RESOURCE_TYPES = ('file', 'file.upload', 'api', 'metadata')
 
 resource = {
     'id': basestring,
@@ -75,7 +75,7 @@ schema = Schema({
     'id': basestring,
     'name': basestring,
     'title': basestring,
-    'notes': All(basestring, normalize_string),
+    'notes': Any(All(basestring, normalize_string), None),
     'license_id': All(DefaultTo('not-specified'), basestring),
     'tags': [tag],
 


### PR DESCRIPTION
This PR handle empty notes and `metadata` resource type in CKAN harvester