### PR TITLE
Fix datasets pagination on organization admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix organization admin pagination [#1372](https://github.com/opendatateam/udata/issues/1372)
 
 ## 1.2.10 (2018-01-24)
 

--- a/js/views/organization.vue
+++ b/js/views/organization.vue
@@ -57,7 +57,7 @@ import Followers from 'models/followers';
 import Metrics from 'models/metrics';
 import Organization from 'models/organization';
 import CommunityResources from 'models/communityresources';
-import {PageList} from 'models/base';
+import {PageList, ModelPage} from 'models/base';
 // Widgets
 import DatasetList from 'components/dataset/list.vue';
 import DiscussionList from 'components/discussions/list.vue';
@@ -80,7 +80,8 @@ export default {
                 search: 'title',
                 mask: ReuseList.MASK
             }),
-            datasets: new PageList({
+            datasets: new ModelPage({
+                query: {page_size: 10, sort: '-created'},
                 ns: 'organizations',
                 fetch: 'list_organization_datasets',
                 search: 'title',

--- a/udata/api/fields.py
+++ b/udata/api/fields.py
@@ -8,6 +8,7 @@ from dateutil.parser import parse
 from flask import request, url_for
 from flask_restplus.fields import *  # noqa
 
+from udata.utils import multi_to_dict
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class NextPageUrl(String):
     def output(self, key, obj):
         if not getattr(obj, 'has_next', None):
             return None
-        args = request.args.copy()
+        args = multi_to_dict(request.args)
         args.update(request.view_args)
         args['page'] = obj.page + 1
         return url_for(request.endpoint, _external=True, **args)
@@ -52,7 +53,7 @@ class PreviousPageUrl(String):
     def output(self, key, obj):
         if not getattr(obj, 'has_prev', None):
             return None
-        args = request.args.copy()
+        args = multi_to_dict(request.args)
         args.update(request.view_args)
         args['page'] = obj.page - 1
         return url_for(request.endpoint, _external=True, **args)

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -543,7 +543,7 @@ class OrganizationDatasetsAPITest(APITestCase):
         response = self.get(url_for('api.org_datasets', org=org))
 
         self.assert200(response)
-        self.assertEqual(len(response.json), len(datasets))
+        self.assertEqual(len(response.json['data']), len(datasets))
 
     def test_list_org_datasets_private(self):
         '''Should include private datasets when member'''
@@ -556,7 +556,7 @@ class OrganizationDatasetsAPITest(APITestCase):
         response = self.get(url_for('api.org_datasets', org=org))
 
         self.assert200(response)
-        self.assertEqual(len(response.json), len(datasets))
+        self.assertEqual(len(response.json['data']), len(datasets))
 
     def test_list_org_datasets_hide_private(self):
         '''Should not include private datasets when not member'''
@@ -567,7 +567,7 @@ class OrganizationDatasetsAPITest(APITestCase):
         response = self.get(url_for('api.org_datasets', org=org))
 
         self.assert200(response)
-        self.assertEqual(len(response.json), len(datasets))
+        self.assertEqual(len(response.json['data']), len(datasets))
 
     def test_list_org_datasets_with_size(self):
         '''Should list organization datasets'''
@@ -575,10 +575,10 @@ class OrganizationDatasetsAPITest(APITestCase):
         DatasetFactory.create_batch(3, organization=org)
 
         response = self.get(
-            url_for('api.org_datasets', org=org), qs={'size': 2})
+            url_for('api.org_datasets', org=org), qs={'page_size': 2})
 
         self.assert200(response)
-        self.assertEqual(len(response.json), 2)
+        self.assertEqual(len(response.json['data']), 2)
 
 
 class OrganizationReusesAPITest(APITestCase):


### PR DESCRIPTION
Fix #1372 

NB: the other lists (discussions, issues...) on this page should be fine because they're not limited server side and correctly paginated on client side.