### PR TITLE
Force build for tags and publish for maintenance branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,12 +145,21 @@ workflows:
   version: 2
   build:
     jobs:
-      - python
-      - assets
+      - python:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - assets:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - dist:
           requires:
             - python
             - assets
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - publish:
           requires:
             - dist
@@ -159,5 +168,6 @@ workflows:
               only:
                 - master
                 - dev
+                - /v[0-9]+(\.[0-9]+)*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix CircleCI automated publication on release tags
+  [#1120](https://github.com/opendatateam/udata/pull/1120)
 
 ## 1.1.5 (2017-09-11)
 


### PR DESCRIPTION
This PR fix/tune the workflows filters to:
- build on release tags (tags are not built on CircleCI by default)
- publish builds from maintenance branches

Reference documentation: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution