### PR TITLE
improve(admin): add an indicator on collapsible blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
   [#928](https://github.com/opendatateam/udata/issues/928)
     - Changed notification style to toast
     - Fix notifications that weren't displayed on form submission
+- Add a toggle indicator on dataset quality blocks that are collapsible
+  [#915](https://github.com/opendatateam/udata/issues/915)
 
 ## 1.0.11 (2017-05-25)
 

--- a/js/components/dataset/quality-section.vue
+++ b/js/components/dataset/quality-section.vue
@@ -3,6 +3,7 @@
     <h3 class="pointer" :class="textClass" @click="toggle">
         <span class="fa" :class="iconClass"></span>
         {{ title }}
+        <span class="fa pull-right" :class="angleClass"></span>
     </h3>
     <div class="collapse" :class="contentClass">
         <slot></slot>
@@ -53,6 +54,12 @@ export default {
                 'text-success': this.condition && !this.showInfo,
                 'text-warning': !this.condition && !this.showInfo,
                 'text-info': this.showInfo,
+            };
+        },
+        angleClass() {
+            return {
+                'fa-angle-down': !this.expanded,
+                'fa-angle-up': this.expanded
             };
         }
     },


### PR DESCRIPTION
![capture d ecran 2017-05-29 a 11 28 14](https://cloud.githubusercontent.com/assets/1301085/26544608/a3633f20-4462-11e7-91a1-27d51ed15b43.png)

Another way to do it would look like this: 
![capture d ecran 2017-05-29 a 11 27 14](https://cloud.githubusercontent.com/assets/1301085/26544741/3792d318-4463-11e7-83c1-4229898e52f7.png)
Plus and minus are a bit clearer, but they're a bit too big here because they're contained in a `h3`.
I believe `h3` is also too big though (bigger than the panel title), so it wouldn't be much of a problem if we diminish its size.

What do you prefer?

Fix #915 