### PR TITLE
Honor Markdown content in datasets description and dataset resources description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Display organization metrics in the organization page tab labels [#1022](https://github.com/opendatateam/udata/pull/1022)
 - Organization dashboard page has been merged into the main organization page [#1023](https://github.com/opendatateam/udata/pull/1023)
 - Fix an issue causing a loss of data input at the global search input level [#1019](https://github.com/opendatateam/udata/pull/1019)
+- Honor Markdown content in datasets description and dataset resources description [#1092](https://github.com/opendatateam/udata/pull/1092)
 
 ## 1.1.0 (2017-07-05)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -12,7 +12,7 @@ from mongoengine.signals import pre_save, post_save
 from mongoengine.fields import DateTimeField
 from werkzeug import cached_property
 
-from udata.frontend.markdown import mdstrip
+from udata.frontend.markdown import render as md_render
 from udata.models import db, WithMetrics, BadgeMixin, SpatialCoverage
 from udata.i18n import lazy_gettext as _
 from udata.utils import hash_url
@@ -244,7 +244,7 @@ class ResourceMixin(object):
             result['fileFormat'] = self.mime
 
         if self.description:
-            result['description'] = mdstrip(self.description)
+            result['description'] = md_render(self.description)
 
         # These 2 values are not standard
         if self.checksum:
@@ -550,7 +550,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
         }
 
         if self.description:
-            result['description'] = mdstrip(self.description)
+            result['description'] = md_render(self.description)
 
         if self.license and self.license.url:
             result['license'] = self.license.url

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -105,6 +105,19 @@ def mdstrip(value, length=None, end='…'):
     return text
 
 
+def render(value):
+    '''
+    Render safe markdown for the frontend (like modals etc.)
+    '''
+    unsafe_rendered = md(value)
+    # Maybe we would like to preserve some tags
+    # and remove dubious tags (script, object)
+    # and remove dubious attrs (onclick, onfocus, etc.)
+    #
+    # safe_rendered = do_striptags(rendered)
+    return unsafe_rendered
+
+
 def init_app(app):
     parser = CommonMark.Parser  # Not an instance because not thread-safe(?)
     renderer = CommonMark.HtmlRenderer()


### PR DESCRIPTION
# Goal

Description is edited with markdown controls and is thus often used to describe the content of the resources. It's best to reflect the formatting intents of the writers to make them readable, and to make it easier to consume the exposed datasets.

# Security concerns

A few issues which could arise from this:

- malicious scripts
- malicious javascript actions in interactive attributes (`onclick`, etc.)
- text content is very long and requires an action from users to scroll

Content seem to be already sanitised (\o/) when saving.


# Caveats

I certainly have broken the tests — happy to change them if this PR is a direction where we feel good to go.

Long contents could be be clipped on the client side at some point:

- we preserve the integrity of the content in the JSON-LD data
- we preserve the usability of the informations, and keep it at hand

# Frontend

![image](https://user-images.githubusercontent.com/138627/29413136-417af8ae-8353-11e7-9fc3-d911b45d5b9a.png)

# Admin (rendered)

![image](https://user-images.githubusercontent.com/138627/29413164-53d2105a-8353-11e7-805b-259bdfc3eecf.png)


# Admin (editing)

![image](https://user-images.githubusercontent.com/138627/29413183-664fda1e-8353-11e7-8905-86e27cd30a80.png)


