### PR TITLE
Harvest error handling improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#1068](https://github.com/opendatateam/udata/issues/1068)
 - Added a contact button to trigger discussions
   [#1076](https://github.com/opendatateam/udata/pull/1076)
+- Improve harvest error handling
+  [#1078](https://github.com/opendatateam/udata/pull/1078)
 
 ## 1.1.1 (2017-07-31)
 

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -128,7 +128,7 @@ class BaseFormatter(logging.Formatter):
     def format(self, record):
         '''Customize the line prefix and indent multiline logs'''
         record.__dict__['prefix'] = self._prefix(record.levelname)
-        record.msg = record.msg.replace('\n', '\n  | ')
+        record.msg = str(record.msg).replace('\n', '\n  | ')
         return super(BaseFormatter, self).format(record)
 
     def formatException(self, ei):

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -63,7 +63,7 @@ class BaseBackend(object):
 
     def harvest(self):
         '''Start the harvesting process'''
-        if self.perform_initialization():
+        if self.perform_initialization() is not None:
             self.process_items()
             self.finalize()
         return self.job

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -84,8 +84,6 @@ class BaseBackend(object):
             if not self.dryrun:
                 self.job.save()
         except Exception as e:
-            log.error("Error in initialization : %s" % (str(e)))
-            log.exception(e)
             self.job.status = 'failed'
             error = HarvestError(message=str(e),
                                  details=traceback.format_exc())

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -85,8 +85,7 @@ class BaseBackend(object):
                 self.job.save()
         except Exception as e:
             self.job.status = 'failed'
-            error = HarvestError(message=str(e),
-                                 details=traceback.format_exc())
+            error = HarvestError(message=str(e))
             self.job.errors.append(error)
             self.end()
             msg = 'Initialization failed for "{0.name}" ({0.backend})'


### PR DESCRIPTION
This PRs improve harvest errors handling:
- Prevent multiple logging of a single exception
- Improve type detection error during DCAT backend initialization
- Ensure empty jobs always finish
- Don't store stacktrace any more in case of error (no relevant to the end user and already available while developping in the console or in Sentry in production)