### PR TITLE
Point out to udata in feathub

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -15,6 +15,6 @@ Bugs are [reported directly on Github][github-new-issue] following the proposed 
 For daily chat, development discussions and so on we idle on [Gitter][gitter].
 
 [etalab]: https://github.com/etalab
-[feathub]: http://feathub.com/
+[feathub]: https://feathub.com/opendatateam/udata
 [github-new-issue]: https://github.com/opendatateam/udata/issues/new
 [gitter]: https://gitter.im/opendatateam/udata


### PR DESCRIPTION
It'd be more straightforward to point out to the udata's entry in feathub rather than to http://feathub.com.
(it works both with and without being logged in from github)