### PR TITLE
Preven from displaying a random territory when search doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Prevent a random territory from being displayed when query doesn't match [#1124](https://github.com/opendatateam/udata/pull/1124)
 
 ## 1.1.6 (2017-09-11)
 

--- a/udata/features/territories/__init__.py
+++ b/udata/features/territories/__init__.py
@@ -13,7 +13,7 @@ def check_for_territories(query):
     Results are sorted by population and area (biggest first).
     """
     if not query or not current_app.config.get('ACTIVATE_TERRITORIES'):
-        return GeoZone.objects.none()
+        return []
 
     dbqs = db.Q()
     query = query.lower()


### PR DESCRIPTION
This PR fixes a case where search doesn't match any torritory but still display one (random)