### PR TITLE
Ensure unicode objects are not casted to str but properly encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `ValueError`s are not hidden anymore by the Bad Request error page, they are logged. [#1382](https://github.com/opendatateam/udata/pull/1382)
 - Spatial encoding fixes: prevent breaking unicode errors. [#1381](https://github.com/opendatateam/udata/pull/1381)
 - Ensure the multiple term search uses a `AND` operator [#1384](https://github.com/opendatateam/udata/pull/1384)
-- Facets encoding fixes: ensure lazy string are propery encoded. [#1388](https://github.com/opendatateam/udata/pull/1388)
+- Facets encoding fixes: ensure lazy strings are propery encoded. [#1388](https://github.com/opendatateam/udata/pull/1388)
 
 ## 1.2.9 (2018-01-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `ValueError`s are not hidden anymore by the Bad Request error page, they are logged. [#1382](https://github.com/opendatateam/udata/pull/1382)
 - Spatial encoding fixes: prevent breaking unicode errors. [#1381](https://github.com/opendatateam/udata/pull/1381)
 - Ensure the multiple term search uses a `AND` operator [#1384](https://github.com/opendatateam/udata/pull/1384)
+- Facets encoding fixes: ensure lazy string are propery encoded. [#1388](https://github.com/opendatateam/udata/pull/1388)
 
 ## 1.2.9 (2018-01-17)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ directory = udata/translations
 statistics = true
 
 [extract_messages]
-#keywords = _ gettext ngettext ugettext ungettext gettext_lay ugettext_lazy
+keywords = _ N_ P_ L_ gettext ngettext pgettext npgettext lazy_gettext lazy_pgettext 
 mapping_file = babel.cfg
 add_comments = TRANSLATORS:
 output_file = udata/translations/udata.pot

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -8,7 +8,7 @@ from werkzeug.local import LocalProxy
 from werkzeug import cached_property
 
 from udata.app import cache
-from udata.i18n import gettext as _, get_locale, language
+from udata.i18n import gettext as _, lazy_gettext as L_, get_locale, language
 from udata.models import db
 from udata.core.storages import logos
 
@@ -22,8 +22,8 @@ __all__ = (
 
 
 BASE_GRANULARITIES = [
-    ('poi', _('POI')),
-    ('other', _('Other')),
+    ('poi', L_('POI')),
+    ('other', L_('Other')),
 ]
 
 ADMIN_LEVEL_MIN = 1
@@ -271,7 +271,7 @@ def get_spatial_granularities(lang):
     with language(lang):
         return [
             (l.id, _(l.name)) for l in GeoLevel.objects
-        ] + BASE_GRANULARITIES
+        ] + [(id, label.value) for id, label in BASE_GRANULARITIES]
 
 
 spatial_granularities = LocalProxy(
@@ -295,7 +295,7 @@ class SpatialCoverage(db.EmbeddedDocument):
 
     @property
     def granularity_label(self):
-        return _(dict(spatial_granularities)[self.granularity or 'other'])
+        return dict(spatial_granularities)[self.granularity or 'other']
 
     @property
     def top_label(self):

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -8,7 +8,7 @@ from werkzeug.local import LocalProxy
 from werkzeug import cached_property
 
 from udata.app import cache
-from udata.i18n import gettext as _, lazy_gettext as L_, get_locale, language
+from udata.i18n import _, L_, get_locale, language
 from udata.models import db
 from udata.core.storages import logos
 

--- a/udata/i18n.py
+++ b/udata/i18n.py
@@ -101,16 +101,19 @@ babel = Babel(default_domain=domain)
 # Create shortcuts for the default Flask domain
 def gettext(*args, **kwargs):
     return domain.gettext(*args, **kwargs)
+
 _ = gettext
 
 
 def ngettext(*args, **kwargs):
     return domain.ngettext(*args, **kwargs)
+
 N_ = ngettext
 
 
 def pgettext(*args, **kwargs):
     return domain.pgettext(*args, **kwargs)
+
 P_ = pgettext
 
 
@@ -120,6 +123,8 @@ def npgettext(*args, **kwargs):
 
 def lazy_gettext(*args, **kwargs):
     return domain.lazy_gettext(*args, **kwargs)
+
+L_ = lazy_gettext
 
 
 def lazy_pgettext(*args, **kwargs):

--- a/udata/search/fields.py
+++ b/udata/search/fields.py
@@ -15,6 +15,7 @@ from elasticsearch_dsl.faceted_search import (
 )
 from flask_restplus import inputs
 from jinja2 import Markup
+from speaklater import is_lazy_string
 
 from udata.i18n import lazy_gettext as _, format_date
 from udata.utils import to_bool
@@ -43,8 +44,10 @@ def obj_to_string(obj):
         return None
     elif isinstance(obj, bytes):
         return obj.decode('utf-8')
-    elif isinstance(obj, str):
+    elif isinstance(obj, basestring):
         return obj
+    elif is_lazy_string(obj):
+        return obj.value
     elif hasattr(obj, '__html__'):
         return obj.__html__()
     else:


### PR DESCRIPTION
More fixes on unicode handling (Remove a double translation and ensure lazy_string are properly encoded in search facets)

Connects to #1381 