### PR TITLE
Celery ignore results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix flask_security celery tasks context [#1249](https://github.com/opendatateam/udata/pull/1249)
 - Fix `dataset.quality` handling when no format filled [#1265](https://github.com/opendatateam/udata/pull/1265)
-- Ignore celery tasks results except for harvest tasks which require it
+- Ignore celery tasks results except for tasks which require it and lower the default results expiration to 6 hours [#1281](https://github.com/opendatateam/udata/pull/1281)
 
 ## 1.2.3 (2017-10-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix flask_security celery tasks context [#1249](https://github.com/opendatateam/udata/pull/1249)
 - Fix `dataset.quality` handling when no format filled [#1265](https://github.com/opendatateam/udata/pull/1265)
+- Ignore celery tasks results except for harvest tasks which require it
 
 ## 1.2.3 (2017-10-27)
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -26,7 +26,7 @@ def harvest(self, ident):
         chord(items)(finalize)
 
 
-@task
+@task(ignore_result=False)
 def harvest_item(source_id, item_id):
     log.info('Harvesting item %s for source "%s"', item_id, source_id)
 
@@ -41,7 +41,7 @@ def harvest_item(source_id, item_id):
     return (item_id, result)
 
 
-@task
+@task(ignore_result=False)
 def harvest_finalize(results, source_id):
     log.info('Finalize harvesting for source "%s"', source_id)
     source = HarvestSource.get(source_id)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -32,6 +32,7 @@ class Defaults(object):
         'fanout_patterns': True,
     }
     CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+    CELERY_TASK_IGNORE_RESULT = True
     CELERY_TASK_SERIALIZER = 'pickle'
     CELERY_RESULT_SERIALIZER = 'pickle'
     CELERY_ACCEPT_CONTENT = ['pickle', 'json']

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 from kombu import Exchange, Queue
 
+HOUR = 60 * 60
+
 
 class Defaults(object):
     DEBUG = False
@@ -32,6 +34,7 @@ class Defaults(object):
         'fanout_patterns': True,
     }
     CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+    CELERY_RESULT_EXPIRES = 6 * HOUR  # Results are kept 6 hours
     CELERY_TASK_IGNORE_RESULT = True
     CELERY_TASK_SERIALIZER = 'pickle'
     CELERY_RESULT_SERIALIZER = 'pickle'
@@ -101,7 +104,7 @@ class Defaults(object):
     # Flask WTF settings
     CSRF_SESSION_KEY = 'Default uData csrf key'
 
-    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 30 * 24 * 60 * 60  # 30 days
+    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 30 * 24 * HOUR  # 30 days
 
     AUTO_INDEX = True
 


### PR DESCRIPTION
This PR tweaks celery results handling:
- results are not kept by default anymore and tasks requiring it have to explicitely notify it (harvest tasks which are using chords requires it)
- default results expiration is lowered to 6 hours instead of the default 24 hours.