### PR TITLE
Test settings and tmpfs

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+    db_test:
+        image: mongo:3.2
+        tmpfs: /data/db/
+        ports:
+          - "27018:27017"
+
+    search_test:
+        image: udata/elasticsearch:2.4.5
+        tmpfs: /usr/share/elasticsearch/data
+        ports:
+          - "9201:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,11 @@ services:
 
 
 
-        search:
-            image: udata/elasticsearch:2.4.5
-            volumes:
-              - ./data/search/data:/usr/share/elasticsearch/data
-            expose:
-              - "9200"
-            ports:
-              - "9200:9200"
+    search:
+        image: udata/elasticsearch:2.4.5
+        volumes:
+          - ./data/search/data:/usr/share/elasticsearch/data
+        expose:
+          - "9200"
+        ports:
+          - "9200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,31 @@
-db:
-    image: mongo:3.2
-    command: mongod
-    volumes:
-      - ./data/db:/data/db
-    expose:
-      - "27017"
-    ports:
-    - "27017:27017"
+version: "3"
+services:
+    db:
+        image: mongo:3.2
+        command: mongod
+        volumes:
+          - ./data/db:/data/db
+        expose:
+          - "27017"
+        ports:
+        - "27017:27017"
 
-broker:
-    image: redis
-    volumes:
-      - ./data/broker:/data
-    expose:
-      - "6379"
-    ports:
-    - "6379:6379"
+    broker:
+        image: redis
+        volumes:
+          - ./data/broker:/data
+        expose:
+          - "6379"
+        ports:
+          - "6379:6379"
 
-search:
-    image: udata/elasticsearch:2.4.5
-    volumes:
-      - ./data/search/data:/usr/share/elasticsearch/data
-    expose:
-      - "9200"
-    ports:
-      - "9200:9200"
+
+
+        search:
+            image: udata/elasticsearch:2.4.5
+            volumes:
+              - ./data/search/data:/usr/share/elasticsearch/data
+            expose:
+              - "9200"
+            ports:
+              - "9200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
         - "27017:27017"
 
     mongo_test:
-        image: mongo:3.4.0
-        tmpfs: /tmp/db
+        image: mongo:3.2.0
+        tmpfs: /data/db/
         expose:
           - "27018"
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ services:
         ports:
         - "27017:27017"
 
+    mongo_test:
+        image: mongo:3.4.0
+        tmpfs: /tmp/db
+        expose:
+          - "27018"
+        ports:
+          - "27018:27017"
+
     broker:
         image: redis
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,6 @@ services:
         ports:
         - "27017:27017"
 
-    db_test:
-        image: mongo:3.2
-        tmpfs: /data/db/
-        ports:
-          - "27018:27017"
-
     broker:
         image: redis
         volumes:
@@ -32,9 +26,3 @@ services:
           - "9200"
         ports:
           - "9200:9200"
-
-    search_test:
-        image: udata/elasticsearch:2.4.5
-        tmpfs: /usr/share/elasticsearch/data
-        ports:
-          - "9201:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         - "27017:27017"
 
     db_test:
-        image: mongo:3.2.0
+        image: mongo:3.2
         tmpfs: /data/db/
         ports:
           - "27018:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
     db:
         image: mongo:3.2
-        command: mongod
         volumes:
           - ./data/db:/data/db
         expose:
@@ -10,11 +9,9 @@ services:
         ports:
         - "27017:27017"
 
-    mongo_test:
+    db_test:
         image: mongo:3.2.0
         tmpfs: /data/db/
-        expose:
-          - "27018"
         ports:
           - "27018:27017"
 
@@ -27,8 +24,6 @@ services:
         ports:
           - "6379:6379"
 
-
-
     search:
         image: udata/elasticsearch:2.4.5
         volumes:
@@ -37,3 +32,9 @@ services:
           - "9200"
         ports:
           - "9200:9200"
+
+    search_test:
+        image: udata/elasticsearch:2.4.5
+        tmpfs: /usr/share/elasticsearch/data
+        ports:
+          - "9201:9200"

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -155,6 +155,12 @@ RFC-1738 formatted URLs are also supported:
 ELASTICSEARCH_URL = 'http://<user>:<password>@<host>:<port>'
 ```
 
+### ELASTICSEARCH_URL_TEST
+
+**default**: same as `ELASTICSEARCH_URL`
+
+An optionnal alternative elasticsearch server url that may be used for testing.
+
 ### ELASTICSEARCH_INDEX_BASENAME
 
 **default**: `'udata'`
@@ -191,6 +197,12 @@ Authentication is also supported in the URL:
 ```python
 MONGODB_HOST = 'mongodb://<user>:<password>@<host>:<port>/<database>'
 ```
+
+### MONGODB_HOST_TEST
+
+**default**: same as `MONGODB_HOST` with a `-test` suffix on the collection
+
+An optionnal alternative mongo database used for testing.
 
 ## Celery options
 

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -3,6 +3,20 @@
 There a three complementary ways of testing your work: unit tests for the backend,
 unit tests for the frontend and integration tests.
 
+## Test middleware
+
+If you need to use an alternative Mongo or Elasticsearch instance during tests,
+you can provides the alternate urls in you `udata.cfg`
+with `MONGODB_HOST_TEST` and `ELASTICSEARCH_URL_TEST`.
+
+**ex**: To make use of the tmpfs based middleware provided by docker-compose, use:
+
+```python
+MONGODB_HOST_TEST = 'mongodb://localhost:27018/udata'
+ELASTICSEARCH_URL_TEST = 'localhost:9201'
+```
+
+
 ## Backend unit tests
 
 The easiest way is to run Python tests with [nosetest][].

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -3,7 +3,7 @@
 There a three complementary ways of testing your work: unit tests for the backend,
 unit tests for the frontend and integration tests.
 
-## Test middleware
+## Test middlewares
 
 If you need to use an alternative Mongo or Elasticsearch instance during tests,
 you can provides the alternate urls in you `udata.cfg`
@@ -15,6 +15,15 @@ with `MONGODB_HOST_TEST` and `ELASTICSEARCH_URL_TEST`.
 MONGODB_HOST_TEST = 'mongodb://localhost:27018/udata'
 ELASTICSEARCH_URL_TEST = 'localhost:9201'
 ```
