### PR TITLE
Use tmpfs mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,11 @@ services:
 
 
 
-        search:
-            image: udata/elasticsearch:2.4.5
-            volumes:
-              - ./data/search/data:/usr/share/elasticsearch/data
-            expose:
-              - "9200"
-            ports:
-              - "9200:9200"
+    search:
+        image: udata/elasticsearch:2.4.5
+        volumes:
+          - ./data/search/data:/usr/share/elasticsearch/data
+        expose:
+          - "9200"
+        ports:
+          - "9200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,31 @@
-db:
-    image: mongo:3.2
-    command: mongod
-    volumes:
-      - ./data/db:/data/db
-    expose:
-      - "27017"
-    ports:
-    - "27017:27017"
+version: "3"
+services:
+    db:
+        image: mongo:3.2
+        command: mongod
+        volumes:
+          - ./data/db:/data/db
+        expose:
+          - "27017"
+        ports:
+        - "27017:27017"
 
-broker:
-    image: redis
-    volumes:
-      - ./data/broker:/data
-    expose:
-      - "6379"
-    ports:
-    - "6379:6379"
+    broker:
+        image: redis
+        volumes:
+          - ./data/broker:/data
+        expose:
+          - "6379"
+        ports:
+          - "6379:6379"
 
-search:
-    image: udata/elasticsearch:2.4.5
-    volumes:
-      - ./data/search/data:/usr/share/elasticsearch/data
-    expose:
-      - "9200"
-    ports:
-      - "9200:9200"
+
+
+        search:
+            image: udata/elasticsearch:2.4.5
+            volumes:
+              - ./data/search/data:/usr/share/elasticsearch/data
+            expose:
+              - "9200"
+            ports:
+              - "9200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
         - "27017:27017"
 
     mongo_test:
-        image: mongo:3.4.0
-        tmpfs: /tmp/db
+        image: mongo:3.2.0
+        tmpfs: /data/db/
         expose:
           - "27018"
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ services:
         ports:
         - "27017:27017"
 
+    mongo_test:
+        image: mongo:3.4.0
+        tmpfs: /tmp/db
+        expose:
+          - "27018"
+        ports:
+          - "27018:27017"
+
     broker:
         image: redis
         volumes:

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -103,7 +103,6 @@ from udata.features.territories.models import *  # noqa
 def init_app(app):
     if app.config['TESTING']:
         app.config['MONGODB_DB'] = '{MONGODB_DB}-test'.format(**app.config)
-        app.config['MONGODB_PORT'] = 27018
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -103,6 +103,7 @@ from udata.features.territories.models import *  # noqa
 def init_app(app):
     if app.config['TESTING']:
         app.config['MONGODB_DB'] = '{MONGODB_DB}-test'.format(**app.config)
+        app.config['MONGODB_PORT'] = 27018
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)


### PR DESCRIPTION
This PR makes tests run 30 seconds faster.

You need to add : 
``MONGODB_PORT=27018``
to your configuration to activate the use of tmpfs