### PR TITLE
Fix overflowing icon on small-box component

### DIFF
--- a/js/components/containers/small-box.vue
+++ b/js/components/containers/small-box.vue
@@ -1,3 +1,9 @@
+<style lang="less">
+.small-box {
+    overflow: hidden;
+}
+</style>
+
 <template>
     <a class="small-box pointer" :class="[ bgcolor ]" @click="click">
         <div class="inner">


### PR DESCRIPTION
When hovering a small-box component, the icon would slightly zoom out of the box.
Fixed with an `overflow: hidden`

Fix #921 