### PR TITLE
Do not publish anymore development version on PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,11 +177,7 @@ workflows:
             - dist
           filters:
             branches:
-              only:
-                - master
-                - dev
-                - /v[0-9]+(\.[0-9]+)*/
-                - /feature\/.*/
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global

--- a/docs/versionning.md
+++ b/docs/versionning.md
@@ -99,7 +99,7 @@ git push -u myrepository my-fix
 Sometimes a new feature or an EPIC requires more than one pull request and a lot of testing.
 For these cases, it's not desirable to use the `master` branch to test until it's stable because we want to keep the `master` branch as stable as possible.
 
-To handle these cases we are using feature branches, named like `feature/my-feature`. These branches will build on CircleCI and publish [local versions](pep440-local) packages on PyPI.
+To handle these cases we are using feature branches, named like `feature/my-feature`. These branches will build on CircleCI and produce a [local version](pep440-local) package.
 
 The local identifier will be the feature branch name so the version number will be `X.Y.Z.devBBB+my-feature` where `BBB` is the build number.
 


### PR DESCRIPTION
As CircleCI stores build artifacts and they are publicly available and PyPI does not support the publication of local version, this PR deactivate PyPI publication for other builds than tagged builds.