### PR TITLE
Use AND operator for multiple terms multi_match query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Make the dataset page reuses section and cards themable. [#1378](https://github.com/opendatateam/udata/pull/1378)
 - `ValueError`s are not hidden anymore by the Bad Request error page, they are logged. [#1382](https://github.com/opendatateam/udata/pull/1382)
 - Spatial encoding fixes: prevent breaking unicode errors. [#1381](https://github.com/opendatateam/udata/pull/1381)
-- Ensure the multiple term search use a `AND` operator [#1384](https://github.com/opendatateam/udata/pull/1384)
+- Ensure the multiple term search uses a `AND` operator [#1384](https://github.com/opendatateam/udata/pull/1384)
 
 ## 1.2.9 (2018-01-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Make the dataset page reuses section and cards themable. [#1378](https://github.com/opendatateam/udata/pull/1378)
 - `ValueError`s are not hidden anymore by the Bad Request error page, they are logged. [#1382](https://github.com/opendatateam/udata/pull/1382)
 - Spatial encoding fixes: prevent breaking unicode errors. [#1381](https://github.com/opendatateam/udata/pull/1381)
+- Ensure the multiple term search use a `AND` operator [#1384](https://github.com/opendatateam/udata/pull/1384)
 
 ## 1.2.9 (2018-01-17)
 

--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -134,8 +134,8 @@ class SearchQuery(FacetedSearch):
                 included.append(term)
         if included:
             search = search.query(self.multi_match(included))
-        if excluded:
-            search = search.query(~self.multi_match(excluded))
+        for term in excluded:
+            search = search.query(~self.multi_match([term]))
         return search
 
     def build_search(self):
@@ -152,6 +152,8 @@ class SearchQuery(FacetedSearch):
 
     def multi_match(self, terms):
         params = {'query': ' '.join(terms)}
+        if len(terms) > 1:
+            params['operator'] = 'and'
         # Optionnal search type
         if self.match_type:
             params['type'] = self.match_type

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -556,7 +556,7 @@ class SearchQueryTest(SearchTestMixin, SearchTestCase):
     def test_query_with_multiple_including_and_excluding_terms(self):
         '''A query should detect negation on each term in query_string'''
         search_query = search.search_for(FakeSearch,
-                                         q='test -negated value -other')
+                                         q='test -negated1 value -negated2')
         expected = {
             'bool': {
                 'must': [
@@ -570,13 +570,13 @@ class SearchQueryTest(SearchTestMixin, SearchTestCase):
                 ],
                 'must_not': [
                     {'multi_match': {
-                        'query': 'negated',
+                        'query': 'negated1',
                         'analyzer': search.i18n_analyzer._name,
                         'type': 'cross_fields',
                         'fields': ['title^2', 'description']
                     }},
                     {'multi_match': {
-                        'query': 'other',
+                        'query': 'negated2',
                         'analyzer': search.i18n_analyzer._name,
                         'type': 'cross_fields',
                         'fields': ['title^2', 'description']

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -471,6 +471,18 @@ class SearchQueryTest(SearchTestMixin, SearchTestCase):
         }}
         self.assert_dict_equal(get_query(search_query), expected)
 
+    def test_with_multiple_terms(self):
+        '''A query with multiple terms should use the AND operator'''
+        search_query = search.search_for(FakeSearch, q='test value')
+        expected = {'multi_match': {
+            'query': 'test value',
+            'analyzer': search.i18n_analyzer._name,
+            'type': 'cross_fields',
+            'operator': 'and',
+            'fields': ['title^2', 'description']
+        }}
+        self.assert_dict_equal(get_query(search_query), expected)
+
     def test_default_analyzer(self):
         '''Default analyzer is overridable'''
         class FakeAnalyzerSearch(FakeSearch):
@@ -532,6 +544,39 @@ class SearchQueryTest(SearchTestMixin, SearchTestCase):
                 'must_not': [
                     {'multi_match': {
                         'query': 'negated',
+                        'analyzer': search.i18n_analyzer._name,
+                        'type': 'cross_fields',
+                        'fields': ['title^2', 'description']
+                    }}
+                ]
+            }
+        }
+        self.assert_dict_equal(get_query(search_query), expected)
+
+    def test_query_with_multiple_including_and_excluding_terms(self):
+        '''A query should detect negation on each term in query_string'''
+        search_query = search.search_for(FakeSearch,
+                                         q='test -negated value -other')
+        expected = {
+            'bool': {
+                'must': [
+                    {'multi_match': {
+                        'query': 'test value',
+                        'analyzer': search.i18n_analyzer._name,
+                        'type': 'cross_fields',
+                        'operator': 'and',
+                        'fields': ['title^2', 'description']
+                    }}
+                ],
+                'must_not': [
+                    {'multi_match': {
+                        'query': 'negated',
+                        'analyzer': search.i18n_analyzer._name,
+                        'type': 'cross_fields',
+                        'fields': ['title^2', 'description']
+                    }},
+                    {'multi_match': {
+                        'query': 'other',
                         'analyzer': search.i18n_analyzer._name,
                         'type': 'cross_fields',
                         'fields': ['title^2', 'description']


### PR DESCRIPTION
This PR ensure that queries multiple included terms use the `AND` operator.
It does not apply for negated terms as we want to ensure each negated term contribute to removal.