### PR TITLE
Vertical align icons and metadata in timeline layout

### DIFF
--- a/js/components/activities/timeline.vue
+++ b/js/components/activities/timeline.vue
@@ -169,20 +169,25 @@ export default {
 @import "~admin-lte/build/less/timeline";
 
 .timeline {
+    li > .timeline-item > .timeline-header {
+        border-bottom: none;
+    }
+    li > .timeline-item > .time {
+        margin-top: 10px;
+    }
     li > .timeline-icon {
         background: #f0f0f0;
+        margin-top:10px;
+        top: 3px;
     }
     li > .timeline-icon-more {
         cursor: pointer;
         background: #ffb311;
     }
-    .card {
-        margin-left: 10%;
-        margin-right: 10%;
 
-        @media (max-width: @screen-sm-min) {
-            margin-left: 0;
-            margin-right: 0;
+    @media (min-width: @screen-sm-max) {
+        .card {
+            max-width: 80%;
         }
     }
 }


### PR DESCRIPTION
This PR does a few things:

- it vertically aligns timeline header items (icon and date) with the title baseline
- it left aligns the card to the left while preventing it to spread too much on wider screens

# Before

[Initial proposal](https://github.com/etalab/udata-gouvfr/issues/192).

![image](https://user-images.githubusercontent.com/138627/27491513-a2cd08b6-583a-11e7-8ba7-10dce1633318.png)

# Default Theme

![image](https://user-images.githubusercontent.com/138627/28670350-2b78df3c-72d0-11e7-8807-fccf7edcb8fb.png)

![image](https://user-images.githubusercontent.com/138627/28670382-52bbe1d4-72d0-11e7-9d7d-6497e9890981.png)

# udata-gouvfr Theme

![image](https://user-images.githubusercontent.com/138627/28670437-92891d36-72d0-11e7-87cc-175068741021.png)

![image](https://user-images.githubusercontent.com/138627/28670454-a27a8040-72d0-11e7-9ddd-fd212d0cf7fa.png)

![image](https://user-images.githubusercontent.com/138627/29283566-3a7fb5de-811f-11e7-90ec-ca06faff94b7.png)


#1059 has to be merged first
fixes etalab/udata-gouvfr#192