### PR TITLE
Prevent js crash for geometryless zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `.ttl` and `.n3` as supported file extensions [#1183](https://github.com/opendatateam/udata/pull/1183)
 - Improve logging for adhoc scripts [#1184](https://github.com/opendatateam/udata/pull/1184)
 - Improve URLs validation (support new tlds, unicode URLs...) [#1182](https://github.com/opendatateam/udata/pull/1182)
+- Properly serialize empty geometries for zones missing it
 
 ## 1.1.8 (2017-09-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Add `.ttl` and `.n3` as supported file extensions [#1183](https://github.com/opendatateam/udata/pull/1183)
 - Improve logging for adhoc scripts [#1184](https://github.com/opendatateam/udata/pull/1184)
 - Improve URLs validation (support new tlds, unicode URLs...) [#1182](https://github.com/opendatateam/udata/pull/1182)
-- Properly serialize empty geometries for zones missing it
+- Properly serialize empty geometries for zones missing it and prevent leaflet crash on invalid bounds [#1188](https://github.com/opendatateam/udata/pull/1188)
 
 ## 1.1.8 (2017-09-28)
 

--- a/js/components/leaflet-map.vue
+++ b/js/components/leaflet-map.vue
@@ -57,7 +57,8 @@ export default {
                     }
                 });
                 this.layer.addTo(this.map);
-                this.map.fitBounds(this.layer.getBounds());
+                const bounds = this.layer.getBounds();
+                if (bounds.isValid()) this.map.fitBounds(bounds);
             }
         }
     }

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -28,6 +28,7 @@ BASE_GRANULARITIES = [
 
 ADMIN_LEVEL_MIN = 1
 ADMIN_LEVEL_MAX = 110
+EMPTY_GEOM = {'type': 'MultiPolygon', 'coordinates': []}
 
 
 class GeoLevel(db.Document):
@@ -249,7 +250,7 @@ class GeoZone(db.Document):
         return {
             'id': self.id,
             'type': 'Feature',
-            'geometry': self.geom,
+            'geometry': self.geom or EMPTY_GEOM,
             'properties': {
                 'slug': self.slug,
                 'name': gettext(self.name),

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -44,6 +44,33 @@ class SpatialApiTest(APITestCase):
         self.assertEqual(properties['keys'], zone.keys)
         self.assertEqual(properties['logo'], zone.logo_url(external=True))
 
+    def test_zones_api_no_geom(self):
+        zone = GeoZoneFactory(geom=None)
+
+        url = url_for('api.zones', ids=[zone.id])
+        response = self.get(url)
+        self.assert200(response)
+
+        self.assertEqual(len(response.json['features']), 1)
+
+        feature = response.json['features'][0]
+        self.assertEqual(feature['type'], 'Feature')
+        self.assertJsonEqual(feature['geometry'], {
+            'type': 'MultiPolygon',
+            'coordinates': [],
+        })
+        self.assertEqual(feature['id'], zone.id)
+
+        properties = feature['properties']
+        self.assertEqual(properties['name'], zone.name)
+        self.assertEqual(properties['code'], zone.code)
+        self.assertEqual(properties['level'], zone.level)
+        self.assertEqual(properties['parents'], zone.parents)
+        self.assertEqual(properties['population'], zone.population)
+        self.assertEqual(properties['area'], zone.area)
+        self.assertEqual(properties['keys'], zone.keys)
+        self.assertEqual(properties['logo'], zone.logo_url(external=True))
+
     def test_zones_api_many(self):
         zones = [GeoZoneFactory() for _ in range(3)]
 


### PR DESCRIPTION
This PRs properly serialize geometryless zones into an empty MultiPolygon and prevent leaflet from crashing when computing boundaries.

Fix etalab/udata-gouvfr#221