### PR TITLE
Prevent fetch harvest sources when owner id is not yet available

### DIFF
--- a/js/components/harvest/sources.vue
+++ b/js/components/harvest/sources.vue
@@ -130,7 +130,9 @@ export default {
     },
     watch: {
         'owner.id': function(ownerid) {
-            this.sources.fetch({owner: ownerid});
+            if (ownerid) {
+                this.sources.fetch({owner: ownerid});
+            }
         }
     }
 };


### PR DESCRIPTION
This PR avoid a 500 HTTP error when displaying an organization admin page and the organization is not yet available (race condition not easily reproducible)