### PR TITLE
Added a producer contact button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Handle territory URLs generation without validity
   [#1068](https://github.com/opendatateam/udata/issues/1068)
+- Added a contact button to trigger discussions
+  [#1076](https://github.com/opendatateam/udata/pull/1076)
 
 ## 1.1.1 (2017-07-31)
 

--- a/js/components/discussions/threads-form.vue
+++ b/js/components/discussions/threads-form.vue
@@ -2,7 +2,7 @@
 <form role="form" class="clearfix animated" @submit.prevent="submit">
     <div class="form-group">
         <label for="title-new-discussion">{{ _('Title') }}</label>
-        <input type="text" id="title-new-discussion" v-model="title" class="form-control" required />
+        <input v-el:title type="text" id="title-new-discussion" v-model="title" class="form-control" required />
         <label for="comment-new-discussion">{{ _('Comment') }}</label>
         <textarea v-el:textarea id="comment-new-discussion" v-model="comment" class="form-control" rows="3" required></textarea>
     </div>
@@ -36,8 +36,12 @@ export default {
             comment = comment || '';
             this.comment = comment;
             this.title = title || '';
-            this.$els.textarea.setSelectionRange(comment.length, comment.length);
-            this.$els.textarea.focus();
+            if (title) {
+                this.$els.textarea.setSelectionRange(comment.length, comment.length);
+                this.$els.textarea.focus();
+            } else {
+                this.$els.title.focus();
+            }
         },
         submit() {
             const data = {

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -140,6 +140,12 @@
                         </div>
                         {% endif %}
                         <div class="btn-group btn-group-sm">
+                            <button type="button" class="btn btn-warning" @click="$refs.discussions.start('')">
+                                <span class="fa fa-envelope-o"></span>
+                                {{ _('Contact the producer') }}
+                            </button>
+                        </div>
+                        <div class="btn-group btn-group-sm">
                             {{ follow_btn(dataset, ['fa-star-o', 'fa-star']) }}
                         </div>
                         <div class="btn-group btn-group-sm">

--- a/udata/templates/organization/sidebar-producer.html
+++ b/udata/templates/organization/sidebar-producer.html
@@ -14,6 +14,12 @@
 {% else %}
 <br/>
 {% endif %}
+<button type="button" class="btn btn-sm btn-block btn-left btn-warning" @click="$refs.discussions.start('')"
+    v-tooltip="'{{ _('Contact the producer') }}'" tooltip-placement="left">
+    <span class="fa fa-envelope-o"></span>
+    {# TRANSLATORS: This is an action (present indicative). #}
+    {{ _('Contact') }}
+</button>
 <follow-button with-label classes="btn-block btn-sm btn-left btn-warning"
     {% if is_following(organization) %}following{% endif %}
     url="{{ url_for('api.organization_followers', id=organization.id|string) }}"

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -95,6 +95,12 @@
                             {{ share_btn(reuse.title) }}
                             {{ issues_btn(reuse) }}
                         </div>
+                        <div class="btn-group btn-group-sm">
+                            <button type="button" class="btn btn-warning" @click="$refs.discussions.start('')">
+                                <span class="fa fa-envelope-o"></span>
+                                {{ _('Contact the producer') }}
+                            </button>
+                        </div>
                         {% if can_edit %}
                         <div class="btn-group btn-group-sm">
                             <a href="{{ url_for('admin.index', path='reuse/{id}/'.format(id=reuse.id)) }}" class="btn btn-success">


### PR DESCRIPTION
This PR added some contact buttons on dataset and reuses pages. This button simply trigger a scroll to the discussion sectio and open the new discussion form.

*Dataset producer sidebar*
![screenshot-www data dev-2017-08-03-10-13-03](https://user-images.githubusercontent.com/15725/28913592-d9be46e6-7838-11e7-8db6-2240f3046fed.png)

*Dataset button bar*
![screenshot-www data dev-2017-08-03-10-13-33](https://user-images.githubusercontent.com/15725/28913630-04fd27fa-7839-11e7-8d62-033756d77adb.png)

*Reuse producer sidebar*
![screenshot-www data dev-2017-08-03-10-14-57](https://user-images.githubusercontent.com/15725/28913637-0db373c2-7839-11e7-84df-574ca9918689.png)

*Reuse button bar*
![screenshot-www data dev-2017-08-03-10-15-44](https://user-images.githubusercontent.com/15725/28913680-3001e5bc-7839-11e7-834b-f00e7354b6c8.png)

**note**: there is new string to translate
