### PR TITLE
html2text==2018.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix html2text dependency version [#1362](https://github.com/opendatateam/udata/pull/1362)
 
 ## 1.2.7 (2018-01-10)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -25,7 +25,7 @@ Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
 Flask-WTF==0.14.2
 Flask==0.12.2
-html2text==2018.9.1
+html2text==2018.1.9
 lxml==4.1.1
 mongoengine==0.14.3
 msgpack-python==0.4.8


### PR DESCRIPTION
A release with a wrong version number of `html2text==2018.9.1` was published and then removed from pypi. This pins the right version.
  