### PR TITLE
Fix the organization members grid in admin (fix #934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix the organization members grid in admin
+  [#934](https://github.com/opendatateam/udata/issues/934)
 
 ## 1.1.4 (2017-09-05)
 

--- a/js/components/organization/members.vue
+++ b/js/components/organization/members.vue
@@ -70,12 +70,10 @@
         </div>
     </div><!-- /.box-header -->
     <div v-if="!validating" class="box-body row">
-        <div class="col-xs-3 col-lg-2 text-center user-face"
-             v-for="member in org.members">
-            <a class="pointer"
-                @click="member_click(member)">
+        <div class="col-xs-4 col-lg-3 text-center user-face" v-for="member in org.members">
+            <a class="pointer" @click="member_click(member)">
                 <img class="img-circle" :alt="_('User Image')"
-                    :src="member.user.avatar || avatar_placeholder"/>
+                    :src="member.user.avatar_thumbnail || avatar_placeholder"/>
                 <strong>{{member.user | display}}</strong>
                 <small class="text-muted">{{member.role}}</small>
             </a>


### PR DESCRIPTION
This PR fixes the organization members grid in admin:
- ensure the square thumbnail is used
- use a larger size for each member to avoid names truncation

## Before
### Small screen
![screenshot-www data dev-2017-09-08-17-45-20](https://user-images.githubusercontent.com/15725/30219811-85176892-94bd-11e7-86ee-6b759ae0f00c.png)


### Large screen
![screenshot-www data dev-2017-09-08-17-30-25](https://user-images.githubusercontent.com/15725/30219430-4b1b8598-94bc-11e7-96a5-2d6d5ceb6ef0.png)

## After
### Small screen
![screenshot-www data dev-2017-09-08-17-36-13](https://user-images.githubusercontent.com/15725/30219410-3b0eb968-94bc-11e7-90a3-cf1271288d36.png)

### Large screen
![screenshot-www data dev-2017-09-08-17-28-59](https://user-images.githubusercontent.com/15725/30219453-5ab53710-94bc-11e7-80d8-471d2235b080.png)



