### PR TITLE
Upgrade to latest elasticsearch and elasticsearch-dsl 2.x

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -5,8 +5,8 @@ celery==4.1.0
 celerybeat-mongo==0.1.0
 chardet==3.0.4
 CommonMark==0.7.4
-elasticsearch==2.3.0
-elasticsearch-dsl==2.1.0
+elasticsearch==2.4.1
+elasticsearch-dsl==2.2.0
 factory-boy==2.9.2
 Faker==0.8.10
 Flask-BabelEx==0.9.3

--- a/udata/tests/organization/test_organization_tasks.py
+++ b/udata/tests/organization/test_organization_tasks.py
@@ -20,12 +20,12 @@ class OrganizationTasksTest(SearchTestMixin, TestCase):
         tasks.purge_organizations()
 
         dataset = Dataset.objects(id=dataset.id).first()
-        self.assertEqual(dataset.organization, None)
+        self.assertIsNone(dataset.organization)
 
         organization = Organization.objects(name='delete me').first()
-        self.assertEqual(organization, None)
+        self.assertIsNone(organization)
 
         indexed_dataset = DatasetSearch.get(id=dataset.id,
                                             using=es.client,
                                             index=es.index_name)
-        self.assertEqual(indexed_dataset.organization, '')
+        self.assertIsNone(indexed_dataset.organization)


### PR DESCRIPTION
As PyUP can't detect updated ES 2.X dependencies, this PR manually upgrade `elasticsearch` and `elasticsearch-dsl` to their latest 2.x releases.