### PR TITLE
Optimize reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Introduce `udata search index` commmand to replace both deprecated `udata search init` and `udata search reindex` commands. They will be removed in udata 1.4. [#1233](https://github.com/opendatateam/udata/pull/1233)
 
 ## 1.2.0 (2017-10-20)
 

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -114,3 +114,41 @@ $ udata job run job-name -a arg1 arg2 -k key1=value key2=value
 **Note**: this is a low level command.
 Most of the time, you won't need it because there will be a dedicated command
 to perform the task you need.
+
+
+## Reindexing data
+
+Sometimes, you need to reindex data (in case of model breaking changes, workers defect...).
+You can use the `udata search index` command to do so.
+
+This command supports both full reindex without arguments and partial with model names as arguments:
+
+```shell
+# Reindex everything
+udata search index
+# Only reindex reuses and organizations
+udata search index reuses organizations
+```
+
+By default the command deletes the previous index in case of success or the new unfinished index in case of error but you can ask to keep indexes with the `-k/--keep` parameter
+
+```shell
+# Reindex everything but keep the old index
+udata search index -k
+```
+
+When used from an interactive terminal the command also prompt for deletion confirmation if an index with the same name already exists. This can be bypassed with the `-f/--force` parameter.
+
+```shell
+# Reindex everything and delete old index
+udata search index -f
+```
+
+It's possible to do a partial reindex by providing models (both singular and plural are supported) as arguments:
+
+```shell
+# Only reindex datasets and reuses (plural form)
+udata search index datasets reuses
+# Only reindex datasets and reuses (singular form)
+udata search index dataset reuse
+```

--- a/udata/commands/init.py
+++ b/udata/commands/init.py
@@ -9,7 +9,7 @@ from udata.commands import manager, IS_INTERACTIVE, green
 from udata.core.dataset.commands import licenses
 from udata.core.user import commands as user_commands
 from udata.i18n import lazy_gettext as _
-from udata.search.commands import init as init_search
+from udata.search.commands import index
 
 from .db import migrate
 from .fixtures import generate_fixtures
@@ -24,7 +24,7 @@ def init():
     log.info('Apply DB migrations if needed')
     migrate(record=True)
 
-    init_search(delete=True, force=not IS_INTERACTIVE)
+    index()
 
     if IS_INTERACTIVE:
         text = _('Do you want to create a superadmin user?')

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -8,10 +8,10 @@ import signal
 from contextlib import contextmanager
 from datetime import datetime
 
+from flask import current_app
 from flask_script import prompt_bool
-from flask_script.commands import InvalidCommand
 
-from udata.commands import submanager
+from udata.commands import submanager, IS_INTERACTIVE
 from udata.search import es, adapter_catalog
 
 
@@ -26,6 +26,8 @@ m = submanager(
 )
 
 TIMESTAMP_FORMAT = '%Y-%m-%d-%H-%M'
+
+DEPRECATION_MSG = '{cmd} command will be removed in udata 1.4, use index command instead'
 
 
 def default_index_name():
@@ -48,7 +50,7 @@ def iter_qs(qs, adapter):
 
 
 def iter_for_index(docs, index_name):
-    '''Iter over ES documents ensuring a given index'''
+    '''Iterate over ES documents ensuring a given index'''
     for doc in docs:
         doc['_index'] = index_name
         yield doc
@@ -88,14 +90,13 @@ def disable_refresh(index_name):
 
 def enable_refresh(index_name):
     '''
-    Enable refresh after indexing and force merge
+    Enable refresh and force merge. To be used after indexing.
 
     See: https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html#bulk
     '''  # noqa
+    refresh_interval = current_app.config['ELASTICSEARCH_REFRESH_INTERVAL']
     es.indices.put_settings(index=index_name, body={
-        'index': {
-            'refresh_interval': '1s'
-        }
+        'index': {'refresh_interval': refresh_interval}
     })
     es.indices.forcemerge(index=index_name)
 
@@ -135,6 +136,7 @@ def handle_error(index_name, keep=False):
     try:
         yield
     except KeyboardInterrupt:
+        print('')  # Proper warning message under the "^C" display
         log.warning('Interrupted by signal')
     except Exception as e:
         log.error(e)
@@ -144,46 +146,12 @@ def handle_error(index_name, keep=False):
     sys.exit(-1)
 
 
-@m.option(dest='models', nargs='+', metavar='model',
-          help='Model to reindex')
-@m.option('-k', '--keep', default=False, action='store_true',
-          help='Keep index in case of error')
-def reindex(models, keep=False):
-    '''Reindex models'''
-    doc_types_names = [m.__name__.lower() for m in adapter_catalog.keys()]
-    models = [model.lower().rstrip('s') for model in models]
-    for model in models:
-        if model not in doc_types_names:
-            log.error('Unknown model %s', model)
-            sys.exit(-1)
-
-    index_name = default_index_name()
-    log.info('Initiliazing index "{0}"'.format(index_name))
-    es.initialize(index_name)
-    disable_refresh(index_name)
-    with handle_error(index_name, keep):
-        for adapter in iter_adapters():
-            if adapter.doc_type().lower() in models:
-                index_model(index_name, adapter)
-            else:
-                log.info('Copying {0} objects to the new index'.format(
-                         adapter.model.__name__))
-                # Need upgrade to Elasticsearch-py 5.0.0
-                # es.reindex({
-                #     'source': {'index': es.index_name, 'type': adapter.doc_type()},
-                #     'dest': {'index': index_name}
-                # })
-                # http://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.reindex
-                # This method (introduced in Elasticsearch 2.3 but only in Elasticsearch-py 5.0.0)
-                # triggers a server-side documents copy.
-                # Instead we use this helper for meant for backward compatibility
-                # but with poor performance as copy is client-side (scan+bulk)
-                es_reindex(es.client, es.index_name, index_name, scan_kwargs={
-                    'doc_type': adapter.doc_type()
-                })
-
-    enable_refresh(index_name)
-    set_alias(index_name)
+@m.option('-t', '--type', dest='doc_type', required=True,
+          help='Only reindex a given type')
+def reindex(doc_type):
+    '''[DEPRECATED] Reindex models'''
+    log.warn(DEPRECATION_MSG.format(cmd='reindex'))
+    index([doc_type], force=True, keep=False)
 
 
 @m.option('-n', '--name', default=None, help='Optionnal index name')
@@ -194,22 +162,66 @@ def reindex(models, keep=False):
 @m.option('-k', '--keep', default=False, action='store_true',
           help='Keep index in case of error')
 def init(name=None, delete=False, force=False, keep=False):
+    '''[DEPRECATED] Initialize or rebuild the search index'''
+    log.warn(DEPRECATION_MSG.format(cmd='init'))
+    index(name=name, force=force, keep=not delete)
+
+
+@m.option(dest='models', nargs='*', metavar='model',
+          help='Model to reindex')
+@m.option('-n', '--name', default=None, help='Optionnal index name')
+@m.option('-f', '--force', default=False, action='store_true',
+          help='Do not prompt on deletion')
+@m.option('-k', '--keep', default=False, action='store_true',
+          help='Do not delete indexes')
+def index(models=None, name=None, force=False, keep=False):
     '''Initialize or rebuild the search index'''
     index_name = name or default_index_name()
+
+    doc_types_names = [m.__name__.lower() for m in adapter_catalog.keys()]
+    models = [model.lower().rstrip('s') for model in (models or [])]
+    for model in models:
+        if model not in doc_types_names:
+            log.error('Unknown model %s', model)
+            sys.exit(-1)
+
     log.info('Initiliazing index "{0}"'.format(index_name))
     if es.indices.exists(index_name):
-        if force or prompt_bool(('Index {0} will be deleted, are you sure ?'
-                                 .format(index_name))):
+        if IS_INTERACTIVE and not force:
+            msg = 'Index {0} will be deleted, are you sure?'
+            delete = prompt_bool(msg.format(index_name))
+        else:
+            delete = True
+        if delete:
             es.indices.delete(index_name)
         else:
             sys.exit(-1)
 
     es.initialize(index_name)
-    disable_refresh(index_name)
 
     with handle_error(index_name, keep):
+
+        disable_refresh(index_name)
         for adapter in iter_adapters():
-            index_model(index_name, adapter)
+            if not models or adapter.doc_type().lower() in models:
+                index_model(index_name, adapter)
+            else:
+                log.info('Copying {0} objects to the new index'.format(
+                         adapter.model.__name__))
+                # Need upgrade to Elasticsearch-py 5.0.0 to write:
+                # es.reindex({
+                #     'source': {'index': es.index_name, 'type': adapter.doc_type()},
+                #     'dest': {'index': index_name}
+                # })
+                #
+                # http://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.reindex
+                # This method (introduced in Elasticsearch 2.3 but only in Elasticsearch-py 5.0.0)
+                # triggers a server-side documents copy.
+                # Instead we use this helper for meant for backward compatibility
+                # but with poor performance as copy is client-side (scan+bulk)
+                es_reindex(es.client, es.index_name, index_name, scan_kwargs={
+                    'doc_type': adapter.doc_type()
+                })
 
     enable_refresh(index_name)
-    set_alias(index_name, delete=delete)
+    set_alias(index_name, delete=not keep)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -23,6 +23,7 @@ class Defaults(object):
     # Elasticsearch configuration
     ELASTICSEARCH_URL = 'localhost:9200'
     ELASTICSEARCH_INDEX_BASENAME = 'udata'
+    ELASTICSEARCH_REFRESH_INTERVAL = '1s'
 
     # BROKER_TRANSPORT = 'redis'
     CELERY_BROKER_URL = 'redis://localhost:6379'


### PR DESCRIPTION
This PR brings a huge performance improvement on reindexing as well as improved errors handling and a more flexible and unique `index` command.

## A single command

Both commands (`search init` and `search reindex`) have been merged into a single `search index` command.
This command is more flexible (models as variable arguments, plural or singular, delete obselete index by default...) and more powerful (allows to reindex multiple models in a single pass).

Previous commands still exists but will show a deprecation warning when used.

```shell
udata search init -df
WARNING: reindex command will be removed in udata 1.4, use index command instead
-> Initiliazing index "udata-prod-2017-10-21-15-52"
```

According to [deprecation policy](http://udata.readthedocs.io/en/stable/versionning/#deprecation-policy) removal should be in udata 1.4 (An issue should be created).

### Full reindexing

Simply execute the command without arguments

```
# Index deletion with user confirmation prompt
udata search index
# No confirmation prompt on deletion
udata search index -f
# Previous index deleted (or unfinished one on error)
udata search index -k
```

### Partial reindex

Models are now simple arguments instead of the `-t` option from the previous `search reindex` command.

This means that to only reindex reuses and organizations you can do it in a single pass with:

```shell
udata search index reuse organization
```

instead of two passes before:

```shell
udata search reindex -t reuse
udata search reindex -t organization
```

The command also accept plural forms as it is a common error:

```shell
udata search index datasets
```

## Performances

Performance improvements comes from following [Tune for indexing speed guide](https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html) and the [bulk indexing section from the Update settings documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html#bulk).

**Consequences:**
- indexation is way faster
- resources consumption on the Elasticsearch side (both CPU and RAM) remains low (and way lower than before) during the whole reindexing


### Before

```shell
time udata search init -df
-> Initiliazing index "udata-prod-2017-10-21-15-59"
-> Indexing Dataset objects
-> Indexing GeoZone objects
-> Indexing Organization objects
-> Indexing Reuse objects
-> Indexing User objects
-> Creating alias "udata-prod" on index "udata-prod-2017-10-21-15-59"

real	23m28,467s
user	11m39,063s
sys	0m24,022s
```

### After

```shell
time udata search init
-> Initiliazing index "udata-prod-2017-10-21-13-41"
-> Indexing Dataset objects
-> Indexing GeoZone objects
-> Indexing Organization objects
-> Indexing Reuse objects
-> Indexing User objects
-> Creating alias "udata-prod" on index "udata-prod-2017-10-21-13-41"

real	6m20,919s
user	4m56,989s
sys	0m6,892s
```

## Error handling

This PR improves error handling on indexation. No more ugly stacktrace, only the errors details (which where not displayed before by the way).
Now, both commands also properly handle kill signals and keyboard interrupt.

In case of error, the unfinished index is now properly deleted and so avoid having a lots of unfinished indexes (consuming ES memory).

```shell
-> Initiliazing index "udata-prod-2017-10-21-15-52"
-> Indexing Dataset objects
^C
WARNING: Interrupted by signal
-> Removing index udata-prod-2017-10-21-15-52
```

For debugging purpose, you can keep the unfinished index with the `-k/--keep` parameter.


## Documentation

At last, the `search index` command is now documented in the "Administrative tasks" section.
