### PR TITLE
Prevent empty organization from being crawled too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix topic creation [#1333](https://github.com/opendatateam/udata/pull/1333)
 - Add a `udata worker status` command to list pending tasks.[breaking] The `udata worker` command is replaced by `udata worker start`. [#1324](https://github.com/opendatateam/udata/pull/1324)
-- Prevent crawlers from indexing spammy datasets and reuses [#1334](https://github.com/opendatateam/udata/pull/1334)
+- Prevent crawlers from indexing spammy datasets, reuses and organizations [#1334](https://github.com/opendatateam/udata/pull/1334) [#1335](https://github.com/opendatateam/udata/pull/1335)
 
 ## 1.2.5 (2017-12-14)
 

--- a/udata/templates/organization/display.html
+++ b/udata/templates/organization/display.html
@@ -1,10 +1,12 @@
 {% extends theme("organization/display_base.html") %}
 
+{% set is_hidden = (reuses.total or 0) + (datasets.total or 0) <= 0 %}
 {% set meta = {
     'title': org.name,
     'description': org.description|mdstrip(60)|forceescape,
     'image': org.logo(external=True),
     'keywords': [_('organization')],
+    'robots': 'noindex, nofollow' if is_hidden else '',
 } %}
 
 {% set bundle = 'organization' %}

--- a/udata/tests/frontend/test_organization_frontend.py
+++ b/udata/tests/frontend/test_organization_frontend.py
@@ -46,6 +46,8 @@ class OrganizationBlueprintTest(FrontTestCase):
         url = url_for('organizations.show', org=organization)
         response = self.get(url)
         self.assert200(response)
+        self.assertNotIn(b'<meta name="robots" content="noindex, nofollow">',
+                         response.data)
         json_ld = self.get_json_ld(response)
         self.assertEquals(json_ld['@context'], 'http://schema.org')
         self.assertEquals(json_ld['@type'], 'Organization')
@@ -173,6 +175,15 @@ class OrganizationBlueprintTest(FrontTestCase):
         '''It should render the organization page'''
         response = self.get(url_for('organizations.show', org='not-found'))
         self.assert404(response)
+
+    def test_no_index_on_empty(self):
+        '''It should prevent crawlers from indexing empty organizations'''
+        organization = OrganizationFactory()
+        url = url_for('organizations.show', org=organization)
+        response = self.get(url)
+        self.assert200(response)
+        self.assertIn(b'<meta name="robots" content="noindex, nofollow"',
+                      response.data)
 
     def test_datasets_csv(self):
         with self.autoindex():


### PR DESCRIPTION
Almost the same as #1334 but for organizations.
