### PR TITLE
Fix #1027 - use enclosing divs to avoid fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix an issue preventing reuse edition:
+  [#1027](https://github.com/opendatateam/udata/issues/1027)
 
 ## 1.1.0 (2017-07-05)
 

--- a/js/components/reuse/form.vue
+++ b/js/components/reuse/form.vue
@@ -1,5 +1,7 @@
 <template>
-<vform v-ref:form :fields="fields" :model="reuse"></vform>
+<div>
+  <vform v-ref:form :fields="fields" :model="reuse"></vform>
+</div>
 </template>
 
 <script>

--- a/js/views/reuse-edit.vue
+++ b/js/views/reuse-edit.vue
@@ -1,7 +1,9 @@
 <template>
-<form-layout icon="retweet" :title="title" :save="save" :cancel="cancel" footer="true" :model="reuse">
-    <reuse-form v-ref:form :reuse="reuse"></reuse-form>
-</form-layout>
+<div>
+    <form-layout icon="retweet" :title="title" :save="save" :cancel="cancel" footer="true" :model="reuse">
+      <reuse-form v-ref:form :reuse="reuse"></reuse-form>
+    </form-layout>
+</div>
 </template>
 
 <script>


### PR DESCRIPTION
Was causing `this.$scrollTo(this.$el)` in `reuse-edit.vue` to crash because some parent components where fragments.