### PR TITLE
Flask-Security i18n

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -20,7 +20,7 @@ Flask-Navigation==0.2.0
 Flask-OAuthlib==0.9.4
 flask-restplus==0.10.1
 Flask-Script==2.0.6
-Flask-Security-Fork==2.0.1
+Flask-Security==3.0.0
 Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
 Flask-WTF==0.14.2

--- a/udata/i18n.py
+++ b/udata/i18n.py
@@ -58,6 +58,14 @@ class PluggableDomain(Domain):
                                                          domain='wtforms')
                 translations.merge(wtforms_translations)
 
+                import flask_security
+                flask_security_translations = Translations.load(
+                    join(flask_security.__path__[0], 'translations'),
+                    locale,
+                    domain='flask_security'
+                )
+                translations.merge(flask_security_translations)
+
                 for plugin_name in current_app.config['PLUGINS']:
                     module_name = 'udata_{0}'.format(plugin_name)
                     module = import_module(module_name)
@@ -75,7 +83,7 @@ class PluggableDomain(Domain):
                 theme_translations_dir = join(theme.current.path, 'translations')
                 if exists(theme_translations_dir):
                     domain = theme.current.identifier
-                    theme_translations = Translations.load(theme_translations,
+                    theme_translations = Translations.load(theme_translations_dir,
                                                            locale,
                                                            domain=domain)
                     translations.merge(theme_translations)


### PR DESCRIPTION
Fix #626 

Before merging:
- wait for new `Flask-Security` release (see #626 for details)
- pin this new release into `install.pip` instead of my fork or `Flask-Security-Fork`