### PR TITLE
Optimize indexation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix the scroll to a discussion sub-thread [#1206](https://github.com/opendatateam/udata/pull/1206)
 - Fix duplication in discussions [migration] [#1209](https://github.com/opendatateam/udata/pull/1209)
 - Explicit dataset search reuse facet context (only known reuses) [#1219](https://github.com/opendatateam/udata/pull/1219)
+- Optimize indexation a little bit [#1215](https://github.com/opendatateam/udata/pull/1215)
 
 ## 1.1.8 (2017-09-28)
 

--- a/udata/core/reuse/search.py
+++ b/udata/core/reuse/search.py
@@ -134,13 +134,20 @@ class ReuseSearch(ModelSearchAdapter):
 
         and exclude ``_id``, ``_cls`` and ``owner`` fields.
         """
+        datasets = Dataset.objects(id__in=[r.id for r in reuse.datasets])
+        datasets = list(datasets.only('id', 'title').no_dereference())
+        organization = None
+        owner = None
+        if reuse.organization:
+            organization = Organization.objects(id=reuse.organization.id).first()
+        elif reuse.owner:
+            owner = User.objects(id=reuse.owner.id).first()
         return {
             'title': reuse.title,
             'description': reuse.description,
             'url': reuse.url,
-            'organization': (str(reuse.organization.id)
-                             if reuse.organization else None),
-            'owner': str(reuse.owner.id) if reuse.owner else None,
+            'organization': str(organization.id) if organization else None,
+            'owner': str(owner.id) if owner else None,
             'type': reuse.type,
             'tags': reuse.tags,
             'tag_suggest': reuse.tags,
@@ -150,7 +157,7 @@ class ReuseSearch(ModelSearchAdapter):
             'dataset': [{
                 'id': str(d.id),
                 'title': d.title
-            } for d in reuse.datasets if isinstance(d, Dataset)],
+            } for d in datasets],
             'metrics': reuse.metrics,
             'featured': reuse.featured,
             'extras': reuse.extras,

--- a/udata/core/user/search.py
+++ b/udata/core/user/search.py
@@ -35,7 +35,6 @@ class UserSearch(ModelSearchAdapter):
     user_suggest = Completion(analyzer=simple,
                               search_analyzer=simple,
                               payloads=True)
-    roles = String(index='not_analyzed')
 
     fields = (
         'last_name^6',
@@ -99,5 +98,4 @@ class UserSearch(ModelSearchAdapter):
                 },
             },
             'visible': user.visible,
-            'roles': [role.name for role in user.roles],
         }

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -44,11 +44,11 @@ def index_model(index_name, adapter):
         qs = qs.visible()
     if adapter.exclude_fields:
         qs = qs.exclude(*adapter.exclude_fields)
-    for obj in qs.timeout(False):
+    for obj in qs.no_dereference().timeout(False):
         if adapter.is_indexable(obj):
             try:
-                adapter = adapter.from_model(obj)
-                adapter.save(using=es.client, index=index_name)
+                doc = adapter.from_model(obj)
+                doc.save(using=es.client, index=index_name)
             except:
                 log.exception('Unable to index %s "%s"',
                               model.__name__, str(obj.id))


### PR DESCRIPTION
This PR optimize indexation by:
- removing some field that weren't in use (ex: `user.role`)
- turning off the automatic derefencing while iterating over objects to only fetch what's necessary