### PR TITLE
Middleware URLs: doc and harmonization

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -134,14 +134,9 @@ ELASTICSEARCH_URL = 'http://<user>:<password>@<host>:<port>'
 
 ## Mongoengine/Flask-Mongoengine options
 
-### MONGODB_SETTINGS
+### MONGODB_HOST
 
-**default**:
-```python
-MONGODB_SETTINGS = {
-    'host': 'mongodb://localhost:27017/udata'
-}
-```
+**default**: `'mongodb://localhost:27017/udata'`
 
 The mongodb database used by udata.
 During tests, the test database will use the same name suffixed by `-test`
@@ -152,9 +147,7 @@ for more details.
 Authentication is also supported in the URL:
 
 ```python
-MONGODB_SETTINGS = {
-    'host': 'mongodb://<user>:<password>@<host>:<port>/<database>'
-}
+MONGODB_HOST = 'mongodb://<user>:<password>@<host>:<port>/<database>'
 ```
 
 ## Celery options

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -129,7 +129,7 @@ ELASTICSEARCH_URL = 'elasticserver:9200'
 RFC-1738 formatted URLs are also supported:
 
 ```python
-ELASTICSEARCH_URL = 'https://user:secret@other_host:443'
+ELASTICSEARCH_URL = 'http://<user>:<password>@<host>:<port>'
 ```
 
 ## Mongoengine/Flask-Mongoengine options

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -126,29 +126,36 @@ The elasticsearch server url used for search indexing.
 ELASTICSEARCH_URL = 'elasticserver:9200'
 ```
 
+RFC-1738 formatted URLs are also supported:
+
+```python
+ELASTICSEARCH_URL = 'https://user:secret@other_host:443'
+```
+
 ## Mongoengine/Flask-Mongoengine options
 
-### MONGODB_HOST
+### MONGODB_SETTINGS
 
-**default**: `localhost`
-
-The mongodb hostname used by udata.
-
-### MONGODB_PORT
-
-**default**: `27017`
-
-The mongodb post used by udata.
-
-### MONGODB_DB
-
-**default**: `udata`
+**default**:
+```python
+MONGODB_SETTINGS = {
+    'host': 'mongodb://localhost:27017/udata'
+}
+```
 
 The mongodb database used by udata.
 During tests, the test database will use the same name suffixed by `-test`
 
 See [the official Flask-MongoEngine documentation][flask-mongoengine-doc]
 for more details.
+
+Authentication is also supported in the URL:
+
+```python
+MONGODB_SETTINGS = {
+    'host': 'mongodb://<user>:<password>@<host>:<port>/<database>'
+}
+```
 
 ## Celery options
 
@@ -167,6 +174,13 @@ CELERY_ACCEPT_CONTENT = ['pickle', 'json']
 CELERYD_HIJACK_ROOT_LOGGER = False
 CELERYBEAT_SCHEDULER = 'udata.tasks.Scheduler'
 CELERY_MONGODB_SCHEDULER_COLLECTION = "schedules"
+```
+
+Authentication is supported on Redis:
+
+```python
+CELERY_RESULT_BACKEND = 'redis://u:<password>@<host>:<port>'
+BROKER_URL = 'redis://u:<password>@<host>:<port>'
 ```
 
 You can see the full list of Celery options in the [Celery official documentation][celery-doc].

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -105,11 +105,9 @@ from udata.features.territories.models import *  # noqa
 def init_app(app):
     # use `{database_name}-test` database for testing
     if app.config['TESTING']:
-        parsed_url = urlparse(app.config['MONGODB_SETTINGS']['host'])
+        parsed_url = urlparse(app.config['MONGODB_HOST'])
         parsed_url = parsed_url._replace(path='%s-test' % parsed_url.path)
-        app.config['MONGODB_SETTINGS'] = {
-            'host': parsed_url.geturl()
-        }
+        app.config['MONGODB_HOST'] = parsed_url.geturl()
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import importlib
 import logging
 
+from urlparse import urlparse
+
 from bson import ObjectId, DBRef
 from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 from mongoengine.base import TopLevelDocumentMetaclass, get_document
@@ -101,8 +103,13 @@ from udata.features.territories.models import *  # noqa
 
 
 def init_app(app):
