### PR TITLE
fix(breadcrumb): display breadcrumb on all template inheriting from `base.html`

### DIFF
--- a/udata/templates/base.html
+++ b/udata/templates/base.html
@@ -1,4 +1,7 @@
 {% extends theme('raw.html') %}
+{% from theme('macros/breadcrumb.html') import breadcrumb with context %}
+{% set section_class = section_class|default('default') %}
+{% set toolbar_class = toolbar_class|default('') %}
 
 {% block body %}
     {% include theme("header.html") with context %}
@@ -16,6 +19,12 @@
         {% endfor %}
       {% endif %}
     {% endwith %}
+
+    {{ breadcrumb(self,
+        breadcrum_class=breadcrum_class,
+        toolbar_class=toolbar_class
+    ) }}
+
     {% block content %}{% endblock %}
     {% include theme('footer.html') %}
     {% include theme('publish-action-modal.html') %}

--- a/udata/templates/layouts/1-column.html
+++ b/udata/templates/layouts/1-column.html
@@ -1,14 +1,7 @@
 {% extends theme('base.html') %}
-{% from theme('macros/breadcrumb.html') import breadcrumb with context %}
-{% set section_class = section_class|default('default') %}
-{% set toolbar_class = toolbar_class|default('') %}
+
 
 {% block content %}
-{{ breadcrumb(self,
-    breadcrum_class=breadcrum_class,
-    toolbar_class=toolbar_class
-) }}
-
 <section class="{{ section_class }}">
     <div class="container {{ container_class }}">
         {% block main_content %}{% endblock %}

--- a/udata/templates/layouts/2-columns.html
+++ b/udata/templates/layouts/2-columns.html
@@ -1,10 +1,6 @@
 {% extends theme('base.html') %}
-{% from theme('macros/breadcrumb.html') import breadcrumb with context %}
-{% set section_class = section_class|default('default') %}
 
 {% block content %}
-{{ breadcrumb(self) }}
-
 <section class="{{ section_class }}">
     <div class="container {{ container_class }}">
         <div class="row">

--- a/udata/templates/site/map.html
+++ b/udata/templates/site/map.html
@@ -14,7 +14,6 @@
 {% endblock %}
 
 {% block content %}
-{{ breadcrumb(self) }}
 <section class="big-map">
     <leaflet-map :fixed="false" v-ref:map></leaflet-map>
 </section>

--- a/udata/templates/topic/display_base.html
+++ b/udata/templates/topic/display_base.html
@@ -12,7 +12,6 @@
 {% set body_class = 'topic-display' %}
 
 {% block content %}
-{{ breadcrumb(self) }}
 {% block main_content %}{% endblock %}
 <section class="content topic-section related-tags-section">
     <header>


### PR DESCRIPTION
It also has the benefit of making clear what is the content type of a page.

# Dataset

![image](https://user-images.githubusercontent.com/138627/28630372-087342ce-7222-11e7-8d8a-273f8ead5fd2.png)

# Organization

![image](https://user-images.githubusercontent.com/138627/28630424-2376fb92-7222-11e7-9e74-3fa168b9d018.png)


fix #1056 