### PR TITLE
Starts using celery queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Ensure search does not fail when a deleted object has not been
   unindexed yet
   [#1063](https://github.com/opendatateam/udata/issues/1063)
+- Start using Celery queues to handle task priorities
+  [#1067](https://github.com/opendatateam/udata/pull/1067)
 
 ## 1.1.0 (2017-07-05)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -175,6 +175,16 @@ gid = www-data
 smart-attach-daemon = /tmp/celery-worker.pid %(home)/bin/celery -A udata.worker worker --pidfile=/tmp/celery-worker.pid
 exec-as-user-atexit = kill -TERM `cat /tmp/celery-worker.pid`
 ```
+
+**note:** You can handle tasks priorities by starting 3 workers
+with the following `smart-attach-daemon` commands:
+```
+/tmp/celery-worker.pid %(home)/bin/celery -A udata.worker -Q high worker
+/tmp/celery-worker.pid %(home)/bin/celery -A udata.worker -Q high,default worker
+/tmp/celery-worker.pid %(home)/bin/celery -A udata.worker -Q high,default,low worker
+```
+
+
 **`/etc/uwsgi/apps-available/udata-beat.ini`**
 
 ```inifile

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from kombu import Exchange, Queue
+
 
 class Defaults(object):
     DEBUG = False
@@ -31,6 +33,40 @@ class Defaults(object):
     CELERY_MONGODB_SCHEDULER_COLLECTION = "schedules"
     # CELERY_TASK_SERIALIZER = 'pickle'
     # CELERYD_POOL = 'gevent'
+
+    # Default celery routing
+    CELERY_DEFAULT_QUEUE = 'default'
+    CELERY_QUEUES = (
+        # Default queue (on default exchange)
+        Queue('default', routing_key='task.#'),
+        # High priority for urgent tasks
+        Queue('high', Exchange('high', type='topic'), routing_key='high.#'),
+        # Low priority for slow tasks
+        Queue('low', Exchange('low', type='topic'), routing_key='low.#'),
+    )
+    CELERY_DEFAULT_EXCHANGE = 'default'
+    CELERY_DEFAULT_EXCHANGE_TYPE = 'topic'
+    CELERY_DEFAULT_ROUTING_KEY = 'task.default'
+    CELERY_ROUTES = {
+        # High priority for search tasks
+        'udata.search.reindex': {
+            'queue': 'high',
+            'routing_key': 'high.search',
+        },
+        # Low priority for harvest operations
+        'harvest': {
+            'queue': 'low',
+            'routing_key': 'low.harvest',
+        },
+        'udata.harvest.tasks.harvest_item': {
+            'queue': 'low',
+            'routing_key': 'low.harvest',
+        },
+        'udata.harvest.tasks.harvest_finalize': {
+            'queue': 'low',
+            'routing_key': 'low.harvest',
+        },
+    }
 
     CACHE_KEY_PREFIX = 'udata-cache'
     CACHE_TYPE = 'redis'


### PR DESCRIPTION
This PR introduce [Celery routing and routing](http://docs.celeryproject.org/en/3.1/userguide/routing.html) usage.

This create by default 3 queues:
- `high` for high priority tasks (ie. search indexation)
- `default` for common tasks
- `low` for slow tasks (ie. harvest tasks by example)

This allows to start workers like this:
```shell
celery -A udata.worker -Q high worker
celery -A udata.worker -Q high,default worker
celery -A udata.worker -Q high,default,low worker
```
and will ensure that high priority tasks are always handled and low priority tasks (slow tasks) won't flood the default queue.

If no `-Q` parameter is set, the worker still consume all the known queues.