### PR TITLE
Pin oauthlib to working version

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -31,6 +31,7 @@ mongoengine==0.13.0
 msgpack-python==0.4.8
 pillow==4.2.0
 bcrypt==3.1.3
+oauthlib==2.0.2
 pyliblzma==0.5.3
 python-dateutil==2.6.0
 pytz==2017.2


### PR DESCRIPTION
This PR pin oauthlib to the last working version until flask-oauthlib is fixed to support last release