### PR TITLE
Added SPATIAL_SEARCH_EXCLUDE_LEVELS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Make the spatial search levels exclusion list configurable through `SPATIAL_SEARCH_EXCLUDE_LEVELS`.
+  [#1101](https://github.com/opendatateam/udata/pull/1101)
 
 ## 1.1.2 (2017-09-04)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -92,6 +92,14 @@ The duration used for templates' cache, in minutes.
 
 This is the allowed resources extensions list that user can upload.
 
+## Spatial configuration
+
+### SPATIAL_SEARCH_EXCLUDE_LEVELS
+
+**default**: `tuple()`
+
+List spatial levels that shoudn't be indexed (for time, performance and user experience).
+
 ## Territories configuration
 
 ### ACTIVATE_TERRITORIES

--- a/udata/core/spatial/search.py
+++ b/udata/core/spatial/search.py
@@ -73,7 +73,8 @@ class GeoZoneSearch(ModelSearchAdapter):
 
     @classmethod
     def is_indexable(cls, zone):
-        return zone.level not in ('fr/iris', 'fr/canton', 'fr/district')
+        excluded = current_app.config['SPATIAL_SEARCH_EXCLUDE_LEVELS']
+        return zone.level not in excluded
 
     @classmethod
     def serialize(cls, zone):

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -155,6 +155,9 @@ class Defaults(object):
 
     HARVEST_PREVIEW_MAX_ITEMS = 20
 
+    # Lists levels that shouldn't be indexed
+    SPATIAL_SEARCH_EXCLUDE_LEVELS = tuple()
+
     ACTIVATE_TERRITORIES = False
     # The order is important to compute parents/children, smaller first.
     HANDLED_LEVELS = tuple()


### PR DESCRIPTION
This PR makes the spatial zones levels to exclude from indexation configurable with `SPATIAL_SEARCH_EXCLUDE_LEVELS`
    