### PR TITLE
Prevent empty harvest run to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Markdown content is now easily themable (namespaced into a `markdown` class) [#1389](https://github.com/opendatateam/udata/pull/1389)
 - Fix discussions and community resources alignment on datasets and reuses pages [#1390](https://github.com/opendatateam/udata/pull/1390)
 - Fix discussions style on default theme [#1393](https://github.com/opendatateam/udata/pull/1393)
+- Ensure empty harvest jobs properly end [#1395](https://github.com/opendatateam/udata/pull/1395)
 
 ## 1.2.9 (2018-01-17)
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -18,12 +18,15 @@ def harvest(self, ident):
     source = HarvestSource.get(ident)
     Backend = backends.get(source.backend)
     backend = Backend(source)
-    if backend.perform_initialization():
+    items = backend.perform_initialization()
+    if items > 0:
         finalize = harvest_finalize.s(ident)
         items = [
             harvest_item.s(ident, item.remote_id) for item in backend.job.items
         ]
         chord(items)(finalize)
+    elif items == 0:
+        backend.finalize()
 
 
 @task(ignore_result=False)


### PR DESCRIPTION
Prevent empty harvest jobs to fail with Celery

Fix #1394