### PR TITLE
Release local build on feature branches and use global org context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,16 @@ jobs:
           name: Build a distributable package
           command: |
             source venv/bin/activate
-            if [[ $CIRCLE_TAG ]]; then inv pydist; else inv pydist -b $CIRCLE_BUILD_NUM; fi
+            if [[ $CIRCLE_TAG ]]; then
+                # This is a tagged release
+                inv pydist
+            elif [[ "$CIRCLE_BRANCH" == feature/* ]]; then
+                # This is a feature branch
+                inv pydist -b $CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}
+            else
+                # This is a simple development build
+                inv pydist -b $CIRCLE_BUILD_NUM
+            fi
       - store_artifacts:
           path: dist
       - persist_to_workspace:
@@ -169,5 +178,7 @@ workflows:
                 - master
                 - dev
                 - /v[0-9]+(\.[0-9]+)*/
+                - /feature\/.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          context: org-global

--- a/docs/versionning.md
+++ b/docs/versionning.md
@@ -94,6 +94,15 @@ git commit
 git push -u myrepository my-fix
 ```
 
+## Feature branches
+
+Sometimes a new feature or an EPIC requires more than one pull request and a lot of testing.
+For these cases, it's not desirable to use the `master` branch to test until it's stable because we want to keep the `master` branch as stable as possible.
+
+To handle these cases we are using feature branches, named like `feature/my-feature`. These branches will build on CircleCI and publish [local versions](pep440-local) packages on PyPI.
+
+The local identifier will be the feature branch name so the version number will be `X.Y.Z.devBBB+my-feature` where `BBB` is the build number.
+
 ## Deprecation policy
 
 **When it's possible** deprecation are signaled 2 minor versions before being really dropped.
@@ -107,3 +116,4 @@ It's up to the developpers and system administrators to read the [changelog](cha
 [milestones]: https://github.com/opendatateam/udata/milestones
 [CircleCI]: https://circleci.com/gh/opendatateam/udata
 [pep440]: https://www.python.org/dev/peps/pep-0440/
+[pep440-local]: https://www.python.org/dev/peps/pep-0440/#local-version-segments


### PR DESCRIPTION
This PR publish local builds for feature branches, ie. a branch `feature/my-feature` with a `X.Y.Z.dev` version will publish a `udata-X.Y.Z.devBBB+my-feature` where `BBB` is the build number.

This PR also makes use of the `org-global` context during the `publish` step to retrieve PyPI credentials.