### PR TITLE
Less register blueprint

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -257,7 +257,7 @@ The OAuth2 token duration.
 
 ### OAUTH2_PROVIDER_ERROR_ENDPOINT
 
-**default**: `'oauth-i18n.oauth_error'`
+**default**: `'oauth.oauth_error'`
 
 The OAuth2 error page. Do not modify unless you know what you are doing.
 

--- a/udata/admin/views.py
+++ b/udata/admin/views.py
@@ -6,7 +6,7 @@ from udata.auth import login_required
 from udata.i18n import I18nBlueprint
 
 
-blueprint = I18nBlueprint('admin', __name__, url_prefix='/blueprint')
+blueprint = I18nBlueprint('admin', __name__, url_prefix='/admin')
 
 
 @blueprint.route('/', defaults={'path': ''})

--- a/udata/admin/views.py
+++ b/udata/admin/views.py
@@ -6,11 +6,11 @@ from udata.auth import login_required
 from udata.i18n import I18nBlueprint
 
 
-admin = I18nBlueprint('admin', __name__, url_prefix='/admin')
+blueprint = I18nBlueprint('admin', __name__, url_prefix='/blueprint')
 
 
-@admin.route('/', defaults={'path': ''})
-@admin.route('/<path:path>')
+@blueprint.route('/', defaults={'path': ''})
+@blueprint.route('/<path:path>')
 @login_required
 def index(path):
     return theme.render('admin.html')

--- a/udata/api/oauth2.py
+++ b/udata/api/oauth2.py
@@ -10,7 +10,7 @@ from werkzeug.security import gen_salt
 from werkzeug.exceptions import Unauthorized
 
 from udata import theme
-from udata.app import Blueprint, csrf
+from udata.app import csrf
 from udata.auth import current_user, login_required, login_user
 from udata.i18n import I18nBlueprint, lazy_gettext as _
 from udata.models import db
@@ -18,8 +18,7 @@ from udata.core.storages import images, default_image_basename
 
 
 oauth = OAuth2Provider()
-bp = Blueprint('oauth', __name__)
-i18n = I18nBlueprint('oauth-i18n', __name__)
+blueprint = I18nBlueprint('oauth', __name__)
 
 
 GRANT_EXPIRATION = 100  # 100 seconds
@@ -186,14 +185,14 @@ def save_token(token, request, *args, **kwargs):
     )
 
 
-@bp.route('/oauth/token', methods=['POST'])
+@blueprint.route('/oauth/token', methods=['POST'], localize=False)
 @csrf.exempt
 @oauth.token_handler
 def access_token():
     return None
 
 
-@i18n.route('/oauth/authorize', methods=['GET', 'POST'])
+@blueprint.route('/oauth/authorize', methods=['GET', 'POST'])
 @oauth.authorize_handler
 @login_required
 def authorize(*args, **kwargs):
@@ -210,7 +209,7 @@ def authorize(*args, **kwargs):
         abort(405)
 
 
-@i18n.route('/oauth/error')
+@blueprint.route('/oauth/error')
 def oauth_error():
     return theme.render('api/oauth_error.html')
 
@@ -229,5 +228,4 @@ def check_credentials():
 
 def init_app(app):
     oauth.init_app(app)
