### PR TITLE
Only show notification on success of update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Fix wrongly timed notification on dataset creation with misformed tags [#1332](https://github.com/opendatateam/udata/pull/1332)
 - Fix topic creation [#1333](https://github.com/opendatateam/udata/pull/1333)
 - Add a `udata worker status` command to list pending tasks.[breaking] The `udata worker` command is replaced by `udata worker start`. [#1324](https://github.com/opendatateam/udata/pull/1324)
 - Prevent crawlers from indexing spammy datasets and reuses [#1334](https://github.com/opendatateam/udata/pull/1334)

--- a/js/components/dataset/form.vue
+++ b/js/components/dataset/form.vue
@@ -78,17 +78,6 @@ export default {
         },
         validate() {
             const isValid = this.$refs.form.validate();
-
-            if (isValid & !this.hideNotifications) {
-                /*
-                this.$dispatch('notify', {
-                    autoclose: true,
-                    title: this._('Changes saved'),
-                    details: this._('Your dataset has been updated.')
-                });
-                */
-            }
-
             return isValid;
         },
         on_error(response) {

--- a/js/components/dataset/form.vue
+++ b/js/components/dataset/form.vue
@@ -80,11 +80,13 @@ export default {
             const isValid = this.$refs.form.validate();
 
             if (isValid & !this.hideNotifications) {
+                /*
                 this.$dispatch('notify', {
                     autoclose: true,
                     title: this._('Changes saved'),
                     details: this._('Your dataset has been updated.')
                 });
+                */
             }
 
             return isValid;

--- a/js/views/dataset-edit.vue
+++ b/js/views/dataset-edit.vue
@@ -30,12 +30,12 @@ export default {
     },
     methods: {
         save() {
-            let form = this.$refs.form;
+            const form = this.$refs.form;
             if (form.validate()) {
                 this.dataset.update(form.serialize(), (response) => {
-                    this.dataset.on_fetched(response); 
+                    this.dataset.on_fetched(response);
                     
-                    if(!form.hideNotifications){
+                    if (!form.hideNotifications) {
                         this.$dispatch('notify', {
                             autoclose: true,
                             title: this._('Changes saved'),
@@ -44,7 +44,7 @@ export default {
                     }
 
                     this.$go({name: 'dataset', params: {oid: this.dataset.id}});
-                }, (error)=>{
+                }, error => {
                     this.dataset.loading = false;
                     form.on_error(error);
                 });

--- a/js/views/dataset-edit.vue
+++ b/js/views/dataset-edit.vue
@@ -44,7 +44,7 @@ export default {
                     }
 
                     this.$go({name: 'dataset', params: {oid: this.dataset.id}});
-                }, error => {
+                }, (error) => {
                     this.dataset.loading = false;
                     form.on_error(error);
                 });

--- a/js/views/dataset-edit.vue
+++ b/js/views/dataset-edit.vue
@@ -30,12 +30,24 @@ export default {
     },
     methods: {
         save() {
-            const form = this.$refs.form;
+            let form = this.$refs.form;
             if (form.validate()) {
                 this.dataset.update(form.serialize(), (response) => {
-                    this.dataset.on_fetched(response);
-                    this.$go({name: 'dataset', params: {oid: this.dataset.id}});
-                }, form.on_error);
+                    this.dataset.on_fetched(response); 
+                    
+                    if(!form.hideNotifications){
+                        this.$dispatch('notify', {
+                            autoclose: true,
+                            title: this._('Changes saved'),
+                            details: this._('Your dataset has been updated.')
+                        });
+                    }
+
+                    //this.$go({name: 'dataset', params: {oid: this.dataset.id}});
+                }, (error)=>{
+                    this.dataset.loading = false;
+                    form.on_error(error);
+                });
             }
         },
         cancel() {

--- a/js/views/dataset-edit.vue
+++ b/js/views/dataset-edit.vue
@@ -43,7 +43,7 @@ export default {
                         });
                     }
 
-                    //this.$go({name: 'dataset', params: {oid: this.dataset.id}});
+                    this.$go({name: 'dataset', params: {oid: this.dataset.id}});
                 }, (error)=>{
                     this.dataset.loading = false;
                     form.on_error(error);


### PR DESCRIPTION
FIX #1266 

There is still a remaining usability issue because the form does not highlight the faulty tag yet.

