### PR TITLE
Spatial zones temporal resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fix "Center the full picture" on user avatar upload   
 [#1130](https://github.com/opendatateam/udata/issues/1130)
 - Hide issue modal forbidden actions [#1128](https://github.com/opendatateam/udata/pull/1128)
-- Ensure spatial coverage zones are resolved when submitted from the API.
+- Ensure spatial coverage zones are resolved when submitted from the API or when querying oembed API. [#1140](https://github.com/opendatateam/udata/pull/1140)
 
 ## 1.1.6 (2017-09-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix "Center the full picture" on user avatar upload   
 [#1130](https://github.com/opendatateam/udata/issues/1130)
 - Hide issue modal forbidden actions [#1128](https://github.com/opendatateam/udata/pull/1128)
+- Ensure spatial coverage zones are resolved when submitted from the API.
 
 ## 1.1.6 (2017-09-11)
 

--- a/udata/core/spatial/factories.py
+++ b/udata/core/spatial/factories.py
@@ -109,13 +109,24 @@ class SpatialCoverageFactory(factory.mongoengine.MongoEngineFactory):
     granularity = factory.Faker('spatial_granularity')
 
 
+def geoid(zone):
+    '''
+    Build a GeoID from a given zone
+
+    GeoID, see https://github.com/etalab/geoids
+    '''
+    spatial = ':'.join((zone.level, zone.code))
+    if not zone.validity:
+        return spatial
+    else:
+        return '@'.join((spatial, zone.validity.start.isoformat()))
+
+
 class GeoZoneFactory(factory.mongoengine.MongoEngineFactory):
     class Meta:
         model = GeoZone
 
-    # GeoID, see https://github.com/etalab/geoids.
-    id = factory.LazyAttribute(
-        lambda o: 'fr:commune:' + o.code + '@1970-01-01')
+    id = factory.LazyAttribute(geoid)
     level = factory.Faker('unique_string')
     name = factory.Faker('city')
     slug = factory.Faker('slug')

--- a/udata/core/spatial/factories.py
+++ b/udata/core/spatial/factories.py
@@ -7,11 +7,13 @@ from faker.providers import BaseProvider
 
 from geojson.utils import generate_random
 
-from udata.utils import add_faker_provider
+from udata.factories import DateRangeFactory
+from udata.utils import faker_provider
 
 from .models import GeoLevel, GeoZone, SpatialCoverage, spatial_granularities
 
 
+@faker_provider
 class GeoJsonProvider(BaseProvider):
     '''A Fake GeoJSON provider'''
 
@@ -91,15 +93,12 @@ class GeoJsonProvider(BaseProvider):
         }
 
 
+@faker_provider
 class SpatialProvider(BaseProvider):
     def spatial_granularity(self):
         return self.generator.random_element([
             row[0] for row in spatial_granularities
         ])
-
-
-add_faker_provider(GeoJsonProvider)
-add_faker_provider(SpatialProvider)
 
 
 class SpatialCoverageFactory(factory.mongoengine.MongoEngineFactory):
@@ -122,6 +121,7 @@ class GeoZoneFactory(factory.mongoengine.MongoEngineFactory):
     slug = factory.Faker('slug')
     code = factory.Faker('zipcode')
     geom = factory.Faker('multipolygon')
+    validity = factory.SubFactory(DateRangeFactory)
 
 
 class GeoLevelFactory(factory.mongoengine.MongoEngineFactory):

--- a/udata/core/spatial/factories.py
+++ b/udata/core/spatial/factories.py
@@ -10,6 +10,7 @@ from geojson.utils import generate_random
 from udata.factories import DateRangeFactory
 from udata.utils import faker_provider
 
+from . import geoids
 from .models import GeoLevel, GeoZone, SpatialCoverage, spatial_granularities
 
 
@@ -109,24 +110,11 @@ class SpatialCoverageFactory(factory.mongoengine.MongoEngineFactory):
     granularity = factory.Faker('spatial_granularity')
 
 
-def geoid(zone):
-    '''
-    Build a GeoID from a given zone
-
-    GeoID, see https://github.com/etalab/geoids
-    '''
-    spatial = ':'.join((zone.level, zone.code))
-    if not zone.validity:
-        return spatial
-    else:
-        return '@'.join((spatial, zone.validity.start.isoformat()))
-
-
 class GeoZoneFactory(factory.mongoengine.MongoEngineFactory):
     class Meta:
         model = GeoZone
 
-    id = factory.LazyAttribute(geoid)
+    id = factory.LazyAttribute(geoids.from_zone)
     level = factory.Faker('unique_string')
     name = factory.Faker('city')
     slug = factory.Faker('slug')

--- a/udata/core/spatial/forms.py
+++ b/udata/core/spatial/forms.py
@@ -31,6 +31,29 @@ class ZonesField(ModelList, Field):
     model = GeoZone
     widget = ZonesAutocompleter()
 
+    def fetch_objects(self, geoids):
+        '''
+        Custom object retrieval.
+
+        Zones are resolved from their identifier
+        instead of the default bulk fetch by ID.
+        '''
+        zones = []
+        no_match = []
+        for geoid in geoids:
+            zone = GeoZone.objects.resolve(geoid)
+            if zone:
+                zones.append(zone)
+            else:
+                no_match.append(geoid)
+
+        if no_match:
+            msg = _('Unknown geoid(s): {identifiers}').format(
+                identifiers=', '.join(str(id) for id in no_match))
+            raise validators.ValidationError(msg)
+
+        return zones
+
 
 class GeomField(Field):
     def process_formdata(self, valuelist):

--- a/udata/core/spatial/geoids.py
+++ b/udata/core/spatial/geoids.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+'''
+This module centralize GeoID resources and helpers.
+
+See https://github.com/etalab/geoids for more details
+'''
+from __future__ import unicode_literals
+
+from datetime import date, datetime
+
+
+__all__ = ('END_OF_TIME', 'GeoIDError', 'parse', 'build', 'from_zone')
+
+# Arbitrary date value used as validity.end
+# for zone not yet ended
+END_OF_TIME = date(9999, 12, 31)
+
+
+class GeoIDError(ValueError):
+    '''Raised when an error occur while parsing or building a GeoID'''
+    pass
+
+
+def parse(text):
+    '''Parse a geoid from text and return a tuple (level, code, validity)'''
+    if '@' in text:
+        spatial, validity = text.split('@')
+    else:
+        spatial = text
+        validity = 'latest'
+    if ':' not in spatial:
+        raise GeoIDError('Bad GeoID format: {0}'.format(text))
+    level, code = spatial.rsplit(':', 1)
+    return level, code, validity
+
+
+def build(level, code, validity=None):
+    '''Serialize a GeoID from its parts'''
+    spatial = ':'.join((level, code))
+    if not validity:
+        return spatial
+    elif isinstance(validity, basestring):
+        return '@'.join((spatial, validity))
+    elif isinstance(validity, datetime):
+        return '@'.join((spatial, validity.date().isoformat()))
+    elif isinstance(validity, date):
+        return '@'.join((spatial, validity.isoformat()))
+    else:
+        msg = 'Unknown GeoID validity type: {0}'
+        raise GeoIDError(msg.format(type(validity).__name__))
+
+
+def from_zone(zone):
+    '''Build a GeoID from a given zone'''
+    validity = zone.validity.start if zone.validity else None
+    return build(zone.level, zone.code, validity)

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -12,10 +12,12 @@ from udata.i18n import lazy_gettext as _, gettext, get_locale
 from udata.models import db
 from udata.core.storages import logos
 
+from . import geoids
+
 
 __all__ = (
     'GeoLevel', 'GeoZone', 'SpatialCoverage', 'BASE_GRANULARITIES',
-    'spatial_granularities', 'parse_geoid',
+    'spatial_granularities',
 )
 
 
@@ -26,26 +28,6 @@ BASE_GRANULARITIES = [
 
 ADMIN_LEVEL_MIN = 1
 ADMIN_LEVEL_MAX = 110
-
-# Arbitrary date value used as validity.end
-# for zone not yet ended
-END_OF_TIME = date(9999, 12, 31)
-
-
-def parse_geoid(text):
-    '''
-    Parse a geoid from text
-    and return a tuple (level, code, validity)
-
-    GeoID, see https://github.com/etalab/geoids.
-    '''
-    if '@' in text:
-        spatial, validity = text.split('@')
-    else:
-        spatial = text
-        validity = 'latest'
-    level, code = spatial.rsplit(':', 1)
-    return level, code, validity
 
 
 class GeoLevel(db.Document):
@@ -87,7 +69,7 @@ class GeoZoneQuerySet(db.BaseQuerySet):
         the result will be the resolved GeoID
         instead of the resolved zone.
         '''
-        level, code, validity = parse_geoid(geoid)
+        level, code, validity = geoids.parse(geoid)
         qs = self(level=level, code=code)
         if id_only:
             qs = qs.only('id')

--- a/udata/core/spatial/tests/test_fields.py
+++ b/udata/core/spatial/tests/test_fields.py
@@ -13,8 +13,9 @@ from udata.tests import TestCase
 from udata.utils import faker
 
 from ..factories import GeoZoneFactory
-from ..models import SpatialCoverage, END_OF_TIME
 from ..forms import SpatialCoverageField
+from ..geoids import END_OF_TIME
+from ..models import SpatialCoverage
 
 
 A_YEAR = timedelta(days=365)

--- a/udata/core/spatial/tests/test_fields.py
+++ b/udata/core/spatial/tests/test_fields.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals, absolute_import
 
 import json
 
+from datetime import timedelta
+
 from werkzeug.datastructures import MultiDict
 
 from udata.forms import Form
@@ -11,8 +13,11 @@ from udata.tests import TestCase
 from udata.utils import faker
 
 from ..factories import GeoZoneFactory
-from ..models import SpatialCoverage
+from ..models import SpatialCoverage, END_OF_TIME
 from ..forms import SpatialCoverageField
+
+
+A_YEAR = timedelta(days=365)
 
 
 class SpatialCoverageFieldTest(TestCase):
@@ -288,3 +293,55 @@ class SpatialCoverageFieldTest(TestCase):
 
         self.assertEqual(len(fake.spatial.zones), 1)
         self.assertEqual(fake.spatial.zones[0], zone)
+
+    def test_resolve_zones_from_json(self):
+        Fake, FakeForm = self.factory()
+        zone = GeoZoneFactory()
+
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        validity = faker.date_between(start_date=zone.validity.start,
+                                      end_date=zone.validity.end)
+        geoid = '{0.level}:{0.code}@{1}'.format(zone, validity.isoformat())
+
+        fake = Fake()
+        form = FakeForm.from_json({
+            'spatial': {
+                'zones': [geoid],
+                'granularity': faker.spatial_granularity()
+            }
+        })
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(len(fake.spatial.zones), 1)
+        self.assertEqual(fake.spatial.zones[0], zone)
+
+    def test_resolve_zones_from_json_failure(self):
+        Fake, FakeForm = self.factory()
+        GeoZoneFactory.create_batch(3)
+        form = FakeForm.from_json({
+            'spatial': {
+                'zones': [
+                    '{0}:{0}@{0}'.format(faker.unique_string())
+                    for _ in range(2)
+                ],
+                'granularity': faker.spatial_granularity()
+            }
+        })
+
+        form.validate()
+
+        self.assertIn('spatial', form.errors)
+        self.assertEqual(len(form.errors['spatial']), 1)
+
+        self.assertIn('zones', form.errors['spatial'])
+        self.assertEqual(len(form.errors['spatial']['zones']), 1)

--- a/udata/core/spatial/tests/test_geoid.py
+++ b/udata/core/spatial/tests/test_geoid.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
+from udata.tests import TestCase
+
+from .. import geoids
+from ..models import GeoZone
+from udata.utils import faker
+
+
+class GeoIDTests(TestCase):
+    def test_parse_full_geoid(self):
+        geoid = 'level:code@1984-06-07'
+
+        level, code, validity = geoids.parse(geoid)
+
+        self.assertEqual(level, 'level')
+        self.assertEqual(code, 'code')
+        self.assertEqual(validity, '1984-06-07')
+
+    def test_parse_implicit_latest(self):
+        geoid = 'level:code'
+
+        level, code, validity = geoids.parse(geoid)
+
+        self.assertEqual(level, 'level')
+        self.assertEqual(code, 'code')
+        self.assertEqual(validity, 'latest')
+
+    def test_parse_nested_levels(self):
+        geoid = 'nested:level:code@1984-06-07'
+
+        level, code, validity = geoids.parse(geoid)
+
+        self.assertEqual(level, 'nested:level')
+        self.assertEqual(code, 'code')
+        self.assertEqual(validity, '1984-06-07')
+
+    def test_parse_invalid_geoid(self):
+        geoid = 'this-is-not-a-geoid'
+
+        with self.assertRaises(geoids.GeoIDError):
+            geoids.parse(geoid)
+
+    def test_build_without_validity(self):
+        level = 'level'
+        code = 'code'
+
+        geoid = geoids.build(level, code)
+
+        self.assertEqual(geoid, 'level:code')
+
+    def test_build_with_validity_as_string(self):
+        level = 'level'
+        code = 'code'
+        validity = 'latest'
+
+        geoid = geoids.build(level, code, validity)
+
+        self.assertEqual(geoid, 'level:code@latest')
+
+    def test_build_with_validity_as_date(self):
+        level = 'level'
+        code = 'code'
+        validity = faker.past_date()
+
+        geoid = geoids.build(level, code, validity)
+
+        self.assertEqual(geoid, 'level:code@{0:%Y-%m-%d}'.format(validity))
+
+    def test_build_with_validity_as_datetime(self):
+        level = 'level'
+        code = 'code'
+        validity = faker.past_datetime()
+
+        geoid = geoids.build(level, code, validity)
+
+        self.assertEqual(geoid, 'level:code@{0:%Y-%m-%d}'.format(validity))
+
+    def test_build_with_invalid_validity_type(self):
+        level = 'level'
+        code = 'code'
+        validity = object()
+
+        with self.assertRaises(geoids.GeoIDError):
+            geoids.build(level, code, validity)
+
+    def test_from_zone_with_validity(self):
+        level = 'level'
+        code = 'code'
+        start = faker.past_date()
+        validity = {'start': start, 'end': geoids.END_OF_TIME}
+        zone = GeoZone(level=level, code=code, validity=validity)
+
+        geoid = geoids.from_zone(zone)
+
+        self.assertEqual(geoid, 'level:code@{0:%Y-%m-%d}'.format(start))
+
+    def test_from_zone_without_validity(self):
+        level = 'level'
+        code = 'code'
+        zone = GeoZone(level=level, code=code, validity=None)
+
+        geoid = geoids.from_zone(zone)
+
+        self.assertEqual(geoid, 'level:code')

--- a/udata/core/spatial/tests/test_models.py
+++ b/udata/core/spatial/tests/test_models.py
@@ -7,7 +7,8 @@ from udata.tests import TestCase, DBTestMixin
 from udata.utils import faker
 
 from ..factories import GeoZoneFactory, GeoLevelFactory
-from ..models import GeoZone, SpatialCoverage, END_OF_TIME
+from ..geoids import END_OF_TIME
+from ..models import GeoZone, SpatialCoverage
 
 
 A_YEAR = timedelta(days=365)

--- a/udata/core/spatial/tests/test_models.py
+++ b/udata/core/spatial/tests/test_models.py
@@ -1,13 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from udata.tests import TestCase
+from datetime import timedelta, date
+
+from udata.tests import TestCase, DBTestMixin
+from udata.utils import faker
 
 from ..factories import GeoZoneFactory, GeoLevelFactory
-from ..models import SpatialCoverage
+from ..models import GeoZone, SpatialCoverage, END_OF_TIME
 
 
-class SpacialCoverageTest(TestCase):
+A_YEAR = timedelta(days=365)
+
+
+class SpacialCoverageTest(DBTestMixin, TestCase):
     def test_top_label_empty(self):
         coverage = SpatialCoverage()
         self.assertIsNone(coverage.top_label)
@@ -29,3 +35,149 @@ class SpacialCoverageTest(TestCase):
         coverage = SpatialCoverage(zones=[small, medium, big])
 
         self.assertEqual(coverage.top_label, big.name)
+
+
+class SpatialTemporalResolutionTest(DBTestMixin, TestCase):
+    def test_valid_at_with_validity(self):
+        zone = GeoZoneFactory()
+        earlier = zone.validity.start - A_YEAR
+        later = zone.validity.end + A_YEAR
+        GeoZoneFactory(code=zone.code,
+                       validity__start=earlier - A_YEAR,
+                       validity__end=earlier)
+        GeoZoneFactory(code=zone.code,
+                       validity__start=later,
+                       validity__end=later + A_YEAR)
+
+        valid_at = zone.validity.start + timedelta(1)
+        qs = GeoZone.objects(code=zone.code).valid_at(valid_at)
+
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first(), zone)
+
+    def test_valid_at_without_validity(self):
+        zone = GeoZoneFactory(validity=None)
+        GeoZoneFactory.create_batch(2)
+
+        qs = GeoZone.objects(code=zone.code).valid_at(date.today())
+
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first(), zone)
+
+    def test_valid_at_with_start_validity(self):
+        zone = GeoZoneFactory()
+        earlier = zone.validity.start - A_YEAR
+        later = zone.validity.end + A_YEAR
+        GeoZoneFactory(code=zone.code,
+                       validity__start=earlier - A_YEAR,
+                       validity__end=earlier)
+        GeoZoneFactory(code=zone.code,
+                       validity__start=later,
+                       validity__end=later + A_YEAR)
+
+        valid_at = zone.validity.start
+        qs = GeoZone.objects(code=zone.code).valid_at(valid_at)
+
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first(), zone)
+
+    def test_latest_with_validity(self):
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        result = GeoZone.objects(code=zone.code).latest()
+
+        self.assertEqual(result, zone)
+
+    def test_latest_with_validity_ended(self):
+        zone = GeoZoneFactory(validity__end=date.today() - timedelta(1))
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        result = GeoZone.objects(code=zone.code).latest()
+
+        self.assertEqual(result, zone)
+
+    def test_latest_without_validity(self):
+        zone = GeoZoneFactory(validity=None)
+        GeoZoneFactory.create_batch(2, validity=None)
+
+        result = GeoZone.objects(code=zone.code).latest()
+
+        self.assertEqual(result, zone)
+
+    def test_resolve_with_validity_exact_match(self):
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        validity = zone.validity.start.isoformat()
+        geoid = '{0.level}:{0.code}@{1}'.format(zone, validity)
+        result = GeoZone.objects.resolve(geoid)
+
+        self.assertEqual(result, zone)
+
+    def test_resolve_with_validity_match(self):
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        validity = faker.date_between(start_date=zone.validity.start,
+                                      end_date=zone.validity.end)
+        geoid = '{0.level}:{0.code}@{1}'.format(zone, validity.isoformat())
+        result = GeoZone.objects.resolve(geoid)
+
+        self.assertEqual(result, zone)
+
+    def test_resolve_with_latest(self):
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        geoid = '{0.level}:{0.code}@latest'.format(zone)
+        result = GeoZone.objects.resolve(geoid)
+
+        self.assertEqual(result, zone)
+
+    def test_resolve_without_validity(self):
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        geoid = '{0.level}:{0.code}'.format(zone)
+        result = GeoZone.objects.resolve(geoid)
+
+        self.assertEqual(result, zone)
+
+    def test_resolve_id_only(self):
+        zone = GeoZoneFactory(validity__end=END_OF_TIME)
+        for i in range(3):
+            start = zone.validity.start - (i + 1) * A_YEAR
+            end = zone.validity.start - i * A_YEAR
+            GeoZoneFactory(code=zone.code,
+                           validity__start=start, validity__end=end)
+
+        validity = zone.validity.start.isoformat()
+        geoid = '{0.level}:{0.code}@{1}'.format(zone, validity)
+        result = GeoZone.objects.resolve(geoid, id_only=True)
+
+        self.assertEqual(result, zone.id)

--- a/udata/factories.py
+++ b/udata/factories.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import factory
+
+from faker.providers.date_time import Provider as DTProvider
+
+from .models import DateRange
+from .utils import faker_provider
+
+
+# Until https://github.com/joke2k/faker/pull/596 is merged
+
+@faker_provider
+class DateTimeProvider(DTProvider):
+    def date_between(self, start_date='-30y', end_date='now'):
+        return self.date_time_between(start_date=start_date,
+                                      end_date=end_date).date()
+
+
+class DateRangeFactory(factory.mongoengine.MongoEngineFactory):
+    class Meta:
+        model = DateRange
+
+    start = factory.Faker('date_between', start_date='-10y', end_date='-5y')
+    end = factory.Faker('date_between', start_date='-5y', end_date='-2y')

--- a/udata/features/oembed/api.py
+++ b/udata/features/oembed/api.py
@@ -45,18 +45,18 @@ class OEmbedsAPI(API):
                     return api.abort(400, 'Unknown dataset ID.')
             elif (item_kind == 'territory' and
                     current_app.config.get('ACTIVATE_TERRITORIES')):
+
                 try:
                     country, level, code, kind = item_id.split(':')
                 except ValueError:
                     return api.abort(400, 'Invalid territory ID.')
-                try:
-                    geozone = GeoZone.objects.get(
-                        id=':'.join([country, level, code]))
-                except GeoZone.DoesNotExist:
+                geoid = ':'.join((country, level, code))
+                zone = GeoZone.objects.resolve(geoid)
+                if not zone:
                     return api.abort(400, 'Unknown territory identifier.')
                 if level in TERRITORY_DATASETS:
                     if kind in TERRITORY_DATASETS[level]:
-                        item = TERRITORY_DATASETS[level][kind](geozone)
+                        item = TERRITORY_DATASETS[level][kind](zone)
                     else:
                         return api.abort(400, 'Unknown territory dataset id.')
                 else:

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -442,7 +442,17 @@ class ModelList(object):
                     for id in valuelist[0].split(',') if id]
         else:
             oids = [clean_oid(id, self.model) for id in valuelist]
+        self.data = self.fetch_objects(oids)
 
+    def fetch_objects(self, oids):
+        '''
+        This methods is used to fetch models
+        from a list of identifiers.
+
+        Default implementation performs a bulk query on identifiers.
+
+        Override this method to customize the objects retrieval.
+        '''
         objects = self.model.objects.in_bulk(oids)
         if len(objects.keys()) != len(oids):
             non_existants = set(oids) - set(objects.keys())
@@ -450,7 +460,7 @@ class ModelList(object):
                 identifiers=', '.join(str(ne) for ne in non_existants))
             raise validators.ValidationError(msg)
 
-        self.data = [objects[id] for id in oids]
+        return [objects[id] for id in oids]
 
 
 class NestedModelList(fields.FieldList):

--- a/udata/harvest/tests/factories.py
+++ b/udata/harvest/tests/factories.py
@@ -32,7 +32,7 @@ class HarvestJobFactory(factory.mongoengine.MongoEngineFactory):
 
     created = dtfactory('-3h', '-2h')
     started = dtfactory('-2h', '-1h')
-    ended = dtfactory('-1h', 'new')
+    ended = dtfactory('-1h', 'now')
     status = FuzzyChoice(HarvestJob.status.choices)
     source = factory.SubFactory(HarvestSourceFactory)
 

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -150,12 +150,12 @@ class TerritoryConverter(ModelConverter, PathConverter):
 
         code = getattr(obj, 'code', None)
         slug = getattr(obj, 'slug', None)
-        validity = getattr(obj, 'validity', {})
+        validity = getattr(obj, 'validity', None)
         if code and slug:
             return '{level_name}/{code}@{start_date}/{slug}'.format(
                 level_name=level_name,
                 code=code,
-                start_date=validity.get('start', 'latest'),
+                start_date=getattr(validity, 'start') or 'latest',
                 slug=slug
             )
         else:

--- a/udata/tests/features/territories/test_territories_process.py
+++ b/udata/tests/features/territories/test_territories_process.py
@@ -3,13 +3,13 @@ from __future__ import unicode_literals
 
 from flask import url_for
 
-from udata.models import Member
-from udata.core.spatial.models import END_OF_TIME
-from udata.core.spatial.factories import GeoZoneFactory, SpatialCoverageFactory
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.organization.factories import OrganizationFactory
-from udata.tests.frontend import FrontTestCase
+from udata.core.spatial.factories import GeoZoneFactory, SpatialCoverageFactory
+from udata.core.spatial.geoids import END_OF_TIME
+from udata.models import Member
 from udata.settings import Testing
+from udata.tests.frontend import FrontTestCase
 
 
 def create_geozones_fixtures():

--- a/udata/tests/features/territories/test_territories_process.py
+++ b/udata/tests/features/territories/test_territories_process.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from flask import url_for
 
 from udata.models import Member
+from udata.core.spatial.models import END_OF_TIME
 from udata.core.spatial.factories import GeoZoneFactory, SpatialCoverageFactory
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.organization.factories import OrganizationFactory
@@ -15,17 +16,17 @@ def create_geozones_fixtures():
     paca = GeoZoneFactory(
         id='fr:region:93@1970-01-09', level='fr:region',
         name='Provence Alpes Côtes dAzur', code='93',
-        validity={'start': '1970-01-09', 'end': '9999-12-31'})
+        validity__start='1970-01-09', validity__end=END_OF_TIME)
     bdr = GeoZoneFactory(
         id='fr:departement:13@1860-07-01', level='fr:departement',
         parents=[paca.id], name='Bouches-du-Rhône', code='13',
         population=1993177, area=0,
-        validity={'start': '1860-07-01', 'end': '9999-12-31'})
+        validity__start='1860-07-01', validity__end=END_OF_TIME)
     arles = GeoZoneFactory(
         id='fr:commune:13004@1942-01-01', level='fr:commune', parents=[bdr.id],
         name='Arles', code='13004', keys={'postal': '13200'},
         population=52439, area=0,
-        validity={'start': '1942-01-01', 'end': '9999-12-31'})
+        validity__start='1942-01-01', validity__end=END_OF_TIME)
     return paca, bdr, arles
 
 
@@ -33,13 +34,13 @@ def create_old_new_regions_fixtures():
     lr = GeoZoneFactory(
         id='fr:region:91@1970-01-09', level='fr:region',
         name='Languedoc-Rousillon', code='91',
-        validity={'start': '1956-01-01', 'end': '2015-12-31'},
+        validity__start='1956-01-01', validity__end='2015-12-31',
         population=2700266)
     occitanie = GeoZoneFactory(
         id='fr:region:76@2016-01-01', level='fr:region',
         name='Languedoc-Rousillon et Midi-Pyrénées',
         ancestors=['fr:region:91@1970-01-09'], code='76',
-        validity={'start': '2016-01-01', 'end': '9999-12-31'},
+        validity__start='2016-01-01', validity__end=END_OF_TIME,
         population=5573000)
     return lr, occitanie
 

--- a/udata/utils.py
+++ b/udata/utils.py
@@ -211,6 +211,16 @@ def unique_string(length=UUID_LENGTH):
     return string[:length] if length else string
 
 
+faker = Faker()
+
+
+def faker_provider(provider):
+    faker.add_provider(provider)
+    factory.Faker.add_provider(provider)
+    return provider
+
+
+@faker_provider
 class UDataProvider(BaseProvider):
     '''
     A Faker provider for UData missing requirements.
@@ -220,14 +230,3 @@ class UDataProvider(BaseProvider):
     def unique_string(self, length=UUID_LENGTH):
         '''Generate a unique string'''
         return unique_string(length)
-
-
-faker = Faker()
-
-
-def add_faker_provider(provider):
-    faker.add_provider(provider)
-    factory.Faker.add_provider(provider)
-
-
-add_faker_provider(UDataProvider)


### PR DESCRIPTION
This PR perform time resolution of spatial zones on:
- dataset submission (create or update)
- OEmbed API querying

This also adds some testing on spatial and GeoID querying:
- make the `GeoZone` model and factory handle predefined typed `validity.start` and `validity.end`
- make the `GeoZoneFactory` coherent by generating a real GeoID given its fake attributes
- test and fix `GeoZoneQuerySet.valid_at(validity)` (issue on exact match)
- add and test `GeoZoneQuerySet.latest()` and `GeoZoneQuerySet.resolve(geoid)` to factorize these reusable queries
- make `9999-12-31` a `END_OF_TIME` constant to make it more visible

Add a temporary Faker DateTime provider until joke2k/faker#596 is available for easier date testing