### PR TITLE
fix(admin): prevent users from going through wizard next step when no files are uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
     - Fix notifications that weren't displayed on form submission
 - Add a toggle indicator on dataset quality blocks that are collapsible
   [#915](https://github.com/opendatateam/udata/issues/915)
-- Display error message on file upload step when there is no file
+- Disable `next` button when no file has been uploaded
   [#930](https://github.com/opendatateam/udata/issues/930)
 
 ## 1.0.11 (2017-05-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@
     - Fix notifications that weren't displayed on form submission
 - Add a toggle indicator on dataset quality blocks that are collapsible
   [#915](https://github.com/opendatateam/udata/issues/915)
+- Display error message on file upload step when there is no file
+  [#930](https://github.com/opendatateam/udata/issues/930)
 
 ## 1.0.11 (2017-05-25)
 

--- a/js/components/widgets/image-picker.vue
+++ b/js/components/widgets/image-picker.vue
@@ -131,10 +131,10 @@ export default {
         save() {
             if (this.HAS_FILE_API) {
                 const data = {};
-                if (this.$refs.thumbnailer.bbox) {
+                try {
                     data.bbox = this.$refs.thumbnailer.bbox;
-                }
-                this.upload(data);
+                    this.upload(data);
+                } catch(e) {}
             } else {
                 this.$dispatch('image:saved');
             }

--- a/js/components/widgets/image-picker.vue
+++ b/js/components/widgets/image-picker.vue
@@ -111,6 +111,7 @@ export default {
                 log.warning('File APIs not supported');
                 this.upload();
             }
+            this.$dispatch('wizard:enable-next')
             return true;
         },
         'uploader:progress': function(id, uploaded, total) {

--- a/js/components/widgets/wizard.vue
+++ b/js/components/widgets/wizard.vue
@@ -56,6 +56,7 @@
                             </button>
                             <button v-if="next_step || finish"
                                 class="btn btn-primary btn-flat pull-right pointer"
+                                :disabled="disableNext"
                                 @click="click_next">
                                 {{ this.step_index + 1 === this.steps.length ? _('Finish') : _('Next') }}
                             </button>
@@ -111,6 +112,9 @@ export default {
                 return;
             }
             return this.steps[this.step_index - 1];
+        },
+        disableNext() {
+            return this.active_step && this.active_step.disableNext;
         }
     },
     components: {Box, Layout},
@@ -162,6 +166,10 @@ export default {
                 Vue.extend(step.component);
             this.$options.components[`step-${index}`] = component;
         });
+    }, events: {
+        'wizard:enable-next': function() {
+            this.active_step.disableNext = false;
+        }
     }
 };
 </script>

--- a/js/views/dataset-wizard.vue
+++ b/js/views/dataset-wizard.vue
@@ -59,7 +59,7 @@ export default {
                 }
             }, {
                 label: this._('Resources'),
-                subtitle: this._('Add your firsts resources'),
+                subtitle: this._('Add your first resources'),
                 component: ResourceForm,
                 init: (component) => {
                     component.dataset = this.dataset;

--- a/js/views/reuse-wizard.vue
+++ b/js/views/reuse-wizard.vue
@@ -61,7 +61,8 @@ export default {
                 next: (component) => {
                     component.save();
                     return false;
-                }
+                },
+                disableNext: true
             }, {
                 label: this._('Share'),
                 subtitle: this._('Communicate about your publication'),


### PR DESCRIPTION
Add an option to disable `next` button and an event to remove the disable state.
Should now display an error notification when the upload goes wrong.
Fix a typo.