### PR TITLE
Prevent a weird search error when displaying some facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [#1096](https://github.com/opendatateam/udata/pull/1096)
 - Lots of fixes admin files upload
   [1094](https://github.com/opendatateam/udata/pull/1094)
+- Prevent the "Bad request error" happening on search but only on some servers
+  [#1097](https://github.com/opendatateam/udata/pull/1097)
 
 ## 1.1.1 (2017-07-31)
 

--- a/udata/search/fields.py
+++ b/udata/search/fields.py
@@ -46,9 +46,9 @@ class Facet(object):
     def labelize(self, value):
         labelize = self.labelizer or self.default_labelizer
         if isinstance(value, basestring):
-            return ' {0} '.format(OR_LABEL).join(
-                str(labelize(v)) for v in value.split(OR_SEPARATOR)
-            )
+            return str(' {0} '.format(OR_LABEL)).join(
+                labelize(v).encode('utf-8') for v in value.split(OR_SEPARATOR)
+            ).decode('utf-8')
         return labelize(value)
 
     def default_labelizer(self, value):


### PR DESCRIPTION
This PR fix a weird error only happening on some config/servers when displaying search result.
I wasn't able to reproduce the issue on my own computer but I was able to identify and fix the issue on a server where it's happening.

The Bad Request error page is displayed because of this https://github.com/opendatateam/udata/blob/master/udata/frontend/error_handlers.py#L9-L11
This make sense because most of the framework (WTForm, Flask-Principal, Flask-RESTPlus...) permit to use `ValueError` as a validation error (and that's what is done everywhere in udata). The problem is that `UnicodeError` and child (`UnicodeDecodeError`, `UnicodeEncodeError`...) extends `ValueError`.

To fix this issue (in another PR), there is 2 possibilities:
- use more specific exceptions that `ValueError` to handle this (prefered)
- make a special case for `UnicodeError` and child (hackish)