### PR TITLE
Cleanup resources checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Introduce `udata search index` commmand to replace both deprecated `udata search init` and `udata search reindex` commands. They will be removed in udata 1.4. [#1233](https://github.com/opendatateam/udata/pull/1233)
 - Rollback oauthlib from 2.0.5 to 2.0.2, pending a permanent solution [#1237](https://github.com/opendatateam/udata/pull/1237)
 - Get cached linkchecker result before hitting API [#1235](https://github.com/opendatateam/udata/pull/1235)
+- Cleanup resources checksum [migration] [#1239](https://github.com/opendatateam/udata/pull/1239)
 
 ## 1.2.0 (2017-10-20)
 

--- a/udata/migrations/2017-10-24-cleanup-resources-checksum.js
+++ b/udata/migrations/2017-10-24-cleanup-resources-checksum.js
@@ -1,0 +1,20 @@
+/*
+ * Remove checksum from resources where it has no value
+ */
+
+var nbCleaned = 0;
+
+db.dataset.find({
+    'resources.checksum': {$exists: true},
+    'resources.checksum.value': {$exists: false},
+}).forEach(dataset => {
+    dataset.resources.forEach(resource => {
+        if (resource.checksum && !resource.checksum.value) {
+            delete resource.checksum;
+            nbCleaned++;
+        }
+    });
+    db.dataset.save(dataset);
+});
+
+print(`Cleaned ${nbCleaned} resource(s) with an unvalid checksum field.`);


### PR DESCRIPTION
Some resources (5 on my local copy of the prod DB) have a `checksum` field with a `type` but without `value`. This results in errors such as https://sentry.data.gouv.fr/etalab/www-datagouvfr/issues/137603/ when saving a resource or dataset.

This migration removes the faulty `checksum` fields.