### PR TITLE
Make terms content an easily customizable markdown content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix `dataset.quality` handling when no format filled [#1265](https://github.com/opendatateam/udata/pull/1265)
 - Ignore celery tasks results except for tasks which require it and lower the default results expiration to 6 hours [#1281](https://github.com/opendatateam/udata/pull/1281)
 - Import community resource avatar style from udata-gouvfr [#1288](https://github.com/opendatateam/udata/pull/1288)
-- Terms are now handled from markdown and customizable with the `SITE_TERMS` setting. [#1285](https://github.com/opendatateam/udata/pull/1285)
+- Terms are now handled from markdown and customizable with the `SITE_TERMS_LOCATION` setting. [#1285](https://github.com/opendatateam/udata/pull/1285)
 
 ## 1.2.3 (2017-10-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix `dataset.quality` handling when no format filled [#1265](https://github.com/opendatateam/udata/pull/1265)
 - Ignore celery tasks results except for tasks which require it and lower the default results expiration to 6 hours [#1281](https://github.com/opendatateam/udata/pull/1281)
 - Import community resource avatar style from udata-gouvfr [#1288](https://github.com/opendatateam/udata/pull/1288)
+- Terms are now handled from markdown and customizable with the `SITE_TERMS` setting. [#1285](https://github.com/opendatateam/udata/pull/1285)
 
 ## 1.2.3 (2017-10-27)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -48,6 +48,13 @@ A secret key used as salt for cryptographic parts.
 
 The site identifier. It is used to attached some database configuration, metrics...
 
+### SITE_TERMS
+
+**default**: `'default'`
+
+The site terms in markdown. It can be either an URL to a markdown content or a local path.
+If this is an URL, the content is downloaded on the first terms page display and cached.
+
 ### PLUGINS
 
 **default**: `[]`

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -48,11 +48,11 @@ A secret key used as salt for cryptographic parts.
 
 The site identifier. It is used to attached some database configuration, metrics...
 
-### SITE_TERMS
+### SITE_TERMS_LOCATION
 
-**default**: `'default'`
+**default**: `generic embedded terms`
 
-The site terms in markdown. It can be either an URL to a markdown content or a local path.
+The site terms in markdown. It can be either an URL or a local path to a markdown content.
 If this is an URL, the content is downloaded on the first terms page display and cached.
 
 ### PLUGINS

--- a/udata/cgu.md
+++ b/udata/cgu.md
@@ -1,0 +1,6 @@
+# Generic terms and conditions
+
+Be excellent to each other.
+
+You see this content because you don't have provided a proper `SITE_TERMS`
+pointing to the rightful content.

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -165,7 +165,7 @@ class SiteDashboard(SiteView, DetailView):
 
 @cache.cached(50)
 def get_terms_content():
-    filename = current_app.config['SITE_TERMS']
+    filename = current_app.config['SITE_TERMS_LOCATION']
     if filename.startswith('http'):
         # We let the error appear because:
         # - we dont want to cache false responses

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -116,7 +116,7 @@ class Defaults(object):
     SITE_AUTHOR_URL = None
     SITE_AUTHOR = 'Udata'
     SITE_GITHUB_URL = 'https://github.com/etalab/udata'
-    SITE_TERMS = pkg_resources.resource_filename(__name__, 'cgu.md')
+    SITE_TERMS_LOCATION = pkg_resources.resource_filename(__name__, 'terms.md')
 
     USE_SSL = False
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pkg_resources
+
 from kombu import Exchange, Queue
 
 HOUR = 60 * 60
@@ -114,6 +116,8 @@ class Defaults(object):
     SITE_AUTHOR_URL = None
     SITE_AUTHOR = 'Udata'
     SITE_GITHUB_URL = 'https://github.com/etalab/udata'
+    SITE_TERMS = pkg_resources.resource_filename(__name__, 'cgu.md')
+
     USE_SSL = False
 
     PLUGINS = []
@@ -142,6 +146,8 @@ class Defaults(object):
         'small',
         'strong',
         'ul',
+        'sup',
+        'sub',
     ]
 
     MD_ALLOWED_ATTRIBUTES = {

--- a/udata/templates/terms.html
+++ b/udata/templates/terms.html
@@ -11,11 +11,10 @@
 {% block content %}
 <section class="content">
     <div class="container">
-        <div class="page-header">
-            <h1>Generic terms and conditions</h1>
-        </div>
         <div class="row">
-            <p>Be excellent to each other.</p>
+            <div class="col-xs-12">
+                {{ terms|markdown }}
+            </div>
         </div>
     </div>
 </section>

--- a/udata/terms.md
+++ b/udata/terms.md
@@ -2,5 +2,5 @@
 
 Be excellent to each other.
 
-You see this content because you don't have provided a proper `SITE_TERMS`
+You see this content because you don't have provided a proper `SITE_TERMS_LOCATION` setting
 pointing to the rightful content.


### PR DESCRIPTION
This PR externalize the terms handling.
udata now expect a markdown content into a remote or local file.
The target file is defined by the `SITE_TERMS` setting.
It default on an embedded markdown content which indicate to the administrator it needs to define terms.

**NB:** [this](https://github.com/opendatateam/udata/blob/master/udata/frontend/markdown.py#L19-L23) prevent `mailto:` links to render as links