### PR TITLE
Fix flask_security celery tasks context - fix #1247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix flask_security celery tasks context [#1249](https://github.com/opendatateam/udata/pull/1249)
 
 ## 1.2.3 (2017-10-27)
 

--- a/udata/app.py
+++ b/udata/app.py
@@ -182,7 +182,6 @@ def init_logging(app):
 
 
 def register_extensions(app):
-    from . import patch_flask_security  # noqa
     from udata import (
         models, routing, tasks, mail, i18n, auth, theme, search, sitemap,
         sentry
@@ -200,6 +199,7 @@ def register_extensions(app):
     search.init_app(app)
     sitemap.init_app(app)
     sentry.init_app(app)
+    from . import patch_flask_security  # noqa
     return app
 
 


### PR DESCRIPTION
`patch_flask_security` import need to be done after `tasks.init_app` so that the Celery configuration is taken into account. 

#1247 was caused by the config `task_serializer` being `json` by default in Celery 4 and our own configuration (set to `pickle`) not taken into account on `flask-security` tasks.