### PR TITLE
Migrate legacy spatial identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   [1094](https://github.com/opendatateam/udata/pull/1094)
 - Prevent the "Bad request error" happening on search but only on some servers
   [#1097](https://github.com/opendatateam/udata/pull/1097)
+- Migrate spatial granularities to new identifiers
+  [#1079](https://github.com/opendatateam/udata/pull/1079)
 
 ## 1.1.1 (2017-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Prevent the "Bad request error" happening on search but only on some servers
   [#1097](https://github.com/opendatateam/udata/pull/1097)
 - Migrate spatial granularities to new identifiers
+- Migrate remaining legacy spatial identifiers
   [#1079](https://github.com/opendatateam/udata/pull/1079)
 
 ## 1.1.1 (2017-07-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   [#1097](https://github.com/opendatateam/udata/pull/1097)
 - Migrate spatial granularities to new identifiers
 - Migrate remaining legacy spatial identifiers
-  [#1079](https://github.com/opendatateam/udata/pull/1079)
+  [#1080](https://github.com/opendatateam/udata/pull/1080)
 
 ## 1.1.1 (2017-07-31)
 

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -128,13 +128,13 @@ class BaseFormatter(logging.Formatter):
     def format(self, record):
         '''Customize the line prefix and indent multiline logs'''
         record.__dict__['prefix'] = self._prefix(record.levelname)
-        record.msg = str(record.msg).replace('\n', '\n  | ')
+        record.msg = str(record.msg).replace('\n', '\n  │ ')
         return super(BaseFormatter, self).format(record)
 
     def formatException(self, ei):
         '''Indent traceback info for better readability'''
         out = super(BaseFormatter, self).formatException(ei)
-        out = str('\n').join(str('  | ') + line for line in out.splitlines())
+        out = str('\n').join(str('  │ ') + line for line in out.splitlines())
         return out
 
     def _prefix(self, name):

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -62,6 +62,7 @@ class GeoZone(db.Document):
     dbpedia = db.StringField()
     flag = db.ImageField(fs=logos)
     blazon = db.ImageField(fs=logos)
+    logo = db.ImageField(fs=logos)
 
     meta = {
         'indexes': [

--- a/udata/features/territories/commands.py
+++ b/udata/features/territories/commands.py
@@ -61,7 +61,7 @@ def migrate_zones_ids():
     drom_zone = GeoZone.objects(id='country-subset:fr:drom').first()
     dromcom_zone = GeoZone.objects(id='country-subset:fr:dromcom').first()
     france_zone = GeoZone.objects(id='country:fr').first()
-    for dataset in Dataset.objects.all():
+    for dataset in Dataset.objects(spatial_exists=True):
         if dataset.spatial and dataset.spatial.zones:
             counter_datasets += 1
             new_zones = []

--- a/udata/features/territories/commands.py
+++ b/udata/features/territories/commands.py
@@ -86,6 +86,13 @@ def migrate_zones_ids():
                         GeoZone
                         .objects(code=zone_id, level='fr:region')
                         .first())
+                elif kind == 'epci':
+                    counter['epcis'] += 1
+                    new_zones.append(
+                        GeoZone
+                        .objects(code=zone_id, level='fr:epci')
+                        .valid_at(dataset.created_at.date())
+                        .first())
                 else:
                     new_zones.append(zone)
             elif zone.id.startswith('country-subset/fr'):
@@ -105,7 +112,6 @@ def migrate_zones_ids():
                 counter['zones'] += 1
                 counter['countrygroups'] += 1
                 new_zones.append(zone.id.replace('/', ':'))
-            # TODO: handle EPCIs
             else:
                 new_zones.append(zone)
         dataset.update(

--- a/udata/features/territories/commands.py
+++ b/udata/features/territories/commands.py
@@ -10,6 +10,7 @@ import tarfile
 
 from collections import Counter
 from datetime import date
+from string import Formatter
 from urllib import urlretrieve
 
 from udata.models import Dataset, GeoZone, SpatialCoverage
@@ -110,18 +111,19 @@ def migrate_zones_ids():
         dataset.update(
             spatial=SpatialCoverage(
                 granularity=dataset.spatial.granularity,
-                zones=[z.id for z in new_zones if z]
+                zones=[getattr(z, 'id', z) for z in new_zones if z]
             )
         )
-    log.info('''Summary
+    log.info(Formatter().vformat('''Summary
     Processed {zones} zones in {datasets} datasets:
     - {countrygroups} country groups (World/UE)
     - {countries} countries
     - France:
         - {regions} regions
         - {counties} counties
+        - {epcis} EPCIs
         - {towns} towns
         - {drom} DROM
         - {dromcom} DROM-COM
-    '''.format(**counter))
+    ''', (), counter))
     log.info('Done')

--- a/udata/features/territories/commands.py
+++ b/udata/features/territories/commands.py
@@ -7,6 +7,8 @@ import lzma
 import os
 import shutil
 import tarfile
+
+from collections import Counter
 from datetime import date
 from urllib import urlretrieve
 
@@ -50,70 +52,76 @@ def migrate_zones_ids():
 
     Should only be run once with the new version of geozones w/ geohisto.
     """
-    counter_datasets = 0
-    counter_zones = 0
-    counter_towns = 0
-    counter_counties = 0
-    counter_regions = 0
-    counter_drom = 0
-    counter_dromcom = 0
-    counter_france = 0
+    counter = Counter()
     drom_zone = GeoZone.objects(id='country-subset:fr:drom').first()
     dromcom_zone = GeoZone.objects(id='country-subset:fr:dromcom').first()
-    france_zone = GeoZone.objects(id='country:fr').first()
-    for dataset in Dataset.objects(spatial_exists=True):
-        if dataset.spatial and dataset.spatial.zones:
-            counter_datasets += 1
-            new_zones = []
-            for zone in dataset.spatial.zones:
-                if zone.id.startswith('fr/'):
-                    counter_zones += 1
-                    country, kind, zone_id = zone.id.split('/')
-                    zone_id = zone_id.upper()  # Corsica 2a/b case.
-                    if kind == 'town':
-                        counter_towns += 1
-                        new_zones.append(
-                            GeoZone
-                            .objects(code=zone_id, level='fr:commune')
-                            .valid_at(date.today())
-                            .first())
-                    elif kind == 'county':
-                        counter_counties += 1
-                        new_zones.append(
-                            GeoZone
-                            .objects(code=zone_id, level='fr:departement')
-                            .valid_at(date.today())
-                            .first())
-                    elif kind == 'region':
-                        counter_regions += 1
-                        # Only link to pre-2016 regions which kept the same id.
-                        new_zones.append(
-                            GeoZone
-                            .objects(code=zone_id, level='fr:region')
-                            .first())
-                    else:
-                        new_zones.append(zone)
-                elif zone.id.startswith('country-subset/fr'):
-                    counter_zones += 1
-                    subset, country, kind = zone.id.split('/')
-                    if kind == 'dom':
-                        counter_drom += 1
-                        new_zones.append(drom_zone)
-                    elif kind == 'domtom':
-                        counter_dromcom += 1
-                        new_zones.append(dromcom_zone)
-                elif zone.id.startswith('country/fr'):
-                    counter_zones += 1
-                    counter_france += 1
-                    new_zones.append(france_zone)
+    # Iter over datasets with zones
+    for dataset in Dataset.objects(spatial__zones__gt=[]):
+        counter['datasets'] += 1
+        new_zones = []
+        for zone in dataset.spatial.zones:
+            if zone.id.startswith('fr/'):
+                counter['zones'] += 1
+                country, kind, zone_id = zone.id.split('/')
+                zone_id = zone_id.upper()  # Corsica 2a/b case.
+                if kind == 'town':
+                    counter['towns'] += 1
+                    new_zones.append(
+                        GeoZone
+                        .objects(code=zone_id, level='fr:commune')
+                        .valid_at(date.today())
+                        .first())
+                elif kind == 'county':
+                    counter['counties'] += 1
+                    new_zones.append(
+                        GeoZone
+                        .objects(code=zone_id, level='fr:departement')
+                        .valid_at(date.today())
+                        .first())
+                elif kind == 'region':
+                    counter['regions'] += 1
+                    # Only link to pre-2016 regions which kept the same id.
+                    new_zones.append(
+                        GeoZone
+                        .objects(code=zone_id, level='fr:region')
+                        .first())
                 else:
                     new_zones.append(zone)
-            dataset.update(
-                spatial=SpatialCoverage(zones=[z.id for z in new_zones if z]))
-    print('{} datasets and {} zones affected.'.format(
-        counter_datasets, counter_zones))
-    print('{} town zones, {} county zones and {} region zones updated.'.format(
-        counter_towns, counter_counties, counter_regions))
-    print('{} France zones, {} DROM zones, {} DROM-COM zones updated.'.format(
-        counter_france, counter_drom, counter_dromcom))
+            elif zone.id.startswith('country-subset/fr'):
+                counter['zones'] += 1
+                subset, country, kind = zone.id.split('/')
+                if kind == 'dom':
+                    counter['drom'] += 1
+                    new_zones.append(drom_zone)
+                elif kind == 'domtom':
+                    counter['dromcom'] += 1
+                    new_zones.append(dromcom_zone)
+            elif zone.id.startswith('country/'):
+                counter['zones'] += 1
+                counter['countries'] += 1
+                new_zones.append(zone.id.replace('/', ':'))
+            elif zone.id.startswith('country-group/'):
+                counter['zones'] += 1
+                counter['countrygroups'] += 1
+                new_zones.append(zone.id.replace('/', ':'))
+            # TODO: handle EPCIs
+            else:
+                new_zones.append(zone)
+        dataset.update(
+            spatial=SpatialCoverage(
+                granularity=dataset.spatial.granularity,
+                zones=[z.id for z in new_zones if z]
+            )
+        )
+    log.info('''Summary
+    Processed {zones} zones in {datasets} datasets:
+    - {countrygroups} country groups (World/UE)
+    - {countries} countries
+    - France:
+        - {regions} regions
+        - {counties} counties
+        - {towns} towns
+        - {drom} DROM
+        - {dromcom} DROM-COM
+    '''.format(**counter))
     log.info('Done')

--- a/udata/migrations/2016-06-24-rename-granularities.js
+++ b/udata/migrations/2016-06-24-rename-granularities.js
@@ -8,32 +8,46 @@ var result = db.dataset.update(
     {$set: {'spatial.granularity': 'fr:commune'}},
     {multi: true}
 );
-print(result.nModified, 'datasets granularity modified for towns.');
+print(result.nModified, 'datasets granularity modified for fr:commune.');
 
 result = db.dataset.update(
     {'spatial.granularity': 'fr/county'},
     {$set: {'spatial.granularity': 'fr:departement'}},
     {multi: true}
 );
-print(result.nModified, 'datasets granularity modified for counties.');
+print(result.nModified, 'datasets granularity modified for fr:departement.');
 
 result = db.dataset.update(
     {'spatial.granularity': 'fr/region'},
     {$set: {'spatial.granularity': 'fr:region'}},
     {multi: true}
 );
-print(result.nModified, 'datasets granularity modified for regions.');
+print(result.nModified, 'datasets granularity modified for fr:region.');
 
 result = db.dataset.update(
     {'spatial.granularity': 'fr/district'},
-    {$set: {'spatial.granularity': 'fr:district'}},
+    {$set: {'spatial.granularity': 'fr:arrondissement'}},
     {multi: true}
 );
-print(result.nModified, 'datasets granularity modified for districts.');
+print(result.nModified, 'datasets granularity modified for fr:arrondissement.');
 
 result = db.dataset.update(
     {'spatial.granularity': 'fr/epci'},
     {$set: {'spatial.granularity': 'fr:epci'}},
     {multi: true}
 );
-print(result.nModified, 'datasets granularity modified for epcis.');
+print(result.nModified, 'datasets granularity modified for fr:epci.');
+
+result = db.dataset.update(
+    {'spatial.granularity': 'fr/canton'},
+    {$set: {'spatial.granularity': 'fr:canton'}},
+    {multi: true}
+);
+print(result.nModified, 'datasets granularity modified for fr:canton.');
+
+result = db.dataset.update(
+    {'spatial.granularity': 'fr/iris'},
+    {$set: {'spatial.granularity': 'fr:iris'}},
+    {multi: true}
+);
+print(result.nModified, 'datasets granularity modified for fr:iris.');


### PR DESCRIPTION
This PRs handle unhandled spatial identifiers and level migration and fixes some cases:
- [x] Rename missing spatial levels
- [x] Fix `fr:district` which is `fr:arrondissement`
- [x] Handle all countries
- [x] Handle country groups
- [x] Handle EPCIs
- [x] Preserve granularity
