### PR TITLE
Fix drag and drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [#1078](https://github.com/opendatateam/udata/pull/1078)
 - Improve elasticsearch configurability
   [#1096](https://github.com/opendatateam/udata/pull/1096)
+- Lots of fixes admin files upload
+  [1094](https://github.com/opendatateam/udata/pull/1094)
 
 ## 1.1.1 (2017-07-31)
 

--- a/js/components/dataset/resource/file-form.vue
+++ b/js/components/dataset/resource/file-form.vue
@@ -1,12 +1,18 @@
 <style lang="less">
+@import '~less/admin/variables';
+
 .resource-upload-dropzone {
-    border: 4px dashed #bbb;
+    border: 4px dashed @gray-lte;
     min-height: 150px;
     padding-top: 10px;
     padding-bottom: 10px;
 
     .lead {
         margin-bottom: 0;
+    }
+
+    .drop-active > & {
+        border: 4px dashed @green;
     }
 }
 </style>

--- a/js/components/dataset/resource/file-form.vue
+++ b/js/components/dataset/resource/file-form.vue
@@ -128,18 +128,17 @@ export default {
             if (typeof this.dataset !== 'undefined') {
                 params = {dataset: this.dataset.id};
             }
-            if (this.is_community) {
-                endpoint += 'community_';
-                params.community = this.resource.id;
-            } else {
-                endpoint += 'dataset_';
-            }
             if (this.resource.id) {
-                endpoint += 'resource';
-                params.rid = this.resource.id;
+                if (this.is_community) {
+                    params.community = this.resource.id;
+                } else {
+                    params.rid = this.resource.id;
+                }
             } else {
-                endpoint += 'resources';
+                endpoint += 'new_';
             }
+            endpoint += this.is_community ? 'community_' : 'dataset_';
+            endpoint += 'resource';
             return operations[endpoint].urlify(params);
         }
     },

--- a/js/components/dataset/resource/file-form.vue
+++ b/js/components/dataset/resource/file-form.vue
@@ -28,7 +28,7 @@
     </span>
     <div class="info-box-content">
         <span class="info-box-text">{{file.name}}</span>
-        <span class="info-box-number">{{file.filesize | filesize}}</span>
+        <span class="info-box-number">{{file.size | filesize}}</span>
         <div class="progress">
             <div class="progress-bar" :style="{width: progress+'%'}"></div>
         </div>

--- a/js/components/dataset/resource/file-form.vue
+++ b/js/components/dataset/resource/file-form.vue
@@ -130,7 +130,6 @@ export default {
         upload_endpoint() {
             const operations = API.datasets.operations;
             let params = {};
-            let endpoint = 'upload_';
             if (typeof this.dataset !== 'undefined') {
                 params = {dataset: this.dataset.id};
             }
@@ -140,11 +139,10 @@ export default {
                 } else {
                     params.rid = this.resource.id;
                 }
-            } else {
-                endpoint += 'new_';
             }
-            endpoint += this.is_community ? 'community_' : 'dataset_';
-            endpoint += 'resource';
+            const route_new = this.resource.id ? '' : 'new_';
+            const route_namespace = this.is_community ? 'community_' : 'dataset_';
+            const endpoint = `upload_${route_new}${route_namespace}resource`;
             return operations[endpoint].urlify(params);
         }
     },

--- a/js/components/dataset/resource/list.vue
+++ b/js/components/dataset/resource/list.vue
@@ -165,7 +165,7 @@ export default {
             el.style.width = `${Math.round(uploaded * 100 / total)}%`;
         },
         'uploader:complete': function(id, response, file) {
-            this.files.splice(this.files.indexOf(file), 1);
+            this.files.$remove(file);
             this.dataset.resources.unshift(response);
         },
         'uploader:error': function(id) {

--- a/js/components/dataset/resource/list.vue
+++ b/js/components/dataset/resource/list.vue
@@ -17,6 +17,10 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+
+        td .progress {
+            margin-top: 5px;
+        }
     }
 
     .drop-active > & {
@@ -53,13 +57,15 @@
                     <td v-if="reordering"></td>
                     <td>
                         <div class="ellipsis">{{ file.name }}</div>
+                    </td>
+                    <td>{{ file.name | fileext }}</td>
+                    <td>{{ file.size | filesize }}</td>
+                    <td colspan="2">
                         <div class="progress progress-xs progress-striped active">
-                          <div class="progress-bar progress-bar-primary"
-                            id="progress-{{file.id}}" style="width: 0%"></div>
+                            <div class="progress-bar progress-bar-primary"
+                                id="progress-{{file.id}}" style="width: 0%"></div>
                         </div>
                     </td>
-                    <td>{{ file.type }}</td>
-                    <td>{{ file.size | filesize }}</td>
                 </tr>
                 <tr v-for="resource in dataset.resources" @click="display(resource)"
                     :class="{ 'pointer': !reodering, 'move': reordering }"
@@ -155,7 +161,7 @@ export default {
     },
     events: {
         'uploader:progress': function(id, uploaded, total) {
-            const el = this.$el.getElementById(`progress-${id}`);
+            const el = document.getElementById(`progress-${id}`);
             el.style.width = `${Math.round(uploaded * 100 / total)}%`;
         },
         'uploader:complete': function(id, response) {

--- a/js/components/dataset/resource/list.vue
+++ b/js/components/dataset/resource/list.vue
@@ -167,6 +167,11 @@ export default {
         'uploader:complete': function(id, response, file) {
             this.files.splice(this.files.indexOf(file), 1);
             this.dataset.resources.unshift(response);
+        },
+        'uploader:error': function(id) {
+            // Remove the progressing file (an error is already displayed globally)
+            const file = this.$uploader.getFile(id);
+            this.files.splice(this.files.indexOf(file), 1);
         }
     },
     ready() {

--- a/js/components/dataset/resource/list.vue
+++ b/js/components/dataset/resource/list.vue
@@ -210,7 +210,7 @@ export default {
     watch: {
         'dataset.id': function(id) {
             if (id) {
-                this.upload_endpoint = API.datasets.operations.upload_dataset_resource.urlify({dataset: id});
+                this.upload_endpoint = API.datasets.operations.upload_new_dataset_resource.urlify({dataset: id});
             }
         }
     }

--- a/js/components/dataset/resource/list.vue
+++ b/js/components/dataset/resource/list.vue
@@ -164,9 +164,8 @@ export default {
             const el = document.getElementById(`progress-${id}`);
             el.style.width = `${Math.round(uploaded * 100 / total)}%`;
         },
-        'uploader:complete': function(id, response) {
-            const file = this.$uploader.getFile(id);
-            this.files.$remove(this.files.indexOf(file));
+        'uploader:complete': function(id, response, file) {
+            this.files.splice(this.files.indexOf(file), 1);
             this.dataset.resources.unshift(response);
         }
     },

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -91,6 +91,9 @@ export default {
     },
 
     filters: {
+        fileext(filename) {
+            return filename.split('.').pop();
+        },
         filesize(size) {
             if (!size || size <= 0) {
                 return '-';

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -164,7 +164,7 @@ export default {
         on_complete(id, name, response) {
             if (!response.success) return;
             const file = this.$uploader.getFile(id);
-            this.files.$remove(this.files.indexOf(file));
+            this.files.$remove(file);
             this.$emit('uploader:complete', id, response, file);
         },
 

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -92,7 +92,7 @@ export default {
 
     filters: {
         filesize(size) {
-            if (size <= 0) {
+            if (!size || size <= 0) {
                 return '-';
             }
             if (size > _1GO) {

--- a/less/admin/vendor.less
+++ b/less/admin/vendor.less
@@ -31,7 +31,7 @@
 // @import '~bootstrap/less/jumbotron';
 @import '~bootstrap/less/thumbnails';
 @import '~bootstrap/less/alerts';
-// @import '~bootstrap/less/progress-bars';
+@import '~bootstrap/less/progress-bars';
 @import '~bootstrap/less/media';
 // @import '~bootstrap/less/list-group';
 // @import '~bootstrap/less/panels';

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "bootstrap-markdown": "^2.10.0",
     "chart.js": "^1.1.1",
     "diff": "^2.2.3",
-    "fine-uploader": "~5.11.10",
+    "fine-uploader": "~5.15.0",
     "font-awesome": "^4.7.0",
     "highlight.js": "^9.9.0",
     "i18next": "3.3.1",

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -259,11 +259,11 @@ class UploadMixin(object):
         }
 
 
-@ns.route('/<dataset:dataset>/upload/', endpoint='upload_dataset_resources')
+@ns.route('/<dataset:dataset>/upload/', endpoint='upload_new_dataset_resource')
 @api.doc(parser=upload_parser, **common_doc)
-class UploadDatasetResources(UploadMixin, API):
+class UploadNewDatasetResource(UploadMixin, API):
     @api.secure
-    @api.doc('upload_dataset_resources')
+    @api.doc('upload_new_dataset_resource')
     @api.marshal_with(upload_fields)
     def post(self, dataset):
         '''Upload a new dataset resource'''
@@ -278,11 +278,11 @@ class UploadDatasetResources(UploadMixin, API):
 
 
 @ns.route('/<dataset:dataset>/upload/community/',
-          endpoint='upload_community_resources')
+          endpoint='upload_new_community_resource')
 @api.doc(parser=upload_parser, **common_doc)
-class UploadCommunityResources(UploadMixin, API):
+class UploadNewCommunityResources(UploadMixin, API):
     @api.secure
-    @api.doc('upload_community_resources')
+    @api.doc('upload_new_community_resource')
     @api.marshal_with(upload_fields)
     def post(self, dataset):
         '''Upload a new community resource'''

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -583,7 +583,7 @@ class DatasetResourceAPITest(APITestCase):
             ])
             dataset = DatasetFactory(organization=org)
         response = self.post(
-            url_for('api.upload_dataset_resources', dataset=dataset),
+            url_for('api.upload_new_dataset_resource', dataset=dataset),
             {'file': (StringIO(b'aaa'), 'test.txt')}, json=False)
         self.assert201(response)
         data = json.loads(response.data)
@@ -926,7 +926,7 @@ class CommunityResourceAPITest(APITestCase):
         dataset = VisibleDatasetFactory()
         self.login()
         response = self.post(
-            url_for('api.upload_community_resources', dataset=dataset),
+            url_for('api.upload_new_community_resource', dataset=dataset),
             {'file': (StringIO(b'aaa'), 'test.txt')}, json=False)
         self.assert201(response)
         data = json.loads(response.data)
@@ -950,7 +950,7 @@ class CommunityResourceAPITest(APITestCase):
             Member(user=user, role='admin')
         ])
         response = self.post(
-            url_for('api.upload_community_resources', dataset=dataset),
+            url_for('api.upload_new_community_resource', dataset=dataset),
             {'file': (StringIO(b'aaa'), 'test.txt')}, json=False)
         self.assert201(response)
         data = json.loads(response.data)


### PR DESCRIPTION
This PR fixes a lot of issue on file upload:
- [x] Update to latest fine uploader
- [x] fix upload endpoint detection (and use more explicit endpoint names)
- [x] restore missing dropzone highlight on resource form
- [x] fix filesize handling (when not defined, switch from legacy `File.fileSize` to `Blob.size`)
- [x] fix broken resource list inline upload layout:
  - [x] column numbers where mismatching (did not follow column addition)
  - [x] progress bar styles where not included
  - [x] mime type (way too long) was displayed instead of extension into format column
- [x] uploaded files where not replaced but duplicated
- [x] error handling on upload does not remove nor mark as errored the faulty files