### PR TITLE
Add a munin output to `udata worker status`

### DIFF
--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -167,9 +167,11 @@ See all waiting Celery tasks across all workers:
 $ udata worker status
 ```
 
-Display waiting tasks in a Munin plugin compatible format:
+Display waiting tasks in a Munin plugin compatible format (you can use the provided [Munin plugin][munin-plugin]):
 
 ```shell
 $ udata worker status --munin -q default
 $ udata worker status --munin-config -q default
 ```
+
+[munin-plugin]: https://github.com/etalab/munin-plugins/tree/master/udata-worker-status

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -166,3 +166,10 @@ See all waiting Celery tasks across all workers:
 ```shell
 $ udata worker status
 ```
+
+Display waiting tasks in a Munin plugin compatible format:
+
+```shell
+$ udata worker status --munin -q default
+$ udata worker status --munin-config -q default
+```

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -72,7 +72,7 @@ def register_commands(manager):
         try:
             __import__(name)
         except ImportError as e:
-            log.warning('Error importing %s: %s', name, e)
+            pass
         except Exception as e:
             log.error('Error during import of %s: %s', name, e)
 

--- a/udata/commands/worker.py
+++ b/udata/commands/worker.py
@@ -35,16 +35,6 @@ def start():
     celery.start()
 
 
-def status_print_header(munin=False):
-    if not munin:
-        print('-' * 40)
-
-
-def status_print_title(queue, queue_length, munin=False):
-    if not munin:
-        print('Queue "%s": %s task(s)' % (queue, queue_length))
-
-
 def status_print_task(count, biggest_task_name, munin=False):
     if not munin:
         print('* %s : %s' % (count[0].ljust(biggest_task_name), count[1]))
@@ -96,9 +86,11 @@ def status(queue, munin, munin_config):
         print(red('Error: no queue found'))
         sys.exit(-1)
     for queue in queues:
-        status_print_header(munin=munin)
+        if not munin:
+            print('-' * 40)
         queue_length = r.llen(queue)
-        status_print_title(queue, queue_length, munin=munin)
+        if not munin:
+            print('Queue "%s": %s task(s)' % (queue, queue_length))
         counter = Counter()
         biggest_task_name = 0
         for task in r.lrange(queue, 0, -1):
@@ -109,4 +101,5 @@ def status(queue, munin, munin_config):
             counter[task_name] += 1
         for count in counter.most_common():
             status_print_task(count, biggest_task_name, munin=munin)
-    status_print_header(munin)
+    if not munin:
+        print('-' * 40)

--- a/udata/commands/worker.py
+++ b/udata/commands/worker.py
@@ -109,8 +109,7 @@ def get_redis_connection():
 def status(queue, munin, munin_config):
     """List queued tasks aggregated by name"""
     if munin_config:
-        status_print_config(queue)
-        return
+        return status_print_config(queue)
     queues = get_queues(queue)
     for queue in queues:
         status_print_queue(queue, munin=munin)

--- a/udata/commands/worker.py
+++ b/udata/commands/worker.py
@@ -66,6 +66,7 @@ def status_print_config(queue):
                       timeout=TASKS_LIST_CACHE_DURATION)
     print('graph_title Waiting tasks for queue %s' % queue)
     print('graph_vlabel Nb of tasks')
+    print('graph_category celery')
     for task in tasks:
         print('%s.label %s' % (format_field_for_munin(task), task))
 

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -148,6 +148,6 @@ def init_app(app):
         try:
             importlib.import_module(name)
         except ImportError as e:
-            log.warning('Error importing %s: %s', name, e)
+            pass
         except Exception as e:
             log.error('Error during import of %s: %s', name, e)


### PR DESCRIPTION
Fix #1328

Usage:

```
$ udata worker status --munin -q default
piwik_current_metrics.value 10
update_metric.value 20
another_task.value 42
```

```
$ udata worker status --munin-config -q default
graph_title Waiting tasks for queue default
graph_vlabel Nb tasks
piwik_current_metrics.label piwik-current-metrics
update_metric.label update-metric
another_task.label another-task
# ... all possible tasks, even non queued ones #
```

Warnings at extensions init have been removed in order not to pollute the CLI output.