### PR TITLE
Load, payload and reload fixes and tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix the organization members grid in admin
   [#934](https://github.com/opendatateam/udata/issues/934)
+- Fix and tune harvest admin loading state and payload size
+  [#1113](https://github.com/opendatateam/udata/issues/1113)
 
 ## 1.1.4 (2017-09-05)
 

--- a/js/components/harvest/item.vue
+++ b/js/components/harvest/item.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-<modal class="job-item-modal"
+<modal class="job-item-modal" v-ref:modal
     :class="{
         'modal-success': item.status === 'done',
         'modal-danger': item.status === 'failed',

--- a/js/components/harvest/job.vue
+++ b/js/components/harvest/job.vue
@@ -4,7 +4,7 @@
     :title="title"
     bodyclass="table-responsive no-padding"
     :p="p" :track="false"
-    :loading="loading !== undefined ? loading : p.loading"
+    :loading="loading !== undefined ? loading : job.loading"
     :fields="fields"
     track="remote_id"
     :empty="empty"
@@ -64,11 +64,11 @@ import Datatable from 'components/datatable/widget.vue';
 export default {
     name: 'JobDetails',
     props: {
-        job: {
-            type: Object,
-            default: () => new HarvestJob()
+        job: HarvestJob,
+        loading: {
+            type: Boolean,
+            default: undefined
         },
-        loading: Boolean,
         empty: String
     },
     components: {Datatable},
@@ -93,7 +93,7 @@ export default {
     },
     computed: {
         title() {
-            return this.job.id ? ('Job ' + this.job.id) : 'Job';
+            return this.job.id ? `Job ${this.job.id}` : 'Job';
         },
     },
     events: {
@@ -117,7 +117,7 @@ export default {
     },
     watch: {
         'job.items': function(items) {
-            this.p.data = items;
+            this.p = new PageList({data: items});
         }
     }
 };

--- a/js/components/harvest/source.vue
+++ b/js/components/harvest/source.vue
@@ -4,6 +4,7 @@
         boxclass="harvest-jobs-widget"
         :fields="fields"
         :p="jobs"
+        :loading="source.loading || jobs.loading"
         :empty="_('No job yet')">
         <header slot="header">
             {{{ source.description | markdown }}}
@@ -23,6 +24,8 @@ import {STATUS_CLASSES, STATUS_I18N} from 'models/harvest/job';
 import Datatable from 'components/datatable/widget.vue';
 import HarvestJobs from 'models/harvest/jobs';
 
+const MASK = ['id', 'created', 'status'];
+
 export default {
     components: {Datatable},
     props: {
@@ -32,7 +35,7 @@ export default {
     data() {
         return {
             title: this._('Jobs'),
-            jobs: new HarvestJobs({query: {page_size: 10}}),
+            jobs: new HarvestJobs({query: {page_size: 10}, mask: MASK}),
             fields: [{
                 label: this._('Date'),
                 key: 'created',

--- a/js/components/harvest/sources.vue
+++ b/js/components/harvest/sources.vue
@@ -16,7 +16,7 @@ import {STATUS_CLASSES, STATUS_I18N} from 'models/harvest/job';
 import Datatable from 'components/datatable/widget.vue';
 import placeholders from 'helpers/placeholders';
 
-const MASK = ['id', 'name', 'owner', 'last_job{status,ended}', 'organization', 'backend', 'validation{state}'];
+const MASK = ['id', 'name', 'owner', 'last_job{status,ended}', 'organization{name,logo_thumbnail}', 'backend', 'validation{state}'];
 
 export default {
     MASK,
@@ -41,7 +41,7 @@ export default {
                 fields.push({
                     key(item) {
                         if (item.organization) {
-                            return item.organization.logo || placeholders.organization;
+                            return item.organization.logo_thumbnail || placeholders.organization;
                         } else {
                             return item.owner.avatar || placeholders.user;
                         }

--- a/js/models/harvest/job.js
+++ b/js/models/harvest/job.js
@@ -25,12 +25,11 @@ export const STATUS_I18N = {
 
 export class HarvestJob extends Model {
     fetch() {
-        if (this.id || this.slug) {
-            this.$api('harvest.get_job', {
-                dataset: this.id || this.slug
-            }, this.on_fetched);
+        if (this.id) {
+            this.loading = true;
+            this.$api('harvest.get_harvest_job', {ident: this.id}, this.on_fetched);
         } else {
-            log.error('Unable to fetch Dataset: no identifier specified');
+            log.error('Unable to fetch Job');
         }
         return this;
     }

--- a/js/views/harvester-edit.vue
+++ b/js/views/harvester-edit.vue
@@ -24,11 +24,13 @@ import HarvestSource from 'models/harvest/source';
 import ItemModal from 'components/harvest/item.vue';
 import Preview from 'components/harvest/preview.vue';
 
+const MASK = ['id', 'name', 'description', 'owner', 'last_job{status,ended}', 'organization', 'backend', 'validation{state}'];
+
 export default {
     name: 'harvester-edit',
     data() {
         return {
-            source: new HarvestSource(),
+            source: new HarvestSource({mask: MASK}),
         };
     },
     components: {Box, FormLayout, HarvestForm, Preview},

--- a/js/views/harvester.vue
+++ b/js/views/harvester.vue
@@ -37,6 +37,7 @@
 
 <script>
 import HarvestSource from 'models/harvest/source';
+import HarvestJob from 'models/harvest/job';
 import ItemModal from 'components/harvest/item.vue';
 import Vue from 'vue';
 import Preview from 'components/harvest/preview.vue';
@@ -44,12 +45,14 @@ import SourceWidget from 'components/harvest/source.vue';
 import JobWidget from 'components/harvest/job.vue';
 import Layout from 'components/layout.vue';
 
+const MASK = ['id', 'name', 'owner', 'organization', 'backend', 'validation{state}'];
+
 export default {
     name: 'HarvestSourceView',
     components: {Preview, SourceWidget, JobWidget, Layout},
     data() {
         return {
-            source: new HarvestSource(),
+            source: new HarvestSource({mask: MASK}),
             current_job: null,
             current_item: null,
             actions: [{
@@ -87,7 +90,7 @@ export default {
     },
     events: {
         'harvest:job:selected': function(job) {
-            this.current_job = job;
+            this.current_job = new HarvestJob({data: job}).fetch();
             return true;
         },
         'harvest:job:item:selected': function(item) {
@@ -98,7 +101,7 @@ export default {
     },
     methods: {
         edit() {
-            this.$go('/harvester/' + this.source.id + '/edit');
+            this.$go({name: 'harvester-edit', params: {oid: this.source.id}});
         },
         confirm_delete() {
             this.$root.$modal(
@@ -111,13 +114,17 @@ export default {
                 require('components/harvest/validation-modal.vue'),
                 {source: this.source}
             );
-        }
+        },
+        schedule() {
+            this.$go({name: 'harvester-schedule', params: {oid: this.source.id}});
+        },
+        unschedule() {
+            this.$go({name: 'harvester-unschedule', params: {oid: this.source.id}});
+        },
     },
     route: {
         data() {
-            if (this.$route.params.oid !== this.source.id) {
-                this.source.fetch(this.$route.params.oid);
-            }
+            this.source.fetch(this.$route.params.oid);
         }
     }
 };

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -104,8 +104,6 @@ source_fields = api.model('HarvestSource', {
                              required=True, default=False),
     'validation': fields.Nested(validation_fields, readonly=True,
                                 description='Has the source been validated'),
-    'config': fields.Raw(description='The source specific configuration',
-                         default={}),
     'last_job': fields.Nested(job_fields,
                               description='The last job for this source',
                               allow_null=True, readonly=True),


### PR DESCRIPTION
This PR:
- fixes the loading states on harvest admin
- reduce the size of the harvest admin views payload by using masks
- removes a duplicated harvest API parameter in documentation
- fixes the `HarvestJob.fetch()` method on JS model
- ensure that named routes are used