### PR TITLE
(Tentative) fix for comment duplication - fix #1041

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@
 - Improve URLs validation (support new tlds, unicode URLs...) [#1182](https://github.com/opendatateam/udata/pull/1182)
 - Properly serialize empty geometries for zones missing it and prevent leaflet crash on invalid bounds [#1188](https://github.com/opendatateam/udata/pull/1188)
 - Start validating some configuration parameters [#1197](https://github.com/opendatateam/udata/pull/1197)
-- Migration to remove resources without title or url [#1200](https://github.com/opendatateam/udata/pull/1200)
+- Remove resources without title or url [migration] [#1200](https://github.com/opendatateam/udata/pull/1200)
 - Improve harvesting licenses detection [#1203](https://github.com/opendatateam/udata/pull/1203)
 - Added missing delete post and topic admin actions [#1202](https://github.com/opendatateam/udata/pull/1202)
 - Switch from static theme avatars/placeholders to [identicons](https://en.wikipedia.org/wiki/Identicon) for readability (mostly on discussions) [#1193](https://github.com/opendatateam/udata/pull/1193)
 - Fix the scroll to a discussion sub-thread [#1206](https://github.com/opendatateam/udata/pull/1206)
+- Fix duplication in discussions [migration] [#1209](https://github.com/opendatateam/udata/pull/1209)
 
 ## 1.1.8 (2017-09-28)
 

--- a/js/components/discussions/thread-form.vue
+++ b/js/components/discussions/thread-form.vue
@@ -1,10 +1,10 @@
 <template>
-<form role="form" class="clearfix animated" @submit.prevent="submit">
+<form role="form" class="clearfix animated" @submit.prevent @submit="submit">
     <div class="form-group">
         <label for="comment-new-message">{{ _('Comment') }}</label>
         <textarea v-el:textarea id="comment-new-message" v-model="comment" class="form-control" rows="3" required></textarea>
     </div>
-    <button @click="submit" :disabled="this.sending || !this.comment" class="btn btn-primary btn-block pull-right submit-new-message">
+    <button type="submit" :disabled="this.sending || !this.comment" class="btn btn-primary btn-block pull-right submit-new-message">
         {{ _('Submit your comment') }}
     </button>
 </form>

--- a/js/components/discussions/thread-form.vue
+++ b/js/components/discussions/thread-form.vue
@@ -1,5 +1,5 @@
 <template>
-<form role="form" class="clearfix animated" @submit.prevent @submit="submit">
+<form role="form" class="clearfix animated" @submit.prevent="submit">
     <div class="form-group">
         <label for="comment-new-message">{{ _('Comment') }}</label>
         <textarea v-el:textarea id="comment-new-message" v-model="comment" class="form-control" rows="3" required></textarea>

--- a/udata/migrations/2017-10-11-deduplicate-discussions.js
+++ b/udata/migrations/2017-10-11-deduplicate-discussions.js
@@ -1,0 +1,62 @@
+/*
+ * Deduplicate discussions by content, dataset and author.
+ */
+
+var nbTopLevelRemoved = 0;
+var nbNestedRemoved = 0;
+
+function getUniqueAnswers(answers) {
+    var uniqueAnswers = [];
+    answers.forEach(answer => {
+        const existing = uniqueAnswers.find(uAnswer => {
+            return answer.posted_by.toString() === uAnswer.posted_by.toString()
+                && answer.content === uAnswer.content;
+        });
+        if (!existing) uniqueAnswers.push(answer);
+    });
+    return uniqueAnswers;
+}
+
+// Remove duplicate top level discussions
+// And re-assing non duplicated answers if any
+db.discussion.aggregate([
+    {$group: {
+        _id: {author: '$user', subject: '$subject', title: '$title'},
+        ids: {$addToSet: '$_id'},
+        count: {$sum: 1}
+    }},
+    {$match: {count: {$gt: 1}}},
+]).forEach(row => {
+    const discussions = db.discussion.find({_id: {$in: row.ids}});
+    const answers = discussions.toArray().reduce((acc, disc) => {
+        return acc.concat(disc.discussion);
+    }, []);
+    var uniqueAnswers = getUniqueAnswers(answers);
+    discussions[0].discussion = uniqueAnswers;
+    db.discussion.save(discussions[0]);
+    discussions.toArray().slice(1).forEach(discussion => {
+        nbTopLevelRemoved += 1;
+        db.discussion.remove({_id: discussion._id});
+    });
+});
+
+print(`${nbTopLevelRemoved} top level discussion(s) removed.`);
+
+// Remove duplicate nested comments
+db.discussion.aggregate([
+    {$unwind: '$discussion'},
+    {$group: {
+        _id: {author: '$user', subject: '$subject', title: '$title', content: '$discussion.content'},
+        ids: {$addToSet: '$_id'},
+        count: {$sum: 1}
+    }},
+    {$match: {count: {$gt: 1}}},
+]).forEach(row => {
+    discussion = db.discussion.find({_id: row.ids[0]})[0];
+    const uniqueAnswers = getUniqueAnswers(discussion.discussion);
+    nbNestedRemoved += (discussion.discussion.length - uniqueAnswers.length);
+    discussion.discussion = uniqueAnswers;
+    db.discussion.save(discussion);
+});
+
+print(`${nbNestedRemoved} nested level discussion(s) removed.`);

--- a/udata/migrations/2017-10-11-deduplicate-discussions.js
+++ b/udata/migrations/2017-10-11-deduplicate-discussions.js
@@ -1,5 +1,5 @@
 /*
- * Deduplicate discussions by content, dataset and author.
+ * Deduplicate discussions by content, subject and author.
  */
 
 var nbTopLevelRemoved = 0;
@@ -18,7 +18,7 @@ function getUniqueAnswers(answers) {
 }
 
 // Remove duplicate top level discussions
-// And re-assing non duplicated answers if any
+// And re-assign non duplicated answers if any
 db.discussion.aggregate([
     {$group: {
         _id: {author: '$user', subject: '$subject', title: '$title'},


### PR DESCRIPTION
Resolution steps:
- remove the `:disabled="this.sending || !this.comment"` for testing
- realize that the POST request is sent twice even with a single click
- fix this by removing the extraneous submit method on the button (the one on the form is enough)
- re-add the `:disabled="this.sending || !this.comment"`

There is also a migration to remove the existing duplicates. Please review this carefully ⚠️.