### PR TITLE
Ensure territories export an image in page metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#1101](https://github.com/opendatateam/udata/pull/1101)
 - Fix facets labelizer with html handling
   [#1102](https://github.com/opendatateam/udata/issues/1102)
+- Ensure territories pages have image defined in metadatas
+  [#1103](https://github.com/opendatateam/udata/issues/1103)
 
 ## 1.1.2 (2017-09-04)
 

--- a/udata/templates/territories/commune.html
+++ b/udata/templates/territories/commune.html
@@ -3,7 +3,6 @@
 {% set meta = {
     'title': territory.name,
     'description': _('Datasets related to the town of %(name)s with INSEE code %(code)s and postal code %(postal)s', name=territory.name, code=territory.code, postal=territory.postal_string),
-    'image': logo,
     'keywords': [territory.name, territory.code, territory.postal_string],
 } %}
 

--- a/udata/templates/territories/departement.html
+++ b/udata/templates/territories/departement.html
@@ -3,7 +3,6 @@
 {% set meta = {
     'title': territory.name,
     'description': _('Datasets related to the county of %(name)s with INSEE code %(code)s', name=territory.name, code=territory.code),
-    'image': logo,
     'keywords': [territory.name, territory.code],
 } %}
 

--- a/udata/templates/territories/region.html
+++ b/udata/templates/territories/region.html
@@ -3,7 +3,6 @@
 {% set meta = {
     'title': territory.name,
     'description': _('Datasets related to the region of %(name)s with INSEE code %(code)s', name=territory.name, code=territory.code),
-    'image': logo,
     'keywords': [territory.name, territory.code],
 } %}
 

--- a/udata/templates/territories/territory.html
+++ b/udata/templates/territories/territory.html
@@ -1,7 +1,13 @@
 {% extends theme("layouts/1-column.html") %}
 
 {% set bundle = 'territory' %}
-{% set logo=territory.logo_url(external=True) or theme_static('img/placeholder_territory.png', external=True) %}
+{% set logo = territory.logo_url(external=True) or theme_static('img/placeholder_territory.png', external=True) %}
+{#
+   Children variables outside of blocks are set before parents
+   so children template can't access logo outside of blocks.
+   Workaround: inject logo in meta object from parent template (until a better solution is found)
+#}
+{% set ___ = meta.__setitem__('image', logo) %}
 {% set body_class="territory" %}
 
 {% block main_content %}


### PR DESCRIPTION
This PR fixes the embed preview for territories pages (ie. flag or blazon wasn't displayed)