### PR TITLE
Fixes Swagger.js no setting jQuery.ajax contentType parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix topic creation [#1333](https://github.com/opendatateam/udata/pull/1333)
 - Add a `udata worker status` command to list pending tasks.[breaking] The `udata worker` command is replaced by `udata worker start`. [#1324](https://github.com/opendatateam/udata/pull/1324)
 - Prevent crawlers from indexing spammy datasets, reuses and organizations [#1334](https://github.com/opendatateam/udata/pull/1334) [#1335](https://github.com/opendatateam/udata/pull/1335)
+- Ensure Swagger.js properly set jQuery.ajax contentType parameter (and so data is properly serialized) [#1126](https://github.com/opendatateam/udata/issues/1126)
 
 ## 1.2.5 (2017-12-14)
 

--- a/js/models/base.js
+++ b/js/models/base.js
@@ -10,7 +10,7 @@ export const DEFAULT_PAGE_SIZE = 10;
 
 /**
  * This request interceptor add the missing jQuery.ajax contentType parameters
- * when required (ie. when swagge as set the proper Content-Type header)
+ * when required (ie. when swagger has set the proper Content-Type header)
  */
 const requestInterceptor = {
     apply(obj) {

--- a/js/models/base.js
+++ b/js/models/base.js
@@ -9,6 +9,19 @@ import mask from './mask';
 export const DEFAULT_PAGE_SIZE = 10;
 
 /**
+ * This request interceptor add the missing jQuery.ajax contentType parameters
+ * when required (ie. when swagge as set the proper Content-Type header)
+ */
+const requestInterceptor = {
+    apply(obj) {
+        if (obj.headers['Content-Type']) {
+            obj.contentType = obj.headers['Content-Type'];
+        }
+        return obj;
+    }
+}
+
+/**
  * Common class behaviors.
  *
  * Provide:
@@ -103,12 +116,13 @@ export class Base {
         API.onReady(() => {
             const [namespace, method] = endpoint.split('.');
             const operation = API[namespace][method];
+            const opts = {requestInterceptor};
 
             if (this.$options.mask && !('X-Fields' in data)) {
                 data['X-Fields'] = mask(this.$options.mask);
             }
 
-            operation(data, on_success.bind(this), on_error.bind(this));
+            operation(data, opts, on_success.bind(this), on_error.bind(this));
         });
     }
 }


### PR DESCRIPTION
This PR fixes a nasty bug with Swagger.js/jQuery.

## Context
Swagger.js only set the `Content-Type` HTTP header on request but does not give the `contentType` parameter to `jQuery.ajax`.

## Consequence
`jQuery` consider the request body as url encoded and reencode content. As a side effect, all `%20` characters are replaced by `+` signs.

## Resolution
This PR adds a hackish Swagger.js request interceptor which set the `jQuery.ajax` `contentType` parameter to the same value than the `Content-Type` header.
This fixes many side-effects:
- `%20` are not replaced by `+` signs anymore (#1126)
- default success and error handlers are taken in account (side effect of operation call signature change)
- any places where double encoding was occurring (I'm sure we missed some of them) are fixed too