### PR TITLE
Remove ignored domains from linkchecker front

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -70,11 +70,6 @@ export const csrf_token = _meta('csrf-token');
 export const check_urls = _jsonMeta('check-urls');
 
 /**
- * List of ignored domain for url check
- */
-export const check_urls_ignore = _jsonMeta('check-urls-ignore');
-
-/**
  * The API root/base URL
  */
 export const api_root = _meta('api-root');
@@ -173,7 +168,6 @@ export default {
     auth_url,
     sentry,
     check_urls,
-    check_urls_ignore,
     is_territory_enabled,
     is_delete_me_enabled,
     hidpi,

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -34,16 +34,10 @@ new Vue({
         LeafletMap, DiscussionThreads, FeaturedButton, IntegrateButton, IssuesButton, ShareButton, FollowButton
     },
     data() {
-        const data = {
+        return {
             dataset: this.extractDataset(),
             userReuses: []
         };
-        if (config.check_urls) {
-            const port = location.port ? `:${location.port}` : '';
-            const domain = `${location.hostname}${port}`;
-            data.ignore = [domain].concat(config.check_urls_ignore || []);
-        }
-        return data;
     },
     ready() {
         this.loadCoverageMap();
@@ -155,29 +149,27 @@ new Vue({
             const resource_el = document.querySelector(`#resource-${resource['@id']}`);
             const el = resource_el.querySelector('.format-label');
             const checkurl = resource_el.dataset.checkurl;
-            if (!this.ignore.some(domain => url.origin.endsWith(domain))) {
-                if (url.protocol.startsWith('ftp')) {
-                    el.classList.add('format-label-warning');
-                    el.setTooltip(this._('The server may be hard to reach (FTP).'), true);
-                } else {
-                    this.$api.get(checkurl)
-                    .then((res) => {
-                        const status = res['check:status'];
-                        if (status >= 200 && status < 400) {
-                            el.classList.add('format-label-success')
-                        } else if (status >= 400 && status < 500) {
-                            el.classList.add('format-label-danger');
-                            el.setTooltip(this._('The resource cannot be found.'), true);
-                        } else if (status >= 500) {
-                            el.classList.add('format-label-warning');
-                            el.setTooltip(this._('An error occured on the remote server. This may be temporary.'), true);
-                        }
-                    })
-                    .catch(error => {
-                        el.classList.add('format-label-unchecked');
-                        console.log('Something went wrong with the linkchecker', error);
-                    });
-                }
+            if (url.protocol.startsWith('ftp')) {
+                el.classList.add('format-label-warning');
+                el.setTooltip(this._('The server may be hard to reach (FTP).'), true);
+            } else {
+                this.$api.get(checkurl)
+                .then((res) => {
+                    const status = res['check:status'];
+                    if (status >= 200 && status < 400) {
+                        el.classList.add('format-label-success')
+                    } else if (status >= 400 && status < 500) {
+                        el.classList.add('format-label-danger');
+                        el.setTooltip(this._('The resource cannot be found.'), true);
+                    } else if (status >= 500) {
+                        el.classList.add('format-label-warning');
+                        el.setTooltip(this._('An error occured on the remote server. This may be temporary.'), true);
+                    }
+                })
+                .catch(error => {
+                    el.classList.add('format-label-unchecked');
+                    console.log('Something went wrong with the linkchecker', error);
+                });
             }
         },
 

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -47,7 +47,6 @@
 {% endif %}
 
 <meta name="check-urls" content="{{ config.LINKCHECKING_ENABLED|tojson }}" />
-<meta name="check-urls-ignore" content="{{ config.LINKCHECKING_IGNORE_DOMAINS|tojson|urlencode }}" />
 <meta name="territory-enabled" content="{{ 'true' if config.ACTIVATE_TERRITORIES else 'false' }}">
 
 <meta name="delete-me-enabled" content="{{ 'true' if config.DELETE_ME else 'false' }}">


### PR DESCRIPTION
As from this PR, there will always be a request to the link checker API for reach resource. But the `LINKCHECKING_IGNORE_DOMAINS` won't trigger any real link checking if the domain is in it and will always consider the resource as available.