### PR TITLE
Display membership modal actions buttons for admins and on display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Display membership modal actions buttons for site administrators and on membership display. [#1176](https://github.com/opendatateam/udata/pull/1176)
 
 ## 1.1.7 (2017-09-25)
 

--- a/js/components/organization/member-modal.vue
+++ b/js/components/organization/member-modal.vue
@@ -17,10 +17,10 @@
 <user-modal :user="user" v-ref:modal>
     <role-form class="member-form" v-ref:form
         :fields="fields" :model="member" :defs="defs"
-        :readonly="!is_admin" :fill="true">
+        :readonly="!can_edit" :fill="true">
     </role-form>
-    <br v-if="is_admin" />
-    <div v-if="is_admin && !member_exists"  class="btn-group btn-group-justified">
+    <br v-if="can_edit" />
+    <div v-if="can_edit"  class="btn-group btn-group-justified">
         <div class="btn-group">
             <button type="button" class="btn btn-success btn-flat"
                 @click="submit">
@@ -35,7 +35,7 @@
             </button>
         </div>
     </div>
-    <div v-if="is_admin && member_exists" class="btn-group btn-group-justified">
+    <div v-if="can_edit && member_exists" class="btn-group btn-group-justified">
         <div class="btn-group">
             <button type="button" class="btn btn-danger btn-flat" @click="delete">
                 <span class="fa fa-user-times"></span>
@@ -76,8 +76,8 @@ export default {
         };
     },
     computed: {
-        is_admin() {
-            return this.org.is_admin(this.$root.me);
+        can_edit() {
+            return this.$root.me.is_admin || this.org.is_admin(this.$root.me);
         },
         member_exists() {
             return this.org.is_member(this.user);


### PR DESCRIPTION
This PR ensure actions buttons are visibles when when displaying the membership modal for organization adminstrators **AND** site administrators

![screenshot-www data dev-2017-09-28-11-43-43-957](https://user-images.githubusercontent.com/15725/30960180-8d84a262-a442-11e7-873c-a7834157eb26.png)


 Fix etalab/data.gouv.fr#25