### PR TITLE
Check only the uncollapsed resources at first on dataset view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Check only the uncollapsed resources at first on dataset view [#1246](https://github.com/opendatateam/udata/pull/1246)
 
 ## 1.2.2 (2017-10-26)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -396,6 +396,14 @@ Whether or not discussions should be enabled on posts
 
 The default page size for post listing
 
+## Datasets configuration
+
+### DATASET_MAX_RESOURCES_UNCOLLAPSED
+
+**default** `6`
+
+Max number of resources to display uncollapsed in dataset view.
+
 
 ## Example configuration file
 

--- a/js/config.js
+++ b/js/config.js
@@ -158,6 +158,11 @@ export const tiles_config = {subdomains: 'abcd', attribution: tiles_attributions
  */
 export const tags = {MIN_LENGTH: 3, MAX_LENGTH: 32};
 
+/**
+ * Max number of resources to display uncollapsed in dataset view
+ */
+export const dataset_max_resources_uncollapsed = _jsonMeta('dataset-max-resources-uncollapsed');
+
 
 export default {
     user,
@@ -181,4 +186,5 @@ export default {
     tiles_attributions,
     tiles_url,
     tiles_config,
+    dataset_max_resources_uncollapsed,
 };

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -87,6 +87,7 @@ new Vue({
             new Velocity(e.target, {height: 0, opacity: 0}, {complete(els) {
                 els[0].remove();
             }});
+            this.checkResourcesCollapsed();
         },
 
         /**
@@ -139,11 +140,24 @@ new Vue({
         },
 
         /**
-         * Asynchronously check all resources status
+         * Asynchronously check non-collapsed resources status
          */
         checkResources() {
             if (config.check_urls) {
-                this.dataset.resources.forEach(this.checkResource);
+                this.dataset.resources
+                    .slice(0, config.dataset_max_resources_uncollapsed)
+                    .forEach(this.checkResource);
+            }
+        },
+
+        /**
+         * Asynchronously check collapsed resources status
+         */
+        checkResourcesCollapsed() {
+            if (config.check_urls) {
+                this.dataset.resources
+                    .slice(config.dataset_max_resources_uncollapsed)
+                    .forEach(this.checkResource);
             }
         },
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -237,6 +237,11 @@ class Defaults(object):
     # Default pagination size on listing
     POST_DEFAULT_PAGINATION = 20
 
+    # Dataset settings
+    ###########################################################################
+    # Max number of resources to display uncollapsed in dataset view
+    DATASET_MAX_RESOURCES_UNCOLLAPSED = 6
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -86,8 +86,7 @@
                 <div class="list-group resources-list">
                     <h3>{{ _('Resources') }}</h3>
 
-                    {# TODO: extract max_resources conf #}
-                    {% set max_resources = 6 %}
+                    {% set max_resources = config.DATASET_MAX_RESOURCES_UNCOLLAPSED %}
                     {% for resource in dataset.resources %}
                         {% if loop.index0 == max_resources %}
                         <div id="collapsed-resources" class="collapse">

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -49,8 +49,8 @@
 <meta name="check-urls" content="{{ config.LINKCHECKING_ENABLED|tojson }}" />
 <meta name="check-urls-cache-duration" content="{{ config.LINKCHECKING_CACHE_DURATION }}" />
 <meta name="territory-enabled" content="{{ 'true' if config.ACTIVATE_TERRITORIES else 'false' }}">
-
 <meta name="delete-me-enabled" content="{{ 'true' if config.DELETE_ME else 'false' }}">
+<meta name="dataset-max-resources-uncollapsed" content="{{ config.DATASET_MAX_RESOURCES_UNCOLLAPSED }}">
 
 {% if json_ld %}
 <script id="json_ld" type="application/ld+json">{{ json_ld|safe }}</script>


### PR DESCRIPTION
This PR ensures only the uncollapsed resources are link checked, until "show all resources" button is clicked.

Could probably be done a little better in a future version: only restrain from triggering uncached checks, not all checks. The gain would be minimal though, since all the resources on the same dataset tend to have the same `check:date`.