### PR TITLE
Display avatar when communautary resource is an organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Prevent a random territory from being displayed when query doesn't match [#1124](https://github.com/opendatateam/udata/pull/1124)
+- Display avatar when the community resource owner is an organization [#1125](https://github.com/opendatateam/udata/pull/1125)
 
 ## 1.1.6 (2017-09-11)
 

--- a/udata/frontend/helpers.py
+++ b/udata/frontend/helpers.py
@@ -182,9 +182,9 @@ def avatar(ctx, user, size, classes=''):
 
 @front.app_template_filter()
 @contextfilter
-def owner_avatar(ctx, obj, size=32):
+def owner_avatar(ctx, obj, size=32, classes=''):
     markup = '''
-        <a class="avatar" href="{url}" title="{title}">
+        <a class="avatar {classes}" href="{url}" title="{title}">
             <img src="{avatar_url}" class="avatar" alt="{title}"
             width="{size}" height="{size}"/>
         </a>
@@ -194,6 +194,7 @@ def owner_avatar(ctx, obj, size=32):
         url=owner_url(obj),
         size=size,
         avatar_url=owner_avatar_url(ctx, obj, size),
+        classes=classes
     ))
 
 

--- a/udata/templates/dataset/resource/list-item.html
+++ b/udata/templates/dataset/resource/list-item.html
@@ -17,8 +17,8 @@
             date=resource.modified|dateformat('full'),
         ) }}
     </p>
-    {% if resource.owner %}
-    {{ resource.owner|avatar(52, 'resource-owner') }}
+    {% if resource.owner or resource.organization %}
+    {{ resource|owner_avatar(52, 'resource-owner') }}
     {% endif %}
 
     {% if can_edit_resource(resource if resource.from_community else dataset) %}


### PR DESCRIPTION
This issue fixes the case where a communautary resource is owned by an organization and avatar is not displayed.

Fix etalab/data.gouv.fr#23