### PR TITLE
Sanitize mdstrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Sanitize mdstrip [#1351](https://github.com/opendatateam/udata/pull/1351)
 
 ## 1.2.6 (2018-01-04)
 

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -7,7 +7,8 @@ import bleach
 import CommonMark
 from flask import current_app, Markup
 from werkzeug.local import LocalProxy
-from jinja2.filters import do_truncate, do_striptags
+from jinja2.filters import do_truncate
+from jinja2.utils import escape
 
 from udata.i18n import _
 
@@ -91,7 +92,7 @@ def mdstrip(value, length=None, end='…'):
     '''
     Truncate and strip tags from a markdown source
 
-    The markdown source is truncated at the excerpt if present and
+    The markdown source is truncated at except if present and
     smaller than the required length. Then, all html tags are stripped.
     '''
     if not value:
@@ -99,7 +100,7 @@ def mdstrip(value, length=None, end='…'):
     if EXCERPT_TOKEN in value:
         value = value.split(EXCERPT_TOKEN, 1)[0]
     rendered = md(value)
-    text = do_striptags(rendered)
+    text = escape(rendered)
     if length > 0:
         text = do_truncate(None, text, length, end=end, leeway=2)
     return text

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -92,7 +92,7 @@ def mdstrip(value, length=None, end='…'):
     '''
     Truncate and strip tags from a markdown source
 
-    The markdown source is truncated at except if present and
+    The markdown source is truncated at the excerpt if present and
     smaller than the required length. Then, all html tags are stripped.
     '''
     if not value:

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -7,7 +7,7 @@ import bleach
 import CommonMark
 from flask import current_app, Markup
 from werkzeug.local import LocalProxy
-from jinja2.filters import do_truncate
+from jinja2.filters import do_truncate, do_striptags
 from jinja2.utils import escape
 
 from udata.i18n import _
@@ -65,14 +65,7 @@ class UDataMarkdown(object):
     def __call__(self, stream, source_tooltip=False):
         if not stream:
             return ''
-        # Sanitize malicious attempts but keep the `EXCERPT_TOKEN`.
-        # By default, only keeps `bleach.ALLOWED_TAGS`.
-        stream = bleach.clean(
-            stream,
-            tags=current_app.config['MD_ALLOWED_TAGS'],
-            attributes=current_app.config['MD_ALLOWED_ATTRIBUTES'],
-            styles=current_app.config['MD_ALLOWED_STYLES'],
-            strip_comments=False)
+        stream = bleach_clean(stream)
         # Turn markdown to HTML.
         ast = self.parser().parse(stream)
         html = self.renderer.render(ast)
@@ -88,6 +81,19 @@ class UDataMarkdown(object):
         return Markup(html)
 
 
+def bleach_clean(stream):
+    """
+    Sanitize malicious attempts but keep the `EXCERPT_TOKEN`.
+    By default, only keeps `bleach.ALLOWED_TAGS`.
+    """
+    return bleach.clean(
+        stream,
+        tags=current_app.config['MD_ALLOWED_TAGS'],
+        attributes=current_app.config['MD_ALLOWED_ATTRIBUTES'],
+        styles=current_app.config['MD_ALLOWED_STYLES'],
+        strip_comments=False)
+
+
 def mdstrip(value, length=None, end='…'):
     '''
     Truncate and strip tags from a markdown source
@@ -100,7 +106,8 @@ def mdstrip(value, length=None, end='…'):
     if EXCERPT_TOKEN in value:
         value = value.split(EXCERPT_TOKEN, 1)[0]
     rendered = md(value)
-    text = escape(rendered)
+    text = do_striptags(rendered)
+    text = bleach_clean(text)
     if length > 0:
         text = do_truncate(None, text, length, end=end, leeway=2)
     return text

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -103,7 +103,7 @@ class DatasetBlueprintTest(FrontTestCase):
         self.assertEquals(json_ld['@context'], 'http://schema.org')
         self.assertEquals(json_ld['@type'], 'Dataset')
         self.assertEquals(json_ld['@id'], str(dataset.id))
-        self.assertEquals(json_ld['description'], 'a&éèëù$£')
+        self.assertEquals(json_ld['description'], 'a&amp;éèëù$£')
         self.assertEquals(json_ld['alternateName'], dataset.slug)
         self.assertEquals(json_ld['dateCreated'][:16],
                           dataset.created_at.isoformat()[:16])
@@ -178,6 +178,15 @@ class DatasetBlueprintTest(FrontTestCase):
                           }])
         self.assertEquals(json_ld['license'], 'http://www.datagouv.fr/licence')
         self.assertEquals(json_ld['author']['@type'], 'Person')
+
+    def test_json_ld_sanitize(self):
+        '''Json-ld should be sanitized'''
+        dataset = DatasetFactory(description='an <script>evil()</script>')
+        url = url_for('datasets.show', dataset=dataset)
+        response = self.get(url)
+        json_ld = self.get_json_ld(response)
+        self.assertEquals(json_ld['description'],
+                          'an &lt;script&gt;evil()&lt;/script&gt;')
 
     def test_raise_404_if_private(self):
         '''It should raise a 404 if the dataset is private'''


### PR DESCRIPTION
Jinja `do_striptags` result is not safe to piped into a `safe` filter, for example when we output `json_ld`.

Not totally sure about the impact of this on the rest of the site, but some nasty things happening on a reuse do not happen anymore and the reuse stil displays fine.