### PR TITLE
Drop useless robots.txt view

### DIFF
--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -29,7 +29,6 @@ from udata.utils import multi_to_dict
 from .models import current_site
 from .rdf import build_catalog
 
-noI18n = Blueprint('noI18n', __name__)
 blueprint = I18nBlueprint('site', __name__)
 
 
@@ -64,11 +63,6 @@ def home():
     processor = theme.current.get_processor('home')
     context = processor(context)
     return theme.render('home.html', **context)
-
-
-@noI18n.route('/robots.txt')
-def static_from_root():
-    return send_from_directory(current_app.static_folder, request.path[1:])
 
 
 @blueprint.route('/map/')

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -65,7 +65,7 @@ def init_app(app):
 
     from udata.core.storages.views import blueprint as storages_blueprint
     from udata.core.user.views import blueprint as user_blueprint
-    from udata.core.site.views import noI18n, blueprint as site_blueprint
+    from udata.core.site.views import blueprint as site_blueprint
     from udata.core.dataset.views import blueprint as dataset_blueprint
     from udata.core.reuse.views import blueprint as reuse_blueprint
     from udata.core.organization.views import blueprint as org_blueprint
@@ -80,7 +80,6 @@ def init_app(app):
 
     app.register_blueprint(storages_blueprint)
     app.register_blueprint(user_blueprint)
-    app.register_blueprint(noI18n)
     app.register_blueprint(site_blueprint)
     app.register_blueprint(dataset_blueprint)
     app.register_blueprint(reuse_blueprint)

--- a/udata/static/robots.txt
+++ b/udata/static/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /fr/users/
-Disallow: /en/users/
-Disallow: /es/users/

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -25,17 +25,6 @@ class SiteViewsTest(FrontTestCase):
             self.assertIsInstance(current_site._get_current_object(), Site)
             self.assertEqual(current_site.id, self.app.config['SITE_ID'])
 
-    def test_render_robotstxt(self):
-        '''It should render the robots.txt with all pages allowed.'''
-        response = self.get('/robots.txt')
-        self.assertEqual(response.data.split('\n'), [
-            'User-agent: *',
-            'Disallow: /fr/users/',
-            'Disallow: /en/users/',
-            'Disallow: /es/users/',
-            ''
-        ])
-
     def test_render_home(self):
         '''It should render the home page'''
         for i in range(3):


### PR DESCRIPTION
Remove the hard-coded `robots.txt` because:
- it is not maintained
- protected views don't exists anymore
- there is a `<meta[name=robots]>` tag in every view
- it's the only remaining commited file in the `static` directory
- you can provide your own robots.txt directly from the reverse-proxy configuration