### PR TITLE
Fix wizard pill height

### DIFF
--- a/js/components/widgets/wizard.vue
+++ b/js/components/widgets/wizard.vue
@@ -1,8 +1,11 @@
 <style lang="less">
 .wizard {
     .nav.nav-pills > li {
+        height: 100%;
+
         > a {
             border-radius: 4px;
+            height: 100%;
         }
 
         &.active {


### PR DESCRIPTION
Make pills 💊 take the full size of their container.

Fix #925 

![image](https://cloud.githubusercontent.com/assets/1301085/26502363/dd36bbe6-423c-11e7-9e04-6b84c0f6cce2.png)
