### PR TITLE
Ensure setup.py long description renders on packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,9 @@ jobs:
           name: Build a distributable package
           command: |
             source venv/bin/activate
+            # Check long description renders properly
+            python setup.py check -r -s
+            # Build a wheel release
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release
                 inv pydist

--- a/requirements/circleci.pip
+++ b/requirements/circleci.pip
@@ -1,2 +1,3 @@
 -r test.pip
 invoke==0.21.0
+readme-renderer==17.2


### PR DESCRIPTION
This PR ensures that the long description (package details displayed on PyPI) renders properly (ie. Markdown to restructuredtext works and PyPI is able to parse the result)