### PR TITLE
Entrypoint-based harvesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@
   [#499](https://github.com/opendatateam/udata/issues/499)
 - Images placeholders are now entirely provided by themes
   [#707](https://github.com/opendatateam/udata/issues/707)
+- Harvester declaration is now entrypoint-based
+  [#1004](https://github.com/opendatateam/udata/pull/1004)
 
 ## 1.0.11 (2017-05-25)
 

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -165,12 +165,10 @@ from __future__ import unicode_literals
 from udata.models import db, Resource
 from udata.utils import faker
 
-from . import BaseBackend, register
+from udata.harvest.backends.base import BaseBackend
 
 
-@register
 class RandomBackend(BaseBackend):
-    name = 'random'
     display_name = 'Random'
 
     def initialize(self):
@@ -213,6 +211,29 @@ class RandomBackend(BaseBackend):
         return dataset
 
 ```
+
+You need to properly expose the harvester as a `udata.harvesters` entrypoint in your `setup.py`:
+
+```python
+setup(
+    '...'
+    entry_points={
+        'udata.harvesters': [
+            'random = canonical.path.to_the:RandomBackend',
+        ]
+    },
+    '...'
+)
+```
+
+The easiest way is to start from the
+[dedicated cookiecutter template][cookiecutter-template]:
+
+```bash
+pip install cookiecutter
+cookiecutter gh:opendatateam/cookiecutter-udata-harvester
+```
+This will create a new package with a harvester skeleton on which you can start hacking.
 
 You may take a look at the [existing backends][backends-repository] to see exiting implementations.
 

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,11 @@ setup(
         ],
         'udata.themes': [
             'default = udata.theme.default',
+        ],
+        'udata.harvesters': [
+            'ods = udata.harvest.backends.ods:OdsHarvester',
+            'ckan = udata.harvest.backends.ckan:CkanBackend',
+            'dcat = udata.harvest.backends.dcat:DcatBackend',
         ]
     },
     license='GNU AGPLv3+',

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -18,7 +18,10 @@ from .models import (
 
 ns = api.namespace('harvest', 'Harvest related operations')
 
-backends_ids = [b.name for b in actions.list_backends()]
+
+def backends_ids():
+    return [b.name for b in actions.list_backends()]
+
 
 error_fields = api.model('HarvestError', {
     'created_at': fields.ISODateTime(description='The error creation date',
@@ -259,10 +262,10 @@ class ListBackendsAPI(API):
     @api.marshal_with(backend_fields)
     def get(self):
         '''List all available harvest backends'''
-        return [
+        return sorted([
             {'id': b.name, 'label': b.display_name}
             for b in actions.list_backends()
-        ]
+        ], key=lambda b: b['label'])
 
 
 @ns.route('/job_status', endpoint='havest_job_status')

--- a/udata/harvest/backends/ckan.py
+++ b/udata/harvest/backends/ckan.py
@@ -15,7 +15,7 @@ from voluptuous import (
 from udata.models import db, Resource, License, SpatialCoverage
 from udata.utils import get_by, daterange_start, daterange_end
 
-from . import BaseBackend, register
+from .base import BaseBackend
 from ..exceptions import HarvestException, HarvestSkipException
 from ..filters import (
     boolean, email, to_date, slug, normalize_tag, normalize_string,
@@ -98,9 +98,7 @@ schema = Schema({
 }, required=True, extra=True)
 
 
-@register
 class CkanBackend(BaseBackend):
-    name = 'ckan'
     display_name = 'CKAN'
 
     def get_headers(self):

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -11,7 +11,7 @@ from udata.rdf import (
 )
 from udata.core.dataset.rdf import dataset_from_rdf
 
-from . import BaseBackend, register
+from .base import BaseBackend
 
 log = logging.getLogger(__name__)
 
@@ -43,9 +43,7 @@ def extract_graph(source, target, node, specs):
             extract_graph(source, target, o, specs[p])
 
 
-@register
 class DcatBackend(BaseBackend):
-    name = 'dcat'
     display_name = 'DCAT'
 
     def initialize(self):

--- a/udata/harvest/backends/ods.py
+++ b/udata/harvest/backends/ods.py
@@ -6,16 +6,14 @@ import logging
 import html2text
 
 from udata.models import License, Resource
-from . import BaseBackend, register
+from .base import BaseBackend
 from ..exceptions import HarvestSkipException
 
 
 log = logging.getLogger(__name__)
 
 
-@register
 class OdsHarvester(BaseBackend):
-    name = 'ods'
     display_name = 'OpenDataSoft'
     verify_ssl = False
 

--- a/udata/harvest/forms.py
+++ b/udata/harvest/forms.py
@@ -11,16 +11,15 @@ from .models import VALIDATION_STATES, VALIDATION_REFUSED
 __all__ = 'HarvestSourceForm', 'HarvestSourceValidationForm'
 
 
-backends = [(b.name, b.display_name) for b in list_backends()]
-
-
 class HarvestSourceForm(Form):
     name = fields.StringField(_('Name'), [validators.required()])
     description = fields.MarkdownField(
         _('Description'),
         description=_('Some optionnal details about this harvester'))
     url = fields.URLField(_('URL'), [validators.required()])
-    backend = fields.SelectField(_('Backend'), choices=backends)
+    backend = fields.SelectField(_('Backend'), choices=lambda: [
+        (b.name, b.display_name) for b in list_backends()
+    ])
     owner = fields.CurrentUserField()
     organization = fields.PublishAsField(_('Publish as'))
 

--- a/udata/harvest/tests/factories.py
+++ b/udata/harvest/tests/factories.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 import factory
 
 from factory.fuzzy import FuzzyChoice
-
 from flask.signals import Namespace
+from mock import patch
 
 from udata.core.dataset.factories import DatasetFactory
 
@@ -45,7 +45,6 @@ mock_process = ns.signal('backend:process')
 DEFAULT_COUNT = 3
 
 
-@backends.register
 class FactoryBackend(backends.BaseBackend):
     name = 'factory'
 
@@ -57,3 +56,16 @@ class FactoryBackend(backends.BaseBackend):
     def process(self, item):
         mock_process.send(self, item=item)
         return DatasetFactory.build(title='dataset-{0}'.format(item.remote_id))
+
+
+class MockBackendsMixin(object):
+    '''A mixin mocking the harvest backend'''
+    def setUp(self):
+        super(MockBackendsMixin, self).setUp()
+        self.patcher = patch('udata.harvest.backends.get_all')
+        mock_get_all = self.patcher.start()
+        mock_get_all.return_value = {'factory': FactoryBackend}
+
+    def tearDown(self):
+        super(MockBackendsMixin, self).tearDown()
+        self.patcher.stop()

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -18,7 +18,7 @@ from udata.core.dataset.factories import DatasetFactory
 from udata.utils import faker, Paginable
 
 from .factories import (
-    HarvestSourceFactory, HarvestJobFactory,
+    HarvestSourceFactory, HarvestJobFactory, MockBackendsMixin,
     mock_initialize, mock_process, DEFAULT_COUNT as COUNT
 )
 from ..models import (
@@ -372,7 +372,7 @@ class HarvestActionsTest(DBTestMixin, TestCase):
         self.assertEqual(result.errors, 1)
 
 
-class ExecutionTestMixin(DBTestMixin):
+class ExecutionTestMixin(MockBackendsMixin, DBTestMixin):
     def test_default(self):
         org = OrganizationFactory()
         source = HarvestSourceFactory(backend='factory', organization=org)
@@ -485,7 +485,7 @@ class HarvestRunTest(ExecutionTestMixin, TestCase):
         return actions.run(*args, **kwargs)
 
 
-class HarvestPreviewTest(DBTestMixin, TestCase):
+class HarvestPreviewTest(MockBackendsMixin, DBTestMixin, TestCase):
     def test_preview(self):
         org = OrganizationFactory()
         source = HarvestSourceFactory(backend='factory', organization=org)

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -16,13 +16,13 @@ from udata.utils import faker
 from ..models import (
     HarvestSource, VALIDATION_ACCEPTED, VALIDATION_REFUSED, VALIDATION_PENDING
 )
-from .factories import HarvestSourceFactory
+from .factories import HarvestSourceFactory, MockBackendsMixin
 
 
 log = logging.getLogger(__name__)
 
 
-class HarvestAPITest(APITestCase):
+class HarvestAPITest(MockBackendsMixin, APITestCase):
     def test_list_backends(self):
         '''It should fetch the harvest backends list from the API'''
         response = self.get(url_for('api.harvest_backends'))


### PR DESCRIPTION
This PR makes harvester declaration entrypoint-based, like themes are.

This avoid using a global dictionnary to stora harvesters.
The documentation has been adapted (and a cookiecutter is coming [here](https://github.com/opendatateam/cookiecutter-udata-harvester)