### PR TITLE
Position the community resource link icon correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix broken post edit page [#1295](https://github.com/opendatateam/udata/pull/1295)
 - Display date of comments in dataset discussions [#1283](https://github.com/opendatateam/udata/pull/1283)
 - Prevent `reindex` command from failing on a specific object and log error instead. [#1293](https://github.com/opendatateam/udata/pull/1293)
+- Position the community resource link icon correctly [#1298](https://github.com/opendatateam/udata/pull/1298)
 
 ## 1.2.4 (2017-12-06)
 

--- a/less/udata/community.less
+++ b/less/udata/community.less
@@ -7,6 +7,10 @@
             border: none;
         }
 
+        .list-group-item-link {
+            margin-right: 65px;
+        }
+
         .tools {
             right: 65px;
         }


### PR DESCRIPTION
Since #1288, the link icon was hidden behind the avatar for community resources.