### PR TITLE
fix absence of label for tabs on the org page (FIX #1320)

### DIFF
--- a/js/components/tabs.vue
+++ b/js/components/tabs.vue
@@ -1,0 +1,24 @@
+<template>
+  <!-- Nav tabs -->
+  <ul class="nav nav-{{navStyle}}" role="tablist">
+    <template v-for="t in headers">
+      <li v-if="!t._tabgroup" :class="{active:t.active, disabled:t.disabled}" @click.prevent="select(t)">
+          <a href="#">{{{ t.header }}}</a>
+      </li>
+      <dropdown v-else :text="t.header" :class="{active:t.active}" :disabled="t.disabled">
+        <li v-for="tab in t.tabs" :class="{disabled:tab.disabled}"><a href="#" @click.prevent="select(tab)">{{tab.header}}</a></li>
+      </dropdown>
+    </template>
+  </ul>
+  <div class="tab-content" v-el:tab-content>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+import TabSet from 'vue-strap/src/Tabset.vue';
+
+export default {
+        mixins: [TabSet]
+};
+</script>

--- a/js/components/tabs.vue
+++ b/js/components/tabs.vue
@@ -1,9 +1,12 @@
+<!--
+    REMOVE ME when https://github.com/yuche/vue-strap/issues/520 will be closed 
+-->
 <template>
   <!-- Nav tabs -->
   <ul class="nav nav-{{navStyle}}" role="tablist">
     <template v-for="t in headers">
       <li v-if="!t._tabgroup" :class="{active:t.active, disabled:t.disabled}" @click.prevent="select(t)">
-          <a href="#">{{{ t.header }}}</a>
+          <a href="#"><slot name="header">{{{ t.header }}}</slot></a>
       </li>
       <dropdown v-else :text="t.header" :class="{active:t.active}" :disabled="t.disabled">
         <li v-for="tab in t.tabs" :class="{disabled:tab.disabled}"><a href="#" @click.prevent="select(tab)">{{tab.header}}</a></li>

--- a/js/front/organization/index.js
+++ b/js/front/organization/index.js
@@ -7,12 +7,13 @@ import log from 'logger';
 
 import Vue from 'vue';
 
-import Tabset from 'vue-strap/src/Tabset.vue';
+// import Tabset from 'vue-strap/src/Tabset.vue';
 
 import FollowButton from 'components/buttons/follow.vue';
 import ActivityTimeline from 'components/activities/timeline.vue';
 import DashboardGraphs from 'components/dashboard/graphs.vue';
 import Tab from 'components/tab';
+import Tabset from 'components/tabs.vue';
 
 import SmallBox from 'components/containers/small-box.vue';
 


### PR DESCRIPTION
Not sure it is the best solution but it seemed more efficient than forking/pr vue-strap. As far I know vue, `<slot>` here are a bit overkill since there is no way to access it simply from the `tabs` template.

![image](https://user-images.githubusercontent.com/27315/34112649-88438290-e40d-11e7-87e8-0c54aa5c73d9.png)
