### PR TITLE
Reindex datasets when an organization is purged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@
   [#1004](https://github.com/opendatateam/udata/pull/1004)
 - Fix the `udata search reindex` command
   [#1009](https://github.com/opendatateam/udata/issues/1009)
+- Reindex datasets when their parent organization is purged
+  [#1008](https://github.com/opendatateam/udata/issues/1008)
 
 ## 1.0.11 (2017-05-25)
 

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -136,7 +136,6 @@ def reindex(obj):
         except:
             log.exception('Unable to index %s "%s"',
                           model.__name__, str(obj.id))
-        adapter.delete(using=es.client, index=es.index_name)
     else:
         log.info('Nothing to do for %s (%s)', model.__name__, obj.id)
 

--- a/udata/tests/organization/test_organization_tasks.py
+++ b/udata/tests/organization/test_organization_tasks.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from .. import TestCase, SearchTestMixin
+
+from udata.models import Dataset, Organization
+from udata.core.dataset.factories import DatasetFactory, ResourceFactory
+from udata.core.dataset.search import DatasetSearch
+from udata.core.organization import tasks
+from udata.search import es
+
+
+class OrganizationTasksTest(SearchTestMixin, TestCase):
+    def test_purge_organizations(self):
+        with self.autoindex():
+            org = Organization.objects.create(
+                name='delete me', deleted='2016-01-01', description='XXX')
+            resources = [ResourceFactory() for _ in range(2)]
+            dataset = DatasetFactory(resources=resources, organization=org)
+
+        tasks.purge_organizations()
+
+        dataset = Dataset.objects(id=dataset.id).first()
+        self.assertEqual(dataset.organization, None)
+
+        organization = Organization.objects(name='delete me').first()
+        self.assertEqual(organization, None)
+
+        indexed_dataset = DatasetSearch.get(id=dataset.id,
+                                            using=es.client,
+                                            index=es.index_name)
+        self.assertEqual(indexed_dataset.organization, '')


### PR DESCRIPTION
Fix #1008 

Should also be done with other linked document types?