### PR TITLE
Unlocalized route on I18nBlueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,9 @@
 - Make metrics deactivable for tests
   [#905](https://github.com/opendatateam/udata/pull/905)
 - Disable `next` button when no file has been uploaded
-  [#930](https://github.com/opendatateam/udata/issues/930)
 - Fix a bug where users cannot create new discussions
+- Allows unlocalized URLs on `I18nBlueprint`
+  [#968](https://github.com/opendatateam/udata/pull/968)
 
 ## 1.0.11 (2017-05-25)
 

--- a/udata/tests/test_i18n.py
+++ b/udata/tests/test_i18n.py
@@ -26,6 +26,14 @@ def hardcoded():
     return out
 
 
+@bp.route('/not-localized/', localize=False)
+def not_localized():
+    out = g.lang_code + '-'
+    with language('fr'):
+        out += g.lang_code
+    return out
+
+
 class I18nBlueprintTest(WebTestMixin, DBTestMixin, TestCase):
     def create_app(self):
         app = super(I18nBlueprintTest, self).create_app()
@@ -73,3 +81,14 @@ class I18nBlueprintTest(WebTestMixin, DBTestMixin, TestCase):
 
         response = self.get('/lang/test/?q=test')
         self.assertRedirects(response, '/fr/lang/test/?q=test')
+
+    def test_lang_ignored_for_localize_false(self):
+        url = url_for('i18nbp.not_localized')
+        self.assertEqual(url, '/not-localized/')
+
+    def test_localized_url_redirect_for_localize_false(self):
+        url = url_for('i18nbp.not_localized_redirect')
+        self.assertEqual(url, '/en/not-localized/')
+
+        response = self.get(url)
+        self.assertRedirects(response, '/not-localized/')


### PR DESCRIPTION
This PR allows to define some non-localized URLs (ie. with language prefix) on `I18nBlueprint`.

There are many place in the application where have defined 2 blueprints for a single set of views, a classic `Blueprint` and a localized `I18nBlueprint`.

This PR allows to perform all this on a single i18nBlueprint and also adds the reverse redirect for unlocalized URLs (ie. `/<lang>/unlocalized/endpoint` redirect to `/unlocalized/endpoint`).