### PR TITLE
Added License.guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@
     - user is prompted for a superadmin user creation
     - user is prompted for a default set of licenses to import
     - user is prompted for some sample data creation
+- Added `License.guess()` helper to improve license matching while harvesting
+  [#967](https://github.com/opendatateam/udata/pull/967)
 
 ## 1.0.11 (2017-05-25)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -37,6 +37,7 @@ pytz==2017.2
 PyYAML==3.12
 redis==2.10.5
 requests==2.14.2
+StringDist==1.0.9
 unicodecsv==0.14.1
 voluptuous==0.10.5
 wtforms-json==0.3.1

--- a/udata/core/dataset/factories.py
+++ b/udata/core/dataset/factories.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 
 import factory
 
-from udata.utils import faker
-
 from .models import Dataset, Resource, Checksum, CommunityResource, License
 
 
@@ -55,5 +53,6 @@ class LicenseFactory(factory.mongoengine.MongoEngineFactory):
     class Meta:
         model = License
 
-    id = factory.Sequence(lambda n: '{0}-{1}'.format(faker.word(), n))
+    id = factory.Faker('unique_string')
     title = factory.Faker('sentence')
+    url = factory.Faker('uri')

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -43,6 +43,17 @@ class SlugField(StringField):
     def generate(self):
         return populate_slug(self.instance, self)
 
+    def slugify(self, value):
+        '''
+        Apply slugification according to specified field rules
+        '''
+        if value is None:
+            return
+
+        return slugify.slugify(value, max_length=self.max_length,
+                               separator=self.separator,
+                               to_lower=self.lower_case)
+
 
 class SlugFollow(Document):
     '''
@@ -87,17 +98,14 @@ def populate_slug(instance, field):
                      not field.update):
         return value
 
+    slug = field.slugify(value)
+
     # This can happen when serializing an object which does not contain
     # the properties used to generate the slug. Typically, when such
     # an object is passed to one of the Celery workers (see issue #20).
-    if value is None:
+    if slug is None:
         return
 
-    if field.lower_case:
-        value = value.lower()
-
-    slug = slugify.slugify(value, max_length=field.max_length,
-                           separator=field.separator)
     # If previous and slug ==
     old_slug = getattr(previous, field.db_field, None)
 

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -33,6 +33,14 @@ from udata.core.user.factories import UserFactory
 class TestCase(BaseTestCase):
     settings = settings.Testing
 
+    def setUp(self):
+        # Ensure compatibility with multiple inheritance
+        super(TestCase, self).setUp()
+
+    def tearsDown(self):
+        # Ensure compatibility with multiple inheritance
+        super(TestCase, self).tearsDown()
+
     def create_app(self):
         '''Create an application a test application.
 

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -177,6 +177,26 @@ class SlugFieldTest(DBTestMixin, TestCase):
         self.assertEqual(len(obj.title), SlugTester.slug.max_length + 1)
         self.assertEqual(len(obj.slug), SlugTester.slug.max_length)
 
+    def test_multiple_spaces(self):
+        field = db.SlugField()
+        self.assertEqual(field.slugify('a  b'), 'a-b')
+
+    def test_lower_case_default(self):
+        field = db.SlugField()
+        self.assertEqual(field.slugify('ABC'), 'abc')
+
+    def test_lower_case_false(self):
+        field = db.SlugField(lower_case=False)
+        self.assertEqual(field.slugify('AbC'), 'AbC')
+
+    def test_custom_separator(self):
+        field = db.SlugField(separator='+')
+        self.assertEqual(field.slugify('a b'), 'a+b')
+
+    def test_is_stripped(self):
+        field = db.SlugField()
+        self.assertEqual(field.slugify('  ab  '), 'ab')
+
 
 class DateFieldTest(DBTestMixin, TestCase):
     def test_none_if_empty_and_not_required(self):


### PR DESCRIPTION
This PR adds a `License.guess()` helper to improve license matching while harvesting.
It performs many checks to find a license:
- exact match by url
- exact match normalized name
- exact match by opendefinition ID
- fallback on string matching with a Damerau-Levenshtein distance (case of typo)