-    app.register_blueprint(bp)
-    app.register_blueprint(i18n)
+    app.register_blueprint(blueprint)

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from flask import request
-from flask_restplus import inputs
 
 from udata import search
 from udata.api import api, API, errors

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import (
-    request, current_app, send_from_directory, Blueprint, json,
-    redirect, url_for
-)
+from flask import request, json, redirect, url_for
 from werkzeug.contrib.atom import AtomFeed
 
 from udata import search, theme

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -18,7 +18,8 @@ from udata.core.spatial.factories import (
 
 
 class SpatialApiTest(APITestCase):
-    modules_to_load = ['core.dataset']
+    modules = ['core.dataset']
+
     def test_zones_api_one(self):
         zone = GeoZoneFactory()
 
@@ -319,7 +320,7 @@ class SpatialApiTest(APITestCase):
 
 
 class SpatialTerritoriesApiTest(APITestCase):
-    modules_to_load = ['core.dataset']
+    modules = ['core.dataset']
     settings = TerritoriesSettings
 
     def test_zone_datasets_with_dynamic_and_setting(self):

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -18,6 +18,7 @@ from udata.core.spatial.factories import (
 
 
 class SpatialApiTest(APITestCase):
+    modules_to_load = ['core.dataset']
     def test_zones_api_one(self):
         zone = GeoZoneFactory()
 
@@ -318,6 +319,7 @@ class SpatialApiTest(APITestCase):
 
 
 class SpatialTerritoriesApiTest(APITestCase):
+    modules_to_load = ['core.dataset']
     settings = TerritoriesSettings
 
     def test_zone_datasets_with_dynamic_and_setting(self):

--- a/udata/core/tags/views.py
+++ b/udata/core/tags/views.py
@@ -12,10 +12,10 @@ from .models import Tag
 log = logging.getLogger(__name__)
 
 
-bp = I18nBlueprint('tags', __name__)
+blueprint = I18nBlueprint('tags', __name__)
 
 
-@bp.route('/tags.csv', endpoint='csv')
+@blueprint.route('/tags.csv', endpoint='csv')
 def tags_csv():
     adapter = TagCsvAdapter(Tag.objects.order_by('-total'))
     return csv.stream(adapter, 'tags')

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -55,12 +55,15 @@ def _load_views(app, module):
         log.error('Error importing %s views: %s', module, e)
 
 
+VIEWS = ['core.storages', 'core.user', 'core.site', 'core.dataset',
+         'core.reuse', 'core.organization', 'core.followers',
+         'core.topic', 'core.post', 'core.tags', 'admin', 'search',
+         'features.territories']
+
+
 def init_app(app, views=None):
-    if views is None:
-        views = ['core.storages', 'core.user', 'core.site', 'core.dataset',
-                 'core.reuse', 'core.organization', 'core.followers',
-                 'core.topic', 'core.post', 'core.tags', 'admin', 'search',
-                 'features.territories']
+    views = views or VIEWS
+
     init_markdown(app)
 
     from . import helpers, error_handlers  # noqa

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -55,41 +55,18 @@ def _load_views(app, module):
         log.error('Error importing %s views: %s', module, e)
 
 
-def init_app(app):
+def init_app(app, views=None):
+    if views is None:
+        views = ['core.storages', 'core.user', 'core.site', 'core.dataset',
+                 'core.reuse', 'core.organization', 'core.followers',
+                 'core.topic', 'core.post', 'core.tags', 'admin', 'search',
+                 'features.territories']
     init_markdown(app)
 
     from . import helpers, error_handlers  # noqa
 
-    # Load all core views and blueprint
-    import udata.search.views  # noqa
-
-    from udata.core.storages.views import blueprint as storages_blueprint
-    from udata.core.user.views import blueprint as user_blueprint
-    from udata.core.site.views import blueprint as site_blueprint
-    from udata.core.dataset.views import blueprint as dataset_blueprint
-    from udata.core.reuse.views import blueprint as reuse_blueprint
-    from udata.core.organization.views import blueprint as org_blueprint
-    from udata.core.followers.views import blueprint as follow_blueprint
-    from udata.core.topic.views import blueprint as topic_blueprint
-    from udata.core.post.views import blueprint as post_blueprint
-    from udata.core.tags.views import bp as tags_blueprint
-    from udata.admin.views import admin as admin_blueprint
-    from udata.features.territories.views import (
-        blueprint as territories_blueprint
-    )
-
-    app.register_blueprint(storages_blueprint)
-    app.register_blueprint(user_blueprint)
-    app.register_blueprint(site_blueprint)
-    app.register_blueprint(dataset_blueprint)
-    app.register_blueprint(reuse_blueprint)
-    app.register_blueprint(org_blueprint)
-    app.register_blueprint(follow_blueprint)
-    app.register_blueprint(topic_blueprint)
-    app.register_blueprint(post_blueprint)
-    app.register_blueprint(tags_blueprint)
-    app.register_blueprint(admin_blueprint)
-    app.register_blueprint(territories_blueprint)
+    for view in views:
+        _load_views(app, 'udata.{}.views'.format(view))
 
     # Load all plugins views and blueprints
     for plugin in app.config['PLUGINS']:

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 
 class HarvestAPITest(MockBackendsMixin, APITestCase):
+    modules_to_load = ['core.organization', 'core.user', 'core.dataset']
     def test_list_backends(self):
         '''It should fetch the harvest backends list from the API'''
         response = self.get(url_for('api.harvest_backends'))

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -24,7 +24,8 @@ log = logging.getLogger(__name__)
 
 
 class HarvestAPITest(MockBackendsMixin, APITestCase):
-    modules_to_load = ['core.organization', 'core.user', 'core.dataset']
+    modules = ['core.organization', 'core.user', 'core.dataset']
+
     def test_list_backends(self):
         '''It should fetch the harvest backends list from the API'''
         response = self.get(url_for('api.harvest_backends'))

--- a/udata/search/views.py
+++ b/udata/search/views.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 from flask import request
 
 from udata import search, theme
-from udata.frontend import front
 from udata.models import Dataset, Organization, Reuse
 from udata.utils import multi_to_dict
 from udata.features.territories import check_for_territories
+from udata.i18n import I18nBlueprint
+
+blueprint = I18nBlueprint('search', __name__)
 
 # Maps template variables names to model types
 MAPPING = {
@@ -17,7 +19,7 @@ MAPPING = {
 }
 
 
-@front.route('/search/', endpoint='search')
+@blueprint.route('/search/', endpoint='index')
 def render_search():
     params = multi_to_dict(request.args)
     params['facets'] = True

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -117,7 +117,7 @@ class Defaults(object):
 
     STATIC_DIRS = []
 
-    OAUTH2_PROVIDER_ERROR_ENDPOINT = 'oauth-i18n.oauth_error'
+    OAUTH2_PROVIDER_ERROR_ENDPOINT = 'oauth.oauth_error'
 
     MD_ALLOWED_TAGS = [
         'a',

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -55,7 +55,7 @@
                             {% endif %}
                             {% for badge in dataset.badges %}
                                 <small class="small-badge">
-                                    <a href="{{ url_for('front.search', badge=badge) }}"
+                                    <a href="{{ url_for('search.index', badge=badge) }}"
                                         title="{{ _('See all datasets with that badge.') }}">
                                         <span class="fa fa-bookmark"></span>
                                         {{ dataset.badge_label(badge) }}</a>
@@ -191,7 +191,7 @@
                             <li>
                                 <a href v-tooltip title="{{ _('Badges') }}"><span class="fa fa-fw fa-bookmark"></span></a>
                                 {% for badge in dataset.badges %}
-                                    <a href="{{ url_for('front.search', badge=badge) }}">
+                                    <a href="{{ url_for('search.index', badge=badge) }}">
                                         {{ dataset.badge_label(badge) }}</a>{% if not loop.last %}, {% endif %}
                                 {% endfor %}
                             </li>
@@ -270,7 +270,7 @@
 
                         <div class="tags">
                             {% for tag in dataset.tags %}
-                            <a href="{{ url_for('front.search', tag=tag) }}"
+                            <a href="{{ url_for('search.index', tag=tag) }}"
                                 class="btn btn-primary btn-grey btn-xs"
                                 title="{{ tag }}">
                                 {{ tag|truncate(14, True) }}

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -213,7 +213,7 @@
 
 
 {# Display the site search component with raw html fallback #}
-{% set default_action = url_for('front.search') %}
+{% set default_action = url_for('search.index') %}
 {% set default_placeholder = _('Search') %}
 {% macro site_search(action=default_action, placeholder=default_placeholder, territory=None, size=None, class=None) -%}
 <site-search v-ref:search action="{{ action }}" placeholder="{{ placeholder }}"

--- a/udata/templates/organization/display_base.html
+++ b/udata/templates/organization/display_base.html
@@ -42,7 +42,7 @@
                             <p class="text-center">
                                 {% for badge in org.badges %}
                                     <small class="small-badge">
-                                        <a href="{{ url_for('front.search', badge=badge) }}"
+                                        <a href="{{ url_for('search.index', badge=badge) }}"
                                             title="{{ _('See all organizations with that badge.') }}">
                                             <span class="fa fa-bookmark"></span>
                                             {{ org.badge_label(badge) }}</a>

--- a/udata/templates/post/subnav.html
+++ b/udata/templates/post/subnav.html
@@ -9,7 +9,7 @@
         <div class="search_sidebar col-sm-5 col-md-4 col-xs-12" role="search">
 
             <nav class="sidebar panel">
-                <site-search v-ref:search action="{{ url_for('front.search') }}"
+                <site-search v-ref:search action="{{ url_for('search.index') }}"
                     size="lg" placeholder="{{ _('Search') }}">
                 </site-search>
             </nav>

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -185,7 +185,7 @@
 
                         <div class="tags">
                             {% for tag in reuse.tags %}
-                            <a href="{{ url_for('front.search', tag=tag) }}"
+                            <a href="{{ url_for('search.index', tag=tag) }}"
                                 class="btn btn-primary btn-grey btn-xs"
                                 title="{{ tag }}">
                                 {{ tag|truncate(14, True) }}

--- a/udata/templates/topic/display_base.html
+++ b/udata/templates/topic/display_base.html
@@ -31,7 +31,7 @@
             <div class="col-xs-12">
                 <div class="tags">
                     {% for tag in topic.tags %}
-                    <a href="{{ url_for('front.search', tag=tag) }}"
+                    <a href="{{ url_for('search.index', tag=tag) }}"
                         class="btn btn-primary btn-grey btn-xs"
                         title="{{ tag }}">
                         {{ tag|truncate(14, True) }}

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -38,8 +38,9 @@ class FakeAPI(API):
 
 
 class APIAuthTest(APITestCase):
-    modules_to_load = ['admin', 'core.dataset', 'core.reuse', 'core.site',
-                      'core.organization', 'core.user']
+    modules = ['admin', 'search', 'core.dataset', 'core.reuse', 'core.site',
+               'core.organization', 'core.user']
+
     def oauth_app(self, name='test-client'):
         owner = UserFactory()
         return OAuth2Client.objects.create(
@@ -156,6 +157,7 @@ class APIAuthTest(APITestCase):
             redirect_uri=client.default_redirect_uri
         ))
 
+        print(response)
         self.assert200(response)
 
     def test_authorization_decline(self):

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -38,6 +38,8 @@ class FakeAPI(API):
 
 
 class APIAuthTest(APITestCase):
+    modules_to_load = ['admin', 'core.dataset', 'core.reuse', 'core.site',
+                      'core.organization', 'core.user']
     def oauth_app(self, name='test-client'):
         owner = UserFactory()
         return OAuth2Client.objects.create(

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -151,7 +151,7 @@ class APIAuthTest(APITestCase):
 
         client = self.oauth_app()
         response = self.get(url_for(
-            'oauth-i18n.authorize',
+            'oauth.authorize',
             response_type='code',
             client_id=client.client_id,
             redirect_uri=client.default_redirect_uri
@@ -166,7 +166,7 @@ class APIAuthTest(APITestCase):
 
         client = self.oauth_app()
         response = self.post(url_for(
-            'oauth-i18n.authorize',
+            'oauth.authorize',
             response_type='code',
             client_id=client.client_id,
             redirect_uri=client.default_redirect_uri
@@ -186,7 +186,7 @@ class APIAuthTest(APITestCase):
         client = self.oauth_app()
 
         response = self.post(url_for(
-            'oauth-i18n.authorize',
+            'oauth.authorize',
             response_type='code',
             client_id=client.client_id,
             redirect_uri=client.default_redirect_uri

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -37,7 +37,8 @@ SAMPLE_GEOM = {
 
 
 class DatasetAPITest(APITestCase):
-    modules_to_load = ['core.user', 'core.dataset', 'core.organization']
+    modules = ['core.user', 'core.dataset', 'core.organization']
+    
     def test_dataset_api_list(self):
         '''It should fetch a dataset list from the API'''
         with self.autoindex():
@@ -547,7 +548,7 @@ class DatasetBadgeAPITest(APITestCase):
 
 
 class DatasetResourceAPITest(APITestCase):
-    modules_to_load = None
+    modules = None
     def setUp(self):
         self.login()
         self.dataset = DatasetFactory(owner=self.user)
@@ -899,7 +900,7 @@ class DatasetReferencesAPITest(APITestCase):
 
 
 class CommunityResourceAPITest(APITestCase):
-    modules_to_load = ['core.dataset', 'core.user', 'core.organization']
+    modules = ['core.dataset', 'core.user', 'core.organization']
 
     def test_community_resource_api_get(self):
         '''It should fetch a community resource from the API'''

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -37,6 +37,7 @@ SAMPLE_GEOM = {
 
 
 class DatasetAPITest(APITestCase):
+    modules_to_load = ['core.user', 'core.dataset', 'core.organization']
     def test_dataset_api_list(self):
         '''It should fetch a dataset list from the API'''
         with self.autoindex():
@@ -546,6 +547,7 @@ class DatasetBadgeAPITest(APITestCase):
 
 
 class DatasetResourceAPITest(APITestCase):
+    modules_to_load = None
     def setUp(self):
         self.login()
         self.dataset = DatasetFactory(owner=self.user)
@@ -897,6 +899,7 @@ class DatasetReferencesAPITest(APITestCase):
 
 
 class CommunityResourceAPITest(APITestCase):
+    modules_to_load = ['core.dataset', 'core.user', 'core.organization']
 
     def test_community_resource_api_get(self):
         '''It should fetch a community resource from the API'''

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -26,6 +26,8 @@ from . import APITestCase
 
 
 class MeAPITest(APITestCase):
+    modules_to_load = ['core.user', 'core.organization', 'core.dataset',
+                      'core.reuse']
 
     def test_get_profile(self):
         '''It should fetch my user data on GET'''

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -26,8 +26,7 @@ from . import APITestCase
 
 
 class MeAPITest(APITestCase):
-    modules_to_load = ['core.user', 'core.organization', 'core.dataset',
-                      'core.reuse']
+    modules = ['core.user', 'core.organization', 'core.dataset', 'core.reuse']
 
     def test_get_profile(self):
         '''It should fetch my user data on GET'''

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -40,6 +40,8 @@ class OEmbedSettings(Testing):
 
 
 class OEmbedsDatasetAPITest(APITestCase):
+    modules_to_load = ['core.organization', 'features.territories',
+                       'core.dataset']
     settings = OEmbedSettings
 
     def setUp(self):

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -40,8 +40,7 @@ class OEmbedSettings(Testing):
 
 
 class OEmbedsDatasetAPITest(APITestCase):
-    modules_to_load = ['core.organization', 'features.territories',
-                       'core.dataset']
+    modules = ['core.organization', 'features.territories', 'core.dataset']
     settings = OEmbedSettings
 
     def setUp(self):
@@ -152,7 +151,7 @@ class OEmbedsDatasetAPITest(APITestCase):
         url = url_for('api.oembeds', references=reference)
         response = self.get(url)
         self.assert200(response)
-        
+
         data = json.loads(response.data)[0]
         self.assertIn('html', data)
         self.assertIn('width', data)

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -22,6 +22,7 @@ from udata.core.reuse.factories import ReuseFactory
 
 
 class OrganizationAPITest(APITestCase):
+    modules_to_load = ['core.organization', 'core.user']
     def test_organization_api_list(self):
         '''It should fetch an organization list from the API'''
         with self.autoindex():
@@ -141,6 +142,7 @@ class OrganizationAPITest(APITestCase):
 
 
 class MembershipAPITest(APITestCase):
+    modules_to_load = ['core.user', 'core.organization']
     def test_request_membership(self):
         organization = OrganizationFactory()
         user = self.login()
@@ -527,6 +529,7 @@ class MembershipAPITest(APITestCase):
 
 
 class OrganizationDatasetsAPITest(APITestCase):
+    modules_to_load = ['core.organization', 'core.dataset']
     def test_list_org_datasets(self):
         '''Should list organization datasets'''
         org = OrganizationFactory()
@@ -574,6 +577,7 @@ class OrganizationDatasetsAPITest(APITestCase):
 
 
 class OrganizationReusesAPITest(APITestCase):
+    modules_to_load = ['core.organization', 'core.reuse']
     def test_list_org_reuses(self):
         '''Should list organization reuses'''
         org = OrganizationFactory()
@@ -609,6 +613,7 @@ class OrganizationReusesAPITest(APITestCase):
 
 
 class OrganizationIssuesAPITest(APITestCase):
+    modules_to_load = ['core.user']
     def test_list_org_issues(self):
         '''Should list organization issues'''
         user = UserFactory()
@@ -635,6 +640,7 @@ class OrganizationIssuesAPITest(APITestCase):
 
 
 class OrganizationDiscussionsAPITest(APITestCase):
+    modules_to_load = ['core.user']
     def test_list_org_discussions(self):
         '''Should list organization discussions'''
         user = UserFactory()

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -20,9 +20,12 @@ from udata.core.user.factories import UserFactory, AdminFactory
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.reuse.factories import ReuseFactory
 
+import udata.core.badges.tasks  # noqa
+
 
 class OrganizationAPITest(APITestCase):
-    modules_to_load = ['core.organization', 'core.user']
+    modules = ['core.organization', 'core.user']
+
     def test_organization_api_list(self):
         '''It should fetch an organization list from the API'''
         with self.autoindex():
@@ -142,7 +145,8 @@ class OrganizationAPITest(APITestCase):
 
 
 class MembershipAPITest(APITestCase):
-    modules_to_load = ['core.user', 'core.organization']
+    modules = ['core.user', 'core.organization']
+
     def test_request_membership(self):
         organization = OrganizationFactory()
         user = self.login()
@@ -529,7 +533,8 @@ class MembershipAPITest(APITestCase):
 
 
 class OrganizationDatasetsAPITest(APITestCase):
-    modules_to_load = ['core.organization', 'core.dataset']
+    modules = ['core.organization', 'core.dataset']
+
     def test_list_org_datasets(self):
         '''Should list organization datasets'''
         org = OrganizationFactory()
@@ -577,7 +582,8 @@ class OrganizationDatasetsAPITest(APITestCase):
 
 
 class OrganizationReusesAPITest(APITestCase):
-    modules_to_load = ['core.organization', 'core.reuse']
+    modules = ['core.organization', 'core.reuse']
+
     def test_list_org_reuses(self):
         '''Should list organization reuses'''
         org = OrganizationFactory()
@@ -613,7 +619,8 @@ class OrganizationReusesAPITest(APITestCase):
 
 
 class OrganizationIssuesAPITest(APITestCase):
-    modules_to_load = ['core.user']
+    modules = ['core.user']
+
     def test_list_org_issues(self):
         '''Should list organization issues'''
         user = UserFactory()
@@ -640,7 +647,8 @@ class OrganizationIssuesAPITest(APITestCase):
 
 
 class OrganizationDiscussionsAPITest(APITestCase):
-    modules_to_load = ['core.user']
+    modules = ['core.user']
+
     def test_list_org_discussions(self):
         '''Should list organization discussions'''
         user = UserFactory()
@@ -667,6 +675,8 @@ class OrganizationDiscussionsAPITest(APITestCase):
 
 
 class OrganizationBadgeAPITest(APITestCase):
+    modules = ['core.user', 'core.organization']
+
     @classmethod
     def setUpClass(cls):
         # Register at least two badges

--- a/udata/tests/api/test_posts_api.py
+++ b/udata/tests/api/test_posts_api.py
@@ -11,7 +11,8 @@ from udata.core.user.factories import AdminFactory
 
 
 class PostsAPITest(APITestCase):
-    modules_to_load = ['core.dataset', 'core.reuse', 'core.user', 'core.post']
+    modules = ['core.dataset', 'core.reuse', 'core.user', 'core.post']
+
     def test_post_api_list(self):
         '''It should fetch a post list from the API'''
         posts = PostFactory.create_batch(3)

--- a/udata/tests/api/test_posts_api.py
+++ b/udata/tests/api/test_posts_api.py
@@ -11,6 +11,7 @@ from udata.core.user.factories import AdminFactory
 
 
 class PostsAPITest(APITestCase):
+    modules_to_load = ['core.dataset', 'core.reuse', 'core.user', 'core.post']
     def test_post_api_list(self):
         '''It should fetch a post list from the API'''
         posts = PostFactory.create_batch(3)

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -17,8 +17,8 @@ from . import APITestCase
 
 
 class ReuseAPITest(APITestCase):
-    modules_to_load = ['core.dataset', 'core.reuse', 'core.user',
-                       'core.organization']
+    modules = ['core.dataset', 'core.reuse', 'core.user', 'core.organization']
+
     def test_reuse_api_list(self):
         '''It should fetch a reuse list from the API'''
         with self.autoindex():

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -17,6 +17,8 @@ from . import APITestCase
 
 
 class ReuseAPITest(APITestCase):
+    modules_to_load = ['core.dataset', 'core.reuse', 'core.user',
+                       'core.organization']
     def test_reuse_api_list(self):
         '''It should fetch a reuse list from the API'''
         with self.autoindex():

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -11,7 +11,8 @@ from . import APITestCase
 
 
 class TopicsAPITest(APITestCase):
-    modules_to_load = ['core.dataset', 'core.topic', 'core.reuse', 'core.user']
+    modules = ['core.dataset', 'core.topic', 'core.reuse', 'core.user']
+
     def test_topic_api_list(self):
         '''It should fetch a topic list from the API'''
         topics = TopicFactory.create_batch(3)

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -11,6 +11,7 @@ from . import APITestCase
 
 
 class TopicsAPITest(APITestCase):
+    modules_to_load = ['core.dataset', 'core.topic', 'core.reuse', 'core.user']
     def test_topic_api_list(self):
         '''It should fetch a topic list from the API'''
         topics = TopicFactory.create_batch(3)

--- a/udata/tests/api/test_transfer_api.py
+++ b/udata/tests/api/test_transfer_api.py
@@ -15,7 +15,8 @@ from . import APITestCase
 
 
 class TransferAPITest(APITestCase):
-    modules_to_load = ['core.user', 'core.dataset']
+    modules = ['core.user', 'core.dataset']
+
     @patch('udata.features.transfer.api.request_transfer')
     def test_request_dataset_transfer(self, action):
         user = self.login()

--- a/udata/tests/api/test_transfer_api.py
+++ b/udata/tests/api/test_transfer_api.py
@@ -15,6 +15,7 @@ from . import APITestCase
 
 
 class TransferAPITest(APITestCase):
+    modules_to_load = ['core.user', 'core.dataset']
     @patch('udata.features.transfer.api.request_transfer')
     def test_request_dataset_transfer(self, action):
         user = self.login()

--- a/udata/tests/api/test_user_api.py
+++ b/udata/tests/api/test_user_api.py
@@ -11,6 +11,7 @@ from . import APITestCase
 
 
 class UserAPITest(APITestCase):
+    modules_to_load = ['core.user']
     def test_follow_user(self):
         '''It should follow an user on POST'''
         user = self.login()

--- a/udata/tests/api/test_user_api.py
+++ b/udata/tests/api/test_user_api.py
@@ -11,7 +11,8 @@ from . import APITestCase
 
 
 class UserAPITest(APITestCase):
-    modules_to_load = ['core.user']
+    modules = ['core.user']
+
     def test_follow_user(self):
         '''It should follow an user on POST'''
         user = self.login()

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -18,27 +18,27 @@ from udata.core.dataset.rdf import (
     dataset_to_rdf, dataset_from_rdf, resource_to_rdf, resource_from_rdf,
     temporal_from_rdf, frequency_to_rdf
 )
-from udata.core.dataset.views import blueprint as dataset_blueprint
+# from udata.core.dataset.views import blueprint as dataset_blueprint
 from udata.core.organization.factories import OrganizationFactory
-from udata.core.organization.views import blueprint as org_blueprint
-from udata.core.site.views import blueprint as site_blueprint
+# from udata.core.organization.views import blueprint as org_blueprint
+# from udata.core.site.views import blueprint as site_blueprint
 from udata.core.user.factories import UserFactory
-from udata.core.user.views import blueprint as user_blueprint
+# from udata.core.user.views import blueprint as user_blueprint
 from udata.rdf import DCAT, DCT, FREQ, SPDX, SCHEMA
 from udata.tests import TestCase, DBTestMixin
+from udata.tests.frontend import FrontTestCase
 from udata.utils import faker
 
-from udata.tests.frontend import FrontTestCase
 
-
-class DatasetToRdfTest(DBTestMixin, TestCase):
-    def create_app(self):
-        app = super(DatasetToRdfTest, self).create_app()
-        app.register_blueprint(dataset_blueprint)
-        app.register_blueprint(org_blueprint)
-        app.register_blueprint(user_blueprint)
-        app.register_blueprint(site_blueprint)
-        return app
+class DatasetToRdfTest(FrontTestCase):
+    modules = ['core.dataset', 'core.organization', 'core.user', 'core.site']
+    # def create_app(self):
+    #     app = super(DatasetToRdfTest, self).create_app()
+    #     app.register_blueprint(dataset_blueprint)
+    #     app.register_blueprint(org_blueprint)
+    #     app.register_blueprint(user_blueprint)
+    #     app.register_blueprint(site_blueprint)
+    #     return app
 
     def test_minimal(self):
         dataset = DatasetFactory.build()  # Does not have an URL
@@ -730,6 +730,8 @@ class RdfToDatasetTest(DBTestMixin, TestCase):
 
 
 class DatasetRdfViewsTest(FrontTestCase):
+    modules = ['core.dataset', 'core.organization', 'core.user', 'core.site']
+
     def test_rdf_default_to_jsonld(self):
         dataset = DatasetFactory()
         expected = url_for('datasets.rdf_format',

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -18,12 +18,8 @@ from udata.core.dataset.rdf import (
     dataset_to_rdf, dataset_from_rdf, resource_to_rdf, resource_from_rdf,
     temporal_from_rdf, frequency_to_rdf
 )
-# from udata.core.dataset.views import blueprint as dataset_blueprint
 from udata.core.organization.factories import OrganizationFactory
-# from udata.core.organization.views import blueprint as org_blueprint
-# from udata.core.site.views import blueprint as site_blueprint
 from udata.core.user.factories import UserFactory
-# from udata.core.user.views import blueprint as user_blueprint
 from udata.rdf import DCAT, DCT, FREQ, SPDX, SCHEMA
 from udata.tests import TestCase, DBTestMixin
 from udata.tests.frontend import FrontTestCase
@@ -32,13 +28,6 @@ from udata.utils import faker
 
 class DatasetToRdfTest(FrontTestCase):
     modules = ['core.dataset', 'core.organization', 'core.user', 'core.site']
-    # def create_app(self):
-    #     app = super(DatasetToRdfTest, self).create_app()
-    #     app.register_blueprint(dataset_blueprint)
-    #     app.register_blueprint(org_blueprint)
-    #     app.register_blueprint(user_blueprint)
-    #     app.register_blueprint(site_blueprint)
-    #     return app
 
     def test_minimal(self):
         dataset = DatasetFactory.build()  # Does not have an URL

--- a/udata/tests/features/territories/test_territories_api.py
+++ b/udata/tests/features/territories/test_territories_api.py
@@ -12,6 +12,7 @@ from udata.tests.features.territories.test_territories_process import (
 
 
 class TerritoriesAPITest(APITestCase):
+    modules_to_load = ['features.territories']
     settings = TerritoriesSettings
 
     def setUp(self):

--- a/udata/tests/features/territories/test_territories_api.py
+++ b/udata/tests/features/territories/test_territories_api.py
@@ -12,7 +12,7 @@ from udata.tests.features.territories.test_territories_process import (
 
 
 class TerritoriesAPITest(APITestCase):
-    modules_to_load = ['features.territories']
+    modules = ['features.territories']
     settings = TerritoriesSettings
 
     def setUp(self):

--- a/udata/tests/features/territories/test_territories_process.py
+++ b/udata/tests/features/territories/test_territories_process.py
@@ -51,6 +51,9 @@ class TerritoriesSettings(Testing):
 
 
 class TerritoriesTest(FrontTestCase):
+    modules_to_load = ['features.territories', 'admin', 'core.dataset',
+                       'core.reuse', 'core.site', 'core.organization',
+                       'core.user']
     settings = TerritoriesSettings
 
     def setUp(self):

--- a/udata/tests/features/territories/test_territories_process.py
+++ b/udata/tests/features/territories/test_territories_process.py
@@ -51,9 +51,8 @@ class TerritoriesSettings(Testing):
 
 
 class TerritoriesTest(FrontTestCase):
-    modules_to_load = ['features.territories', 'admin', 'core.dataset',
-                       'core.reuse', 'core.site', 'core.organization',
-                       'core.user']
+    modules = ['features.territories', 'admin', 'core.dataset', 'core.reuse',
+               'core.site', 'core.organization', 'core.user', 'search']
     settings = TerritoriesSettings
 
     def setUp(self):

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -6,14 +6,19 @@ import re
 
 from udata.tests import TestCase, WebTestMixin, SearchTestMixin
 
+from udata.core.site import init_app as init_site
+from udata.core.followers import init_app as init_followers
 from udata import frontend, api
 
 
 class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
+    modules_to_load = []
     def create_app(self):
         app = super(FrontTestCase, self).create_app()
         api.init_app(app)
-        frontend.init_app(app)
+        frontend.init_app(app, self.modules_to_load)
+        init_site(app)
+        init_followers(app)
         return app
 
     def get_json_ld(self, response):

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -6,19 +6,16 @@ import re
 
 from udata.tests import TestCase, WebTestMixin, SearchTestMixin
 
-from udata.core.site import init_app as init_site
-from udata.core.followers import init_app as init_followers
 from udata import frontend, api
 
 
 class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
-    modules_to_load = []
+    modules = []
+
     def create_app(self):
         app = super(FrontTestCase, self).create_app()
         api.init_app(app)
-        frontend.init_app(app, self.modules_to_load)
-        init_site(app)
-        init_followers(app)
+        frontend.init_app(app, self.modules)
         return app
 
     def get_json_ld(self, response):

--- a/udata/tests/frontend/test_csv.py
+++ b/udata/tests/frontend/test_csv.py
@@ -121,8 +121,8 @@ def with_basename():
 
 
 class CsvTest(FrontTestCase):
-    modules_to_load = ['admin', 'core.dataset', 'core.reuse', 'core.site',
-                       'core.organization']
+    modules = ['admin', 'core.dataset', 'core.reuse', 'core.site',
+               'core.organization', 'search']
 
     def create_app(self):
         app = super(CsvTest, self).create_app()

--- a/udata/tests/frontend/test_csv.py
+++ b/udata/tests/frontend/test_csv.py
@@ -121,6 +121,9 @@ def with_basename():
 
 
 class CsvTest(FrontTestCase):
+    modules_to_load = ['admin', 'core.dataset', 'core.reuse', 'core.site',
+                       'core.organization']
+
     def create_app(self):
         app = super(CsvTest, self).create_app()
         init_metrics(app)

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -19,8 +19,9 @@ from . import FrontTestCase
 
 
 class DatasetBlueprintTest(FrontTestCase):
-    modules_to_load = ['core.dataset', 'admin', 'core.reuse', 'core.site',
-                      'core.organization', 'core.user']
+    modules = ['core.dataset', 'admin', 'search', 'core.reuse', 'core.site',
+               'core.organization', 'core.user', 'core.followers']
+
     def test_render_list(self):
         '''It should render the dataset list page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -19,6 +19,8 @@ from . import FrontTestCase
 
 
 class DatasetBlueprintTest(FrontTestCase):
+    modules_to_load = ['core.dataset', 'admin', 'core.reuse', 'core.site',
+                      'core.organization', 'core.user']
     def test_render_list(self):
         '''It should render the dataset list page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_errors.py
+++ b/udata/tests/frontend/test_errors.py
@@ -25,6 +25,8 @@ def route_500():
 
 
 class CustomErrorPagesTest(FrontTestCase):
+    modules_to_load = ['admin', 'core.dataset', 'core.reuse', 'core.site',
+                       'core.organization']
     def create_app(self):
         app = super(CustomErrorPagesTest, self).create_app()
         app.register_blueprint(errors)

--- a/udata/tests/frontend/test_errors.py
+++ b/udata/tests/frontend/test_errors.py
@@ -25,8 +25,9 @@ def route_500():
 
 
 class CustomErrorPagesTest(FrontTestCase):
-    modules_to_load = ['admin', 'core.dataset', 'core.reuse', 'core.site',
-                       'core.organization']
+    modules = ['admin', 'core.dataset', 'core.reuse', 'core.site',
+               'core.organization', 'search']
+
     def create_app(self):
         app = super(CustomErrorPagesTest, self).create_app()
         app.register_blueprint(errors)

--- a/udata/tests/frontend/test_frontend_filters.py
+++ b/udata/tests/frontend/test_frontend_filters.py
@@ -21,6 +21,7 @@ def dr(start, end):
 
 
 class FrontEndRootTest(FrontTestCase):
+    modules_to_load = ['core.site']
     def test_rewrite(self):
         '''url_rewrite should replace a parameter in the URL if present'''
         url = url_for('site.home', one='value', two='two')

--- a/udata/tests/frontend/test_frontend_filters.py
+++ b/udata/tests/frontend/test_frontend_filters.py
@@ -21,7 +21,8 @@ def dr(start, end):
 
 
 class FrontEndRootTest(FrontTestCase):
-    modules_to_load = ['core.site']
+    modules = ['core.site']
+
     def test_rewrite(self):
         '''url_rewrite should replace a parameter in the URL if present'''
         url = url_for('site.home', one='value', two='two')

--- a/udata/tests/frontend/test_organization_frontend.py
+++ b/udata/tests/frontend/test_organization_frontend.py
@@ -20,6 +20,8 @@ from . import FrontTestCase
 
 
 class OrganizationBlueprintTest(FrontTestCase):
+    modules_to_load = ['core.organization', 'admin', 'core.dataset',
+                       'core.reuse', 'core.site', 'core.user']
     def test_render_list(self):
         '''It should render the organization list page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_organization_frontend.py
+++ b/udata/tests/frontend/test_organization_frontend.py
@@ -20,8 +20,9 @@ from . import FrontTestCase
 
 
 class OrganizationBlueprintTest(FrontTestCase):
-    modules_to_load = ['core.organization', 'admin', 'core.dataset',
-                       'core.reuse', 'core.site', 'core.user']
+    modules = ['core.organization', 'admin', 'search', 'core.dataset',
+               'core.reuse', 'core.site', 'core.user', 'core.followers']
+
     def test_render_list(self):
         '''It should render the organization list page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_post_frontend.py
+++ b/udata/tests/frontend/test_post_frontend.py
@@ -9,8 +9,9 @@ from . import FrontTestCase
 
 
 class OrganizationBlueprintTest(FrontTestCase):
-    modules_to_load = ['core.post', 'admin', 'core.dataset', 'core.reuse',
-                      'core.site', 'core.organization']
+    modules = ['core.post', 'admin', 'core.dataset', 'core.reuse',
+               'core.site', 'core.organization', 'search']
+
     def test_render_list(self):
         '''It should render the post list page'''
         # with self.autoindex():

--- a/udata/tests/frontend/test_post_frontend.py
+++ b/udata/tests/frontend/test_post_frontend.py
@@ -9,6 +9,8 @@ from . import FrontTestCase
 
 
 class OrganizationBlueprintTest(FrontTestCase):
+    modules_to_load = ['core.post', 'admin', 'core.dataset', 'core.reuse',
+                      'core.site', 'core.organization']
     def test_render_list(self):
         '''It should render the post list page'''
         # with self.autoindex():

--- a/udata/tests/frontend/test_reuse_frontend.py
+++ b/udata/tests/frontend/test_reuse_frontend.py
@@ -16,8 +16,9 @@ from . import FrontTestCase
 
 
 class ReuseBlueprintTest(FrontTestCase):
-    modules_to_load  = ['core.reuse', 'admin', 'core.dataset', 'core.site',
-                       'core.organization', 'core.user']
+    modules = ['core.reuse', 'admin', 'search', 'core.dataset', 'core.site',
+               'core.organization', 'core.user', 'core.followers']
+
     def test_render_list(self):
         '''It should render the reuse list page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_reuse_frontend.py
+++ b/udata/tests/frontend/test_reuse_frontend.py
@@ -16,6 +16,8 @@ from . import FrontTestCase
 
 
 class ReuseBlueprintTest(FrontTestCase):
+    modules_to_load  = ['core.reuse', 'admin', 'core.dataset', 'core.site',
+                       'core.organization', 'core.user']
     def test_render_list(self):
         '''It should render the reuse list page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_root_frontend.py
+++ b/udata/tests/frontend/test_root_frontend.py
@@ -19,11 +19,11 @@ class FrontEndRootTest(FrontTestCase):
                 DatasetFactory(organization=org)
                 ReuseFactory(organization=org)
 
-        response = self.get(url_for('front.search'))
+        response = self.get(url_for('search.index'))
         self.assert200(response)
 
     def test_render_search_no_data(self):
         '''It should render the search page without data'''
         self.init_search()
-        response = self.get(url_for('front.search'))
+        response = self.get(url_for('search.index'))
         self.assert200(response)

--- a/udata/tests/frontend/test_root_frontend.py
+++ b/udata/tests/frontend/test_root_frontend.py
@@ -11,6 +11,8 @@ from . import FrontTestCase
 
 
 class FrontEndRootTest(FrontTestCase):
+    modules_to_load = ['core.dataset', 'core.reuse', 'core.organization',
+                       'admin', 'core.site']
     def test_render_search(self):
         '''It should render the search page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_search_frontend.py
+++ b/udata/tests/frontend/test_search_frontend.py
@@ -10,9 +10,10 @@ from udata.core.organization.factories import OrganizationFactory
 from . import FrontTestCase
 
 
-class FrontEndRootTest(FrontTestCase):
-    modules_to_load = ['core.dataset', 'core.reuse', 'core.organization',
-                       'admin', 'core.site']
+class SearchFrontTest(FrontTestCase):
+    modules = ['core.dataset', 'core.reuse', 'core.organization',
+               'admin', 'core.site', 'search']
+
     def test_render_search(self):
         '''It should render the search page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_territories.py
+++ b/udata/tests/frontend/test_territories.py
@@ -10,8 +10,8 @@ from udata.tests.frontend import FrontTestCase
 
 
 class TerritoriesTest(FrontTestCase):
-    modules_to_load = ['features.territories', 'admin', 'core.dataset',
-                       'core.reuse', 'core.site', 'core.organization']
+    modules = ['features.territories', 'admin', 'search', 'core.dataset',
+               'core.reuse', 'core.site', 'core.organization']
 
     def setUp(self):
         super(TerritoriesTest, self).setUp()

--- a/udata/tests/frontend/test_territories.py
+++ b/udata/tests/frontend/test_territories.py
@@ -10,6 +10,8 @@ from udata.tests.frontend import FrontTestCase
 
 
 class TerritoriesTest(FrontTestCase):
+    modules_to_load = ['features.territories', 'admin', 'core.dataset',
+                       'core.reuse', 'core.site', 'core.organization']
 
     def setUp(self):
         super(TerritoriesTest, self).setUp()

--- a/udata/tests/frontend/test_topic_frontend.py
+++ b/udata/tests/frontend/test_topic_frontend.py
@@ -73,6 +73,8 @@ class TopicSearchTest(SearchTestMixin, TestCase):
 
 
 class TopicsBlueprintTest(FrontTestCase):
+    modules_to_load = ['core.topic', 'admin', 'core.dataset', 'core.reuse',
+                      'core.site', 'core.organization']
     def test_render_display(self):
         '''It should render a topic page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_topic_frontend.py
+++ b/udata/tests/frontend/test_topic_frontend.py
@@ -73,8 +73,9 @@ class TopicSearchTest(SearchTestMixin, TestCase):
 
 
 class TopicsBlueprintTest(FrontTestCase):
-    modules_to_load = ['core.topic', 'admin', 'core.dataset', 'core.reuse',
-                      'core.site', 'core.organization']
+    modules = ['core.topic', 'admin', 'core.dataset', 'core.reuse',
+               'core.site', 'core.organization', 'search']
+
     def test_render_display(self):
         '''It should render a topic page'''
         with self.autoindex():

--- a/udata/tests/frontend/test_user_frontend.py
+++ b/udata/tests/frontend/test_user_frontend.py
@@ -13,6 +13,8 @@ from . import FrontTestCase
 
 
 class UserBlueprintTest(FrontTestCase):
+    modules_to_load = ['core.user', 'admin', 'core.dataset', 'core.reuse',
+                      'core.site', 'core.organization']
     def test_render_profile(self):
         '''It should render the user profile'''
         user = UserFactory(about='* Title 1\n* Title 2',

--- a/udata/tests/frontend/test_user_frontend.py
+++ b/udata/tests/frontend/test_user_frontend.py
@@ -13,8 +13,9 @@ from . import FrontTestCase
 
 
 class UserBlueprintTest(FrontTestCase):
-    modules_to_load = ['core.user', 'admin', 'core.dataset', 'core.reuse',
-                      'core.site', 'core.organization']
+    modules = ['search', 'core.user', 'admin', 'core.dataset', 'core.reuse',
+               'core.site', 'core.organization', 'core.followers', 'search']
+
     def test_render_profile(self):
         '''It should render the user profile'''
         user = UserFactory(about='* Title 1\n* Title 2',

--- a/udata/tests/site/test_site_api.py
+++ b/udata/tests/site/test_site_api.py
@@ -48,8 +48,8 @@ class MetricsAPITest(APITestCase):
 
 
 class SiteAPITest(APITestCase):
-    modules_to_load = ['core.site', 'core.dataset', 'core.reuse',
-                       'core.organization']
+    modules = ['core.site', 'core.dataset', 'core.reuse', 'core.organization']
+
     def test_get_site(self):
         response = self.get(url_for('api.site'))
         self.assert200(response)

--- a/udata/tests/site/test_site_api.py
+++ b/udata/tests/site/test_site_api.py
@@ -48,6 +48,8 @@ class MetricsAPITest(APITestCase):
 
 
 class SiteAPITest(APITestCase):
+    modules_to_load = ['core.site', 'core.dataset', 'core.reuse',
+                       'core.organization']
     def test_get_site(self):
         response = self.get(url_for('api.site'))
         self.assert200(response)

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -9,27 +9,16 @@ from rdflib.resource import Resource
 
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.dataset.models import Dataset
-from udata.core.dataset.views import blueprint as dataset_blueprint
 from udata.core.organization.factories import OrganizationFactory
-from udata.core.organization.views import blueprint as org_blueprint
 from udata.core.site.factories import SiteFactory
 from udata.core.site.rdf import build_catalog
-from udata.core.site.views import blueprint as site_blueprint
 from udata.core.user.factories import UserFactory
-from udata.core.user.views import blueprint as user_blueprint
 from udata.rdf import CONTEXT, DCAT, DCT, HYDRA
-from udata.tests import TestCase, DBTestMixin
 from udata.tests.frontend import FrontTestCase
 
 
-class CatalogTest(DBTestMixin, TestCase):
-    def create_app(self):
-        app = super(CatalogTest, self).create_app()
-        app.register_blueprint(dataset_blueprint)
-        app.register_blueprint(org_blueprint)
-        app.register_blueprint(user_blueprint)
-        app.register_blueprint(site_blueprint)
-        return app
+class CatalogTest(FrontTestCase):
+    modules = ['core.dataset', 'core.organization', 'core.user', 'core.site']
 
     def test_minimal(self):
         site = SiteFactory()
@@ -153,6 +142,8 @@ class CatalogTest(DBTestMixin, TestCase):
 
 
 class SiteRdfViewsTest(FrontTestCase):
+    modules = ['core.site', 'core.dataset']
+
     def test_expose_jsonld_context(self):
         url = url_for('site.jsonld_context')
         self.assertEqual(url, '/context.jsonld')

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -18,8 +18,9 @@ from udata.tests.frontend import FrontTestCase
 
 
 class SiteViewsTest(FrontTestCase):
-    modules_to_load = ['core.site', 'admin', 'core.dataset', 'core.reuse',
-                      'core.organization']
+    modules = ['core.site', 'admin', 'core.dataset', 'core.reuse',
+               'core.organization', 'search']
+
     def test_site_global(self):
         '''It should create and/or load the current site'''
         with self.app.test_request_context(''):

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -18,6 +18,8 @@ from udata.tests.frontend import FrontTestCase
 
 
 class SiteViewsTest(FrontTestCase):
+    modules_to_load = ['core.site', 'admin', 'core.dataset', 'core.reuse',
+                      'core.organization']
     def test_site_global(self):
         '''It should create and/or load the current site'''
         with self.app.test_request_context(''):

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -6,8 +6,6 @@ from datetime import datetime
 from flask import url_for
 
 from udata.models import Dataset, Member
-from udata.core.user.views import blueprint as user_bp
-from udata.core.dataset.views import blueprint as dataset_bp
 from udata.core.discussions.models import Message, Discussion
 from udata.core.discussions.notifications import discussions_notifications
 from udata.core.discussions.signals import (
@@ -31,10 +29,7 @@ from .api import APITestCase
 
 
 class DiscussionsTest(APITestCase):
-    def create_app(self):
-        app = super(DiscussionsTest, self).create_app()
-        app.register_blueprint(user_bp)
-        return app
+    modules = ['core.user']
 
     def test_new_discussion(self):
         self.app.config['USE_METRICS'] = True
@@ -373,7 +368,7 @@ class DiscussionsTest(APITestCase):
 
 
 class DiscussionCsvTest(FrontTestCase):
-    modules_to_load = ['core.organization']
+    modules = ['core.organization']
 
     def test_discussions_csv_content_empty(self):
         organization = OrganizationFactory()
@@ -481,12 +476,8 @@ class DiscussionsNotificationsTest(TestCase, DBTestMixin):
             self.assertEqual(details['subject']['type'], 'dataset')
 
 
-class DiscussionsMailsTest(TestCase, DBTestMixin):
-    def create_app(self):
-        app = super(DiscussionsMailsTest, self).create_app()
-        app.register_blueprint(user_bp)
-        app.register_blueprint(dataset_bp)
-        return app
+class DiscussionsMailsTest(FrontTestCase):
+    modules = ['core.user', 'core.dataset']
 
     def test_new_discussion_mail(self):
         user = UserFactory()

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -373,6 +373,7 @@ class DiscussionsTest(APITestCase):
 
 
 class DiscussionCsvTest(FrontTestCase):
+    modules_to_load = ['core.organization']
 
     def test_discussions_csv_content_empty(self):
         organization = OrganizationFactory()

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -339,6 +339,7 @@ class IssuesTest(APITestCase):
 
 
 class IssueCsvTest(FrontTestCase):
+    modules_to_load = ['core.organization']
 
     def test_issues_csv_content_empty(self):
         organization = OrganizationFactory()

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -6,8 +6,6 @@ from datetime import datetime
 from flask import url_for
 
 from udata.models import db, Dataset, Member
-from udata.core.dataset.views import blueprint as dataset_bp
-from udata.core.user.views import blueprint as user_bp
 from udata.core.issues.models import Issue, Message
 from udata.core.issues.actions import issues_for
 from udata.core.issues.notifications import issues_notifications
@@ -31,10 +29,7 @@ from .api import APITestCase
 
 
 class IssuesTest(APITestCase):
-    def create_app(self):
-        app = super(IssuesTest, self).create_app()
-        app.register_blueprint(user_bp)
-        return app
+    modules = ['core.user']
 
     def test_new_issue(self):
         self.app.config['USE_METRICS'] = True
@@ -339,7 +334,7 @@ class IssuesTest(APITestCase):
 
 
 class IssueCsvTest(FrontTestCase):
-    modules_to_load = ['core.organization']
+    modules = ['core.organization']
 
     def test_issues_csv_content_empty(self):
         organization = OrganizationFactory()
@@ -571,12 +566,8 @@ class IssuesNotificationsTest(TestCase, DBTestMixin):
             self.assertEqual(details['subject']['type'], 'dataset')
 
 
-class IssuesMailsTest(TestCase, DBTestMixin):
-    def create_app(self):
-        app = super(IssuesMailsTest, self).create_app()
-        app.register_blueprint(user_bp)
-        app.register_blueprint(dataset_bp)
-        return app
+class IssuesMailsTest(FrontTestCase):
+    modules = ['core.user', 'core.dataset']
 
     def test_new_issue_mail(self):
         user = UserFactory()

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 
 
 class TagsTests(FrontTestCase):
+    modules_to_load = ['core.tags']
     def test_csv(self):
         Tag.objects.create(name='datasets-only', counts={'datasets': 15})
         Tag.objects.create(name='reuses-only', counts={'reuses': 10})

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -20,7 +20,8 @@ log = logging.getLogger(__name__)
 
 
 class TagsTests(FrontTestCase):
-    modules_to_load = ['core.tags']
+    modules = ['core.tags']
+
     def test_csv(self):
         Tag.objects.create(name='datasets-only', counts={'datasets': 15})
         Tag.objects.create(name='reuses-only', counts={'reuses': 10})


### PR DESCRIPTION
This PRs includes and supersedes #908 (fix #908) and:
- normalize blueprints variable name to `blueprint`
- reduces the amount of `register_blueprint`
- provides a `modules` attribute helper on FrontTestCase to ease the blueprint registeration
- merges `oauth` blueprints and make use of `localize=False`
- extract `search` into its own blueprint

Result: test duration drop under 5 minutes on my computer