### PR TITLE
Make the "find your organization" cards clickables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Prevent a random territory from being displayed when query doesn't match [#1124](https://github.com/opendatateam/udata/pull/1124)
 - Display avatar when the community resource owner is an organization [#1125](https://github.com/opendatateam/udata/pull/1125)
 - Refactor the "publish as" screen to make it more obvious that an user is publishing under its own name [#1122](https://github.com/opendatateam/udata/pull/1122)
+- Make the "find your organization" screen cards clickable (send to the organization page) [#1129](https://github.com/opendatateam/udata/pull/1129)
 
 ## 1.1.6 (2017-09-11)
 

--- a/js/components/organization/pre-create.vue
+++ b/js/components/organization/pre-create.vue
@@ -62,6 +62,13 @@ export default {
             }));
         }
     },
+    events: {
+        'organization:clicked': function(org) {
+            // TODO: find a better implementation
+            // (ie. open the membership modal from the admin)
+            document.location = org.page;
+        }
+    },
     watch: {
         search_query(query) {
             API.organizations.suggest_organizations({


### PR DESCRIPTION
This PR makes the "Find you organization" screen cards cliackable and temporarily redirect to the organization page.

Fix etalab/data.gouv.fr#3

Next step: make the membership request modal available from the admin interface and display it on click.