### PR TITLE
feature(organization): display datasets/members/reuses counts in org pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Display organization metrics in the organization page tab labels [#1022](https://github.com/opendatateam/udata/pull/1022)
 
 ## 1.1.0 (2017-07-05)
 

--- a/udata/templates/organization/display.html
+++ b/udata/templates/organization/display.html
@@ -43,12 +43,12 @@
 {% block secondary_content %}
 {# Datasets and reuses tabs #}
 {% set dataset_tabs = (
-    ('datasets', _('Datasets'), datasets, {'organization': org.id|string}),
-    ('private-datasets', _('Private datasets'), private_datasets, {}),
+    ('datasets', ngettext('%(num)d dataset', '%(num)d datasets', datasets.total or 0), datasets, {'organization': org.id|string}),
+    ('private-datasets', ngettext('%(num)d private dataset', '%(num)d private datasets', private_datasets.total or 0), private_datasets, {}),
 ) %}
 {% set reuse_tabs = (
-    ('reuses', _('Reuses'), reuses, {'organization': org.id|string}),
-    ('private-reuses', _('Private reuses'), private_reuses, {}),
+    ('reuses', ngettext('%(num)d reuse', '%(num)d reuses', reuses.total or 0), reuses, {'organization': org.id|string}),
+    ('private-reuses', ngettext('%(num)d private reuse', '%(num)d private reuses', private_reuses.total or 0), private_reuses, {}),
 ) %}
 {% set user_tabs = (
     ('members', _('Members'), org.members, {}),
@@ -140,7 +140,7 @@
     {% endfor %}
 
     {% if org.members %}
-    <tab id="members" header="{{ _('Members') }}">
+    <tab id="members" header="{{ ngettext('%(num)d member', '%(num)d members', org.members | length) }}">
         <div class="row card-list">
             {% for member in org.members %}
             <div class="col-md-4">
@@ -152,7 +152,7 @@
     {% endif %}
 
     {% if followers %}
-    <tab id="followers" header="{{ _('Followers') }}">
+    <tab id="followers" header="{{ ngettext('%(num)d follower', '%(num)d followers', followers | length) }}">
         <div class="row card-list">
             {% for follow in followers %}
             <div class="col-md-4" {% if loop.index > 15 %}:class="{hidden: !followersVisible}"{% endif %}">


### PR DESCRIPTION
This is an incremental step to make the tabs a bit more informative as they were.
It also prepares an upcoming pull request which removes the right hand indicators.

![image](https://user-images.githubusercontent.com/138627/28111351-7a84b786-66f5-11e7-8eba-ea766df06762.png)
