### PR TITLE
improve(admin): fix datatable cell width

### DIFF
--- a/js/components/dataset/list.vue
+++ b/js/components/dataset/list.vue
@@ -21,7 +21,8 @@ export default {
                 key: 'title',
                 sort: 'title',
                 align: 'left',
-                type: 'text'
+                type: 'text',
+                width: 200
             }, {
                 label: this._('Creation'),
                 key: 'created_at',

--- a/js/components/datatable/table.vue
+++ b/js/components/datatable/table.vue
@@ -1,7 +1,15 @@
 <style lang="less">
 .datatable {
-    th {
-        white-space: nowrap;
+    thead tr th {
+        padding-right: 20px;
+        position: relative;
+        vertical-align: top;
+    }
+
+    .fa {
+        position: absolute;
+        top: 13px;
+        right: 3px;
     }
 }
 </style>


### PR DESCRIPTION
Set a default width for dataset name and removed the `whitespace: nowrap` to prevent column to stretch regarding column title.

![image](https://cloud.githubusercontent.com/assets/1301085/26587513/dba7c946-4552-11e7-9996-3a55fc4455c9.png)

Fix #922