### PR TITLE
Make linters ignore some non-significant files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+udata/static/

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,23 @@ exclude-dir=udata/ext
     udata/translations
 
 [flake8]
-exclude = doc,.git,bower
+exclude =
+    .cache,
+    .git,
+    __pycache__,
+    build,
+    data,
+    dist,
+    docs,
+    instance,
+    js,
+    less,
+    node_modules,
+    reports,
+    requirements,
+    specs,
+    udata/static,
+    udata/templates
 
 [wheel]
 universal = 1


### PR DESCRIPTION
This PR make linters (ESlint and Flake8) ignore some non-significant files.
This should improve some editors with embeded linters (ie. Atom) CPU/memory consumption