### PR TITLE
Fix datasets which temporal coverage was reversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix duplication in discussions [migration] [#1209](https://github.com/opendatateam/udata/pull/1209)
 - Explicit dataset search reuse facet context (only known reuses) [#1219](https://github.com/opendatateam/udata/pull/1219)
 - Optimize indexation a little bit [#1215](https://github.com/opendatateam/udata/pull/1215)
+- Fix some reversed temporal coverage [migration] [#1214](https://github.com/opendatateam/udata/pull/1214)
 
 ## 1.1.8 (2017-09-28)
 

--- a/udata/migrations/2017-10-16-fix-switched-temporal-coverage.js
+++ b/udata/migrations/2017-10-16-fix-switched-temporal-coverage.js
@@ -1,0 +1,17 @@
+/*
+ * Ensure all datasets have positive temporal coverage
+ */
+
+var modified = 0;
+
+db.dataset.aggregate([
+     {$project: {_id: true, temporal_coverage: true, reversed: {$cmp: ['$temporal_coverage.start','$temporal_coverage.end']}}},
+     {$match: {reversed:  1}}
+]).forEach(function({_id, temporal_coverage}) {
+    modified += db.dataset.update({_id}, {$set: {temporal_coverage: {
+        start: temporal_coverage.end,
+        end: temporal_coverage.start
+    }}}).nModified;
+});
+
+print(`${modified} datasets had reserved temporal coverage.`);


### PR DESCRIPTION
This PRs fix some datasets that weren't indexed because temporal coverage `start` and `end` where switched