### PR TITLE
Refactor security forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@
     - `name` on all components: no more `Anonymous Component` in Vue debugger
     - No more `Fragments`
     - More ES6 everywhere
-<<<<<<< HEAD
 - Improve and fix notifications:
   [#928](https://github.com/opendatateam/udata/issues/928)
     - Changed notification style to toast
@@ -84,6 +83,8 @@
     - user is prompted for some sample data creation
 - Added `License.guess()` helper to improve license matching while harvesting
   [#967](https://github.com/opendatateam/udata/pull/967)
+- Cleaner login, signup and password related forms
+  [#971](https://github.com/opendatateam/udata/pull/971)
 
 ## 1.0.11 (2017-05-25)
 

--- a/udata/templates/macros/forms.html
+++ b/udata/templates/macros/forms.html
@@ -14,7 +14,6 @@
 
 {% macro field(f, sizes='sm-2,md-3') %}
 <fieldset>
-    <legend>{{f.label}}</legend>
     {% if f.subfield %}
       {% for subfield in f %}
       {{ field(subfield, sizes) }}
@@ -26,7 +25,6 @@
     <label for="{{ f.id }}"
         class="{{ cols.label }} control-label{% if f.flags.required %} required{% endif %}">
         {{ f.label.text }}
-        {% if f.description %}<span class="form-help" data-content="{{ f.description }}"></span>{% endif %}
     </label>
     <div class="field-wrapper {{ cols.control }}">
         {% if f.type == 'RadioField' %}


### PR DESCRIPTION
Light refactoring of `Flask-Security` related forms.

1. Remove fieldset
2. Remove description

Looks cleaner IMHO. Fix #957. Replace #960.

<img width="741" alt="capture d ecran 2017-06-13 16 11 29" src="https://user-images.githubusercontent.com/119625/27086819-a27b4286-5053-11e7-9a5b-a3d8ddc8e9bf.png">
<img width="733" alt="capture d ecran 2017-06-13 16 12 00" src="https://user-images.githubusercontent.com/119625/27086818-a27af6f0-5053-11e7-97fa-5b2243241378.png">
<img width="484" alt="capture d ecran 2017-06-13 16 12 22" src="https://user-images.githubusercontent.com/119625/27086817-a27837ee-5053-11e7-9318-9970d33c14b1.png">
<img width="657" alt="capture d ecran 2017-06-13 16 12 30" src="https://user-images.githubusercontent.com/119625/27086816-a2733f82-5053-11e7-9954-858f3dd3b5a0.png">
<img width="657" alt="capture d ecran 2017-06-13 16 12 49" src="https://user-images.githubusercontent.com/119625/27086820-a28130e2-5053-11e7-95e3-32bb416a883c.png">
