### PR TITLE
Improve licenses detection in harvesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Properly serialize empty geometries for zones missing it and prevent leaflet crash on invalid bounds [#1188](https://github.com/opendatateam/udata/pull/1188)
 - Start validating some configuration parameters [#1197](https://github.com/opendatateam/udata/pull/1197)
 - Migration to remove resources without title or url [#1200](https://github.com/opendatateam/udata/pull/1200)
+- Improve harvesting licenses detection [#1203](https://github.com/opendatateam/udata/pull/1203)
 
 ## 1.1.8 (2017-09-28)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -372,10 +372,7 @@ def dataset_from_rdf(graph, dataset=None):
             elif isinstance(value, RdfResource):
                 licenses.add(value.identifier.toPython())
 
-    for text in licenses:
-        license = License.guess(text)
-        if license:
-            dataset.license = license
-            break
+    default_license = dataset.license or License.default()
+    dataset.license = License.guess(*licenses, default=default_license)
 
     return dataset

--- a/udata/harvest/backends/ods.py
+++ b/udata/harvest/backends/ods.py
@@ -115,10 +115,12 @@ class OdsHarvester(BaseBackend):
 
         dataset.tags = list(tags)
 
-        ods_license_id = ods_metadata.get('license')
-        if ods_license_id and ods_license_id in self.LICENSES:
-            license_id = self.LICENSES[ods_license_id]
-            dataset.license = License.objects.get(id=license_id)
+        # Detect license
+        default_license = dataset.license or License.default()
+        license_id = ods_metadata.get('license')
+        dataset.license = License.guess(license_id,
+                                        self.LICENSES.get(license_id),
+                                        default=default_license)
 
         dataset.resources = []
 

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -247,6 +247,19 @@ class LicenseModelTest(DBTestMixin, TestCase):
         found = License.guess('should not be found')
         self.assertIsNone(found)
 
+    def test_not_found_with_default(self):
+        license = LicenseFactory()
+        found = License.guess('should not be found', default=license)
+        self.assertEqual(found.id, license.id)
+
+    def test_none(self):
+        found = License.guess(None)
+        self.assertIsNone(found)
+
+    def test_empty_string(self):
+        found = License.guess('')
+        self.assertIsNone(found)
+
     def test_exact_match_by_id(self):
         license = LicenseFactory()
         found = License.guess(license.id)
@@ -292,5 +305,11 @@ class LicenseModelTest(DBTestMixin, TestCase):
     def test_match_by_title_with_mismatching_case(self):
         license = LicenseFactory(title='License ODBl')
         found = License.guess('License ODBL')
+        self.assertIsInstance(found, License)
+        self.assertEqual(license.id, found.id)
+
+    def test_multiple_strings(self):
+        license = LicenseFactory()
+        found = License.guess('should not match', license.id)
         self.assertIsInstance(found, License)
         self.assertEqual(license.id, found.id)


### PR DESCRIPTION
This PRs improve the `Licence.guess()` helper by allowing a list of string and a default fallback license.
It also expose the default license as `License.default()`
All harvesters now use the same algorithm.