### PR TITLE
Transmit link checker status to frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [#1103](https://github.com/opendatateam/udata/issues/1103)
 - Strip tags in autocomplete results
   [#1104](https://github.com/opendatateam/udata/pull/1104)
+- Transmit link checker status to frontend
+  [#1048](https://github.com/opendatateam/udata/issues/1048)
 
 ## 1.1.2 (2017-09-04)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -538,4 +538,4 @@ class CheckUrlAPI(API):
             # We keep 503 which means the URL checker is unreachable.
             return error, status == 503 and status or 500
         else:
-            return response
+            return response, status


### PR DESCRIPTION
Fix #1048 

Reading the source code on frontend, I think this is the way it was supposed to be implemented: https://github.com/opendatateam/udata/blob/master/js/front/dataset/index.js#L163