### PR TITLE
Prevent webpack false positive

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "vue-html-loader": "^1.2.3",
     "vue-loader": "8.5.3",
     "vue-style-loader": "^1.0.0",
-    "webpack": "1.13.1"
+    "webpack": "1.13.1",
+    "webpack-fail-plugin": "^2.0.0"
   },
   "dependencies": {
     "Chart.StackedBar.js": "regaddi/Chart.StackedBar.js#1.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,8 @@ module.exports = {
         languages,
     },
     plugins: [
+        // Prevent webpack 1.x false positive
+        require('webpack-fail-plugin'),
         // Fix AdminLTE packaging
         new webpack.NormalModuleReplacementPlugin(
             /admin-lte\/build\/img\/boxed-bg\.jpg$/,


### PR DESCRIPTION
This ensure assets build fail with exit code different than 0 (and so prevent false positive builds)