### PR TITLE
Search: Display figures inline in tabs

### DIFF
--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -24,41 +24,31 @@
     {% if datasets %}
         <li class="active" data-tab="datasets">
             <a href @click.prevent="setTab('datasets')">
-                {{ _('Datasets')}}
-                <span class="badge">{{ datasets.total }}</span>
+                {{ ngettext('%(num)d dataset', '%(num)d datasets',datasets.total)}}
             </a>
         </li>
     {% endif %}
     {% if reuses %}
         <li{% if not datasets %} class="active"{% endif %} data-tab="reuses">
             <a href @click.prevent="setTab('reuses')">
-                {{ _('Reuses') }}
-                <span class="badge">{{ reuses.total }}</span>
+                {{ ngettext('%(num)d reuse', '%(num)d reuses', reuses.total) }}
             </a>
         </li>
     {% endif %}
     {% if organizations %}
         <li{% if not datasets and not reuses %} class="active"{% endif %} data-tab="organizations">
             <a href @click.prevent="setTab('organizations')">
-                {{ _('Organizations') }}
-                <span class="badge">{{ organizations.total }}</span>
+                {{ ngettext('%(num)d organization', '%(num)d organizations', organizations.total) }}
             </a>
         </li>
     {% endif %}
     {% if territories %}
         <li{% if not datasets and not reuses and not organizations %} class="active"{% endif %} data-tab="territories">
             {% set total=territories|length %}
-            {% if total==1 %}
-                <a href="{{ territories.0.url }}">
-                    {{ _('Territory:') }}
-                    <span class="badge">{{ territories.0.name }}</span>
-                </a>
-            {% else %}
-                <a href @click.prevent="setTab('territories')">
-                    {{ _('Territories') }}
-                    <span class="badge">{{ total }}</span>
-                </a>
-            {% endif %}
+            <a href{% if total==1 %}="{{ territories.0.url }}"{% else %}  @click.prevent="setTab('territories')"{% endif %}>
+                {{ ngettext('Territory: %(name)s', '%(num)d territories', total, name=territories.0.name) }}
+            </a>
+
         </li>
     {% endif %}
 </ul>

--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -16,10 +16,11 @@
 {% set datasets_search_url = url_for('datasets.list') %}
 {% set reuses_search_url = url_for('reuses.list') %}
 {% set organizations_search_url = url_for('organizations.list') %}
+{% set breadcrum_class='search-bar'%}
 
 {% block breadcrumb_bar %}
 <!-- Nav tabs -->
-<ul class="nav nav-tabs search-tabs">
+<ul class="nav nav-tabs search-tabs nav-tabs--search-tabs">
     {% if datasets %}
         <li class="active" data-tab="datasets">
             <a href @click.prevent="setTab('datasets')">


### PR DESCRIPTION
Also, advocate for a CSS class semantic which reflects it is not a breadcrumb but a search bar.

<img width="765" alt="screen shot 2017-06-24 at 00 24 05" src="https://user-images.githubusercontent.com/138627/27503384-774c1bf8-5873-11e7-8deb-b9560d9210f1.png">

# Before / After

![searchbar gif](https://user-images.githubusercontent.com/138627/27503515-9b9bab94-5874-11e7-8c25-732ba3c4ad24.gif)