### PR TITLE
Hide forbidden actions from issue modal (fix etalab/data.gouv.fr#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Make the "find your organization" screen cards clickable (send to the organization page) [#1129](https://github.com/opendatateam/udata/pull/1129)
 - Fix "Center the full picture" on user avatar upload   
 [#1130](https://github.com/opendatateam/udata/issues/1130)
+- Hide issue modal forbidden actions [#1128](https://github.com/opendatateam/udata/pull/1128)
 
 ## 1.1.6 (2017-09-11)
 

--- a/js/admin.vue
+++ b/js/admin.vue
@@ -52,6 +52,17 @@ export default {
                 details: this._('The error identifier is {id}', {id: e.data.event_id}),
             });
         });
+    },
+    methods: {
+        handleApiError(error) {
+            const notif = {type: 'danger', icon: 'exclamation-circle'};
+            if (error.status === 403) {
+                notif.title = this._('Operation not permitted');
+                notif.details = this._('You are not allowed to perform this operation');
+                notif.icon = 'ban'
+            }
+            this.notifications.push(notif);
+        }
     }
 };
 </script>


### PR DESCRIPTION
This PR does 2 things:
- ensure that issue modal only display buttons that the user can use
- provide a default error handler for the admin part (right now, only handling 403)