### PR TITLE
Discussion api fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Migrate spatial granularities to new identifiers
 - Migrate remaining legacy spatial identifiers
   [#1080](https://github.com/opendatateam/udata/pull/1080)
+- Fix the discussion API documention
+  [#1093](https://github.com/opendatateam/udata/pull/1093)
 
 ## 1.1.1 (2017-07-31)
 

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -21,34 +21,29 @@ from .signals import (
 ns = api.namespace('discussions', 'Discussion related operations')
 
 message_fields = api.model('DiscussionMessage', {
-    'content': fields.String(description='The message body', required=True),
-    'posted_by': fields.Nested(
-        user_ref_fields, description='The message author', required=True),
-    'posted_on': fields.ISODateTime(
-        description='The message posting date', required=True),
+    'content': fields.String(description='The message body'),
+    'posted_by': fields.Nested(user_ref_fields,
+                               description='The message author'),
+    'posted_on': fields.ISODateTime(description='The message posting date'),
 })
 
 discussion_fields = api.model('Discussion', {
-    'id': fields.String(
-        description='The discussion identifier', readonly=True),
+    'id': fields.String(description='The discussion identifier'),
     'subject': fields.Nested(api.model_reference,
-                             description='The discussion target object',
-                             required=True),
+                             description='The discussion target object'),
     'class': fields.ClassName(description='The object class',
-                              discriminator=True, required=True),
-    'title': fields.String(description='The discussion title', required=True),
+                              discriminator=True),
+    'title': fields.String(description='The discussion title'),
     'user': fields.Nested(
-        user_ref_fields, description='The discussion author', required=True),
-    'created': fields.ISODateTime(
-        description='The discussion creation date', readonly=True),
-    'closed': fields.ISODateTime(
-        description='The discussion closing date', readonly=True),
+        user_ref_fields, description='The discussion author'),
+    'created': fields.ISODateTime(description='The discussion creation date'),
+    'closed': fields.ISODateTime(description='The discussion closing date'),
     'closed_by': fields.String(
         attribute='closed_by.id',
-        description='The user who closed the discussion', readonly=True),
+        description='The user who closed the discussion'),
     'discussion': fields.Nested(message_fields),
-    'url': fields.UrlFor(
-        'api.discussion', description='The discussion API URI', readonly=True),
+    'url': fields.UrlFor('api.discussion',
+                         description='The discussion API URI'),
 })
 
 start_discussion_fields = api.model('DiscussionStart', {

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -51,6 +51,16 @@ discussion_fields = api.model('Discussion', {
         'api.discussion', description='The discussion API URI', readonly=True),
 })
 
+start_discussion_fields = api.model('DiscussionStart', {
+    'title': fields.String(description='The title of the discussion to open',
+                           required=True),
+    'comment': fields.String(description='The content of the initial comment',
+                             required=True),
+    'subject': fields.Nested(api.model_reference,
+                             description='The discussion target object',
+                             required=True),
+})
+
 comment_discussion_fields = api.model('DiscussionResponse', {
     'comment': fields.String(
         description='The comment to submit', required=True),
@@ -149,7 +159,7 @@ class DiscussionsAPI(API):
 
     @api.secure
     @api.doc('create_discussion')
-    @api.expect(discussion_fields)
+    @api.expect(start_discussion_fields)
     @api.marshal_with(discussion_fields)
     def post(self):
         '''Create a new Discussion'''


### PR DESCRIPTION
This PR fixes the discussions API documentation:
- fix the `POST /discussions/` payload documentation
- remove useless attributes from read-only models