### PR TITLE
fix non-sorting posts behaviour in editorial view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Display date of comments in dataset discussions [#1283](https://github.com/opendatateam/udata/pull/1283)
 - Prevent `reindex` command from failing on a specific object and log error instead. [#1293](https://github.com/opendatateam/udata/pull/1293)
 - Position the community resource link icon correctly [#1298](https://github.com/opendatateam/udata/pull/1298)
+- Add a sort option to query of list of posts in API [#1301](https://github.com/opendatateam/udata/pull/1301)
 
 ## 1.2.4 (2017-12-06)
 

--- a/js/components/post/list.vue
+++ b/js/components/post/list.vue
@@ -34,7 +34,7 @@ export default {
             },{
                 label: this._('Creation'),
                 key: 'created_at',
-                sort: 'created',
+                sort: 'created_at',
                 align: 'left',
                 type: 'timeago',
                 width: 120

--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -61,6 +61,7 @@ post_page_fields = api.model('PostPage', fields.pager(post_fields))
 
 parser = api.page_parser()
 
+parser.add_argument('sort', type=str, default='-created_at', location='args', help='The sorting attribute')
 
 @ns.route('/', endpoint='posts')
 class PostsAPI(API):
@@ -70,7 +71,7 @@ class PostsAPI(API):
     def get(self):
         '''List all posts'''
         args = parser.parse_args()
-        return (Post.objects.order_by('-created')
+        return (Post.objects.order_by(args['sort'])
                             .paginate(args['page'], args['page_size']))
 
     @api.doc('create_post', responses={400: 'Validation error'})


### PR DESCRIPTION
fix etalab/data.gouv.fr#41

This one was a deep dive in the full stack. I had to add the sort rule in the python. Not sure about the interaction with swagger.

There might be unnoticed bugs since only datasets and reuses since to acknowledge `sort` in their listing query.