### PR TITLE
Improve console logging for adhoc scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **BREAKING** Switch to `Flask-Security`. `Flask-Security-Fork` should be uninstalled before installing the new requirements [#958](https://github.com/opendatateam/udata/pull/958)
 - Added a `udata info` command for diagnostic purpose [#1179](https://github.com/opendatateam/udata/pull/1179)
 - Add `.ttl` and `.n3` as supported file extensions [#1183](https://github.com/opendatateam/udata/pull/1183)
+- Improve logging for adhoc scripts [#1184](https://github.com/opendatateam/udata/pull/1184)
 
 ## 1.1.8 (2017-09-28)
 

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -109,6 +109,11 @@ def set_logging(app):
     app.logger.handlers = []
     app.logger.addHandler(handler)
 
+    logger = logging.getLogger('__main__')
+    logger.setLevel(log_level)
+    logger.handlers = []
+    logger.addHandler(handler)
+
     for name in app.config['PLUGINS']:
         logger = logging.getLogger('udata_{0}'.format(name))
         logger.setLevel(log_level)


### PR DESCRIPTION
This PR ensure adhoc scripts have a proper logger (which is `__main__`)