### PR TITLE
Migration to remove void resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improve URLs validation (support new tlds, unicode URLs...) [#1182](https://github.com/opendatateam/udata/pull/1182)
 - Properly serialize empty geometries for zones missing it and prevent leaflet crash on invalid bounds [#1188](https://github.com/opendatateam/udata/pull/1188)
 - Start validating some configuration parameters [#1197](https://github.com/opendatateam/udata/pull/1197)
+- Migration to remove resources without title or url [#1200](https://github.com/opendatateam/udata/pull/1200)
 
 ## 1.1.8 (2017-09-28)
 

--- a/udata/migrations/2017-10-05-purge-void-resources.js
+++ b/udata/migrations/2017-10-05-purge-void-resources.js
@@ -1,0 +1,23 @@
+/*
+ * Remove resources with missing required fields (url or title)
+ */
+
+var nbRemoved = 0;
+
+const removedNoTitle = db.dataset.update(
+    {resources: {$gt: []}},
+    {$pull: {resources: {title: null}}},
+    {multi: true}
+);
+
+nbRemoved += removedNoTitle.nRemoved;
+
+const removedNoURL = db.dataset.update(
+    {resources: {$gt: []}},
+    {$pull: {resources: {url: null}}},
+    {multi: true}
+);
+
+nbRemoved += removedNoURL.nRemoved;
+
+print(`Removed ${nbRemoved} resource(s) without title or URL.`);


### PR DESCRIPTION
Remove resources without `title` or `url` from the DB. On `data.gouv.fr`, this matches:

```
ObjectId("53698e19a3a729239d203399") Fonds stratégique pour le développement de la presse (FSDP) - Aides attribuées
ObjectId("583e801488ee387693c65bb3") SYME05 - Bornes de recharge pour véhicule électrique
```