### PR TITLE
Add extras fields to discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add extras field in discussions [#1360](https://github.com/opendatateam/udata/pull/1360)
 
 ## 1.2.7 (2018-01-10)
 

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -44,6 +44,7 @@ discussion_fields = api.model('Discussion', {
     'discussion': fields.Nested(message_fields),
     'url': fields.UrlFor('api.discussion',
                          description='The discussion API URI'),
+    'extras': fields.Raw(description='Extra attributes as key-value pairs'),
 })
 
 start_discussion_fields = api.model('DiscussionStart', {
@@ -54,6 +55,7 @@ start_discussion_fields = api.model('DiscussionStart', {
     'subject': fields.Nested(api.model_reference,
                              description='The discussion target object',
                              required=True),
+    'extras': fields.Raw(description='Extras attributes as key-value pairs'),
 })
 
 comment_discussion_fields = api.model('DiscussionResponse', {

--- a/udata/core/discussions/forms.py
+++ b/udata/core/discussions/forms.py
@@ -11,10 +11,11 @@ __all__ = ('DiscussionCreateForm', 'DiscussionCommentForm')
 
 class DiscussionCreateForm(ModelForm):
     model_class = Discussion
-    
+
     title = fields.StringField(_('Title'), [validators.required()])
     comment = fields.StringField(_('Comment'), [validators.required()])
     subject = fields.ModelField(_('Subject'), [validators.required()])
+    extras = fields.ExtrasField(extras=Discussion.extras)
 
 
 class DiscussionCommentForm(Form):

--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -23,6 +23,7 @@ class Discussion(db.Document):
     created = db.DateTimeField(default=datetime.now, required=True)
     closed = db.DateTimeField()
     closed_by = db.ReferenceField('User')
+    extras = db.ExtrasField()
 
     meta = {
         'indexes': [


### PR DESCRIPTION
We need it for transport.data.gouv.fr
It'll be only accessible through API for now

fix  #1359