### PR TITLE
fix(search): populate Search field with user provided value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Display organization metrics in the organization page tab labels [#1022](https://github.com/opendatateam/udata/pull/1022)
 - Organization dashboard page has been merged into the main organization page [#1023](https://github.com/opendatateam/udata/pull/1023)
+- Fix an issue causing a loss of data input at the global search input level [#1019](https://github.com/opendatateam/udata/pull/1019)
 
 ## 1.1.0 (2017-07-05)
 

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -63,11 +63,18 @@ export default {
         size: String,
         territoryId: String,
     },
+    created() {
+        const {query} = this.$location;
+
+        const originalField = this.$options.el.querySelector('#search');
+        const queryStringValue = decodeURIComponent(query.q.replace('+', ' '));
+
+        this.query = originalField.value || queryStringValue || '';
+    },
     data() {
-        const query = this.$location.query.q || '';
         return {
             current: -1,
-            query: decodeURIComponent(query.replace('+', ' ')),
+            query: null,
             show: false,
             cache: new Cache('site-search', sessionStorage),
             groups: [


### PR DESCRIPTION
This pull request populates the _query_ field when the Vue component is initialised.

# The Good

It works.

# The Bad

I have not found any particular documentation for `$options.el` so it might break when upgrading Vue.js.

There are probably better ways to do:

- passing a `value="..."` property to the search field as a prop (could not figure out how to pass the paramter to the search macro)
- maybe a more official way to bind to the original input#search field


# The Ugly

The Vue component relies on the DOM of the original so it can break just by changing the HTML template.

# What's next?

Once this issue is fixed, I would like to remove the code duplication between the HTML view and the Vue component. Either by extending the form and providing only the autocomplete feature.

fix #1016 