### PR TITLE
Refactor the "publish as" screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Prevent a random territory from being displayed when query doesn't match [#1124](https://github.com/opendatateam/udata/pull/1124)
 - Display avatar when the community resource owner is an organization [#1125](https://github.com/opendatateam/udata/pull/1125)
+- Refactor the "publish as" screen to make it more obvious that an user is publishing under its own name [#1122](https://github.com/opendatateam/udata/pull/1122)
 
 ## 1.1.6 (2017-09-11)
 

--- a/js/admin.routes.js
+++ b/js/admin.routes.js
@@ -133,6 +133,7 @@ router.map({
         },
     },
     '/organization/new/': {
+        name: 'organization-new',
         component(resolve) {
             require(['./views/organization-wizard.vue'], resolve);
         }

--- a/js/components/widgets/publish-as.vue
+++ b/js/components/widgets/publish-as.vue
@@ -5,29 +5,35 @@
         {{ _('Choose under which identity you want to publish') }}
     </p>
 </div>
-<div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-        <user-card :user="$root.me" :selected="!selected"></user-card>
-    </div>
+<div class="row" v-if="$root.me.organizations.length">
+    <p class="col-xs-12">{{ _('Publish as an organization') }}</p>
     <div v-for="organization in $root.me.organizations" class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
         <org-card :organization="organization" :selected="selected == organization"></org-card>
     </div>
 </div>
-<div class="row" v-if="!$root.me.organizations">
-    <p class="col-xs-12">{{ _("You are not member of any organization.") }}</p>
-    <p class="col-xs-12">{{ _("Maybe you should find or create your own.") }}</p>
-    <div class="col-xs-12 text-center">
-        <a v-link.literal="/organization/new" class="btn btn-flat btn-primary">{{ _('Find or create your organization') }}</a>
+<div class="row text-center" v-if="!$root.me.organizations.length">
+    <p class="col-xs-12 lead">
+        {{ _("You are not a member of any organization.") }}
+        {{ _("Maybe you should find yours or create your own.") }}
+    </p>
+    <div class="col-xs-12">
+        <a v-link="{name: 'organization-new'}" class="btn btn-flat btn-primary">
+            {{ _('Find or create your organization') }}
+        </a>
     </div>
 </div>
 <div class="row">
+    <p class="col-xs-12">{{ _('Publish in your own name') }}</p>
+    <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
+        <user-card :user="$root.me" :selected="!selected"></user-card>
+    </div>
+</div>
+<div class="row" v-if="$root.me.is_admin">
     <p class="col-xs-12 text-center lead">
        {{ _('As administrator you can choose any organization to publish') }}
     </p>
+    <org-filter cardclass="col-xs-12 col-sm-6 col-md-4 col-lg-3" :selected="selected"></org-filter>
 </div>
-<org-filter v-if="$root.me.is_admin"
-    cardclass="col-xs-12 col-sm-6 col-md-4 col-lg-3" :selected="selected">
-</org-filter>
 </div>
 </template>
 
@@ -40,7 +46,7 @@ export default {
     name: 'publish-as',
     data() {
         return {
-            selected: null
+            selected: this.$root.me.organizations[0]
         };
     },
     components: {UserCard, OrgCard, OrgFilter},
@@ -52,6 +58,11 @@ export default {
         'user:clicked': function(user) {
             this.selected = null;
             return true;
+        }
+    },
+    watch: {
+        '$root.me.organizations': function(orgs) {
+            this.selected = this.$root.me.organizations[0];
         }
     }
 };


### PR DESCRIPTION
Try to make more user publish as their organization from the first time.

To do so, I:
- switched the organizations before/above the current user
- cleary separated the 2 sections
- automaticaly select the first organization when available
- warn/push the user to find or create an organization if he's not already member of at least one
 
## I'm not member of any organization
![screenshot-www data dev-2017-09-11-14-50-20](https://user-images.githubusercontent.com/15725/30285678-15fbc3f4-971f-11e7-8903-a9f76ae90bac.png)

## I'm member of one or more organization(s)
![screenshot-www data dev-2017-09-11-14-55-18](https://user-images.githubusercontent.com/15725/30285679-15febd7a-971f-11e7-8106-73e1b763ae11.png)

## Note

This PR also fixes a bug: some parts where displayed when they shouldn't.