### PR TITLE
fix(discussion): fix discussions opening bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
   [#905](https://github.com/opendatateam/udata/pull/905)
 - Disable `next` button when no file has been uploaded
   [#930](https://github.com/opendatateam/udata/issues/930)
+- Fix a bug where users cannot create new discussions
 
 ## 1.0.11 (2017-05-25)
 

--- a/js/plugins/auth.js
+++ b/js/plugins/auth.js
@@ -41,7 +41,7 @@ export function install(Vue) {
      * @throws  {AuthenticationRequired} When the user is not authentified
      */
     Vue.prototype.$auth = function(message) {
-        if (!user) {
+        if (!this.$user) {
             window.location = get_auth_url(message);
             throw new AuthenticationRequired(message);  // This avoid calling function to continue its execution
         }


### PR DESCRIPTION
Clicking on the discussion creation button would trigger a js error with no feedback for the user.
It should now open a discussion form.