### PR TITLE
Mention lzma dependency for macOS

### DIFF
--- a/docs/local-dependencies.md
+++ b/docs/local-dependencies.md
@@ -5,6 +5,13 @@
 It is recommended to work within a virtualenv to ensure proper dependencies isolation.
 If you're not familiar with that concept, read [Python Virtual Environments - a Primer][].
 
+!!! note
+    On macOS, the library `lzma.h` has to be installed prior to running the next block of commands.
+
+    ```shell
+    $ brew install xz
+    ```
+
 Alright, now you can [install virtualenv][install-virtualenv] and then type these commands knowing what you are doing:
 
 ```shell


### PR DESCRIPTION
Otherwise the following error would be shown:

```
  In file included from src/liblzma.c:1:
  src/liblzma.h:24:10: fatal error: 'lzma.h' file not found
  #include <lzma.h>
           ^
  1 error generated.
  error: command 'clang' failed with exit status 1

  ----------------------------------------
  Failed building wheel for pyliblzma
```