### PR TITLE
Improve/fix the init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
     - `name` on all components: no more `Anonymous Component` in Vue debugger
     - No more `Fragments`
     - More ES6 everywhere
+<<<<<<< HEAD
 - Improve and fix notifications:
   [#928](https://github.com/opendatateam/udata/issues/928)
     - Changed notification style to toast
@@ -75,6 +76,12 @@
   [#968](https://github.com/opendatateam/udata/pull/968)
 - Resource can hold extra metadata into the `extras` attribute
   [#969](https://github.com/opendatateam/udata/pull/969)
+- Improve `init` command:
+    - migrate before trying to index
+    - search indexation/mapping reuse the `search init` command
+    - user is prompted for a superadmin user creation
+    - user is prompted for a default set of licenses to import
+    - user is prompted for some sample data creation
 
 ## 1.0.11 (2017-05-25)
 

--- a/docs/running-project.md
+++ b/docs/running-project.md
@@ -22,7 +22,7 @@ You need to initialize some data before pushing uData to it's full potential:
 ```shell
 # Initialize database, indexes...
 $ udata init
-# Fetch and load licenses
+# Optionnaly fetch and load some licenses
 $ udata licenses https://www.data.gouv.fr/api/1/datasets/licenses
 # Fetch last translations
 $ tx pull

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -23,6 +23,9 @@ log = logging.getLogger(__name__)
 
 manager = Manager()
 
+# Tell wether or not you can prompt user
+IS_INTERACTIVE = sys.__stdin__.isatty()
+
 
 def submanager(name, **kwargs):
     sub_manager = Manager(**kwargs)

--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -1,49 +1,32 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import unicode_literals
 
-from datetime import datetime
 import logging
 
 from udata.commands import manager
-from udata.core.dataset.factories import VisibleDatasetFactory, LicenseFactory
+from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.discussions.factories import DiscussionFactory
-from udata.core.organization.factories import OrganizationFactory, TeamFactory
-from udata.core.reuse.factories import VisibleReuseFactory
-from udata.core.user.factories import AdminFactory
+from udata.core.organization.factories import OrganizationFactory
+from udata.core.organization.models import Member
+from udata.core.reuse.factories import ReuseFactory
+from udata.core.user.factories import UserFactory
 
 log = logging.getLogger(__name__)
 
 
-def generate_datasets(count, organization=None):
-    for _ in range(0, count):
-        dataset = VisibleDatasetFactory(organization=organization)
-        DiscussionFactory(subject=dataset)
-
-
-def generate_reuses(count, user=None):
-    VisibleReuseFactory.create_batch(count, owner=user)
-
-
-def generate_licenses(count):
-    for _ in range(0, count):
-        LicenseFactory()
-
-
 @manager.command
-def generate_fixtures():
+def generate_fixtures(datasets=5, reuses=1):
     '''Build sample fixture data (users, datasets and reuses).'''
-    user = AdminFactory(email='user@udata', password='password',
-                        confirmed_at=datetime.now())
-    log.info('Generated admin user "user@udata" with password "password".')
+    user = UserFactory()
+    log.info('Generated user "{user.email}".'.format(user=user))
 
-    team = TeamFactory(members=[user])
-    organization = OrganizationFactory(teams=[team])
-    log.info('A team and an organization were generated for "user@udata".')
+    organization = OrganizationFactory(members=[Member(user=user)])
+    log.info('Generated organization "{org.name}".'.format(org=organization))
 
-    generate_datasets(count=5, organization=organization)
-    generate_reuses(count=5)
-    log.info('10 new datasets 5 reuses were generated.')
+    for _ in range(datasets):
+        dataset = VisibleDatasetFactory(organization=organization)
+        DiscussionFactory(subject=dataset, user=user)
+        ReuseFactory.create_batch(reuses, datasets=[dataset], owner=user)
 
-    generate_licenses(count=2)
-    log.info('2 new licences were generated.')
+    msg = 'Generated {datasets} dataset(s) with {reuses} reuse(s) each.'
+    log.info(msg.format(**locals()))

--- a/udata/core/dataset/commands.py
+++ b/udata/core/dataset/commands.py
@@ -20,9 +20,12 @@ FLAGS_MAP = {
     'is_osi_compliant': 'osi_compliant',
 }
 
+# Use CKAN license group from opendefinition as default license list
+DEFAULT_LICENSE_FILE = 'http://licenses.opendefinition.org/licenses/groups/ckan.json'  # noqa
+
 
 @manager.command
-def licenses(filename):
+def licenses(filename=DEFAULT_LICENSE_FILE):
     '''Feed the licenses from a JSON file'''
     if filename.startswith('http'):
         json_licenses = requests.get(filename).json()

--- a/udata/core/user/commands.py
+++ b/udata/core/user/commands.py
@@ -40,7 +40,7 @@ def create():
         user = datastore.create_user(**data)
         print '\nUser created successfully'
         print 'User(id=%s email=%s)' % (user.id, user.email)
-        return
+        return user
     print '\nError creating user:'
     for errors in form.errors.values():
         print '\n'.join(errors)


### PR DESCRIPTION
This PR improve the `udata init` command:
- migrate before trying to index
- search indexation/mapping reuse the `search init` command
- user is prompted for a superadmin user creation
- user is prompted for a default set of licenses to import
- user is prompted for some sample data creation
- does not prompt in a non-interactive environment