### PR TITLE
Fix/community resource link icon - take 2

### DIFF
--- a/less/udata/community.less
+++ b/less/udata/community.less
@@ -1,5 +1,5 @@
 .community_container {
-    .resources-list {
+    .community-resources-list {
         .resource-owner {
             position: absolute;
             right: 0px;

--- a/less/udata/community.less
+++ b/less/udata/community.less
@@ -1,5 +1,5 @@
 .community_container {
-    .community-resources-list {
+    .resources-list.community-resources-list {
         .resource-owner {
             position: absolute;
             right: 0px;

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -354,7 +354,7 @@
 
         <h3>{{ _('Community resources') }}</h3>
         <div class="row">
-            <div class="col-sm-9 list-group resources-list smaller">
+            <div class="col-sm-9 list-group community-resources-list resources-list smaller">
             {% for resource in dataset.community_resources %}
                 {% include theme('dataset/resource/list-item.html') %}
             {% endfor %}


### PR DESCRIPTION
Fix the fix in #1298 

Should be ok now, both on default and gouvfr themes.

<img width="574" alt="capture d ecran 2017-12-12 11 21 23" src="https://user-images.githubusercontent.com/119625/33879524-f66a8590-df2e-11e7-9ead-aca5c70e2aab.png">
<img width="590" alt="capture d ecran 2017-12-12 11 22 49" src="https://user-images.githubusercontent.com/119625/33879525-f6c48068-df2e-11e7-889d-91fd98438382.png">