### PR TITLE
Escape HTML string for JS use in form description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
     - Fix notifications that weren't displayed on form submission
 - Add a toggle indicator on dataset quality blocks that are collapsible
   [#915](https://github.com/opendatateam/udata/issues/915)
+- Fix login form password help display [#957](https://github.com/opendatateam/udata/issues/957)
 
 ## 1.0.11 (2017-05-25)
 

--- a/udata/frontend/helpers.py
+++ b/udata/frontend/helpers.py
@@ -350,3 +350,9 @@ def to_json(data):
 def format_number(number):
     '''A locale aware formatter.'''
     return format_number_babel(number, locale=g.lang_code)
+
+
+@front.app_template_filter()
+def escapejs(text):
+    """Escape (HTML) strings for using them in JS"""
+    return json.dumps(str(text))

--- a/udata/templates/macros/forms.html
+++ b/udata/templates/macros/forms.html
@@ -26,7 +26,7 @@
     <label for="{{ f.id }}"
         class="{{ cols.label }} control-label{% if f.flags.required %} required{% endif %}">
         {{ f.label.text }}
-        {% if f.description %}<span class="form-help" data-content="{{ f.description }}"></span>{% endif %}
+        {% if f.description %}<span class="form-help" data-content="{{ f.description|escapejs }}"></span>{% endif %}
     </label>
     <div class="field-wrapper {{ cols.control }}">
         {% if f.type == 'RadioField' %}


### PR DESCRIPTION
Fix #957 

This is probably overkill since from what I can see those descriptions are never displayed? Please advise ;-)