### PR TITLE
Raise raven minimum supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#1113](https://github.com/opendatateam/udata/issues/1113)
 - Automatically schedule validated harvesters and allow to (re)schedule them
   [#1114](https://github.com/opendatateam/udata/pull/1114)
+- Raise the minimum `raven` version to ensure sentry is filtering legit HTTP exceptions
+  [#774](https://github.com/opendatateam/udata/issues/774)
 
 ## 1.1.4 (2017-09-05)
 

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         'test': tests_require,
-        'sentry': ['raven[flask]>=5.3.0'],
+        'sentry': ['raven[flask]>=6.1.0'],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR raises raven minimum supported version to ensure http errors filtering works (fix #774)