### PR TITLE
Fix user and org metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 [#1130](https://github.com/opendatateam/udata/issues/1130)
 - Hide issue modal forbidden actions [#1128](https://github.com/opendatateam/udata/pull/1128)
 - Ensure spatial coverage zones are resolved when submitted from the API or when querying oembed API. [#1140](https://github.com/opendatateam/udata/pull/1140)
-- Prevent user metrics computation when the object owner is an organization
+- Prevent user metrics computation when the object owner is an organization (and vice versa) [#1152](https://github.com/opendatateam/udata/pull/1152)
 
 ## 1.1.6 (2017-09-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 [#1130](https://github.com/opendatateam/udata/issues/1130)
 - Hide issue modal forbidden actions [#1128](https://github.com/opendatateam/udata/pull/1128)
 - Ensure spatial coverage zones are resolved when submitted from the API or when querying oembed API. [#1140](https://github.com/opendatateam/udata/pull/1140)
+- Prevent user metrics computation when the object owner is an organization
 
 ## 1.1.6 (2017-09-11)
 

--- a/udata/core/organization/metrics.py
+++ b/udata/core/organization/metrics.py
@@ -24,7 +24,8 @@ class DatasetsMetric(Metric):
 @Dataset.on_create.connect
 @Dataset.on_update.connect
 def update_datasets_metrics(document, **kwargs):
-    DatasetsMetric(document.organization).trigger_update()
+    if document.organization:
+        DatasetsMetric(document.organization).trigger_update()
 
 
 class ReusesMetric(Metric):
@@ -36,7 +37,11 @@ class ReusesMetric(Metric):
         return Reuse.objects(organization=self.target).count()
 
 
-ReusesMetric.connect(Reuse.on_create, Reuse.on_update)
+@Reuse.on_create.connect
+@Reuse.on_update.connect
+def update_reuses_metrics(document, **kwargs):
+    if document.organization:
+        ReusesMetric(document.organization).trigger_update()
 
 
 class PermitedReusesMetric(Metric):

--- a/udata/core/user/metrics.py
+++ b/udata/core/user/metrics.py
@@ -34,7 +34,8 @@ class DatasetsMetric(UserMetric):
 @Dataset.on_create.connect
 @Dataset.on_update.connect
 def update_datasets_metrics(document, **kwargs):
-    DatasetsMetric(document.owner).trigger_update()
+    if document.owner:
+        DatasetsMetric(document.owner).trigger_update()
 
 
 class ReusesMetric(UserMetric):
@@ -45,7 +46,11 @@ class ReusesMetric(UserMetric):
         return Reuse.objects(owner=self.user).count()
 
 
-ReusesMetric.connect(Reuse.on_create, Reuse.on_update)
+@Reuse.on_create.connect
+@Reuse.on_update.connect
+def update_reuses_metrics(document, **kwargs):
+    if document.owner:
+        ReusesMetric(document.owner).trigger_update()
 
 
 @db.Owned.on_owner_change.connect


### PR DESCRIPTION
This PR prevent users and organizations metrics computation when the subject owner is respectively an organization and a user.

**Note**: This should also speed up tests as a side-effect