### PR TITLE
Prevent storing metrics with object_id=None

### DIFF
--- a/udata/core/metrics/models.py
+++ b/udata/core/metrics/models.py
@@ -26,6 +26,8 @@ class MetricsQuerySet(db.BaseQuerySet):
 
     def update_daily(self, obj, date=None, **kwargs):
         oid = obj.id if hasattr(obj, 'id') else obj
+        if not oid:
+            raise ValueError('Unable to get identifier for {0}'.format(obj))
         if isinstance(date, basestring):
             day = date
         else:
@@ -50,7 +52,7 @@ class WithMetrics(object):
 
 
 class Metrics(db.Document):
-    object_id = db.DynamicField(required=True)
+    object_id = db.DynamicField(required=True, null=False, unique_with='date')
     date = db.StringField(required=True)
     level = db.StringField(
         required=True, default='daily',


### PR DESCRIPTION
This PR prevent storing metrics with `object_id=None` and allows to detect from where it comes from.