### PR TITLE
Remove plus signs from search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [#1104](https://github.com/opendatateam/udata/pull/1104)
 - Transmit link checker status to frontend
   [#1048](https://github.com/opendatateam/udata/issues/1048)
+- Remove plus signs from search query
+  [#1048](https://github.com/opendatateam/udata/issues/987)
 
 ## 1.1.2 (2017-09-04)
 

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -64,10 +64,9 @@ export default {
         territoryId: String,
     },
     data() {
-        const query = this.$location.query.q || '';
         return {
             current: -1,
-            query: decodeURIComponent(query.replace('+', ' ')),
+            query: this.$location.query.q || '',
             show: false,
             cache: new Cache('site-search', sessionStorage),
             groups: [

--- a/js/utils.js
+++ b/js/utils.js
@@ -59,7 +59,7 @@ export function parseQS(qs) {
     if (qs.startsWith('?')) qs = qs.substr(1);
     qs.split('&').forEach(function(part) {
         const [key, value] = part.split('=');
-        result[decodeURIComponent(key)] = decodeURIComponent(value);
+        result[decodeURIComponent(key)] = decodeURIComponent(value.replace(/\+/g, '%20'));
     });
     return result;
 }


### PR DESCRIPTION
Fix #987. It also won't erase a potential plus sign from the user's query.

Thanks @oncletom for pairing on this!