### PR TITLE
Allow resources to store extra metadata too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
 - Fix a bug where users cannot create new discussions
 - Allows unlocalized URLs on `I18nBlueprint`
   [#968](https://github.com/opendatateam/udata/pull/968)
+- Resource can hold extra metadata into the `extras` attribute
+  [#969](https://github.com/opendatateam/udata/pull/969)
 
 ## 1.0.11 (2017-05-25)
 

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -62,6 +62,7 @@ resource_fields = api.model('Resource', {
         attribute='modified', readonly=True,
         description='The resource last modification date'),
     'metrics': fields.Raw(description='The resource metrics', readonly=True),
+    'extras': fields.Raw(description='Extra attributes as key-value pairs'),
     'is_available': fields.Raw(
         description='The resource availability', readonly=True),
 })

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -136,6 +136,7 @@ class ResourceMixin(object):
     format = db.StringField()
     mime = db.StringField()
     filesize = db.IntField()  # `size` is a reserved keyword for mongoengine.
+    extras = db.ExtrasField()
 
     created_at = db.DateTimeField(default=datetime.now, required=True)
     modified = db.DateTimeField(default=datetime.now, required=True)


### PR DESCRIPTION
This PR allows resources to store extra metadata in the `extras` attribute like `Dataset.extras`.

Main use case: allows harvesters to store the remote resource identifier to improve the update behavior.