### PR TITLE
Fix discussions and community resources alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Ensure the multiple term search uses a `AND` operator [#1384](https://github.com/opendatateam/udata/pull/1384)
 - Facets encoding fixes: ensure lazy strings are propery encoded. [#1388](https://github.com/opendatateam/udata/pull/1388)
 - Markdown content is now easily themable (namespaced into a `markdown` class) [#1389](https://github.com/opendatateam/udata/pull/1389)
+- Fix discussions and community resources alignment on datasets and reuses pages [#1390](https://github.com/opendatateam/udata/pull/1390)
 
 ## 1.2.9 (2018-01-17)
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -348,10 +348,12 @@
 
         <h3>{{ _('Discussions') }}</h3>
         <div class="row">
-            <discussion-threads v-ref:discussions class="col-sm-9"
-                subject-id="{{ dataset.id }}"
-                subject-class="{{ dataset.__class__.__name__ }}">
-            </discussion-threads>
+            <div class="col-sm-9">
+                <discussion-threads v-ref:discussions
+                    subject-id="{{ dataset.id }}"
+                    subject-class="{{ dataset.__class__.__name__ }}">
+                </discussion-threads>
+            </div>
             <div class="col-sm-3 note">
                 <p>{{ _('Discussion between the organization and the community about this dataset.') }}</p>
             </div>
@@ -359,17 +361,19 @@
 
         <h3>{{ _('Community resources') }}</h3>
         <div class="row">
-            <div class="col-sm-9 list-group community-resources-list resources-list smaller">
-            {% for resource in dataset.community_resources %}
-                {% include theme('dataset/resource/list-item.html') %}
-            {% endfor %}
-                <a class="list-group-item add"
-                    href="{{ url_for('admin.index', path='community-resource/new/', **{'dataset_id': dataset.id}) }}">
-                    <div class="format-label pull-left">+</div>
-                    <h4 class="list-group-item-heading">
-                        {{ _('New community resource') }}
-                    </h4>
-                </a>
+            <div class="col-sm-9">
+                <div class="list-group community-resources-list resources-list smaller">
+                {% for resource in dataset.community_resources %}
+                    {% include theme('dataset/resource/list-item.html') %}
+                {% endfor %}
+                    <a class="list-group-item add"
+                        href="{{ url_for('admin.index', path='community-resource/new/', **{'dataset_id': dataset.id}) }}">
+                        <div class="format-label pull-left">+</div>
+                        <h4 class="list-group-item-heading">
+                            {{ _('New community resource') }}
+                        </h4>
+                    </a>
+                </div>
             </div>
 
             <div class="col-sm-3 note">

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -241,17 +241,13 @@
     </header>
 
     <div class="container">
-        <div class="row">
-            <div class="col-xs-12">
-                <ul class="card-list">
-                    {% for dataset in reuse.datasets %}
-                    <li class="col-md-4 col-sm-6">
-                    {% include theme('dataset/card.html') %}
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </div>
+        <ul class="row card-list">
+            {% for dataset in reuse.datasets %}
+            <li class="col-md-4 col-sm-6">
+                {% include theme('dataset/card.html') %}
+            </li>
+            {% endfor %}
+        </ul>
     </div>
 </section>
 
@@ -269,9 +265,11 @@
     <div class="container">
         <h3>{{ _('Discussions') }}</h3>
         <div class="row">
-            <discussion-threads v-ref:discussions class="col-sm-9"
-                subject-id="{{ reuse.id }}" subject-class="{{ reuse.__class__.__name__ }}">
-            </discussion-threads>
+            <div class="col-sm-9">
+                <discussion-threads v-ref:discussions
+                    subject-id="{{ reuse.id }}" subject-class="{{ reuse.__class__.__name__ }}">
+                </discussion-threads>
+            </div>
             <div class="col-sm-3 note">
                 <p>{{ _('Discussion between the organization and the community about this dataset.') }}</p>
             </div>


### PR DESCRIPTION
This PR fixes alignment on:
- Dataset display page:
  - discussions
  - community resources
- Reuse display page
  - reused datasets
  - discussions

## Dataset display
### Before
![screenshot-data xps-2018-01-22-14-11-49-308](https://user-images.githubusercontent.com/15725/35222539-91d5a518-ff7e-11e7-9689-87e0e127a533.png)
### After
![screenshot-data xps-2018-01-22-14-03-20-183](https://user-images.githubusercontent.com/15725/35222525-85c0093a-ff7e-11e7-90f7-9a9844866a7a.png)

## Reuse display
### Before
![screenshot-data xps-2018-01-22-14-10-47-113](https://user-images.githubusercontent.com/15725/35222537-90404e6a-ff7e-11e7-95c6-1401d10e02ca.png)
### After
![screenshot-data xps-2018-01-22-14-08-01-773](https://user-images.githubusercontent.com/15725/35222535-8ecd6734-ff7e-11e7-9932-d9e21db89e08.png)




