### PR TITLE
Info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixes a lot of encoding issues [#1146](https://github.com/opendatateam/udata/pull/1146)
 - Switch to [Crowdin](https://crowdin.com) to manage translations [#1171](https://github.com/opendatateam/udata/pull/1171)
 - **BREAKING** Switch to `Flask-Security`. `Flask-Security-Fork` should be uninstalled before installing the new requirements [#958](https://github.com/opendatateam/udata/pull/958)
+- Added a `udata info` command for diagnostic purpose [#1179](https://github.com/opendatateam/udata/pull/1179)
 
 ## 1.1.8 (2017-09-28)
 

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -13,6 +13,17 @@ And then get the documentation for subtasks:
 ```shell
 $ udata user -?
 ```
+
+## Diagnostic
+
+If you have some issues, start with:
+
+```shell
+$ udata info
+```
+
+This will display some useful details about your local configuration.
+
 ## Managing users
 
 You can create a user with:

--- a/udata/app.py
+++ b/udata/app.py
@@ -129,6 +129,7 @@ def create_app(config='udata.settings.Defaults', override=None):
     app.config.from_object(config)
     settings = os.environ.get('UDATA_SETTINGS', join(os.getcwd(), 'udata.cfg'))
     if exists(settings):
+        app.settings_file = settings  # Keep track of loaded settings for diagnostic
         app.config.from_pyfile(settings)
 
     if override:

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -25,6 +25,7 @@ manager = Manager()
 
 # Tell wether or not you can prompt user
 IS_INTERACTIVE = sys.__stdin__.isatty()
+WITH_COLORS = sys.stdout.isatty()
 
 
 def submanager(name, **kwargs):
@@ -144,7 +145,7 @@ class BaseFormatter(logging.Formatter):
 
 def color(code):
     '''A simple ANSI color wrapper factory'''
-    return lambda t: '\033[{0}{1}\033[0;m'.format(code, t)
+    return lambda t: '\033[{0}{1}\033[0;m'.format(code, t) if WITH_COLORS else t
 
 
 green = color('1;32m')

--- a/udata/commands/info.py
+++ b/udata/commands/info.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+from flask import current_app
+
+from udata.commands import manager, white
+
+
+log = logging.getLogger(__name__)
+
+
+@manager.command
+def info():
+    '''Display some details about the local configuration'''
+    if hasattr(current_app, 'settings_file'):
+        log.info('Loaded configuration from %s', current_app.settings_file)
+
+    log.info('Current configuration')
+    for key in sorted(current_app.config):
+        print('{0}: {1}'.format(white(key), current_app.config[key]))

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -88,7 +88,6 @@ class Defaults(object):
     SECURITY_CHANGEABLE = True
 
     SECURITY_PASSWORD_HASH = b'bcrypt'
-    SECURITY_PASSWORD_SALT = b'udata'
 
     SECURITY_PASSWORD_SALT = b'Default uData secret password salt'
     SECURITY_CONFIRM_SALT = b'Default uData secret confirm salt'


### PR DESCRIPTION
This PR adds a `udata info` command for diagnostic purpose and improve the ansi colors handling by disabling it when output is piped or redirected.