### PR TITLE
Make the reuse section and cards themable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Markdown rendering is now the same between the back and the frontend. [#604](https://github.com/opendatateam/udata/issues/604)
+- Make the dataset page reuses section and cards themable. [#1378](https://github.com/opendatateam/udata/pull/1378)
 
 ## 1.2.9 (2018-01-17)
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -377,53 +377,14 @@
             </div>
         </div>
 
+        {% block reuses_section %}
         <h3>{{ _('Reuses') }}</h3>
         <div class="row">
             <div class="col-sm-9 reuses-list smaller">
                 <div class="row">
                     {% for reuse in reuses %}
                     <div class="col-sm-6 col-lg-4">
-                        <div id="reuse-{{reuse.id}}" class="thumbnail reuse">
-                            <a class="preview" href="{{ url_for('reuses.show', reuse=reuse) }}">
-                                <img class="media-object img-responsive" alt="{{ reuse.title }}"
-                                    src="{{ reuse.image|placeholder('reuse') }}">
-                            </a>
-                            <div class="caption">
-                                <h4 class="clamp-2">
-                                    <a href="{{ url_for('reuses.show', reuse=reuse) }}" title="{{ reuse.title }}">
-                                        {{ reuse.title }}
-                                    </a>
-                                </h4>
-                                <div class="author">
-                                    {{ reuse|owner_avatar(25) }}
-                                    <a class="user" href="{{ reuse|owner_url }}" title="{{ reuse|owner_name }}">
-                                    {{ reuse|owner_name }}
-                                    </a>
-                                    <span class="date">{{ reuse.created_at|dateformat('long') }}</span>
-                                </div>
-                            </div>
-                            {% if reuse.description %}
-                            <a class="rollover fade in" href="{{url_for('reuses.show', reuse=reuse)}}"
-                                title="{{ reuse.title }}">
-                                {{ reuse.description|mdstrip(180) }}
-                            </a>
-                            {% endif %}
-                            <div class="btn-group btn-group-xs">
-                                <a class="btn btn-default" href="{{ reuse.url }}"
-                                    v-tooltip title="{{ _('Open in a new window') }}">
-                                    <span class="fa fa-external-link"></span>
-                                </a>
-                                {% if current_user.sysadmin or reuse.owner == current_user %}
-                                <a class="btn btn-default" v-tooltip title="{{ _('Edit') }}"
-                                    href="{{ url_for('admin.index', path='reuse/{id}/'.format(id=reuse.id)) }}">
-                                    <span class="fa fa-pencil"></span>
-                                </a>
-                                {% endif %}
-                                {% if current_user.sysadmin %}
-                                <featured-button compact subject-id="{{ reuse.id }}" subject-type="reuse" :featured="{{ reuse.featured|to_json }}"></featured-button>
-                                {% endif %}
-                            </div>
-                        </div>
+                        {% include theme('dataset/reuse-card.html') %}
                     </div>
                     {% endfor %}
                     <div class="col-sm-6 col-md-4">
@@ -445,6 +406,7 @@
                 Reference your work in just a few clicks and increase your visibility.{% endtrans %}</p>
             </div>
         </div>
+        {% endblock %}
 
     </div>
 </section>

--- a/udata/templates/dataset/reuse-card.html
+++ b/udata/templates/dataset/reuse-card.html
@@ -1,0 +1,41 @@
+<div id="reuse-{{reuse.id}}" class="thumbnail reuse">
+    <a class="preview" href="{{ url_for('reuses.show', reuse=reuse) }}">
+        <img class="media-object img-responsive" alt="{{ reuse.title }}"
+            src="{{ reuse.image|placeholder('reuse') }}">
+    </a>
+    <div class="caption">
+        <h4 class="clamp-2">
+            <a href="{{ url_for('reuses.show', reuse=reuse) }}" title="{{ reuse.title }}">
+                {{ reuse.title }}
+            </a>
+        </h4>
+        <div class="author">
+            {{ reuse|owner_avatar(25) }}
+            <a class="user" href="{{ reuse|owner_url }}" title="{{ reuse|owner_name }}">
+            {{ reuse|owner_name }}
+            </a>
+            <span class="date">{{ reuse.created_at|dateformat('long') }}</span>
+        </div>
+    </div>
+    {% if reuse.description %}
+    <a class="rollover fade in" href="{{url_for('reuses.show', reuse=reuse)}}"
+        title="{{ reuse.title }}">
+        {{ reuse.description|mdstrip(180) }}
+    </a>
+    {% endif %}
+    <div class="btn-group btn-group-xs">
+        <a class="btn btn-default" href="{{ reuse.url }}"
+            v-tooltip title="{{ _('Open in a new window') }}">
+            <span class="fa fa-external-link"></span>
+        </a>
+        {% if current_user.sysadmin or reuse.owner == current_user %}
+        <a class="btn btn-default" v-tooltip title="{{ _('Edit') }}"
+            href="{{ url_for('admin.index', path='reuse/{id}/'.format(id=reuse.id)) }}">
+            <span class="fa fa-pencil"></span>
+        </a>
+        {% endif %}
+        {% if current_user.sysadmin %}
+        <featured-button compact subject-id="{{ reuse.id }}" subject-type="reuse" :featured="{{ reuse.featured|to_json }}"></featured-button>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a `reuses_section` block to the dataset display page and extract the reuse card into its own template.
This allows to theme this section and/or to simply override the reuses cards display.