### PR TITLE
Commonmark 0.28 and markdown uniformization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Markdown rendering is now the same between the back and the frontend. [#604](https://github.com/opendatateam/udata/issues/604)
 
 ## 1.2.9 (2018-01-17)
 

--- a/js/helpers/commonmark.js
+++ b/js/helpers/commonmark.js
@@ -1,8 +1,8 @@
 import markdownit from 'markdown-it';
-import { options } from 'markdown-it/lib/presets/commonmark';
+import { options, components } from 'markdown-it/lib/presets/commonmark';
 
 options.linkify = true;
-const markdown = markdownit(options);
+const markdown = markdownit().configure({options, components}).enable('linkify');
 
 export default function(text) {
     return markdown.render(text);

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jquery.browser": "0.1.0",
     "leaflet": "^0.7.7",
     "leaflet-spin": "^1.1.0",
-    "markdown-it": "^7.0.0",
+    "markdown-it": "8.4.0",
     "moment": "^2.14.1",
     "raven-js": "^3.1.1",
     "respond.js": "^1.4.2",

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -4,7 +4,7 @@ blinker==1.4
 celery==4.1.0
 celerybeat-mongo==0.1.0
 chardet==3.0.4
-CommonMark==0.7.3
+CommonMark==0.7.4
 elasticsearch==2.3.0
 elasticsearch-dsl==2.1.0
 factory-boy==2.9.2


### PR DESCRIPTION
This PR ensure both backend and frontend render the same markdown by:
- using the same commonmark specs (0.28)
- fixing the `markdown-it` initialization to ensure the commonmark specs are applied

Connects to #604
Connects to #1081