### PR TITLE
Sidebar improvements: use list for tags and button for profile view

### DIFF
--- a/less/udata/panels.less
+++ b/less/udata/panels.less
@@ -2,3 +2,14 @@
     background: rgba(255, 255, 255, 0.1);
     border: none;
 }
+
+.panel-body {
+    .tags {
+        .list-inline;
+            margin-left: 0;
+
+            > li {
+                padding: 0
+            }
+        }
+}

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -267,21 +267,25 @@
                             {% endif %}
                         </ul>
 
-                        <div class="tags">
+                        <ul class="tags">
                             {% for tag in dataset.tags %}
-                            <a href="{{ url_for('search.index', tag=tag) }}"
-                                class="btn btn-primary btn-grey btn-xs"
+                            <li>
+                                <a href="{{ url_for('search.index', tag=tag) }}"
+                                class="label label-default"
                                 title="{{ tag }}">
-                                {{ tag|truncate(14, True) }}
-                            </a>
+                                    {{ tag|truncate(14, True) }}
+                                </a>
+                            </li>
                             {% endfor %}
-                            <a @click="suggestTag"
-                                class="btn btn-primary btn-dark btn-xs suggest-tag"
-                                title="{{ _('Suggest a tag with a new discussion thread') }}"
-                                v-tooltip tooltip-placement="right">
-                                {{ _('Suggest a tag') }}
-                            </a>
-                        </div>
+                            <li>
+                                <a @click="suggestTag"
+                                    class="label label-primary suggest-tag"
+                                    title="{{ _('Suggest a tag with a new discussion thread') }}"
+                                    v-tooltip tooltip-placement="right">
+                                    {{ _('Suggest a tag') }}
+                                </a>
+                            </li>
+                        </ul>
 
                         <button type="button" @click="showDetails"
                             class="btn btn-primary btn-extras btn-block btn-sm btn-left"

--- a/udata/templates/organization/sidebar-producer.html
+++ b/udata/templates/organization/sidebar-producer.html
@@ -7,13 +7,15 @@
 {% if organization.description %}
 <p>
     {{ organization.description|mdstrip(180) }}
-    <a href="{{ url_for('organizations.show', org=organization) }}"
-        title="{{ _('more') }}"
-        class="btn btn-grey btn-primary btn-mini">+</a>
 </p>
 {% else %}
 <br/>
 {% endif %}
+<a href="{{ url_for('organizations.show', org=organization) }}"
+    class="btn btn-sm btn-block btn-left btn-warning btn-primary">
+    <span class="fa fa-users"></span>
+    {{ _('View Profile') }}
+</a>
 <button type="button" class="btn btn-sm btn-block btn-left btn-warning" @click="$refs.discussions.start('')"
     v-tooltip="'{{ _('Contact the producer') }}'" tooltip-placement="left">
     <span class="fa fa-envelope-o"></span>

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -183,21 +183,25 @@
                         </ul>
 
 
-                        <div class="tags">
+                        <ul class="tags">
                             {% for tag in reuse.tags %}
-                            <a href="{{ url_for('search.index', tag=tag) }}"
-                                class="btn btn-primary btn-grey btn-xs"
+                            <li>
+                                <a href="{{ url_for('search.index', tag=tag) }}"
+                                class="label label-primary"
                                 title="{{ tag }}">
-                                {{ tag|truncate(14, True) }}
-                            </a>
+                                    {{ tag|truncate(14, True) }}
+                                </a>
+                            </li>
                             {% endfor %}
-                            <a @click="suggestTag"
-                                class="btn btn-primary btn-dark btn-xs suggest-tag"
+                            <li>
+                                <a @click="suggestTag"
+                                class="label label-primary suggest-tag"
                                 title="{{ _('Suggest a tag with a new discussion thread') }}"
                                 v-tooltip tooltip-placement="right">
-                                {{ _('Suggest a tag') }}
-                            </a>
-                        </div>
+                                    {{ _('Suggest a tag') }}
+                                </a>
+                            </li>
+                        </ul>
                     </div>
                 </div>
 

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -148,13 +148,17 @@
                             {% if reuse.owner.about %}
                             <p>
                                 {{ reuse.owner.about|mdstrip(180) }}
-                                <a href="{{ url_for('users.show', user=reuse.owner) }}"
-                                    title="{{ _('more') }}"
-                                    class="btn btn-grey btn-primary btn-mini">+</a>
                             </p>
                             {% else %}
                             <br/>
                             {% endif %}
+
+                            <a href="{{ url_for('users.show', user=reuse.owner) }}"
+                                title="{{ _('more') }}"
+                                class="btn btn-block btn-sm btn-left btn-warning btn-primary">
+                                <span class="fa fa-user"></span>
+                                {{ _('View Profile') }}
+                            </a>
                             <follow-button with-label classes="btn-block btn-sm btn-left btn-warning"
                                 {% if is_following(reuse.owner) %}following{% endif %}
                                 url="{{ url_for('api.user_followers', id=reuse.owner.id|string) }}"


### PR DESCRIPTION
These are minor changes:

- the `+` link in owner/org sidebar panel is often mismatched as an "expand text" button otherwise.
- tags can benefit of using the `.label` class instead of `.btn` as well as being enclosed in an `<ul>` element

# Screenshots

## Reuse sidebar

![image](https://user-images.githubusercontent.com/138627/32494854-3b54c394-c3bb-11e7-9ab7-e9e1a1cc8eff.png)

## Dataset sidebar

![image](https://user-images.githubusercontent.com/138627/32494861-42f4a916-c3bb-11e7-91f6-64aa6c42382d.png)
