### PR TITLE
Prevent crawlers from indexing empty reuses or datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix topic creation [#1333](https://github.com/opendatateam/udata/pull/1333)
 - Add a `udata worker status` command to list pending tasks.[breaking] The `udata worker` command is replaced by `udata worker start`. [#1324](https://github.com/opendatateam/udata/pull/1324)
+- Prevent crawlers from indexing spammy datasets and reuses [#1334](https://github.com/opendatateam/udata/pull/1334)
 
 ## 1.2.5 (2017-12-14)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -393,6 +393,14 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
     display_url = property(url_for)
 
     @property
+    def is_visible(self):
+        return not self.is_hidden
+
+    @property
+    def is_hidden(self):
+        return len(self.resources) == 0 or self.private or self.deleted
+
+    @property
     def external_url(self):
         return self.url_for(_external=True)
 

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -108,6 +108,14 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Owned, db.Document):
     display_url = property(url_for)
 
     @property
+    def is_visible(self):
+        return not self.is_hidden
+
+    @property
+    def is_hidden(self):
+        return len(self.datasets) == 0 or self.private or self.deleted
+
+    @property
     def external_url(self):
         return self.url_for(_external=True)
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -9,6 +9,7 @@
     'description': dataset.description|mdstrip(60)|forceescape,
     'image': dataset.organization and dataset.organization.logo(external=True) or '',
     'keywords': [_('dataset')] + dataset.tags,
+    'robots': 'noindex, nofollow' if dataset.is_hidden else '',
 } %}
 
 {% set bundle = 'dataset' %}

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -8,6 +8,7 @@
     'description': reuse.description|mdstrip(60)|forceescape,
     'image': reuse.image(external=True),
     'keywords': [_('reuse')] + reuse.tags,
+    'robots': 'noindex, nofollow' if reuse.is_hidden else '',
 } %}
 
 {% set bundle = 'reuse' %}

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -75,6 +75,8 @@ class DatasetBlueprintTest(FrontTestCase):
         url = url_for('datasets.show', dataset=dataset)
         response = self.get(url)
         self.assert200(response)
+        self.assertNotIn(b'<meta name="robots" content="noindex, nofollow">',
+                         response.data)
 
     def test_json_ld(self):
         '''It should render a json-ld markup into the dataset page'''
@@ -195,6 +197,14 @@ class DatasetBlueprintTest(FrontTestCase):
         dataset = DatasetFactory(deleted=datetime.now(), owner=self.user)
         response = self.get(url_for('datasets.show', dataset=dataset))
         self.assert200(response)
+
+    def test_no_index_on_empty(self):
+        '''It should prevent crawlers from indexing empty datasets'''
+        dataset = DatasetFactory()
+        response = self.get(url_for('datasets.show', dataset=dataset))
+        self.assert200(response)
+        self.assertIn(b'<meta name="robots" content="noindex, nofollow"',
+                      response.data)
 
     def test_not_found(self):
         '''It should render the dataset page'''

--- a/udata/tests/frontend/test_reuse_frontend.py
+++ b/udata/tests/frontend/test_reuse_frontend.py
@@ -57,6 +57,8 @@ class ReuseBlueprintTest(FrontTestCase):
         url = url_for('reuses.show', reuse=reuse)
         response = self.get(url)
         self.assert200(response)
+        self.assertNotIn(b'<meta name="robots" content="noindex, nofollow">',
+                         response.data)
         json_ld = self.get_json_ld(response)
         self.assertEquals(json_ld['@context'], 'http://schema.org')
         self.assertEquals(json_ld['@type'], 'CreativeWork')
@@ -94,6 +96,15 @@ class ReuseBlueprintTest(FrontTestCase):
         '''It should render the reuse page'''
         response = self.get(url_for('reuses.show', reuse='not-found'))
         self.assert404(response)
+
+    def test_no_index_on_empty(self):
+        '''It should prevent crawlers from indexing empty reuses'''
+        reuse = ReuseFactory()
+        url = url_for('reuses.show', reuse=reuse)
+        response = self.get(url)
+        self.assert200(response)
+        self.assertIn(b'<meta name="robots" content="noindex, nofollow"',
+                      response.data)
 
     def test_recent_feed(self):
         datasets = [ReuseFactory(


### PR DESCRIPTION
This PR adds a `<meta name="robots" content="noindex, nofollow" />` tag on empty datasets and reuses to prevent crawlers from indexing them (apply the same rules for them than the portal).
Mostly prevent spammers from benefits of indexing.