### PR TITLE
fix(search): a page without a search query string would break the initialisation of the search form

### DIFF
--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -64,10 +64,10 @@ export default {
         territoryId: String,
     },
     created() {
-        const {query} = this.$location;
+        const {q=''} = this.$location.query;
 
         const originalField = this.$options.el.querySelector('#search');
-        const queryStringValue = decodeURIComponent(query.q.replace('+', ' '));
+        const queryStringValue = decodeURIComponent(q.replace('+', ' '));
 
         this.query = originalField.value || queryStringValue || '';
     },


### PR DESCRIPTION
In continuity of #1019.

It should be shipped in `udata@1.1` to avoid the search to break.