### PR TITLE
Check resource.format existence before computing closed_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix flask_security celery tasks context [#1249](https://github.com/opendatateam/udata/pull/1249)
+- Fix `dataset.quality` when `resource.format` is not filled [#1261](https://github.com/opendatateam/udata/pull/1261)
 
 ## 1.2.3 (2017-10-27)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -206,7 +206,7 @@ class ResourceMixin(object):
     @property
     def closed_format(self):
         """Return True if the specified format is in CLOSED_FORMATS."""
-        return self.format.lower() in CLOSED_FORMATS
+        return self.format and self.format.lower() in CLOSED_FORMATS
 
     def check_availability(self):
         '''


### PR DESCRIPTION
This was causing the computing of `dataset.quality` to silently (sic) fail when one resource had no format declared.