### PR TITLE
Deduplicate org members - fix #1111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [#774](https://github.com/opendatateam/udata/issues/774)
 - Pin GeoJSON version to avoid breaking changes
   [#1118](https://github.com/opendatateam/udata/pull/1118)
+- Deduplicate organization members
+  [#1111](https://github.com/opendatateam/udata/issues/1111)
 
 ## 1.1.4 (2017-09-05)
 

--- a/udata/migrations/2017-07-07-deduplicate-org-members.js
+++ b/udata/migrations/2017-07-07-deduplicate-org-members.js
@@ -1,0 +1,33 @@
+/*
+ * Ensure there's no duplicated members in each organization
+ */
+
+ function is_candidate() {
+     return this.members && this.members.length > 1;
+ }
+
+ var uniqueMembers;
+ var exist;
+ var nbOrgs = 0;
+
+ db.organization.find({'$where': is_candidate}).forEach(org => {
+     uniqueMembers = [];
+     org.members.forEach(member => {
+         if (exist = uniqueMembers.find(m => m.user.equals(member.user))) {
+             print(`Duplicate member ${member.user} for org ${org._id}`);
+             // make sure the higher role is assigned to the deduped user
+             if (member.role === 'admin') {
+                 exist.role = 'admin'
+             }
+         } else {
+             uniqueMembers.push(member);
+         }
+     })
+     if (uniqueMembers.length !== org.members.length) {
+         org.members = uniqueMembers;
+         db.organization.save(org);
+         nbOrgs++;
+     }
+ });
+
+ print(`Deduplicated members of ${nbOrgs} organizations.`);


### PR DESCRIPTION
This adds a migration to ensure only one instance of a user exists in an organization, with the highest role assigned.

NB: the API is protected against double-adding a member, cf `test_organizations_api.py:MembershipAPITest.test_create_member_exists`.

Fix https://github.com/etalab/data.gouv.fr/issues/1 and #1111.