### PR TITLE
Ensure search don't fail when a deleted object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   [#1029](https://github.com/opendatateam/udata/issues/1029)
 - Improve the `purge` command
   [#1039](https://github.com/opendatateam/udata/pull/1039)
+- Ensure search does not fail when a deleted object has not been
+  unindexed yet
+  [#1063](https://github.com/opendatateam/udata/issues/1063)
 
 ## 1.1.0 (2017-07-05)
 

--- a/udata/search/result.py
+++ b/udata/search/result.py
@@ -76,6 +76,9 @@ class SearchResult(Paginable, Response):
             ids = [ObjectId(id) for id in self.get_ids()]
             objects = self.query.model.objects.in_bulk(ids)
             self._objects = [objects.get(id) for id in ids]
+            # Filter out DBref ie. indexed object not found in DB
+            self._objects = [o for o in self._objects
+                             if isinstance(o, self.query.model)]
         return self._objects
 
     @property


### PR DESCRIPTION
Ensure search don't fail when a deleted object is hit while not unindexed yet (fix #1063)