### PR TITLE
Place Territory page components on the grid

### DIFF
--- a/less/udata/territories.less
+++ b/less/udata/territories.less
@@ -17,7 +17,9 @@
     .dataset-item--cta {
         @base-color: #7d8489;
         border: 1px solid @base-color;
-        padding: 0;
+        margin-bottom: @grid-gutter-width;
+        margin-top: @grid-gutter-width;
+        overflow: hidden;
 
         .format-label {
             width: 1em;

--- a/less/udata/territories.less
+++ b/less/udata/territories.less
@@ -3,15 +3,12 @@
         padding: 1em;
     }
     .dataset-list {
-        .col-sm-4 {
-            padding: 5px;
-        }
         .dataset-card {
-            margin: 0 0 1em 0 !important;
+            margin: 0 0 @grid-gutter-width 0 !important;
         }
     }
     .panel {
-        padding: 1em;
+        margin-bottom: 0;
 
         .tab-links {
             margin-top: 1em;

--- a/udata/templates/embed-dataset.html
+++ b/udata/templates/embed-dataset.html
@@ -5,7 +5,7 @@
     }
     .dataset-card {
         border: 1px solid #EEE;
-        min-width: 300px;
+        min-width: 0;
         min-height: 170px;
         clear: both;
         margin: 1em;

--- a/udata/templates/territories/commune.html
+++ b/udata/templates/territories/commune.html
@@ -58,9 +58,11 @@
         </div>
     </div>
 
-    <aside class="col-sm-4 panel panel-default">
-        <leaflet-map v-ref:map class="aside-map" :popup="false"
-            data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">
-        </leaflet-map>
+    <aside class="col-sm-4">
+        <div class="panel panel-default">
+            <leaflet-map v-ref:map class="aside-map" :popup="false"
+                data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">
+            </leaflet-map>
+        </div>
     </aside>
 {% endblock %}

--- a/udata/templates/territories/commune.html
+++ b/udata/templates/territories/commune.html
@@ -14,8 +14,8 @@
         {{ _('County:') }} <a href="{{ territory.current_parent.url }}">{{ territory.current_parent.name }}</a> →
         {{ _('Town:') }} <a href="{{ territory.url }}">{{ territory.name }}</a>
     </p>
-    <div class="col-sm-8">
-        <div class="col-sm-3">
+    <div class="col-sm-8 col-xs-12">
+        <div class="col-xs-3">
             <img src="{{ logo }}" alt="{{ territory.name }}" class="scalable" />
             {% if territory.logo_url() %}
                 <div class="text-center">
@@ -34,7 +34,7 @@
             {% endif %}
         </div>
 
-        <div class="col-sm-9 tab-links">
+        <div class="col-xs-9 tab-links">
             <h1>{{ territory.name }}</h1>
             <p>
                 <strong>
@@ -58,7 +58,7 @@
         </div>
     </div>
 
-    <aside class="col-sm-4">
+    <aside class="col-sm-4 col-xs-12">
         <div class="panel panel-default">
             <leaflet-map v-ref:map class="aside-map" :popup="false"
                 data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">

--- a/udata/templates/territories/departement.html
+++ b/udata/templates/territories/departement.html
@@ -56,9 +56,11 @@
         </div>
     </div>
 
-    <aside class="col-sm-4 panel panel-default">
-        <leaflet-map v-ref:map class="aside-map" :popup="false"
-            data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">
-        </leaflet-map>
+    <aside class="col-sm-4">
+        <div class="panel panel-default">
+            <leaflet-map v-ref:map class="aside-map" :popup="false"
+                data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">
+            </leaflet-map>
+        </div>
     </aside>
 {% endblock %}

--- a/udata/templates/territories/departement.html
+++ b/udata/templates/territories/departement.html
@@ -13,8 +13,8 @@
         {{ _('Region:') }} <a href="{{ territory.current_parent.url }}">{{ territory.current_parent.name }}</a> →
         {{ _('County:') }} <a href="{{ territory.url }}">{{ territory.name }}</a>
     </p>
-    <div class="col-sm-8">
-        <div class="col-sm-3">
+    <div class="col-sm-8 col-xs-12">
+        <div class="col-xs-3">
             <img src="{{ logo }}" alt="{{ territory.name }}" class="scalable" />
             {% if territory.logo_url() %}
                 <div class="text-center">
@@ -33,7 +33,7 @@
             {% endif %}
         </div>
 
-        <div class="col-sm-9 tab-links">
+        <div class="col-xs-9 tab-links">
             <h1>{{ territory.name }}</h1>
             <p>
                 <strong>
@@ -56,7 +56,7 @@
         </div>
     </div>
 
-    <aside class="col-sm-4">
+    <aside class="col-sm-4 col-xs-12">
         <div class="panel panel-default">
             <leaflet-map v-ref:map class="aside-map" :popup="false"
                 data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">

--- a/udata/templates/territories/region.html
+++ b/udata/templates/territories/region.html
@@ -12,8 +12,8 @@
         <a href="{{ url_for('territories.home') }}">France</a> →
         {{ _('Region:') }} <a href="{{ territory.url }}">{{ territory.name }}</a>
     </p>
-    <div class="col-sm-8">
-        <div class="col-sm-3">
+    <div class="col-sm-8 col-xs-12">
+        <div class="col-xs-3">
             <img src="{{ logo }}" alt="{{ territory.name }}" class="scalable" />
             {% if territory.logo_url() %}
                 <div class="text-center">
@@ -32,7 +32,7 @@
             {% endif %}
         </div>
 
-        <div class="col-sm-9 tab-links">
+        <div class="col-xs-9 tab-links">
             <h1>{{ territory.name }}</h1>
             <p>
                 <strong>
@@ -70,7 +70,7 @@
         </div>
     </div>
 
-    <aside class="col-sm-4">
+    <aside class="col-sm-4 col-xs-12">
         <div class="panel panel-default">
             <leaflet-map v-ref:map class="aside-map" :popup="false"
                 data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">

--- a/udata/templates/territories/region.html
+++ b/udata/templates/territories/region.html
@@ -70,10 +70,12 @@
         </div>
     </div>
 
-    <aside class="col-sm-4 panel panel-default">
-        <leaflet-map v-ref:map class="aside-map" :popup="false"
-            data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">
-        </leaflet-map>
+    <aside class="col-sm-4">
+        <div class="panel panel-default">
+            <leaflet-map v-ref:map class="aside-map" :popup="false"
+                data-zones="{{ url_for('api.zones', ids=[territory.id]) }}">
+            </leaflet-map>
+        </div>
     </aside>
 
 {% endblock %}

--- a/udata/templates/territories/territory.html
+++ b/udata/templates/territories/territory.html
@@ -15,13 +15,11 @@
     {% endif %}
     {% block territory_content %}{% endblock %}
 </div>
-<div class="dataset-list">
-    {% if territory_datasets %}
-        {% for dataset in territory_datasets %}
-            <div data-udata-dataset-id="{{ dataset.id }}" class="col-sm-4"></div>
-        {% endfor %}
-    {% else %}
-        <div class="dataset-item--cta col-sm-12 bg-primary">
+
+{% if not territory_datasets %}
+<div class="row">
+    <div class="col-sm-12">
+        <div class="dataset-item--cta bg-primary">
             <div class="format-label pull-left">+</div>
             <p>
                 {% if current_user.is_authenticated %}
@@ -41,13 +39,24 @@
                 {% endif %}
             </p>
         </div>
-    {% endif %}
-    {% for dataset in base_datasets %}
-        <div data-udata-territory-id="{{ dataset.slug }}" class="col-sm-4"></div>
-    {% endfor %}
-    {% for dataset in other_datasets %}
-        <div data-udata-dataset-id="{{ dataset.id }}" class="col-sm-4"></div>
-    {% endfor %}
+    </div>
+</div>
+{% endif %}
+
+<div class="row dataset-list">
+        {% if territory_datasets %}
+            {% for dataset in territory_datasets %}
+                <div data-udata-dataset-id="{{ dataset.id }}" class="col-sm-4"></div>
+            {% endfor %}
+        {% endif %}
+
+        {% for dataset in base_datasets %}
+            <div data-udata-territory-id="{{ dataset.slug }}" class="col-sm-4"></div>
+        {% endfor %}
+
+        {% for dataset in other_datasets %}
+            <div data-udata-dataset-id="{{ dataset.id }}" class="col-sm-4"></div>
+        {% endfor %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
This pull request does several things:

- it makes sure the page is readable on small screens
- it gives more space to the _call to action_
- it relies solely on grid classes to align every element and please OCD people like me


# Desktop and large screens breakpoint

## Before

![image](https://user-images.githubusercontent.com/138627/29371620-b9b27102-82a0-11e7-8d6c-f8244627d68c.png)

## After

![image](https://user-images.githubusercontent.com/138627/29371738-0f58e834-82a1-11e7-9db9-190475473756.png)

# Tablet breakpoint

## Before

![image](https://user-images.githubusercontent.com/138627/29371814-4760605e-82a1-11e7-8cb7-8cbb36a0f249.png)

## After

![image](https://user-images.githubusercontent.com/138627/29371855-67b7097a-82a1-11e7-85cf-10fb1c8105b9.png)

# Small screens breakpoint

## Before

![image](https://user-images.githubusercontent.com/138627/29371895-8637a3a0-82a1-11e7-972d-68b827668459.png)

## After

![image](https://user-images.githubusercontent.com/138627/29371924-9f920480-82a1-11e7-849a-154d0e260b17.png)

fixes etalab/udata-gouvfr#184