### PR TITLE
Ensure min-{height,width} for .user-face img

### DIFF
--- a/js/components/organization/members.vue
+++ b/js/components/organization/members.vue
@@ -38,6 +38,8 @@
         width: 76%;
         max-width: 60px;
         max-height: 60px;
+        min-height: 60px;
+        min-width: 60px;
     }
 
     strong {


### PR DESCRIPTION
On a slow connection, user faces images might not be loaded for a while.
They appear with a 60px width but a 0px height.

This PR ensure they have a proper height even before we receive the first byte of the image.

# Before

![image](https://user-images.githubusercontent.com/138627/30447173-21f4320c-9983-11e7-8e41-3cd876d2b135.png)

# After

![image](https://user-images.githubusercontent.com/138627/30447218-470660ec-9983-11e7-9283-890419e77d2d.png)
