### PR TITLE
Restore Read The Docs search

### DIFF
--- a/docs/custom_theme/searchbox.html
+++ b/docs/custom_theme/searchbox.html
@@ -1,0 +1,5 @@
+<div role="search">
+  <form id="rtd-search-form-alt" class="wy-form" action="{{ base_url }}/search.html" method="get">
+    <input type="text" name="q" placeholder="Search docs" />
+  </form>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_author: Etalab
 repo_url: https://github.com/etalab/udata
 
 theme: readthedocs
+theme_dir: 'docs/custom_theme'
 
 pages:
     - Home: index.md


### PR DESCRIPTION
> It appears that the form action for the searchbox is being injected with this javascript: https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/core/static-src/core/js/doc-embed/mkdocs.js

cf. rtfd/readthedocs.org#1088

refs docksal/docksal#120