### PR TITLE
Improve ES URL and index name configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#1076](https://github.com/opendatateam/udata/pull/1076)
 - Improve harvest error handling
   [#1078](https://github.com/opendatateam/udata/pull/1078)
+- Improve elasticsearch configurability
+  [#1096](https://github.com/opendatateam/udata/pull/1096)
 
 ## 1.1.1 (2017-07-31)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -132,6 +132,25 @@ RFC-1738 formatted URLs are also supported:
 ELASTICSEARCH_URL = 'http://<user>:<password>@<host>:<port>'
 ```
 
+### ELASTICSEARCH_INDEX_BASENAME
+
+**default**: `'udata'`
+
+The base name used to produce elasticsearch index names and alias.
+The default `udata` value will produce:
+- a `udata-{yyyy}-{mm}-{dd}-{HH}-{MM}` index on initialization
+- a `udata` alias on `udata-{yyyy}-{mm}-{dd}-{HH}-{MM}` on initialization
+- a temporary `udata-test` index during each test requiring it
+
+```python
+ELASTICSEARCH_INDEX_BASENAME = 'myindex'
+```
+The above example will produce:
+- a `myindex-{yyyy}-{mm}-{dd}-{HH}-{MM}` index on initialization
+- a `myindex` alias on `myindex-{yyyy}-{mm}-{dd}-{HH}-{MM}` on initialization
+- a temporary `myindex-test` index during each test requiring it
+
+
 ## Mongoengine/Flask-Mongoengine options
 
 ### MONGODB_HOST

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -51,8 +51,6 @@ class ElasticSearch(object):
             self.init_app(app)
 
     def init_app(self, app):
-        app.config.setdefault('ELASTICSEARCH_URL', 'localhost:9200')
-
         # using the app factory pattern _app_ctx_stack.top is None so what
         # do we register on? app.extensions looks a little hackish (I don't
         # know flask well enough to be sure), but that's how it's done in
@@ -75,9 +73,10 @@ class ElasticSearch(object):
 
     @property
     def index_name(self):
+        basename = current_app.config['ELASTICSEARCH_INDEX_BASENAME']
         if current_app.config.get('TESTING'):
-            return '{0}-test'.format(current_app.name)
-        return current_app.name
+            return '{0}-test'.format(basename)
+        return basename
 
     def scan(self, body, **kwargs):
         return scan(self.client, query=body, **kwargs)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -20,6 +20,10 @@ class Defaults(object):
 
     MONGODB_HOST = 'mongodb://localhost:27017/udata'
 
+    # Elasticsearch configuration
+    ELASTICSEARCH_URL = 'localhost:9200'
+    ELASTICSEARCH_INDEX_BASENAME = 'udata'
+
     # BROKER_TRANSPORT = 'redis'
     BROKER_URL = 'redis://localhost:6379'
     BROKER_TRANSPORT_OPTIONS = {


### PR DESCRIPTION
This PR improves the ES configuration by:
- exposing the default `ELASTICSEARCH_URL` in settings.py like any other setting
- introducing the `ELASTICSEARCH_INDEX_BASENAME` which default to `'udata'` to allow index configuration

The base name is used to produce elasticsearch index names and alias.
The default `udata` value will produce:
- a `udata-{yyyy}-{mm}-{dd}-{HH}-{MM}` index on initialization
- a `udata` alias on `udata-{yyyy}-{mm}-{dd}-{HH}-{MM}` on initialization
- a temporary `udata-test` index during each test requireing it

**Ex: **
```python
ELASTICSEARCH_INDEX_BASENAME = 'myindex'
```
The above configuration will produce:
- a `myindex-{yyyy}-{mm}-{dd}-{HH}-{MM}` index on initialization
- a `myindex` alias on `myindex-{yyyy}-{mm}-{dd}-{HH}-{MM}` on initialization
- a temporary `myindex-test` index during each test requireing it

This change is totally backward compatible (no change required for existing configurations) but allows to deploy multiple udata instance on a same elasticsearch cluster