### PR TITLE
Fix URL validation for unicode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added a `udata info` command for diagnostic purpose [#1179](https://github.com/opendatateam/udata/pull/1179)
 - Add `.ttl` and `.n3` as supported file extensions [#1183](https://github.com/opendatateam/udata/pull/1183)
 - Improve logging for adhoc scripts [#1184](https://github.com/opendatateam/udata/pull/1184)
+- Improve URLs validation (support new tlds, unicode URLs...) [#1182](https://github.com/opendatateam/udata/pull/1182)
 
 ## 1.1.8 (2017-09-28)
 

--- a/udata/models/url_field.py
+++ b/udata/models/url_field.py
@@ -1,14 +1,85 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import re
+
 from mongoengine.fields import URLField as MEURLField
+
+
+IP_MIDDLE_OCTET = r'(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5]))'
+IP_LAST_OCTET = r'(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))'
+
+URL_REGEX = re.compile(
+    r'^'
+    # scheme is validated separately
+    r'^(?:[a-z0-9\.\-]*)://'
+    # user:pass authentication
+    r'(?:\S+(?::\S*)?@)?'
+    r'(?:'
+    r'(?P<private_ip>'
+    # IP address exclusion
+    # private & local networks
+    r'(?:localhost)|'
+    r'(?:(?:10|127)' + IP_MIDDLE_OCTET + r'{2}' + IP_LAST_OCTET + r')|'
+    r'(?:(?:169\.254|192\.168)' + IP_MIDDLE_OCTET + IP_LAST_OCTET + r')|'
+    r'(?:172\.(?:1[6-9]|2\d|3[0-1])' + IP_MIDDLE_OCTET + IP_LAST_OCTET + r'))'
+    r'|'
+    # IP address dotted notation octets
+    # excludes loopback network 0.0.0.0
+    # excludes reserved space >= 224.0.0.0
+    # excludes network & broadcast addresses
+    # (first & last IP address of each class)
+    r'(?P<public_ip>'
+    r'(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])'
+    r'' + IP_MIDDLE_OCTET + r'{2}'
+    r'' + IP_LAST_OCTET + r')'
+    r'|'
+    # host name
+    r'(?:(?:[a-z\u00a1-\uffff0-9]-?)*[a-z\u00a1-\uffff0-9]+)'
+    # domain name
+    r'(?:\.(?:[a-z\u00a1-\uffff0-9]-?)*[a-z\u00a1-\uffff0-9]+)*'
+    # TLD identifier
+    r'(?:\.(?:[a-z\u00a1-\uffff]{2,}))'
+    r')'
+    # port number
+    r'(?::\d{2,5})?'
+    # resource path
+    r'(?:/\S*)?'
+    # query string
+    r'(?:\?\S*)?'
+    r'$',
+    re.UNICODE | re.IGNORECASE
+)
 
 
 class URLField(MEURLField):
     '''
     An URL field that automatically strips extra spaces
+    and support uncode domain and paths.
+
+    Public URL can be enforced with `public=True`
+
+    URL_REGEX has been extracted and adapted from:
+        https://github.com/kvesteri/validators/blob/master/validators/url.py
+
+    Main changes are:
+        - scheme validation is handled separately instead of being hard coded
+        - handle `localhost` as a valid private url
     '''
+    _URL_REGEX = URL_REGEX
+
+    def __init__(self, public=False, **kwargs):
+        super(URLField, self).__init__(**kwargs)
+        self.public = public
+
     def to_python(self, value):
         value = super(URLField, self).to_python(value)
         if value:
             return value.strip()
+
+    def validate(self, value):
+        super(URLField, self).validate(value)
+        if self.public:
+            match = self.url_regex.match(value)
+            if match and match.group('private_ip'):
+                self.error('Invalid URL: "{0}" is not public URL')

--- a/udata/tests/forms/test_basic_fields.py
+++ b/udata/tests/forms/test_basic_fields.py
@@ -72,3 +72,17 @@ class UrlFieldTest(TestCase):
         form.validate()
         self.assertIn('url', form.errors)
         self.assertEqual(len(form.errors['url']), 1)
+
+    def test_with_unicode_url(self):
+        Fake, FakeForm = self.factory()
+
+        fake = Fake()
+        url = 'https://www.somewhère.com/with/accënts/'
+        form = FakeForm(MultiDict({'url': url}))
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(fake.url, url)

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -53,6 +53,10 @@ class URLTester(db.Document):
     url = db.URLField()
 
 
+class PublicURLTester(db.Document):
+    url = db.URLField(public=True)
+
+
 class AutoUUIDFieldTest(DBTestMixin, TestCase):
     def test_auto_populate(self):
         '''AutoUUIDField should populate itself if not set'''
@@ -246,6 +250,18 @@ class URLFieldTest(DBTestMixin, TestCase):
         obj = URLTester(url=url)
         obj.save().reload()
         self.assertEqual(obj.url, url.strip())
+
+    def test_handle_unicode(self):
+        url = 'https://www.somewhère.com/with/accënts/'
+        obj = URLTester(url=url)
+        obj.save().reload()
+        self.assertEqual(obj.url, url)
+
+    def test_public(self):
+        url = 'http://10.10.0.2/path/'
+        URLTester(url=url).save()
+        with self.assertRaises(ValidationError):
+            PublicURLTester(url=url).save()
 
 
 class DatetimedTest(DBTestMixin, TestCase):


### PR DESCRIPTION
This PR improves URL fields validation (both model and form level) by supporting more use cases:
- new tlds
- unicode domains
- unicode paths
- allows to accept only public URLs 