+    # use `{database_name}-test` database for testing
     if app.config['TESTING']:
-        app.config['MONGODB_DB'] = '{MONGODB_DB}-test'.format(**app.config)
+        parsed_url = urlparse(app.config['MONGODB_SETTINGS']['host'])
+        parsed_url = parsed_url._replace(path='%s-test' % parsed_url.path)
+        app.config['MONGODB_SETTINGS'] = {
+            'host': parsed_url.geturl()
+        }
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -16,9 +16,7 @@ class Defaults(object):
     CONTACT_EMAIL = 'contact@example.org'
     TERRITORIES_EMAIL = 'territories@example.org'
 
-    MONGODB_SETTINGS = {
-        'host': 'mongodb://localhost:27017/udata'
-    }
+    MONGODB_HOST = 'mongodb://localhost:27017/udata'
 
     # BROKER_TRANSPORT = 'redis'
     BROKER_URL = 'redis://localhost:6379'

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -16,9 +16,9 @@ class Defaults(object):
     CONTACT_EMAIL = 'contact@example.org'
     TERRITORIES_EMAIL = 'territories@example.org'
 
-    MONGODB_HOST = 'localhost'
-    MONGODB_PORT = 27017
-    MONGODB_DB = 'udata'
+    MONGODB_SETTINGS = {
+        'host': 'mongodb://localhost:27017/udata'
+    }
 
     # BROKER_TRANSPORT = 'redis'
     BROKER_URL = 'redis://localhost:6379'

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import logging
 
+from urlparse import urlparse
+
 from celery import Celery, Task
 from celery.utils.log import get_task_logger
 from celerybeatmongo.schedulers import MongoScheduler
@@ -87,12 +89,11 @@ def schedulables():
 def init_app(app):
     celery.main = app.import_name
 
-    default_name = app.config.get('MONGODB_DB', 'celery')
-    app.config.setdefault('CELERY_MONGODB_SCHEDULER_DB', default_name)
+    parsed_url = urlparse(app.config['MONGODB_SETTINGS']['host'])
 
-    from udata.models import db
-    with app.app_context():
-        default_url = 'mongodb://{0}:{1}'.format(*db.connection.address)
+    app.config.setdefault('CELERY_MONGODB_SCHEDULER_DB', parsed_url.path[1:])
+
+    default_url = '{0}://{1}'.format(*parsed_url)
     app.config.setdefault('CELERY_MONGODB_SCHEDULER_URL', default_url)
 
     celery.conf.update(app.config)

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -89,7 +89,7 @@ def schedulables():
 def init_app(app):
     celery.main = app.import_name
 
-    parsed_url = urlparse(app.config['MONGODB_SETTINGS']['host'])
+    parsed_url = urlparse(app.config['MONGODB_HOST'])
 
     app.config.setdefault('CELERY_MONGODB_SCHEDULER_DB', parsed_url.path[1:])
 

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -183,7 +183,7 @@ class WebTestMixin(object):
 class DBTestMixin(object):
     def drop_db(self):
         '''Clear the database'''
-        parsed_url = urlparse(self.app.config['MONGODB_SETTINGS']['host'])
+        parsed_url = urlparse(self.app.config['MONGODB_HOST'])
         # drop the leading /
         db_name = parsed_url.path[1:]
         db.connection.drop_database(db_name)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -12,7 +12,7 @@ import mock
 
 from contextlib import contextmanager
 from StringIO import StringIO
-from urlparse import urljoin
+from urlparse import urljoin, urlparse
 
 from flask import request, url_for
 from flask_testing import TestCase as BaseTestCase
@@ -183,7 +183,9 @@ class WebTestMixin(object):
 class DBTestMixin(object):
     def drop_db(self):
         '''Clear the database'''
-        db_name = self.app.config['MONGODB_DB']
+        parsed_url = urlparse(self.app.config['MONGODB_SETTINGS']['host'])
+        # drop the leading /
+        db_name = parsed_url.path[1:]
         db.connection.drop_database(db_name)
 
     def setUp(self):


### PR DESCRIPTION
- document the use of RFC-1738 formatted URLs for middleware configurations (with authentication support)
- use `MONGODB_SETTINGS` with an URL instead of `MONGODB_*` settings

Fix #881