### PR TITLE
Import css dropdowns handling from udata-gouvfr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Display date of comments in dataset discussions [#1283](https://github.com/opendatateam/udata/pull/1283)
 - Prevent `reindex` command from failing on a specific object and log error instead. [#1293](https://github.com/opendatateam/udata/pull/1293)
 - Position the community resource link icon correctly [#1298](https://github.com/opendatateam/udata/pull/1298)
+- Import dropdown behavior from `udata-gouvfr` and fix hidden submenus on mobile [#1297](https://github.com/opendatateam/udata/pull/1297)
 
 ## 1.2.4 (2017-12-06)
 

--- a/less/site.less
+++ b/less/site.less
@@ -5,6 +5,7 @@
 @import "udata/cards";
 @import "udata/panels";
 @import "udata/buttons";
+@import "udata/dropdowns";
 @import "udata/icons";
 @import "udata/oauth";
 @import "udata/activity";

--- a/less/udata/dropdowns.less
+++ b/less/udata/dropdowns.less
@@ -1,0 +1,22 @@
+.dropdown {
+    // Desktop: display on hover
+    &.dropdown-hover:hover .dropdown-menu {
+        display: block;
+    }
+
+    // Clickable dropdowns
+    &.open .dropdown-menu {
+        display: inline;
+    }
+
+    // Mobile: display inline when menu is open
+    .navbar-collapse.in &.dropdown-hover .dropdown-menu {
+        display: inline;
+        width: 90%;
+        margin: 0 0 15px 15px;
+        position: relative;
+        left: 5%;
+        border: none;
+        box-shadow: none;
+    }
+}


### PR DESCRIPTION
This PRs import CSS dropdowns behavior from gouvfr style (it's a ashred behavior) and fix hidden submenus on mobile.

![screenshot-www data dev-2017-12-11-12-02-36-033](https://user-images.githubusercontent.com/15725/33828325-f5fedaa2-de6b-11e7-82c7-bfbcd4ac41f8.png)
