### PR TITLE
Minimum viable solution to have coherent discussion style for all themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Facets encoding fixes: ensure lazy strings are propery encoded. [#1388](https://github.com/opendatateam/udata/pull/1388)
 - Markdown content is now easily themable (namespaced into a `markdown` class) [#1389](https://github.com/opendatateam/udata/pull/1389)
 - Fix discussions and community resources alignment on datasets and reuses pages [#1390](https://github.com/opendatateam/udata/pull/1390)
+- Fix discussions style on default theme [#1393](https://github.com/opendatateam/udata/pull/1393)
 
 ## 1.2.9 (2018-01-17)
 

--- a/js/components/discussions/thread.vue
+++ b/js/components/discussions/thread.vue
@@ -1,14 +1,32 @@
 <style lang="less">
-.list-group-item {
-    p.list-group-item-heading {
-        a, a:hover {
-            text-decoration: underline;
+.discussion-thread {
+    @vspacing: 10px;
+
+    .list-group-item {
+        p.list-group-item-heading {
+            a, a:hover {
+                text-decoration: underline;
+            }
+        }
+
+        &.list-group-indent {
+            margin-left: 54px;
+            height: inherit;
+            min-height: 54px;
+        }
+
+        &.body-only {
+            margin-top: -@vspacing;
+
+            .list-group-item-heading {
+                margin: 5px;
+            }
         }
     }
 }
 </style>
 <template>
-<div>
+<div class="discussion-thread">
     <div class="list-group-item" :id="discussionIdAttr" @click="toggleDiscussions"
         :class="{expanded: detailed}">
         <div class="format-label pull-left">

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="list-group resources-list smaller">
+<div class="list-group resources-list smaller discussion-threads">
     <discussion-thread v-ref:threads v-for="discussion in discussions" :discussion="discussion" track-by="id">
     </discussion-thread>
     <a class="list-group-item add new-discussion" @click="displayForm" v-show="!formDisplayed">
@@ -143,3 +143,15 @@ export default {
     }
 }
 </script>
+
+<style lang="less">
+.discussion-threads {
+    .list-group-form {
+        height: inherit;
+        
+        form {
+            padding: 1em;
+        }
+    }
+}
+</style>

--- a/less/udata/resource.less
+++ b/less/udata/resource.less
@@ -55,16 +55,11 @@
         }
 
         &.expanded {
-            border-bottom-color: #fafafa;
+            border-bottom-color: @base-color;
         }
 
         &.body-only {
-            margin-top: -@vspacing;
-            border-color: #fafafa;
-
-            .list-group-item-heading {
-                margin: 5px;
-            }
+            border-top-color: @base-color;
         }
 
         &.discussion-messages-list .list-group-item-heading{


### PR DESCRIPTION
This PR import the bare minimum CSS rules from `udata-gouvfr` to have coherent styling on discussion.
Also namespace discussion for future improvement (and theming ability)

## Before

### Thread
![screenshot-data xps-2018-01-22-20-27-21-608](https://user-images.githubusercontent.com/15725/35240214-08e1921e-ffb3-11e7-82f1-642df433a877.png)

### New discussion form
![screenshot-data xps-2018-01-22-21-49-05-289](https://user-images.githubusercontent.com/15725/35244724-78320d34-ffc1-11e7-8c71-c8a52eb37e02.png)

### Thread comment form
![screenshot-data xps-2018-01-22-22-11-31-805](https://user-images.githubusercontent.com/15725/35244714-703acdbe-ffc1-11e7-9601-f4841d822ada.png)

## After

### Thread
![screenshot-data xps-2018-01-22-20-23-10-223](https://user-images.githubusercontent.com/15725/35240215-0a21daee-ffb3-11e7-9698-1304898b81b7.png)

### New discussion form
![screenshot-data xps-2018-01-22-22-09-04-521](https://user-images.githubusercontent.com/15725/35244767-9deb9f9a-ffc1-11e7-8c1b-b3a7f4638755.png)

### Thread comment form
![screenshot-data xps-2018-01-22-22-09-31-077](https://user-images.githubusercontent.com/15725/35244765-9aedfb3a-ffc1-11e7-9cc2-9a03e94a69ae.png)


**NB**: discussion style is a real mess and need some love
**NB**: resources refactoring will break discussions style if nothing is done until then