### PR TITLE
Import community resource avatar style from udatagouvfr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix flask_security celery tasks context [#1249](https://github.com/opendatateam/udata/pull/1249)
 - Fix `dataset.quality` handling when no format filled [#1265](https://github.com/opendatateam/udata/pull/1265)
 - Ignore celery tasks results except for tasks which require it and lower the default results expiration to 6 hours [#1281](https://github.com/opendatateam/udata/pull/1281)
+- Import community resource avatar style from udata-gouvfr [#1288](https://github.com/opendatateam/udata/pull/1288)
 
 ## 1.2.3 (2017-10-27)
 

--- a/less/site.less
+++ b/less/site.less
@@ -9,6 +9,7 @@
 @import "udata/oauth";
 @import "udata/activity";
 @import "udata/resource";
+@import "udata/community";
 @import "udata/territories";
 @import "udata/modal";
 @import "udata/auth";

--- a/less/udata/community.less
+++ b/less/udata/community.less
@@ -1,0 +1,14 @@
+.community_container {
+    .resources-list {
+        .resource-owner {
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            border: none;
+        }
+
+        .tools {
+            right: 65px;
+        }
+    }
+}


### PR DESCRIPTION
The community resource avatar style was in the wrong theme.

Before:
<img width="609" alt="capture d ecran 2017-12-04 11 16 12" src="https://user-images.githubusercontent.com/119625/33547591-d64cf9c8-d8e4-11e7-94b8-578aabbd3d48.png">

After:
<img width="593" alt="capture d ecran 2017-12-04 11 14 40" src="https://user-images.githubusercontent.com/119625/33547589-d6363896-d8e4-11e7-9b51-a62b194e9a23.png">
