### PR TITLE
Harvest auto schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   [#934](https://github.com/opendatateam/udata/issues/934)
 - Fix and tune harvest admin loading state and payload size
   [#1113](https://github.com/opendatateam/udata/issues/1113)
-- Automatically schedule validated harvesters
+- Automatically schedule validated harvesters and allow to (re)schedule them
+  [#1114](https://github.com/opendatateam/udata/pull/1114)
 
 ## 1.1.4 (2017-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   [#934](https://github.com/opendatateam/udata/issues/934)
 - Fix and tune harvest admin loading state and payload size
   [#1113](https://github.com/opendatateam/udata/issues/1113)
+- Automatically schedule validated harvesters
 
 ## 1.1.4 (2017-09-05)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -122,6 +122,21 @@ a given territory. You have to set the smallest territory level first:
 HANDLED_LEVELS = ('fr:commune', 'fr:departement', 'fr:region')
 ```
 
+## Harvesting configuration
+
+### HARVEST_PREVIEW_MAX_ITEMS
+
+**default**: `20`
+
+The number of items to fetch while previewing an harvest source
+
+### HARVEST_DEFAULT_SCHEDULE
+
+**default**: `0 0 * * *`
+
+A cron expression used as default harvester schedule when validating harvesters.
+
+
 ## ElasticSearch configuration
 
 ### ELASTICSEARCH_URL

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -101,6 +101,7 @@ def validate_source(ident, comment=None):
     if current_user.is_authenticated:
         source.validation.by = current_user._get_current_object()
     source.save()
+    schedule(ident, cron=current_app.config['HARVEST_DEFAULT_SCHEDULE'])
     launch(ident)
     return source
 
@@ -154,11 +155,15 @@ def preview(ident):
 
 
 def schedule(ident, minute='*', hour='*',
-             day_of_week='*', day_of_month='*', month_of_year='*'):
+             day_of_week='*', day_of_month='*', month_of_year='*',
+             cron=None):
     '''Schedule an harvesting on a source given a crontab'''
     source = get_source(ident)
     if source.periodic_task:
         raise ValueError('Source {0} is already scheduled'.format(source.name))
+
+    if cron:
+        minute, hour, day_of_week, day_of_month, month_of_year = cron.split()
 
     source.periodic_task = PeriodicTask.objects.create(
         task='harvest',

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -154,32 +154,33 @@ def preview(ident):
     return backend.harvest()
 
 
-def schedule(ident, minute='*', hour='*',
-             day_of_week='*', day_of_month='*', month_of_year='*',
-             cron=None):
+def schedule(ident, cron=None, minute='*', hour='*',
+             day_of_week='*', day_of_month='*', month_of_year='*'):
     '''Schedule an harvesting on a source given a crontab'''
     source = get_source(ident)
-    if source.periodic_task:
-        raise ValueError('Source {0} is already scheduled'.format(source.name))
 
     if cron:
-        minute, hour, day_of_week, day_of_month, month_of_year = cron.split()
+        minute, hour, day_of_month, month_of_year, day_of_week = cron.split()
 
-    source.periodic_task = PeriodicTask.objects.create(
-        task='harvest',
-        name='Harvest {0}'.format(source.name),
-        description='Periodic Harvesting',
-        enabled=True,
-        args=[str(source.id)],
-        crontab=PeriodicTask.Crontab(
-            minute=str(minute),
-            hour=str(hour),
-            day_of_week=str(day_of_week),
-            day_of_month=str(day_of_month),
-            month_of_year=str(month_of_year)
-        ),
+    crontab = PeriodicTask.Crontab(
+        minute=str(minute),
+        hour=str(hour),
+        day_of_week=str(day_of_week),
+        day_of_month=str(day_of_month),
+        month_of_year=str(month_of_year)
     )
-    source.save()
+
+    if source.periodic_task:
+        source.periodic_task.modify(crontab=crontab)
+    else:
+        source.modify(periodic_task=PeriodicTask.objects.create(
+            task='harvest',
+            name='Harvest {0}'.format(source.name),
+            description='Periodic Harvesting',
+            enabled=True,
+            args=[str(source.id)],
+            crontab=crontab,
+        ))
     signals.harvest_source_scheduled.send(source)
     return source
 

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -242,12 +242,11 @@ class HarvestActionsTest(DBTestMixin, TestCase):
     def test_schedule(self):
         source = HarvestSourceFactory()
         with self.assert_emit(signals.harvest_source_scheduled):
-            actions.schedule(str(source.id), hour=0)
+            source = actions.schedule(str(source.id), hour=0)
 
-        source.reload()
         self.assertEqual(len(PeriodicTask.objects), 1)
-        periodic_task = PeriodicTask.objects.first()
-        self.assertEqual(source.periodic_task, periodic_task)
+        periodic_task = source.periodic_task
+        self.assertEqual(periodic_task, PeriodicTask.objects.first())
         self.assertEqual(periodic_task.args, [str(source.id)])
         self.assertEqual(periodic_task.crontab.hour, '0')
         self.assertEqual(periodic_task.crontab.minute, '*')
@@ -260,18 +259,37 @@ class HarvestActionsTest(DBTestMixin, TestCase):
     def test_schedule_from_cron(self):
         source = HarvestSourceFactory()
         with self.assert_emit(signals.harvest_source_scheduled):
-            actions.schedule(str(source.id), cron='0 1 2 3 4')
+            source = actions.schedule(str(source.id), '0 1 2 3 sunday')
 
-        source.reload()
         self.assertEqual(len(PeriodicTask.objects), 1)
-        periodic_task = PeriodicTask.objects.first()
-        self.assertEqual(source.periodic_task, periodic_task)
+        periodic_task = source.periodic_task
+        self.assertEqual(periodic_task, PeriodicTask.objects.first())
         self.assertEqual(periodic_task.args, [str(source.id)])
         self.assertEqual(periodic_task.crontab.minute, '0')
         self.assertEqual(periodic_task.crontab.hour, '1')
-        self.assertEqual(periodic_task.crontab.day_of_week, '2')
-        self.assertEqual(periodic_task.crontab.day_of_month, '3')
-        self.assertEqual(periodic_task.crontab.month_of_year, '4')
+        self.assertEqual(periodic_task.crontab.day_of_month, '2')
+        self.assertEqual(periodic_task.crontab.month_of_year, '3')
+        self.assertEqual(periodic_task.crontab.day_of_week, 'sunday')
+        self.assertTrue(periodic_task.enabled)
+        self.assertEqual(periodic_task.name, 'Harvest {0}'.format(source.name))
+
+    def test_reschedule(self):
+        source = HarvestSourceFactory()
+        with self.assert_emit(signals.harvest_source_scheduled):
+            source = actions.schedule(str(source.id), hour=0)
+
+        with self.assert_emit(signals.harvest_source_scheduled):
+            source = actions.schedule(str(source.id), minute=0)
+
+        self.assertEqual(len(PeriodicTask.objects), 1)
+        periodic_task = source.periodic_task
+        self.assertEqual(periodic_task, PeriodicTask.objects.first())
+        self.assertEqual(periodic_task.args, [str(source.id)])
+        self.assertEqual(periodic_task.crontab.hour, '*')
+        self.assertEqual(periodic_task.crontab.minute, '0')
+        self.assertEqual(periodic_task.crontab.day_of_week, '*')
+        self.assertEqual(periodic_task.crontab.day_of_month, '*')
+        self.assertEqual(periodic_task.crontab.month_of_year, '*')
         self.assertTrue(periodic_task.enabled)
         self.assertEqual(periodic_task.name, 'Harvest {0}'.format(source.name))
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -154,6 +154,8 @@ class Defaults(object):
     DELAY_BEFORE_REMINDER_NOTIFICATION = 30  # Days
 
     HARVEST_PREVIEW_MAX_ITEMS = 20
+    # Harvesters are scheduled at midnight by default
+    HARVEST_DEFAULT_SCHEDULE = '0 0 * * *'
 
     # Lists levels that shouldn't be indexed
     SPATIAL_SEARCH_EXCLUDE_LEVELS = tuple()


### PR DESCRIPTION
This PRs ensures that validated harvest sources are automatically scheduled (using the `HARVEST_DEFAULT_SCHEDULE` setting which is a cron expression) and that they can be rescheduled.