+
+And then start docker-compose with the extra file:
+
+```shell
+$ docker-compose -f docker-compose.yml -f docker-compose.test.yml up
+```
+
+This will start 2 extra services, an Elasticsearch and a MongoDB,
+both tmpfs based and your tests will make use of it and run faster.
 
 
 ## Backend unit tests

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -105,9 +105,14 @@ from udata.features.territories.models import *  # noqa
 def init_app(app):
     # use `{database_name}-test` database for testing
     if app.config['TESTING']:
+<<<<<<< HEAD
         parsed_url = urlparse(app.config['MONGODB_HOST'])
         parsed_url = parsed_url._replace(path='%s-test' % parsed_url.path)
         app.config['MONGODB_HOST'] = parsed_url.geturl()
+=======
+        app.config['MONGODB_DB'] = '{MONGODB_DB}-test'.format(**app.config)
+        app.config['MONGODB_PORT'] = 27018
+>>>>>>> Use mongotest for tests
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -105,9 +105,12 @@ from udata.features.territories.models import *  # noqa
 def init_app(app):
     # use `{database_name}-test` database for testing
     if app.config['TESTING']:
-        parsed_url = urlparse(app.config['MONGODB_HOST'])
-        parsed_url = parsed_url._replace(path='%s-test' % parsed_url.path)
-        app.config['MONGODB_HOST'] = parsed_url.geturl()
+        if 'MONGODB_HOST_TEST' in app.config:
+            app.config['MONGODB_HOST'] = app.config['MONGODB_HOST_TEST']
+        else:
+            parsed_url = urlparse(app.config['MONGODB_HOST'])
+            parsed_url = parsed_url._replace(path='%s-test' % parsed_url.path)
+            app.config['MONGODB_HOST'] = parsed_url.geturl()
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -105,14 +105,9 @@ from udata.features.territories.models import *  # noqa
 def init_app(app):
     # use `{database_name}-test` database for testing
     if app.config['TESTING']:
-<<<<<<< HEAD
         parsed_url = urlparse(app.config['MONGODB_HOST'])
         parsed_url = parsed_url._replace(path='%s-test' % parsed_url.path)
         app.config['MONGODB_HOST'] = parsed_url.geturl()
-=======
-        app.config['MONGODB_DB'] = '{MONGODB_DB}-test'.format(**app.config)
-        app.config['MONGODB_PORT'] = 27018
->>>>>>> Use mongotest for tests
     db.init_app(app)
     for plugin in app.config['PLUGINS']:
         name = 'udata_{0}.models'.format(plugin)

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -55,6 +55,8 @@ class ElasticSearch(object):
         # do we register on? app.extensions looks a little hackish (I don't
         # know flask well enough to be sure), but that's how it's done in
         # flask-pymongo so let's use it for now.
+        if app.config['TESTING'] and 'ELASTICSEARCH_URL_TEST' in app.config:
+                app.config['ELASTICSEARCH_URL'] = app.config['ELASTICSEARCH_URL_TEST']
         app.extensions['elasticsearch'] = Elasticsearch(
             [app.config['ELASTICSEARCH_URL']], serializer=EsJSONSerializer())
 


### PR DESCRIPTION
This PR supersedes #902 and do the following:
- upgrades docker-compose to version 3 syntax
- provides Elasticsearch and Mongo test services with tmpfs storage
- provides optionnal test configuration for:
   - Elasticsearch: `ELASTICSEARCH_URL_TEST`
   - Mongo: `MONGODB_HOST_TEST`

This allows to run test locally with tmpfs middlewares which speed up the test (test duration almost divided by 2 on my station, from 9'45 to 5'10) by just adding this to my `udata.cfg`:
```python
MONGODB_HOST_TEST = 'mongodb://localhost:27018/udata'
ELASTICSEARCH_URL_TEST = 'localhost:9201'
```

**Note**: CircleCI does not support tmpfs right now, but the day he will, we will be able to speed up CircleCI tests too.