### PR TITLE
Switch from nose to pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: |
             mkdir -p reports/python
             source venv/bin/activate
-            nosetests --with-xunit --xunit-file=reports/python/tests.xml  udata
+            inv test --report
       - store_test_results:
           path: reports/python
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: |
             mkdir -p reports/python
             source venv/bin/activate
-            inv test --report
+            inv test --report --ci
       - store_test_results:
           path: reports/python
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix organization admin pagination [#1372](https://github.com/opendatateam/udata/issues/1372)
 - Switch to `flask-cli` and drop `flask-script`. Deprecated commands have been removed. [#1364](https://github.com/opendatateam/udata/pull/1364) [breaking]
 - Fix missing spinners on loading datatables [#1401](https://github.com/opendatateam/udata/pull/1401)
+- Switch to pytest as testing tool and expose a `udata` pytest plugin [#1400](https://github.com/opendatateam/udata/pull/1400)
 
 ## 1.2.10 (2018-01-24)
 

--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -1,2 +1,3 @@
 flake8==3.5.0
 coverage==4.4.2
+pytest-cov==2.5.1

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,6 +1,7 @@
 feedparser==5.2.1
 httpretty==0.8.14
 mock==2.0.0
-pytest-flask==0.10.0
-pytest-sugar==0.8.0
 pytest==3.3.2
+pytest-flask==0.10.0
+pytest-mock==1.6.3
+pytest-sugar==0.8.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,7 +1,6 @@
-Flask-Testing==0.7.1
-mock==2.0.0
-nose>=1.3.7
-rednose>=1.2.1
-nose-exclude>=0.2.0
 feedparser==5.2.1
 httpretty==0.8.14
+mock==2.0.0
+pytest-flask==0.10.0
+pytest-sugar==0.8.0
+pytest==3.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ directory = udata/translations
 statistics = true
 
 [extract_messages]
-keywords = _ N_ P_ L_ gettext ngettext pgettext npgettext lazy_gettext lazy_pgettext 
+keywords = _ N_ P_ L_ gettext ngettext pgettext npgettext lazy_gettext lazy_pgettext
 mapping_file = babel.cfg
 add_comments = TRANSLATORS:
 output_file = udata/translations/udata.pot
@@ -23,6 +23,9 @@ previous = true
 
 [tool:pytest]
 norecursedirs = .git build .tox specs .cache udata/static udata/templates udata/translations
+python_files = test_*.py
+python_functions = test_*
+python_classes = *Test
 
 [flake8]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,20 +21,8 @@ input_file = udata/translations/udata.pot
 output_dir = udata/translations
 previous = true
 
-[nosetests]
-rednose=1
-hide-skips=1
-immediate=1
-cover-erase=1
-cover-branches=1
-cover-package=udata
-logging-filter=udata
-logging-clear-handlers=1
-logging-level=DEBUG
-exclude-dir=udata/ext
-    udata/static
-    udata/templates
-    udata/translations
+[tool:pytest]
+norecursedirs = .git build .tox specs .cache udata/static udata/templates udata/translations
 
 [flake8]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,9 @@ setup(
         'udata.linkcheckers': [
             'no_check = udata.linkchecker.backends:NoCheckLinkchecker',
         ],
+        'pytest11': [
+            'udata = udata.tests.plugin',
+        ],
     },
     license='GNU AGPLv3+',
     keywords='udata opendata portal data',

--- a/tasks.py
+++ b/tasks.py
@@ -56,21 +56,27 @@ def update(ctx, migrate=False):
 
 
 @task
-def test(ctx, fast=False):
+def test(ctx, fast=False, report=False):
     '''Run tests suite'''
     header('Run tests suite')
-    cmd = 'nosetests --rednose --force-color udata'
+    cmd = ['pytest udata']
     if fast:
-        cmd = ' '.join([cmd, '--stop'])
-    lrun(cmd)
+        cmd.append('-x')
+    if report:
+        cmd.append('--junitxml=reports/python/tests.xml')
+    with ctx.cd(ROOT):
+        ctx.run(' '.join(cmd), pty=True)
 
 
 @task
-def cover(ctx):
+def cover(ctx, html=False):
     '''Run tests suite with coverage'''
     header('Run tests suite with coverage')
-    lrun('nosetests --rednose --force-color \
-        --with-coverage --cover-html --cover-package=udata')
+    cmd = 'pytest --cov udata --cov-report term'
+    if html:
+        cmd = ' '.join((cmd, '--cov-report html:reports/python/cover'))
+    with ctx.cd(ROOT):
+        ctx.run(cmd, pty=True)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -56,10 +56,14 @@ def update(ctx, migrate=False):
 
 
 @task
-def test(ctx, fast=False, report=False):
+def test(ctx, fast=False, report=False, verbose=False, ci=False):
     '''Run tests suite'''
     header('Run tests suite')
     cmd = ['pytest udata']
+    if ci:
+        cmd.append('-p no:sugar --color=yes')
+    if verbose:
+        cmd.append('-v')
     if fast:
         cmd.append('-x')
     if report:

--- a/udata/core/badges/tests/test_commands.py
+++ b/udata/core/badges/tests/test_commands.py
@@ -1,44 +1,46 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from tempfile import NamedTemporaryFile
 
 from udata.models import Badge, CERTIFIED, PUBLIC_SERVICE
-from udata.tests import TestCase, DBTestMixin, CliTestMixin
 from udata.core.organization.factories import OrganizationFactory
 
 
-class BadgeCommandTest(CliTestMixin, DBTestMixin, TestCase):
+@pytest.mark.usefixtures('clean_db')
+class BadgeCommandTest:
     def toggle(self, path_or_id, kind):
         return self.cli('badges', 'toggle', path_or_id, kind)
 
-    def test_toggle_badge_on(self):
+    def test_toggle_badge_on(self, cli):
         org = OrganizationFactory()
 
-        self.toggle(str(org.id), PUBLIC_SERVICE)
+        cli('badges', 'toggle', str(org.id), PUBLIC_SERVICE)
 
         org.reload()
-        self.assertEqual(org.badges[0].kind, PUBLIC_SERVICE)
+        assert org.badges[0].kind == PUBLIC_SERVICE
 
-    def test_toggle_badge_off(self):
+    def test_toggle_badge_off(self, cli):
         ps_badge = Badge(kind=PUBLIC_SERVICE)
         certified_badge = Badge(kind=CERTIFIED)
         org = OrganizationFactory(badges=[ps_badge, certified_badge])
 
-        self.toggle(str(org.id), PUBLIC_SERVICE)
+        cli('badges', 'toggle', str(org.id), PUBLIC_SERVICE)
 
         org.reload()
-        self.assertEqual(org.badges[0].kind, CERTIFIED)
+        assert org.badges[0].kind == CERTIFIED
 
-    def test_toggle_badge_on_from_file(self):
+    def test_toggle_badge_on_from_file(self, cli):
         orgs = [OrganizationFactory() for _ in range(2)]
 
         with NamedTemporaryFile() as temp:
             temp.write('\n'.join((str(org.id) for org in orgs)))
             temp.flush()
 
-            self.toggle(temp.name, PUBLIC_SERVICE)
+            cli('badges', 'toggle', temp.name, PUBLIC_SERVICE)
 
         for org in orgs:
             org.reload()
-            self.assertEqual(org.badges[0].kind, PUBLIC_SERVICE)
+            assert org.badges[0].kind == PUBLIC_SERVICE

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -10,6 +10,7 @@ from udata.tests.api import APITestCase
 from udata.tests.features.territories.test_territories_process import (
     create_geozones_fixtures, TerritoriesSettings
 )
+from udata.tests.helpers import assert_json_equal
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.spatial.factories import (
@@ -31,7 +32,7 @@ class SpatialApiTest(APITestCase):
 
         feature = response.json['features'][0]
         self.assertEqual(feature['type'], 'Feature')
-        self.assertJsonEqual(feature['geometry'], zone.geom)
+        assert_json_equal(feature['geometry'], zone.geom)
         self.assertEqual(feature['id'], zone.id)
 
         properties = feature['properties']
@@ -55,7 +56,7 @@ class SpatialApiTest(APITestCase):
 
         feature = response.json['features'][0]
         self.assertEqual(feature['type'], 'Feature')
-        self.assertJsonEqual(feature['geometry'], {
+        assert_json_equal(feature['geometry'], {
             'type': 'MultiPolygon',
             'coordinates': [],
         })
@@ -82,7 +83,7 @@ class SpatialApiTest(APITestCase):
 
         for zone, feature in zip(zones, response.json['features']):
             self.assertEqual(feature['type'], 'Feature')
-            self.assertJsonEqual(feature['geometry'], zone.geom)
+            assert_json_equal(feature['geometry'], zone.geom)
             self.assertEqual(feature['id'], zone.id)
 
             properties = feature['properties']
@@ -326,7 +327,7 @@ class SpatialApiTest(APITestCase):
 
             zone = get_by(subzones, 'id', feature['id'])
             self.assertIsNotNone(zone)
-            self.assertJsonEqual(feature['geometry'], zone.geom)
+            assert_json_equal(feature['geometry'], zone.geom)
 
             properties = feature['properties']
             self.assertEqual(properties['name'], zone.name)

--- a/udata/core/spatial/tests/test_fields.py
+++ b/udata/core/spatial/tests/test_fields.py
@@ -10,6 +10,7 @@ from werkzeug.datastructures import MultiDict
 from udata.forms import Form
 from udata.models import db
 from udata.tests import TestCase
+from udata.tests.helpers import assert_json_equal
 from udata.utils import faker
 
 from ..factories import GeoZoneFactory
@@ -173,7 +174,7 @@ class SpatialCoverageFieldTest(TestCase):
 
         form.populate_obj(fake)
 
-        self.assertJsonEqual(fake.spatial.geom, geom)
+        assert_json_equal(fake.spatial.geom, geom)
 
     def test_with_valid_geom_from_json(self):
         Fake, FakeForm = self.factory()
@@ -187,7 +188,7 @@ class SpatialCoverageFieldTest(TestCase):
 
         form.populate_obj(fake)
 
-        self.assertJsonEqual(fake.spatial.geom, geom)
+        assert_json_equal(fake.spatial.geom, geom)
 
     def test_with_invalid_geom_from_json(self):
         Fake, FakeForm = self.factory()
@@ -275,7 +276,7 @@ class SpatialCoverageFieldTest(TestCase):
 
         form.populate_obj(fake)
 
-        self.assertJsonEqual(fake.spatial.geom, geom)
+        assert_json_equal(fake.spatial.geom, geom)
 
     def test_with_initial_none(self):
         Fake, FakeForm = self.factory()

--- a/udata/features/identicon/tests/test_backends.py
+++ b/udata/features/identicon/tests/test_backends.py
@@ -3,11 +3,11 @@ from __future__ import unicode_literals
 
 from udata.features.identicon.backends import internal
 
-from udata.tests import TestCase
+from udata.tests import TestCase, WebTestMixin
 from udata.utils import faker
 
 
-class InternalBackendTests(TestCase):
+class InternalBackendTests(WebTestMixin, TestCase):
     def assert_stream_equal(self, response1, response2):
         self.assertEqual(list(response1.iter_encoded()),
                          list(response2.iter_encoded()))

--- a/udata/harvest/tests/factories.py
+++ b/udata/harvest/tests/factories.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import factory
+import pytest
 
 from factory.fuzzy import FuzzyChoice
 from flask.signals import Namespace
@@ -61,12 +62,8 @@ class FactoryBackend(backends.BaseBackend):
 
 class MockBackendsMixin(object):
     '''A mixin mocking the harvest backend'''
-    def setUp(self):
-        super(MockBackendsMixin, self).setUp()
-        self.patcher = patch('udata.harvest.backends.get_all')
-        mock_get_all = self.patcher.start()
-        mock_get_all.return_value = {'factory': FactoryBackend}
-
-    def tearDown(self):
-        super(MockBackendsMixin, self).tearDown()
-        self.patcher.stop()
+    @pytest.fixture(autouse=True)
+    def mock_backend(self, mocker):
+        return_value = {'factory': FactoryBackend}
+        mocker.patch('udata.harvest.backends.get_all',
+                     return_value=return_value)

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -46,7 +46,6 @@ def mock_pagination(path, pattern):
 
 class DcatBackendTest(DBTestMixin, TestCase):
     def setUp(self):
-        super(DcatBackendTest, self).setUp()
         # Create fake licenses
         for license_id in 'lool', 'fr-lo':
             License.objects.create(id=license_id, title=license_id)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -102,20 +102,6 @@ class TestCase(unittest.TestCase):
 
         mail_sent.disconnect(on_mail_sent)
 
-    @contextmanager
-    def assert_warn(self, warning_cls):
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter('always', warning_cls)
-            yield
-            warnings.simplefilter('default', warning_cls)
-            assert len(w), 'No warning has been raised'
-            warning = w[-1]
-            msg = '{0} raised and is not a sublcass of {1}'.format(
-                warning.category.__name__, warning_cls.__name__
-            )
-            assert issubclass(warning.category, DeprecationWarning), msg
-
 
 class WebTestMixin(object):
     user = None

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -210,20 +210,3 @@ class SearchTestMixin(DBTestMixin):
         super(SearchTestMixin, self).tearDown()
         if self._used_search and es.indices.exists(index=es.index_name):
             es.indices.delete(index=es.index_name)
-
-
-def mock_task(name, **kwargs):
-    def wrapper(func):
-        return mock.patch(name, **kwargs)(func)
-    return wrapper
-
-
-def filestorage(filename, content):
-    data = (StringIO(str(content))
-            if isinstance(content, basestring) else content)
-    builder = EnvironBuilder(method='POST', data={
-        'file': (data, filename)
-    })
-    env = builder.get_environ()
-    req = Request(env)
-    return req.files['file']

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -8,10 +8,6 @@ import mock
 import pytest
 
 from contextlib import contextmanager
-from StringIO import StringIO
-
-from werkzeug.test import EnvironBuilder
-from werkzeug.wrappers import Request
 
 from udata import settings
 from udata.mail import mail_sent
@@ -46,18 +42,6 @@ class TestCase(unittest.TestCase):
         """Lax date comparison, avoid comparing milliseconds and seconds."""
         __tracebackhide__ = True
         helpers.assert_equal_dates(datetime1, datetime2, limit=1)
-
-    def assertStartswith(self, haystack, needle):
-        __tracebackhide__ = True
-        msg = '{haystack} does not start with {needle}'
-        assert haystack.startswith(needle), msg.format(
-            haystack=haystack, needle=needle
-        )
-
-    def assertJsonEqual(self, first, second):
-        '''Ensure two dict produce the same JSON'''
-        __tracebackhide__ = True
-        helpers.assert_json_equal(first, second)
 
     @contextmanager
     def assert_emit(self, *signals):

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -16,14 +16,6 @@ from . import helpers
 class TestCase(unittest.TestCase):
     settings = settings.Testing
 
-    def setUp(self):
-        # Ensure compatibility with multiple inheritance
-        super(TestCase, self).setUp()
-
-    def tearsDown(self):
-        # Ensure compatibility with multiple inheritance
-        super(TestCase, self).tearsDown()
-
     @pytest.fixture(autouse=True)
     def inject_app(self, app):
         self.app = app
@@ -115,6 +107,5 @@ class SearchTestMixin(DBTestMixin):
 
     def tearDown(self):
         '''Drop indices if needed'''
-        super(SearchTestMixin, self).tearDown()
         if self._used_search and es.indices.exists(index=es.index_name):
             es.indices.delete(index=es.index_name)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -231,25 +231,6 @@ class FSTestMixin(object):
         shutil.rmtree(self.fs_root)
 
 
-class CliTestMixin(object):
-    def cli(self, *args):
-        from click.testing import CliRunner
-        from udata.commands import cli
-
-        if len(args) == 1 and ' ' in args[0]:
-            args = args[0].split()
-
-        runner = CliRunner()
-        with mock.patch.object(cli, 'create_app', return_value=self.app):
-            result = runner.invoke(cli, args, catch_exceptions=False)
-
-        self.assertEqual(result.exit_code, 0,
-                         'The command failed with exit code {0.exit_code}'
-                         ' and the following output:\n{0.output}'
-                         .format(result))
-        return result
-
-
 def mock_task(name, **kwargs):
     def wrapper(func):
         return mock.patch(name, **kwargs)(func)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-import mock
 import pytest
 
 from contextlib import contextmanager
@@ -40,52 +39,6 @@ class TestCase(unittest.TestCase):
         """Lax date comparison, avoid comparing milliseconds and seconds."""
         __tracebackhide__ = True
         helpers.assert_equal_dates(datetime1, datetime2, limit=1)
-
-    @contextmanager
-    def assert_emit(self, *signals):
-        __tracebackhide__ = True
-        specs = []
-
-        def handler(sender, **kwargs):
-            pass
-
-        for signal in signals:
-            m = mock.Mock(spec=handler)
-            signal.connect(m, weak=False)
-            specs.append((signal, m))
-
-        yield
-
-        for signal, mock_handler in specs:
-            signal.disconnect(mock_handler)
-            signal_name = getattr(signal, 'name', str(signal))
-            self.assertTrue(
-                mock_handler.called,
-                'Signal "{0}" should have been emitted'.format(signal_name)
-            )
-
-    @contextmanager
-    def assert_not_emit(self, *signals):
-        __tracebackhide__ = True
-        specs = []
-
-        def handler(sender, **kwargs):
-            pass
-
-        for signal in signals:
-            m = mock.Mock(spec=handler)
-            signal.connect(m, weak=False)
-            specs.append((signal, m))
-
-        yield
-
-        for signal, mock_handler in specs:
-            signal.disconnect(mock_handler)
-            signal_name = getattr(signal, 'name', str(signal))
-            self.assertFalse(
-                mock_handler.called,
-                'Signal "{0}" should NOT have been emitted'.format(signal_name)
-            )
 
 
 class WebTestMixin(object):

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import os
-import shutil
-import tempfile
 import unittest
 import warnings
 
@@ -44,9 +41,6 @@ class TestCase(unittest.TestCase):
         Here for compatibility legacy test classes
         '''
         return self.app
-
-    def data(self, filename):
-        return os.path.join(os.path.dirname(__file__), 'data', filename)
 
     def assertEqualDates(self, datetime1, datetime2, limit=1):  # Seconds.
         """Lax date comparison, avoid comparing milliseconds and seconds."""
@@ -216,19 +210,6 @@ class SearchTestMixin(DBTestMixin):
         super(SearchTestMixin, self).tearDown()
         if self._used_search and es.indices.exists(index=es.index_name):
             es.indices.delete(index=es.index_name)
-
-
-class FSTestMixin(object):
-    def setUp(self):
-        '''Use a temporary FS_ROOT'''
-        super(FSTestMixin, self).setUp()
-        self.fs_root = tempfile.mkdtemp()
-        self.app.config['FS_ROOT'] = self.fs_root
-
-    def tearDown(self):
-        '''Clear the temporary file system'''
-        super(FSTestMixin, self).tearDown()
-        shutil.rmtree(self.fs_root)
 
 
 def mock_task(name, **kwargs):

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import unittest
-import warnings
 
 import mock
 import pytest
@@ -10,7 +9,6 @@ import pytest
 from contextlib import contextmanager
 
 from udata import settings
-from udata.mail import mail_sent
 from udata.search import es
 
 from . import helpers
@@ -88,19 +86,6 @@ class TestCase(unittest.TestCase):
                 mock_handler.called,
                 'Signal "{0}" should NOT have been emitted'.format(signal_name)
             )
-
-    @contextmanager
-    def capture_mails(self):
-        mails = []
-
-        def on_mail_sent(mail):
-            mails.append(mail)
-
-        mail_sent.connect(on_mail_sent)
-
-        yield mails
-
-        mail_sent.disconnect(on_mail_sent)
 
 
 class WebTestMixin(object):

--- a/udata/tests/api/__init__.py
+++ b/udata/tests/api/__init__.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from contextlib import contextmanager
+import pytest
 
-from flask import json
+from contextlib import contextmanager
 
 from udata.core import storages
 from udata.core.storages.views import blueprint
 
-from udata.core.user.factories import UserFactory
 from ..frontend import FrontTestCase
 
 
@@ -19,49 +18,26 @@ class APITestCase(FrontTestCase):
         app.register_blueprint(blueprint)
         return app
 
+    @pytest.fixture(autouse=True)
+    def inject_api(self, api):
+        '''
+        Inject API test client for compatibility with legacy tests.
+        '''
+        self.api = api
+
     @contextmanager
     def api_user(self, user=None):
-        self._api_user = user or UserFactory()
-        if not self._api_user.apikey:
-            self._api_user.generate_api_key()
-            self._api_user.save()
-        yield self._api_user
+        with self.api.user(user) as user:
+            yield user
 
-    def perform(self, verb, url, **kwargs):
-        headers = kwargs.pop('headers', {})
-        headers['Content-Type'] = 'application/json'
+    def get(self, url, *args, **kwargs):
+        return self.api.get(url, *args, **kwargs)
 
-        data = kwargs.get('data')
-        if data is not None:
-            data = json.dumps(data)
-            headers['Content-Length'] = len(data)
-            kwargs['data'] = data
+    def post(self, url, data=None, json=True, *args, **kwargs):
+        return self.api.post(url, data=data, json=json, *args, **kwargs)
 
-        if getattr(self, '_api_user', None):
-            headers['X-API-KEY'] = kwargs.get('X-API-KEY',
-                                              self._api_user.apikey)
+    def put(self, url, data=None, json=True, *args, **kwargs):
+        return self.api.put(url, data=data, json=json, *args, **kwargs)
 
-        kwargs['headers'] = headers
-        method = getattr(super(APITestCase, self), verb)
-        return method(url, **kwargs)
-
-    def get(self, url, client=None, *args, **kwargs):
-        return self.perform('get', url, client=client, *args, **kwargs)
-
-    def post(self, url, data=None, client=None, json=True, *args, **kwargs):
-        if not json:
-            return super(APITestCase, self).post(
-                url, data or {}, client=client, *args, **kwargs)
-        return self.perform('post', url, data=data or {}, client=client,
-                            *args, **kwargs)
-
-    def put(self, url, data=None, client=None, json=True, *args, **kwargs):
-        if not json:
-            return super(APITestCase, self).put(
-                url, data or {}, client=client, *args, **kwargs)
-        return self.perform('put', url, data=data or {}, client=client,
-                            *args, **kwargs)
-
-    def delete(self, url, data=None, client=None, *args, **kwargs):
-        return self.perform('delete', url, data=data or {}, client=client,
-                            *args, **kwargs)
+    def delete(self, url, data=None, *args, **kwargs):
+        return self.api.delete(url, data=data, *args, **kwargs)

--- a/udata/tests/api/__init__.py
+++ b/udata/tests/api/__init__.py
@@ -5,18 +5,11 @@ import pytest
 
 from contextlib import contextmanager
 
-from udata.core import storages
-from udata.core.storages.views import blueprint
-
 from ..frontend import FrontTestCase
 
 
+@pytest.mark.usefixtures('instance_path')
 class APITestCase(FrontTestCase):
-    def create_app(self):
-        app = super(APITestCase, self).create_app()
-        storages.init_app(app)
-        app.register_blueprint(blueprint)
-        return app
 
     @pytest.fixture(autouse=True)
     def inject_api(self, api):

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -461,7 +461,6 @@ class DatasetBadgeAPITest(APITestCase):
         cls.factory = badge_factory(Dataset)
 
     def setUp(self):
-        super(DatasetBadgeAPITest, self).setUp()
         self.login(AdminFactory())
         self.dataset = DatasetFactory(owner=UserFactory())
 
@@ -532,7 +531,6 @@ class DatasetResourceAPITest(APITestCase):
     modules = None
 
     def setUp(self):
-        super(DatasetResourceAPITest, self).setUp()
         self.login()
         self.dataset = DatasetFactory(owner=self.user)
 

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -23,8 +23,6 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.tags import MIN_TAG_LENGTH, MAX_TAG_LENGTH
 from udata.utils import unique_string, faker
 
-from nose.plugins.attrib import attr
-
 
 SAMPLE_GEOM = {
     "type": "MultiPolygon",
@@ -38,7 +36,7 @@ SAMPLE_GEOM = {
 
 class DatasetAPITest(APITestCase):
     modules = ['core.user', 'core.dataset', 'core.organization']
-    
+
     def test_dataset_api_list(self):
         '''It should fetch a dataset list from the API'''
         with self.autoindex():
@@ -124,7 +122,6 @@ class DatasetAPITest(APITestCase):
         response = self.get(url_for('api.dataset', dataset=dataset))
         self.assert200(response)
 
-    @attr('create')
     def test_dataset_api_create(self):
         '''It should create a dataset from the API'''
         data = DatasetFactory.as_dict()
@@ -137,7 +134,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.owner, self.user)
         self.assertIsNone(dataset.organization)
 
-    @attr('create')
     def test_dataset_api_create_as_org(self):
         '''It should create a dataset as organization from the API'''
         self.login()
@@ -154,7 +150,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.organization, org)
         self.assertIsNone(dataset.owner)
 
-    @attr('create')
     def test_dataset_api_create_as_org_permissions(self):
         """It should create a dataset as organization from the API
 
@@ -168,7 +163,6 @@ class DatasetAPITest(APITestCase):
         self.assert400(response)
         self.assertEqual(Dataset.objects.count(), 0)
 
-    @attr('create')
     def test_dataset_api_create_tags(self):
         '''It should create a dataset from the API with tags'''
         data = DatasetFactory.as_dict()
@@ -180,7 +174,6 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.tags, sorted(data['tags']))
 
-    @attr('create')
     def test_dataset_api_fail_to_create_too_short_tags(self):
         '''It should fail to create a dataset from the API because
         the tag is too short'''
@@ -190,7 +183,6 @@ class DatasetAPITest(APITestCase):
             response = self.post(url_for('api.datasets'), data)
         self.assertStatus(response, 400)
 
-    @attr('create')
     def test_dataset_api_fail_to_create_too_long_tags(self):
         '''Should fail creating a dataset with a tag long'''
         data = DatasetFactory.as_dict()
@@ -199,7 +191,6 @@ class DatasetAPITest(APITestCase):
             response = self.post(url_for('api.datasets'), data)
         self.assertStatus(response, 400)
 
-    @attr('create')
     def test_dataset_api_create_and_slugify_tags(self):
         '''It should create a dataset from the API and slugify the tags'''
         data = DatasetFactory.as_dict()
@@ -211,7 +202,6 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.tags, ['aaa-bbb-u'])
 
-    @attr('create')
     def test_dataset_api_create_with_extras(self):
         '''It should create a dataset with extras from the API'''
         data = DatasetFactory.as_dict()
@@ -230,7 +220,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.extras['float'], 42.0)
         self.assertEqual(dataset.extras['string'], 'value')
 
-    @attr('create')
     def test_dataset_api_create_with_resources(self):
         '''It should create a dataset with resources from the API'''
         data = DatasetFactory.as_dict()
@@ -244,7 +233,6 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(len(dataset.resources), 3)
 
-    @attr('create')
     def test_dataset_api_create_with_geom(self):
         '''It should create a dataset with resources from the API'''
         data = DatasetFactory.as_dict()
@@ -258,7 +246,6 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.spatial.geom, SAMPLE_GEOM)
 
-    @attr('create')
     def test_dataset_api_create_with_legacy_frequency(self):
         '''It should create a dataset from the API with a legacy frequency'''
         self.login()
@@ -270,7 +257,6 @@ class DatasetAPITest(APITestCase):
             self.assert201(response)
             self.assertEqual(response.json['frequency'], newFreq)
 
-    @attr('update')
     def test_dataset_api_update(self):
         '''It should update a dataset from the API'''
         user = self.login()
@@ -283,7 +269,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(Dataset.objects.first().description,
                          'new description')
 
-    @attr('update')
     def test_dataset_api_update_with_resources(self):
         '''It should update a dataset from the API with resources parameters'''
         user = self.login()
@@ -298,7 +283,6 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(len(dataset.resources), initial_length + 1)
 
-    @attr('update')
     def test_dataset_api_update_without_resources(self):
         '''It should update a dataset from the API without resources'''
         user = self.login()
@@ -316,7 +300,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.description, data['description'])
         self.assertEqual(len(dataset.resources), initial_length)
 
-    @attr('update')
     def test_dataset_api_update_with_extras(self):
         '''It should update a dataset from the API with extras parameters'''
         user = self.login()
@@ -336,7 +319,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.extras['float'], 42.0)
         self.assertEqual(dataset.extras['string'], 'value')
 
-    @attr('update')
     def test_dataset_api_update_with_no_extras(self):
         '''It should update a dataset from the API with no extras
 
@@ -363,7 +345,6 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.extras['float'], 42.0)
         self.assertEqual(dataset.extras['string'], 'value')
 
-    @attr('update')
     def test_dataset_api_update_with_empty_extras(self):
         '''It should update a dataset from the API with empty extras
 
@@ -388,7 +369,6 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.extras, {})
 
-    @attr('update')
     def test_dataset_api_update_deleted(self):
         '''It should not update a deleted dataset from the API and raise 401'''
         user = self.login()
@@ -481,6 +461,7 @@ class DatasetBadgeAPITest(APITestCase):
         cls.factory = badge_factory(Dataset)
 
     def setUp(self):
+        super(DatasetBadgeAPITest, self).setUp()
         self.login(AdminFactory())
         self.dataset = DatasetFactory(owner=UserFactory())
 
@@ -549,11 +530,12 @@ class DatasetBadgeAPITest(APITestCase):
 
 class DatasetResourceAPITest(APITestCase):
     modules = None
+
     def setUp(self):
+        super(DatasetResourceAPITest, self).setUp()
         self.login()
         self.dataset = DatasetFactory(owner=self.user)
 
-    @attr('create')
     def test_create(self):
         data = ResourceFactory.as_dict()
         with self.api_user():
@@ -563,7 +545,6 @@ class DatasetResourceAPITest(APITestCase):
         self.dataset.reload()
         self.assertEqual(len(self.dataset.resources), 1)
 
-    @attr('create')
     def test_create_2nd(self):
         self.dataset.resources.append(ResourceFactory())
         self.dataset.save()
@@ -576,7 +557,6 @@ class DatasetResourceAPITest(APITestCase):
         self.dataset.reload()
         self.assertEqual(len(self.dataset.resources), 2)
 
-    @attr('create')
     def test_create_with_file(self):
         '''It should create a resource from the API with a file'''
         user = self.login()
@@ -598,7 +578,6 @@ class DatasetResourceAPITest(APITestCase):
         self.assertEqual(len(dataset.resources), 1)
         self.assertTrue(dataset.resources[0].url.endswith('test.txt'))
 
-    @attr('update')
     def test_reorder(self):
         self.dataset.resources = ResourceFactory.build_batch(3)
         self.dataset.save()
@@ -619,7 +598,6 @@ class DatasetResourceAPITest(APITestCase):
                          [str(r['id']) for r in expected_order])
         self.assertEqual(self.dataset.last_modified, initial_last_modified)
 
-    @attr('update')
     def test_update(self):
         resource = ResourceFactory()
         self.dataset.resources.append(resource)
@@ -644,7 +622,6 @@ class DatasetResourceAPITest(APITestCase):
         self.assertEqual(updated.url, data['url'])
         self.assertEqualDates(updated.published, now)
 
-    @attr('update')
     def test_bulk_update(self):
         resources = ResourceFactory.build_batch(2)
         self.dataset.resources.extend(resources)
@@ -677,7 +654,6 @@ class DatasetResourceAPITest(APITestCase):
         new_resource = self.dataset.resources[-1]
         self.assertEqualDates(new_resource.published, now)
 
-    @attr('update')
     def test_update_404(self):
         data = {
             'title': faker.sentence(),
@@ -690,7 +666,6 @@ class DatasetResourceAPITest(APITestCase):
                                         rid=str(ResourceFactory().id)), data)
         self.assert404(response)
 
-    @attr('update')
     def test_update_with_file(self):
         '''It should update a resource from the API with a file'''
         user = self.login()
@@ -924,7 +899,6 @@ class CommunityResourceAPITest(APITestCase):
         data = json.loads(response.data)
         self.assertEqual(data['id'], str(community_resource.id))
 
-    @attr('create')
     def test_community_resource_api_create(self):
         '''It should create a community resource from the API'''
         dataset = VisibleDatasetFactory()
@@ -945,7 +919,6 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(community_resource.owner, self.user)
         self.assertIsNone(community_resource.organization)
 
-    @attr('create')
     def test_community_resource_api_create_as_org(self):
         '''It should create a community resource as org from the API'''
         dataset = VisibleDatasetFactory()
@@ -970,7 +943,6 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(community_resource.organization, org)
         self.assertIsNone(community_resource.owner)
 
-    @attr('update')
     def test_community_resource_api_update(self):
         '''It should update a community resource from the API'''
         user = self.login()
@@ -985,7 +957,6 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(CommunityResource.objects.first().description,
                          'new description')
 
-    @attr('update')
     def test_community_resource_api_update_with_file(self):
         '''It should update a community resource file from the API'''
         dataset = VisibleDatasetFactory()
@@ -1011,7 +982,6 @@ class CommunityResourceAPITest(APITestCase):
         self.assertTrue(
             CommunityResource.objects.first().url.endswith('test.txt'))
 
-    @attr('create')
     def test_community_resource_api_create_remote(self):
         '''It should create a remote community resource from the API'''
         user = self.login()
@@ -1032,7 +1002,6 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(community_resource.owner, user)
         self.assertIsNone(community_resource.organization)
 
-    @attr('create')
     def test_community_resource_api_create_remote_needs_dataset(self):
         '''
         It should prevent remote community resource creation without dataset
@@ -1049,7 +1018,6 @@ class CommunityResourceAPITest(APITestCase):
         self.assertIn('dataset', data['errors'])
         self.assertEqual(CommunityResource.objects.count(), 0)
 
-    @attr('create')
     def test_community_resource_api_create_remote_needs_real_dataset(self):
         '''
         It should prevent remote community resource creation without a valid

--- a/udata/tests/api/test_follow_api.py
+++ b/udata/tests/api/test_follow_api.py
@@ -24,7 +24,6 @@ class FollowFakeAPI(FollowAPI):
 class FollowAPITest(APITestCase):
     def setUp(self):
         self.signal_emitted = False
-        super(FollowAPITest, self).setUp()
 
     def handler(self, sender):
         self.assertIsInstance(sender, Follow)

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -20,6 +20,7 @@ from udata.core.reuse.factories import ReuseFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.user.factories import UserFactory
 from udata.i18n import _
+from udata.tests.helpers import capture_mails
 from udata.utils import faker
 
 from . import APITestCase
@@ -366,7 +367,7 @@ class MeAPITest(APITestCase):
         following = Follow.objects().create(follower=user, following=other_user)
         followed = Follow.objects().create(follower=other_user, following=user)
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             response = self.delete(url_for('api.me'))
         self.assertEqual(len(mails), 1)
         self.assertEqual(mails[0].send_to, set([user.email]))

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -44,11 +44,13 @@ class OEmbedsDatasetAPITest(APITestCase):
     settings = OEmbedSettings
 
     def setUp(self):
+        super(OEmbedsDatasetAPITest, self).setUp()
         self.territory_datasets_backup = {
             k: copy.deepcopy(v) for k, v in TERRITORY_DATASETS.items()
         }
 
     def tearDown(self):
+        super(OEmbedsDatasetAPITest, self).tearDown()
         TERRITORY_DATASETS.update(self.territory_datasets_backup)
 
     def test_oembeds_dataset_api_get(self):

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -44,7 +44,6 @@ class OEmbedsDatasetAPITest(APITestCase):
     settings = OEmbedSettings
 
     def setUp(self):
-        super(OEmbedsDatasetAPITest, self).setUp()
         self.territory_datasets_backup = {
             k: copy.deepcopy(v) for k, v in TERRITORY_DATASETS.items()
         }

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -688,7 +688,6 @@ class OrganizationBadgeAPITest(APITestCase):
         cls.factory = badge_factory(Organization)
 
     def setUp(self):
-        super(OrganizationBadgeAPITest, self).setUp()
         self.login(AdminFactory())
         self.organization = OrganizationFactory()
 

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -686,6 +686,7 @@ class OrganizationBadgeAPITest(APITestCase):
         cls.factory = badge_factory(Organization)
 
     def setUp(self):
+        super(OrganizationBadgeAPITest, self).setUp()
         self.login(AdminFactory())
         self.organization = OrganizationFactory()
 

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -20,6 +20,8 @@ from udata.core.user.factories import UserFactory, AdminFactory
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.reuse.factories import ReuseFactory
 
+from udata.tests.helpers import capture_mails
+
 import udata.core.badges.tasks  # noqa
 
 
@@ -715,7 +717,7 @@ class OrganizationBadgeAPITest(APITestCase):
         data = self.factory.as_dict()
         data['kind'] = CERTIFIED
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             self.post(
                 url_for('api.organization_badges', org=org),
                 data)
@@ -732,7 +734,7 @@ class OrganizationBadgeAPITest(APITestCase):
         data = self.factory.as_dict()
         data['kind'] = PUBLIC_SERVICE
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             self.post(
                 url_for('api.organization_badges', org=org),
                 data)

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -325,6 +325,7 @@ class ReuseBadgeAPITest(APITestCase):
         cls.factory = badge_factory(Reuse)
 
     def setUp(self):
+        super(ReuseBadgeAPITest, self).setUp()
         self.login(AdminFactory())
         self.reuse = ReuseFactory()
 

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -325,7 +325,6 @@ class ReuseBadgeAPITest(APITestCase):
         cls.factory = badge_factory(Reuse)
 
     def setUp(self):
-        super(ReuseBadgeAPITest, self).setUp()
         self.login(AdminFactory())
         self.reuse = ReuseFactory()
 

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -12,6 +12,7 @@ from udata.core.discussions.factories import (
     MessageDiscussionFactory, DiscussionFactory
 )
 from udata.core.user.factories import UserFactory
+from udata.tests.helpers import assert_emit
 
 from .. import TestCase, DBTestMixin
 
@@ -23,11 +24,11 @@ class DatasetModelTest(TestCase, DBTestMixin):
         resource = ResourceFactory()
         expected_signals = post_save, Dataset.after_save, Dataset.on_update
 
-        with self.assert_emit(*expected_signals):
+        with assert_emit(*expected_signals):
             dataset.add_resource(ResourceFactory())
         self.assertEqual(len(dataset.resources), 1)
 
-        with self.assert_emit(*expected_signals):
+        with assert_emit(*expected_signals):
             dataset.add_resource(resource)
         self.assertEqual(len(dataset.resources), 2)
         self.assertEqual(dataset.resources[0].id, resource.id)
@@ -38,11 +39,11 @@ class DatasetModelTest(TestCase, DBTestMixin):
         resource = ResourceFactory(checksum=None)
         expected_signals = post_save, Dataset.after_save, Dataset.on_update
 
-        with self.assert_emit(*expected_signals):
+        with assert_emit(*expected_signals):
             dataset.add_resource(ResourceFactory(checksum=None))
         self.assertEqual(len(dataset.resources), 1)
 
-        with self.assert_emit(*expected_signals):
+        with assert_emit(*expected_signals):
             dataset.add_resource(resource)
         self.assertEqual(len(dataset.resources), 2)
         self.assertEqual(dataset.resources[0].id, resource.id)
@@ -64,7 +65,7 @@ class DatasetModelTest(TestCase, DBTestMixin):
 
         resource.description = 'New description'
 
-        with self.assert_emit(*expected_signals):
+        with assert_emit(*expected_signals):
             dataset.update_resource(resource)
         self.assertEqual(len(dataset.resources), 1)
         self.assertEqual(dataset.resources[0].id, resource.id)
@@ -224,7 +225,7 @@ class DatasetModelTest(TestCase, DBTestMixin):
 
     def test_send_on_delete(self):
         dataset = DatasetFactory()
-        with self.assert_emit(Dataset.on_delete):
+        with assert_emit(Dataset.on_delete):
             dataset.deleted = datetime.now()
             dataset.save()
 

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -247,7 +247,6 @@ class ResourceModelTest(TestCase, DBTestMixin):
 
 class LicenseModelTest(DBTestMixin, TestCase):
     def setUp(self):
-        super(LicenseModelTest, self).setUp()
         # Feed the DB with random data to ensure true matching
         LicenseFactory.create_batch(3)
 

--- a/udata/tests/features/territories/test_territories_api.py
+++ b/udata/tests/features/territories/test_territories_api.py
@@ -16,7 +16,6 @@ class TerritoriesAPITest(APITestCase):
     settings = TerritoriesSettings
 
     def setUp(self):
-        super(TerritoriesAPITest, self).setUp()
         self.paca, self.bdr, self.arles = create_geozones_fixtures()
 
     def test_suggest_no_parameter(self):

--- a/udata/tests/features/territories/test_territories_process.py
+++ b/udata/tests/features/territories/test_territories_process.py
@@ -56,7 +56,6 @@ class TerritoriesTest(FrontTestCase):
     settings = TerritoriesSettings
 
     def setUp(self):
-        super(TerritoriesTest, self).setUp()
         self.paca, self.bdr, self.arles = create_geozones_fixtures()
 
     def test_towns_with_default_base_datasets(self):

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -4,13 +4,30 @@ from __future__ import unicode_literals
 import json
 import re
 
+from flask import template_rendered
+
 from udata.tests import TestCase, WebTestMixin, SearchTestMixin
 
 from udata import frontend, api
 
 
+class ContextVariableDoesNotExist(Exception):
+    pass
+
+
 class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
     modules = []
+
+    def setUp(self):
+        # Ensure compatibility with multiple inheritance
+        super(TestCase, self).setUp()
+        self.templates = []
+        template_rendered.connect(self._add_template)
+
+    def tearsDown(self):
+        # Ensure compatibility with multiple inheritance
+        super(TestCase, self).tearsDown()
+        template_rendered.disconnect(self._add_template)
 
     def create_app(self):
         app = super(FrontTestCase, self).create_app()
@@ -29,3 +46,44 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         self.assertIsNotNone(search, (pattern, response.data))
         json_ld = search.group('json_ld')
         return json.loads(json_ld)
+
+    def _add_template(self, app, template, context):
+        # if len(self.templates) > 0:
+        #     self.templates = []
+        print('add template', template, context)
+        self.templates.append((template, context))
+
+    def assertTemplateUsed(self, name):
+        """
+        Checks if a given template is used in the request.
+
+        :param name: template name
+        """
+        __tracebackhide__ = True
+
+        used_templates = []
+
+        for template, context in self.templates:
+            if template.name == name:
+                return True
+
+            used_templates.append(template)
+
+        msg = 'Template %s not used. Templates were used: %s' % (
+            name, ' '.join(repr(used_templates))
+        )
+        raise AssertionError(msg)
+
+    assert_template_used = assertTemplateUsed
+
+    def get_context_variable(self, name):
+        """
+        Returns a variable from the context passed to the template.
+
+        :param name: name of variable
+        :raises ContextVariableDoesNotExist: if does not exist.
+        """
+        for template, context in self.templates:
+            if name in context:
+                return context[name]
+        raise ContextVariableDoesNotExist

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -8,8 +8,6 @@ from flask import template_rendered
 
 from udata.tests import TestCase, WebTestMixin, SearchTestMixin
 
-from udata import frontend, api
-
 
 class ContextVariableDoesNotExist(Exception):
     pass
@@ -29,12 +27,6 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         super(TestCase, self).tearsDown()
         template_rendered.disconnect(self._add_template)
 
-    def create_app(self):
-        app = super(FrontTestCase, self).create_app()
-        api.init_app(app)
-        frontend.init_app(app, self.modules)
-        return app
-
     def get_json_ld(self, response):
         # In the pattern below, we extract the content of the JSON-LD script
         # The first ? is used to name the extracted string
@@ -48,9 +40,6 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         return json.loads(json_ld)
 
     def _add_template(self, app, template, context):
-        # if len(self.templates) > 0:
-        #     self.templates = []
-        print('add template', template, context)
         self.templates.append((template, context))
 
     def assertTemplateUsed(self, name):

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -3,29 +3,17 @@ from __future__ import unicode_literals
 
 import json
 import re
-
-from flask import template_rendered
+import pytest
 
 from udata.tests import TestCase, WebTestMixin, SearchTestMixin
-
-
-class ContextVariableDoesNotExist(Exception):
-    pass
 
 
 class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
     modules = []
 
-    def setUp(self):
-        # Ensure compatibility with multiple inheritance
-        super(TestCase, self).setUp()
-        self.templates = []
-        template_rendered.connect(self._add_template)
-
-    def tearsDown(self):
-        # Ensure compatibility with multiple inheritance
-        super(TestCase, self).tearsDown()
-        template_rendered.disconnect(self._add_template)
+    @pytest.fixture(autouse=True)
+    def inject_templates(self, templates):
+        self.templates = templates
 
     def get_json_ld(self, response):
         # In the pattern below, we extract the content of the JSON-LD script
@@ -39,9 +27,6 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         json_ld = search.group('json_ld')
         return json.loads(json_ld)
 
-    def _add_template(self, app, template, context):
-        self.templates.append((template, context))
-
     def assertTemplateUsed(self, name):
         """
         Checks if a given template is used in the request.
@@ -49,21 +34,7 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         :param name: template name
         """
         __tracebackhide__ = True
-
-        used_templates = []
-
-        for template, context in self.templates:
-            if template.name == name:
-                return True
-
-            used_templates.append(template)
-
-        msg = 'Template %s not used. Templates were used: %s' % (
-            name, ' '.join(repr(used_templates))
-        )
-        raise AssertionError(msg)
-
-    assert_template_used = assertTemplateUsed
+        self.templates.assert_used(name)
 
     def get_context_variable(self, name):
         """
@@ -72,7 +43,4 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         :param name: name of variable
         :raises ContextVariableDoesNotExist: if does not exist.
         """
-        for template, context in self.templates:
-            if name in context:
-                return context[name]
-        raise ContextVariableDoesNotExist
+        return self.templates.get_context_variable(name)

--- a/udata/tests/frontend/test_search_frontend.py
+++ b/udata/tests/frontend/test_search_frontend.py
@@ -1,32 +1,34 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from flask import url_for
 
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.organization.factories import OrganizationFactory
 
-from . import FrontTestCase
+from udata.tests.helpers import assert200
 
 
-class SearchFrontTest(FrontTestCase):
+@pytest.mark.front
+class SearchFrontTest:
     modules = ['core.dataset', 'core.reuse', 'core.organization',
                'admin', 'core.site', 'search']
 
-    def test_render_search(self):
+    def test_render_search(self, client, autoindex):
         '''It should render the search page'''
-        with self.autoindex():
+        with autoindex():
             for i in range(3):
                 org = OrganizationFactory()
                 DatasetFactory(organization=org)
                 ReuseFactory(organization=org)
 
-        response = self.get(url_for('search.index'))
-        self.assert200(response)
+        response = client.get(url_for('search.index'))
+        assert200(response)
 
-    def test_render_search_no_data(self):
+    def test_render_search_no_data(self, client, autoindex):
         '''It should render the search page without data'''
-        self.init_search()
-        response = self.get(url_for('search.index'))
-        self.assert200(response)
+        response = client.get(url_for('search.index'))
+        assert200(response)

--- a/udata/tests/frontend/test_search_frontend.py
+++ b/udata/tests/frontend/test_search_frontend.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import pytest
-
 from flask import url_for
 
 from udata.core.dataset.factories import DatasetFactory
@@ -12,7 +10,6 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.tests.helpers import assert200
 
 
-@pytest.mark.front
 class SearchFrontTest:
     modules = ['core.dataset', 'core.reuse', 'core.organization',
                'admin', 'core.site', 'search']

--- a/udata/tests/frontend/test_territories.py
+++ b/udata/tests/frontend/test_territories.py
@@ -14,7 +14,6 @@ class TerritoriesTest(FrontTestCase):
                'core.reuse', 'core.site', 'core.organization']
 
     def setUp(self):
-        super(TerritoriesTest, self).setUp()
         self.paca, self.bdr, self.arles = create_geozones_fixtures()
 
     def test_towns(self):

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import json
 import mock
+import os
 import warnings
 
 from udata.mail import mail_sent
@@ -204,4 +205,10 @@ def assert500(response):
 
 
 def full_url(*args, **kwargs):
+    '''Build a full URL'''
     return urljoin(request.url_root, url_for(*args, **kwargs))
+
+
+def data_path(filename):
+    '''Get a test data path'''
+    return os.path.join(os.path.dirname(__file__), 'data', filename)

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+import mock
+import warnings
+
+from udata.mail import mail_sent
+
+from contextlib import contextmanager
+from datetime import timedelta
+from urlparse import urljoin, urlparse
+
+from flask import request, url_for
+
+
+def assert_equal_dates(datetime1, datetime2, limit=1):  # Seconds.
+    """Lax date comparison, avoid comparing milliseconds and seconds."""
+    __tracebackhide__ = True
+    delta = (datetime1 - datetime2)
+    assert timedelta(seconds=-limit) <= delta <= timedelta(seconds=limit)
+
+
+def assert_starts_with(haystack, needle):
+    __tracebackhide__ = True
+    msg = '{haystack} does not start with {needle}'.format(
+        haystack=haystack, needle=needle
+    )
+    assert haystack.startswith(needle), msg
+
+
+def assert_json_equal(first, second):
+    '''Ensure two dict produce the same JSON'''
+    __tracebackhide__ = True
+    json1 = json.loads(json.dumps(first))
+    json2 = json.loads(json.dumps(second))
+    assert json1 == json2
+
+
+@contextmanager
+def assert_emit(*signals):
+    __tracebackhide__ = True
+    specs = []
+
+    def handler(sender, **kwargs):
+        pass
+
+    for signal in signals:
+        m = mock.Mock(spec=handler)
+        signal.connect(m, weak=False)
+        specs.append((signal, m))
+
+    yield
+
+    for signal, mock_handler in specs:
+        signal.disconnect(mock_handler)
+        signal_name = getattr(signal, 'name', str(signal))
+        msg = 'Signal "{0}" should have been emitted'.format(signal_name)
+        assert mock_handler.called, msg
+
+
+@contextmanager
+def assert_not_emit(*signals):
+    __tracebackhide__ = True
+    specs = []
+
+    def handler(sender, **kwargs):
+        pass
+
+    for signal in signals:
+        m = mock.Mock(spec=handler)
+        signal.connect(m, weak=False)
+        specs.append((signal, m))
+
+    yield
+
+    for signal, mock_handler in specs:
+        signal.disconnect(mock_handler)
+        signal_name = getattr(signal, 'name', str(signal))
+        msg = 'Signal "{0}" should NOT have been emitted'.format(signal_name)
+        assert mock_handler.called, msg
+
+
+@contextmanager
+def capture_mails():
+    mails = []
+
+    def on_mail_sent(mail):
+        mails.append(mail)
+
+    mail_sent.connect(on_mail_sent)
+
+    yield mails
+
+    mail_sent.disconnect(on_mail_sent)
+
+
+@contextmanager
+def assert_warn(warning_cls):
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter('always', warning_cls)
+        yield
+        warnings.simplefilter('default', warning_cls)
+    assert len(w), 'No warning has been raised'
+    warning = w[-1]
+    msg = '{0} raised and is not a sublcass of {1}'.format(
+        warning.category.__name__, warning_cls.__name__
+    )
+    assert issubclass(warning.category, DeprecationWarning), msg
+
+
+REDIRECT_CODES = (301, 302, 303, 305, 307)
+REDIRECT_MSG = 'HTTP Status {} expected but got {{}}'.format(
+    ', '.join(str(code) for code in REDIRECT_CODES)
+)
+
+
+def assert_redirects(response, location, message=None):
+    """
+    Checks if response is an HTTP redirect to the
+    given location.
+    :param response: Flask response
+    :param location: relative URL path to SERVER_NAME or an absolute URL
+    """
+    __tracebackhide__ = True
+    parts = urlparse(location)
+
+    if parts.netloc:
+        expected_location = location
+    else:
+        expected_location = urljoin('http://localhost', location)
+    not_redirect = REDIRECT_MSG.format(response.status_code)
+    assert response.status_code in REDIRECT_CODES, message or not_redirect
+    assert response.location == expected_location, message
+
+
+def assert_status(response, status_code, message=None):
+    """
+    Helper method to check matching response status.
+
+    Extracted from parent class to improve output in case of JSON.
+
+    :param response: Flask response
+    :param status_code: response status code (e.g. 200)
+    :param message: Message to display on test failure
+    """
+    __tracebackhide__ = True
+
+    message = message or 'HTTP Status %s expected but got %s' \
+                         % (status_code, response.status_code)
+    if response.mimetype == 'application/json':
+        try:
+            second_line = 'Response content is {0}'.format(response.json)
+            message = '\n'.join((message, second_line))
+        except Exception:
+            pass
+    assert response.status_code == status_code, message
+
+
+def assert200(response):
+    __tracebackhide__ = True
+    assert_status(response, 200)
+
+
+def assert201(response):
+    __tracebackhide__ = True
+    assert_status(response, 201)
+
+
+def assert204(response):
+    __tracebackhide__ = True
+    assert_status(response, 204)
+
+
+def assert400(response):
+    __tracebackhide__ = True
+    assert_status(response, 400)
+
+
+def assert401(response):
+    __tracebackhide__ = True
+    assert_status(response, 401)
+
+
+def assert403(response):
+    __tracebackhide__ = True
+    assert_status(response, 403)
+
+
+def assert404(response):
+    __tracebackhide__ = True
+    assert_status(response, 404)
+
+
+def assert410(response):
+    __tracebackhide__ = True
+    assert_status(response, 410)
+
+
+def assert500(response):
+    __tracebackhide__ = True
+    assert_status(response, 500)
+
+
+def full_url(*args, **kwargs):
+    return urljoin(request.url_root, url_for(*args, **kwargs))

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -96,21 +96,6 @@ def capture_mails():
     mail_sent.disconnect(on_mail_sent)
 
 
-@contextmanager
-def assert_warn(warning_cls):
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter('always', warning_cls)
-        yield
-        warnings.simplefilter('default', warning_cls)
-    assert len(w), 'No warning has been raised'
-    warning = w[-1]
-    msg = '{0} raised and is not a sublcass of {1}'.format(
-        warning.category.__name__, warning_cls.__name__
-    )
-    assert issubclass(warning.category, DeprecationWarning), msg
-
-
 REDIRECT_CODES = (301, 302, 303, 305, 307)
 REDIRECT_MSG = 'HTTP Status {} expected but got {{}}'.format(
     ', '.join(str(code) for code in REDIRECT_CODES)

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import json
 import mock
 import os
-import warnings
 
 from udata.mail import mail_sent
 

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -108,6 +108,7 @@ def assert_redirects(response, location, message=None):
     given location.
     :param response: Flask response
     :param location: relative URL path to SERVER_NAME or an absolute URL
+    :param message: an optionnal failure message
     """
     __tracebackhide__ = True
     parts = urlparse(location)

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -247,3 +247,12 @@ def templates():
     recorder = TemplateRecorder()
     with recorder.capture():
         yield recorder
+
+
+@pytest.fixture
+def httpretty():
+    import httpretty
+    httpretty.reset()
+    httpretty.enable()
+    yield httpretty
+    httpretty.disable()

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -78,7 +78,6 @@ def get_settings(request):
 
 def drop_db(app):
     '''Clear the database'''
-    print('MONGODB_HOST', app.config['MONGODB_HOST'])
     parsed_url = urlparse(app.config['MONGODB_HOST'])
 
     # drop the leading /

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -1,0 +1,163 @@
+import pytest
+
+from contextlib import contextmanager
+from urlparse import urlparse
+
+from flask import json
+from flask.testing import FlaskClient
+from werkzeug.urls import url_encode
+
+from udata import settings
+from udata.app import create_app
+from udata.core.user.factories import UserFactory
+from udata.models import db
+from udata.search import es
+
+
+class TestClient(FlaskClient):
+    def _build_url(self, url, kwargs):
+        if 'qs' not in kwargs:
+            return url
+        qs = kwargs.pop('qs')
+        return '?'.join([url, url_encode(qs)])
+
+    def get(self, url, **kwargs):
+        url = self._build_url(url, kwargs)
+        return super(TestClient, self).get(url, **kwargs)
+
+    def post(self, url, data=None, **kwargs):
+        url = self._build_url(url, kwargs)
+        return super(TestClient, self).post(url, data=data, **kwargs)
+
+    def put(self, url, data=None, **kwargs):
+        url = self._build_url(url, kwargs)
+        return super(TestClient, self).put(url, data=data, **kwargs)
+
+    def delete(self, url, data=None, **kwargs):
+        url = self._build_url(url, kwargs)
+        return super(TestClient, self).delete(url, data=data, **kwargs)
+
+    def login(self, user=None):
+        user = user or UserFactory()
+        with self.session_transaction() as session:
+            session['user_id'] = str(user.id)
+            session['_fresh'] = True
+        return user
+
+
+@pytest.fixture
+def app(request):
+    test_settings = get_settings(request)
+    app = create_app(settings.Defaults, override=test_settings)
+    app.test_client_class = TestClient
+
+    if request.cls and hasattr(request.cls, 'modules'):
+        from udata import frontend, api
+        api.init_app(app)
+        frontend.init_app(app, request.cls.modules)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    '''
+    Fixes https://github.com/pytest-dev/pytest-flask/issues/42
+    '''
+    return app.test_client()
+
+
+def get_settings(request):
+    '''
+    Extract settings from the current test request
+    '''
+    marker = request.node.get_marker('settings')
+    if marker:
+        return marker.args[0]
+    return getattr(request.cls, 'settings', settings.Testing)
+
+
+def drop_db(app):
+    '''Clear the database'''
+    print('MONGODB_HOST', app.config['MONGODB_HOST'])
+    parsed_url = urlparse(app.config['MONGODB_HOST'])
+
+    # drop the leading /
+    db_name = parsed_url.path[1:]
+    db.connection.drop_database(db_name)
+
+
+@pytest.fixture
+def clean_db(app):
+    drop_db(app)
+    yield
+    drop_db(app)
+
+
+class ApiClient(object):
+    def __init__(self, client):
+        self.client = client
+        self._user = None
+
+    @contextmanager
+    def user(self, user=None):
+        self._user = user or UserFactory()
+        if not self._user.apikey:
+            self._user.generate_api_key()
+            self._user.save()
+        yield self._user
+
+    def perform(self, verb, url, **kwargs):
+        headers = kwargs.pop('headers', {})
+        headers['Content-Type'] = 'application/json'
+
+        data = kwargs.get('data')
+        if data is not None:
+            data = json.dumps(data)
+            headers['Content-Length'] = len(data)
+            kwargs['data'] = data
+
+        if self._user:
+            headers['X-API-KEY'] = kwargs.get('X-API-KEY', self._user.apikey)
+
+        kwargs['headers'] = headers
+        method = getattr(self.client, verb)
+        return method(url, **kwargs)
+
+    def get(self, url, *args, **kwargs):
+        return self.perform('get', url, *args, **kwargs)
+
+    def post(self, url, data=None, json=True, *args, **kwargs):
+        if not json:
+            return self.client.post(url, data or {}, *args, **kwargs)
+        return self.perform('post', url, data=data or {}, *args, **kwargs)
+
+    def put(self, url, data=None, json=True, *args, **kwargs):
+        if not json:
+            return self.client.put(url, data or {}, *args, **kwargs)
+        return self.perform('put', url, data=data or {}, *args, **kwargs)
+
+    def delete(self, url, data=None, *args, **kwargs):
+        return self.perform('delete', url, data=data or {}, *args, **kwargs)
+
+
+@pytest.fixture
+def api(client):
+    api_client = ApiClient(client)
+    return api_client
+
+
+@pytest.fixture
+def autoindex(app):
+    app.config['AUTO_INDEX'] = True
+    es.initialize()
+    es.cluster.health(wait_for_status='yellow', request_timeout=10)
+
+    @contextmanager
+    def cm():
+        yield
+        es.indices.refresh(index=es.index_name)
+
+    yield cm
+
+    if es.indices.exists(index=es.index_name):
+        es.indices.delete(index=es.index_name)

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -178,3 +178,16 @@ def cli_fixture(mocker, app):
             return runner.invoke(cli, args, catch_exceptions=False)
 
     return mock_runner
+
+
+@pytest.fixture
+def instance_path(app, tmpdir):
+    '''Use temporary application instance_path'''
+    from udata.core import storages
+    from udata.core.storages.views import blueprint
+
+    app.instance_path = str(tmpdir)
+    storages.init_app(app)
+    app.register_blueprint(blueprint)
+
+    return tmpdir

--- a/udata/tests/reuse/test_reuse_model.py
+++ b/udata/tests/reuse/test_reuse_model.py
@@ -8,6 +8,7 @@ from udata.models import Reuse
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import UserFactory
+from udata.tests.helpers import assert_emit
 
 from .. import TestCase, DBTestMixin
 
@@ -58,6 +59,6 @@ class ReuseModelTest(TestCase, DBTestMixin):
 
     def test_send_on_delete(self):
         reuse = ReuseFactory()
-        with self.assert_emit(Reuse.on_delete):
+        with assert_emit(Reuse.on_delete):
             reuse.deleted = datetime.now()
             reuse.save()

--- a/udata/tests/site/test_site_metrics.py
+++ b/udata/tests/site/test_site_metrics.py
@@ -25,7 +25,6 @@ class FakeSiteMetric(SiteMetric):
 
 class SiteMetricTest(DBTestMixin, TestCase):
     def setUp(self):
-        super(SiteMetricTest, self).setUp()
         self.app.config['USE_METRICS'] = True
         self.updated_emitted = False
         self.need_update_emitted = False

--- a/udata/tests/site/test_site_metrics.py
+++ b/udata/tests/site/test_site_metrics.py
@@ -25,6 +25,7 @@ class FakeSiteMetric(SiteMetric):
 
 class SiteMetricTest(DBTestMixin, TestCase):
     def setUp(self):
+        super(SiteMetricTest, self).setUp()
         self.app.config['USE_METRICS'] = True
         self.updated_emitted = False
         self.need_update_emitted = False

--- a/udata/tests/test_activity.py
+++ b/udata/tests/test_activity.py
@@ -19,6 +19,7 @@ class FakeActivity(Activity):
 
 class ActivityTest(WebTestMixin, DBTestMixin, TestCase):
     def setUp(self):
+        super(ActivityTest, self).setUp()
         self.fake = FakeModel.objects.create(name='fake')
         self.login()
 

--- a/udata/tests/test_activity.py
+++ b/udata/tests/test_activity.py
@@ -19,7 +19,6 @@ class FakeActivity(Activity):
 
 class ActivityTest(WebTestMixin, DBTestMixin, TestCase):
     def setUp(self):
-        super(ActivityTest, self).setUp()
         self.fake = FakeModel.objects.create(name='fake')
         self.login()
 

--- a/udata/tests/test_cli.py
+++ b/udata/tests/test_cli.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from udata.tests import TestCase, CliTestMixin
+
+def test_cli_help(cli):
+    '''Should display help without errors'''
+    cli()
+    cli('-?')
+    cli('-h')
+    cli('--help')
 
 
-class CliTest(CliTestMixin, TestCase):
-    def test_help(self):
-        '''Should display help without errors'''
-        self.cli()
-        self.cli('-?')
-        self.cli('-h')
-        self.cli('--help')
+def test_cli_log_and_printing(cli):
+    '''Should properly log and print'''
+    cli('test log')
 
-    def test_log_and_printing(self):
-        '''Should properly log and print'''
-        self.cli('test log')
 
-    def test_version(self):
-        '''Should display version without errors'''
-        self.cli('--version')
+def test_cli_version(cli):
+    '''Should display version without errors'''
+    cli('--version')

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -27,7 +27,7 @@ from frontend import FrontTestCase
 
 from . import TestCase, DBTestMixin
 from .api import APITestCase
-from .helpers import assert_starts_with, capture_mails
+from .helpers import assert_starts_with, capture_mails, assert_emit
 
 
 class DiscussionsTest(APITestCase):
@@ -38,7 +38,7 @@ class DiscussionsTest(APITestCase):
         user = self.login()
         dataset = Dataset.objects.create(title='Test dataset')
 
-        with self.assert_emit(on_new_discussion):
+        with assert_emit(on_new_discussion):
             response = self.post(url_for('api.discussions'), {
                 'title': 'test title',
                 'comment': 'bla bla',
@@ -107,7 +107,7 @@ class DiscussionsTest(APITestCase):
         dataset = Dataset.objects.create(title='Test dataset',
                                          extras={'key': 'value'})
 
-        with self.assert_emit(on_new_discussion):
+        with assert_emit(on_new_discussion):
             response = self.post(url_for('api.discussions'), {
                 'title': 'test title',
                 'comment': 'bla bla',
@@ -268,7 +268,7 @@ class DiscussionsTest(APITestCase):
         on_new_discussion.send(discussion)  # Updating metrics.
 
         poster = self.login()
-        with self.assert_emit(on_new_discussion_comment):
+        with assert_emit(on_new_discussion_comment):
             response = self.post(url_for('api.discussion', id=discussion.id), {
                 'comment': 'new bla bla'
             })
@@ -306,7 +306,7 @@ class DiscussionsTest(APITestCase):
         )
         on_new_discussion.send(discussion)  # Updating metrics.
 
-        with self.assert_emit(on_discussion_closed):
+        with assert_emit(on_discussion_closed):
             response = self.post(url_for('api.discussion', id=discussion.id), {
                 'comment': 'close bla bla',
                 'close': True
@@ -370,7 +370,7 @@ class DiscussionsTest(APITestCase):
         on_new_discussion.send(discussion)  # Updating metrics.
         self.assertEqual(Discussion.objects(subject=dataset).count(), 1)
 
-        with self.assert_emit(on_discussion_deleted):
+        with assert_emit(on_discussion_deleted):
             response = self.delete(url_for('api.discussion', id=discussion.id))
         self.assertStatus(response, 204)
 

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -22,10 +22,12 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.core.user.factories import UserFactory, AdminFactory
 from udata.utils import faker
 
+
 from frontend import FrontTestCase
 
 from . import TestCase, DBTestMixin
 from .api import APITestCase
+from .helpers import assert_starts_with
 
 
 class DiscussionsTest(APITestCase):
@@ -423,10 +425,8 @@ class DiscussionCsvTest(FrontTestCase):
         self.assert200(response)
 
         headers, data = response.data.decode('utf-8').strip().split('\r\n')
-        self.assertStartswith(
-            data,
-            '"{discussion.id}";"{discussion.user}"'.format(
-                discussion=discussion))
+        expected = '"{discussion.id}";"{discussion.user}"'
+        assert_starts_with(data, expected.format(discussion=discussion))
 
 
 class DiscussionsNotificationsTest(TestCase, DBTestMixin):

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -27,7 +27,7 @@ from frontend import FrontTestCase
 
 from . import TestCase, DBTestMixin
 from .api import APITestCase
-from .helpers import assert_starts_with
+from .helpers import assert_starts_with, capture_mails
 
 
 class DiscussionsTest(APITestCase):
@@ -521,7 +521,7 @@ class DiscussionsMailsTest(FrontTestCase):
             discussion=[message]
         )
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             notify_new_discussion(discussion)
 
         # Should have sent one mail to the owner
@@ -541,7 +541,7 @@ class DiscussionsMailsTest(FrontTestCase):
             discussion=[message, new_message]
         )
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             notify_new_discussion_comment(discussion, message=new_message)
 
         # Should have sent one mail to the owner and the other participants
@@ -566,7 +566,7 @@ class DiscussionsMailsTest(FrontTestCase):
             discussion=[message, second_message, closing_message]
         )
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             notify_discussion_closed(discussion, message=closing_message)
 
         # Should have sent one mail to each participant

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -22,10 +22,12 @@ from udata.core.user.factories import UserFactory
 from udata.core.issues.factories import IssueFactory
 from udata.utils import faker
 
+
 from frontend import FrontTestCase
 
 from . import TestCase, DBTestMixin
 from .api import APITestCase
+from .helpers import assert_starts_with
 
 
 class IssuesTest(APITestCase):
@@ -358,8 +360,8 @@ class IssueCsvTest(FrontTestCase):
         self.assert200(response)
 
         headers, data = response.data.decode('utf-8').strip().split('\r\n')
-        self.assertStartswith(
-            data, '"{issue.id}";"{issue.user}"'.format(issue=issue))
+        expected = '"{issue.id}";"{issue.user}"'.format(issue=issue)
+        assert_starts_with(data, expected)
 
 
 class IssuesActionsTest(TestCase, DBTestMixin):

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -27,7 +27,7 @@ from frontend import FrontTestCase
 
 from . import TestCase, DBTestMixin
 from .api import APITestCase
-from .helpers import assert_starts_with
+from .helpers import assert_starts_with, capture_mails
 
 
 class IssuesTest(APITestCase):
@@ -582,7 +582,7 @@ class IssuesMailsTest(FrontTestCase):
             discussion=[message]
         )
 
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             notify_new_issue(issue)
 
         # Should have sent one mail to the owner
@@ -603,7 +603,7 @@ class IssuesMailsTest(FrontTestCase):
         )
 
         # issue = IssueFactory()
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             notify_new_issue_comment(issue, message=new_message)
 
         # Should have sent one mail to the owner and the other participants
@@ -629,7 +629,7 @@ class IssuesMailsTest(FrontTestCase):
         )
 
         # issue = IssueFactory()
-        with self.capture_mails() as mails:
+        with capture_mails() as mails:
             notify_issue_closed(issue, message=closing_message)
 
         # Should have sent one mail to each participant

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -27,7 +27,7 @@ from frontend import FrontTestCase
 
 from . import TestCase, DBTestMixin
 from .api import APITestCase
-from .helpers import assert_starts_with, capture_mails
+from .helpers import assert_starts_with, assert_emit, capture_mails
 
 
 class IssuesTest(APITestCase):
@@ -39,7 +39,7 @@ class IssuesTest(APITestCase):
         dataset = Dataset.objects.create(title='Test dataset')
 
         url = url_for('api.issues', **{'for': dataset.id})
-        with self.assert_emit(on_new_issue):
+        with assert_emit(on_new_issue):
             response = self.post(url, {
                 'title': 'test title',
                 'comment': 'bla bla',
@@ -247,7 +247,7 @@ class IssuesTest(APITestCase):
         on_new_issue.send(issue)  # Updating metrics.
 
         poster = self.login()
-        with self.assert_emit(on_new_issue_comment):
+        with assert_emit(on_new_issue_comment):
             response = self.post(url_for('api.issue', id=issue.id), {
                 'comment': 'new bla bla'
             })
@@ -285,7 +285,7 @@ class IssuesTest(APITestCase):
         )
         on_new_issue.send(issue)  # Updating metrics.
 
-        with self.assert_emit(on_issue_closed):
+        with assert_emit(on_issue_closed):
             response = self.post(url_for('api.issue', id=issue.id), {
                 'comment': 'close bla bla',
                 'close': True

--- a/udata/tests/test_linkchecker.py
+++ b/udata/tests/test_linkchecker.py
@@ -21,7 +21,6 @@ class LinkcheckerTest(TestCase):
     settings = LinkcheckerTestSettings
 
     def setUp(self):
-        super(LinkcheckerTest, self).setUp()
         self.resource = ResourceFactory()
         self.dataset = DatasetFactory(resources=[self.resource])
 

--- a/udata/tests/test_metrics.py
+++ b/udata/tests/test_metrics.py
@@ -118,6 +118,7 @@ class MetricsModelTest(DBTestMixin, TestCase):
 
 class MetricTest(DBTestMixin, TestCase):
     def setUp(self):
+        super(MetricTest, self).setUp()
         self.app.config['USE_METRICS'] = True
         self.obj = FakeModel.objects.create()
         self.updated_emitted = False

--- a/udata/tests/test_metrics.py
+++ b/udata/tests/test_metrics.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import mock
+
 from datetime import date, timedelta
 
 from udata.models import db, Metrics, WithMetrics
 from udata.core.metrics import Metric
-from udata.tests import TestCase, DBTestMixin, mock_task
+from udata.tests import TestCase, DBTestMixin
 
 
 class FakeModel(WithMetrics, db.Document):
@@ -164,7 +166,7 @@ class MetricTest(DBTestMixin, TestCase):
         metrics = Metrics.objects.last_for(self.obj)
         self.assertEqual(metrics.values['fake'], 'some-value')
 
-    @mock_task('udata.core.metrics.tasks.archive_metric.delay')
+    @mock.patch('udata.core.metrics.tasks.archive_metric.delay')
     def test_not_archived(self, task):
         '''It should not store the updated metric when archived=False'''
         class NotArchivedMetric(Metric):

--- a/udata/tests/test_metrics.py
+++ b/udata/tests/test_metrics.py
@@ -120,7 +120,6 @@ class MetricsModelTest(DBTestMixin, TestCase):
 
 class MetricTest(DBTestMixin, TestCase):
     def setUp(self):
-        super(MetricTest, self).setUp()
         self.app.config['USE_METRICS'] = True
         self.obj = FakeModel.objects.create()
         self.updated_emitted = False

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from flask import json
 
 from uuid import uuid4, UUID
@@ -436,10 +438,10 @@ class MongoConfigTest(TestCase):
             validate_config({'MONGODB_HOST': 'mongodb://somewhere.com:1234/'})
 
     def test_warn_on_deprecated_db_port(self):
-        with self.assert_warn(DeprecationWarning):
+        with pytest.deprecated_call():
             validate_config({'MONGODB_HOST': Defaults.MONGODB_HOST,
                              'MONGODB_PORT': 1234})
-        with self.assert_warn(DeprecationWarning):
+        with pytest.deprecated_call():
             validate_config({'MONGODB_HOST': Defaults.MONGODB_HOST,
                              'MONGODB_DB': 'udata'})
 

--- a/udata/tests/test_notifications.py
+++ b/udata/tests/test_notifications.py
@@ -14,7 +14,6 @@ from .api import APITestCase
 
 class NotificationsMixin(object):
     def setUp(self):
-        super(NotificationsMixin, self).setUp()
         actions._providers = {}
 
 

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -809,6 +809,7 @@ class FacetTestCase(TestCase):
 
 class TestBoolFacet(FacetTestCase):
     def setUp(self):
+        super(TestBoolFacet, self).setUp()
         self.facet = search.BoolFacet(field='boolean')
 
     def test_get_values(self):
@@ -854,6 +855,7 @@ class TestBoolFacet(FacetTestCase):
 
 class TestTermsFacet(FacetTestCase):
     def setUp(self):
+        super(TestTermsFacet, self).setUp()
         self.facet = search.TermsFacet(field='tags')
 
     def test_get_values(self):
@@ -917,6 +919,7 @@ class TestTermsFacet(FacetTestCase):
 
 class TestModelTermsFacet(FacetTestCase, DBTestMixin):
     def setUp(self):
+        super(TestModelTermsFacet, self).setUp()
         self.facet = search.ModelTermsFacet(field='fakes', model=Fake)
 
     def test_labelize_id(self):
@@ -984,6 +987,7 @@ class TestModelTermsFacet(FacetTestCase, DBTestMixin):
 
 class TestModelTermsFacetWithStringId(FacetTestCase, DBTestMixin):
     def setUp(self):
+        super(TestModelTermsFacetWithStringId, self).setUp()
         self.facet = search.ModelTermsFacet(field='fakes',
                                             model=FakeWithStringId)
 
@@ -1046,6 +1050,7 @@ class TestModelTermsFacetWithStringId(FacetTestCase, DBTestMixin):
 
 class TestRangeFacet(FacetTestCase):
     def setUp(self):
+        super(TestRangeFacet, self).setUp()
         self.ranges = [
             ('first', (None, 1)),
             ('second', (1, 5)),
@@ -1138,6 +1143,7 @@ class TestRangeFacet(FacetTestCase):
 
 class TestTemporalCoverageFacet(FacetTestCase):
     def setUp(self):
+        super(TestTemporalCoverageFacet, self).setUp()
         self.facet = search.TemporalCoverageFacet(field='some_field')
 
     def test_get_aggregation(self):

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -809,7 +809,6 @@ class FacetTestCase(TestCase):
 
 class TestBoolFacet(FacetTestCase):
     def setUp(self):
-        super(TestBoolFacet, self).setUp()
         self.facet = search.BoolFacet(field='boolean')
 
     def test_get_values(self):
@@ -855,7 +854,6 @@ class TestBoolFacet(FacetTestCase):
 
 class TestTermsFacet(FacetTestCase):
     def setUp(self):
-        super(TestTermsFacet, self).setUp()
         self.facet = search.TermsFacet(field='tags')
 
     def test_get_values(self):
@@ -919,7 +917,6 @@ class TestTermsFacet(FacetTestCase):
 
 class TestModelTermsFacet(FacetTestCase, DBTestMixin):
     def setUp(self):
-        super(TestModelTermsFacet, self).setUp()
         self.facet = search.ModelTermsFacet(field='fakes', model=Fake)
 
     def test_labelize_id(self):
@@ -987,7 +984,6 @@ class TestModelTermsFacet(FacetTestCase, DBTestMixin):
 
 class TestModelTermsFacetWithStringId(FacetTestCase, DBTestMixin):
     def setUp(self):
-        super(TestModelTermsFacetWithStringId, self).setUp()
         self.facet = search.ModelTermsFacet(field='fakes',
                                             model=FakeWithStringId)
 
@@ -1050,7 +1046,6 @@ class TestModelTermsFacetWithStringId(FacetTestCase, DBTestMixin):
 
 class TestRangeFacet(FacetTestCase):
     def setUp(self):
-        super(TestRangeFacet, self).setUp()
         self.ranges = [
             ('first', (None, 1)),
             ('second', (1, 5)),
@@ -1143,7 +1138,6 @@ class TestRangeFacet(FacetTestCase):
 
 class TestTemporalCoverageFacet(FacetTestCase):
     def setUp(self):
-        super(TestTemporalCoverageFacet, self).setUp()
         self.facet = search.TemporalCoverageFacet(field='some_field')
 
     def test_get_aggregation(self):

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -5,15 +5,12 @@ import os
 import tempfile
 import pytest
 
-from shutil import rmtree
 from StringIO import StringIO
-from tempfile import mkdtemp
 
 from flask import url_for
 
 from udata.core import storages
 from udata.core.storages import utils
-from udata.core.storages.views import blueprint
 
 from . import TestCase, WebTestMixin
 

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
+import pytest
 
 from shutil import rmtree
 from StringIO import StringIO
@@ -81,27 +82,9 @@ class TestConfigurableAllowedExtensions(TestCase):
         self.assertNotIn('exe', storages.CONFIGURABLE_AUTHORIZED_TYPES)
         self.assertNotIn('bat', storages.CONFIGURABLE_AUTHORIZED_TYPES)
 
-class StorageTestMixin(object):
-    def create_app(self):
-        app = super(StorageTestMixin, self).create_app()
-        self._instance_path = app.instance_path
-        app.instance_path = mkdtemp()
-        storages.init_app(app)
-        app.register_blueprint(blueprint)
-        return app
 
-    def tearsDown(self):
-        '''Cleanup the mess'''
-        rmtree(self.app.instance_path)
-        self.app.instance_path = self._instance_path
-        super(StorageTestCase, self).tearsDown()
-
-
-class StorageTestCase(StorageTestMixin, WebTestMixin, TestCase):
-    pass
-
-
-class StorageUploadViewTest(StorageTestCase):
+@pytest.mark.usefixtures('instance_path')
+class StorageUploadViewTest(WebTestMixin, TestCase):
     def test_upload(self):
         self.login()
         response = self.post(

--- a/udata/tests/test_utils.py
+++ b/udata/tests/test_utils.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import unittest
-
 from datetime import date, datetime
 
 from udata.utils import (
@@ -22,139 +20,135 @@ class ObjDict(object):
         self.__dict__.update(d)
 
 
-class GetByFieldTest(unittest.TestCase):
+class GetByFieldTest:
     def test_find_dict(self):
         '''get_by() should find a dictionnary in list'''
         result = get_by(TEST_LIST, 'name', 'bbb')
-        self.assertEqual(result, {'name': 'bbb', 'another': 'ddd'})
+        assert result == {'name': 'bbb', 'another': 'ddd'}
 
     def test_find_object(self):
         '''get_by() should find an object in list'''
         obj_lst = [ObjDict(d) for d in TEST_LIST]
         result = get_by(obj_lst, 'name', 'bbb')
-        self.assertEqual(result.name, 'bbb')
-        self.assertEqual(result.another, 'ddd')
+        assert result.name == 'bbb'
+        assert result.another == 'ddd'
 
     def test_not_found(self):
         '''get_by() should return None if not found'''
-        self.assertIsNone(get_by(TEST_LIST, 'name', 'not-found'))
+        assert get_by(TEST_LIST, 'name', 'not-found') is None
 
     def test_attribute_not_found(self):
         '''get_by() should not fail if an object don't have the given attr'''
-        self.assertIsNone(get_by(TEST_LIST, 'inexistant', 'value'))
+        assert get_by(TEST_LIST, 'inexistant', 'value') is None
 
 
-class DateRangeTest(unittest.TestCase):
+class DateRangeTest:
     def test_parse_daterange_start_empty(self):
-        self.assertIsNone(daterange_start(None))
-        self.assertIsNone(daterange_start(''))
+        assert daterange_start(None) is None
+        assert daterange_start('') is None
 
     def test_parse_daterange_end_empty(self):
-        self.assertIsNone(daterange_end(None))
-        self.assertIsNone(daterange_end(''))
+        assert daterange_end(None) is None
+        assert daterange_end('') is None
 
     def test_parse_daterange_start_full(self):
-        self.assertEqual(daterange_start('1984-06-07'), date(1984, 6, 7))
+        assert daterange_start('1984-06-07') == date(1984, 6, 7)
 
     def test_parse_daterange_end_full(self):
-        self.assertEqual(daterange_end('1984-06-07'), date(1984, 6, 7))
+        assert daterange_end('1984-06-07') == date(1984, 6, 7)
 
     def test_parse_daterange_start_month(self):
-        self.assertEqual(daterange_start('1984-06'), date(1984, 6, 1))
+        assert daterange_start('1984-06') == date(1984, 6, 1)
 
     def test_parse_daterange_end_month(self):
-        self.assertEqual(daterange_end('1984-06'), date(1984, 6, 30))
-        self.assertEqual(daterange_end('1984-07'), date(1984, 7, 31))
+        assert daterange_end('1984-06') == date(1984, 6, 30)
+        assert daterange_end('1984-07') == date(1984, 7, 31)
 
     def test_parse_daterange_end_month_february(self):
-        self.assertEqual(daterange_end('1984-02'), date(1984, 2, 29))
-        self.assertEqual(daterange_end('1985-02'), date(1985, 2, 28))
+        assert daterange_end('1984-02') == date(1984, 2, 29)
+        assert daterange_end('1985-02') == date(1985, 2, 28)
 
     def test_parse_daterange_start_year(self):
-        self.assertEqual(daterange_start('1984'), date(1984, 1, 1))
+        assert daterange_start('1984') == date(1984, 1, 1)
 
     def test_parse_daterange_end_year(self):
-        self.assertEqual(daterange_end('1984'), date(1984, 12, 31))
+        assert daterange_end('1984') == date(1984, 12, 31)
 
     def test_parse_before_1900(self):
-        self.assertEqual(daterange_start('1860'), date(1860, 1, 1))
-        self.assertEqual(daterange_end('1860'), date(1860, 12, 31))
+        assert daterange_start('1860') == date(1860, 1, 1)
+        assert daterange_end('1860') == date(1860, 12, 31)
 
 
-class ToBoolTest(unittest.TestCase):
+class ToBoolTest:
     def test_bool_values(self):
-        self.assertTrue(to_bool(True))
-        self.assertFalse(to_bool(False))
+        assert to_bool(True) is True
+        assert to_bool(False) is False
 
     def test_string_values(self):
-        self.assertTrue(to_bool('True'))
-        self.assertTrue(to_bool('true'))
-        self.assertFalse(to_bool('False'))
-        self.assertFalse(to_bool('false'))
-        self.assertFalse(to_bool('bla'))
-        self.assertTrue(to_bool('T'))
-        self.assertFalse(to_bool('F'))
-        self.assertTrue(to_bool('t'))
-        self.assertFalse(to_bool('f'))
+        assert to_bool('True') is True
+        assert to_bool('true') is True
+        assert to_bool('False') is False
+        assert to_bool('false') is False
+        assert to_bool('bla') is False
+        assert to_bool('T') is True
+        assert to_bool('F') is False
+        assert to_bool('t') is True
+        assert to_bool('f') is False
 
     def test_int_values(self):
-        self.assertFalse(to_bool(0))
-        self.assertFalse(to_bool(-1))
-        self.assertTrue(to_bool(1))
-        self.assertTrue(to_bool(10))
+        assert to_bool(0) is False
+        assert to_bool(-1) is False
+        assert to_bool(1) is True
+        assert to_bool(10) is True
 
 
-class ToIsoTest(unittest.TestCase):
+class ToIsoTest:
     def test_to_iso_date_emtpy(self):
-        self.assertEqual(to_iso_date(None), None)
+        assert to_iso_date(None) is None
 
     def test_to_iso_date_with_datetime(self):
-        self.assertEqual(to_iso_date(datetime(1984, 2, 29, 1, 2, 3)),
-                         '1984-02-29')
+        assert to_iso_date(datetime(1984, 2, 29, 1, 2, 3)) == '1984-02-29'
 
     def test_to_iso_date_with_date(self):
-        self.assertEqual(to_iso_date(date(1984, 2, 29)), '1984-02-29')
+        assert to_iso_date(date(1984, 2, 29)) == '1984-02-29'
 
     def test_to_iso_date_before_1900(self):
-        self.assertEqual(to_iso_date(date(1884, 2, 29)), '1884-02-29')
+        assert to_iso_date(date(1884, 2, 29)) == '1884-02-29'
 
     def test_to_iso_datetime_emtpy(self):
-        self.assertEqual(to_iso_datetime(None), None)
+        assert to_iso_datetime(None) is None
 
     def test_to_iso_datetime_with_datetime(self):
-        self.assertEqual(to_iso_datetime(datetime(1984, 2, 29, 1, 2, 3)),
-                         '1984-02-29T01:02:03')
+        result = to_iso_datetime(datetime(1984, 2, 29, 1, 2, 3))
+        assert result == '1984-02-29T01:02:03'
 
     def test_to_iso_datetime_with_date(self):
-        self.assertEqual(to_iso_datetime(date(1984, 2, 29)),
-                         '1984-02-29T00:00:00')
+        assert to_iso_datetime(date(1984, 2, 29)) == '1984-02-29T00:00:00'
 
     def test_to_iso_datetime_before_1900(self):
-        self.assertEqual(to_iso_datetime(date(1884, 2, 29)),
-                         '1884-02-29T00:00:00')
+        assert to_iso_datetime(date(1884, 2, 29)) == '1884-02-29T00:00:00'
 
     def test_to_iso_emtpy(self):
-        self.assertEqual(to_iso(None), None)
+        assert to_iso(None) is None
 
     def test_to_iso_with_datetime(self):
-        self.assertEqual(to_iso(datetime(1984, 2, 29, 1, 2, 3)),
-                         '1984-02-29T01:02:03')
+        assert to_iso(datetime(1984, 2, 29, 1, 2, 3)) == '1984-02-29T01:02:03'
 
     def test_to_iso_with_date(self):
-        self.assertEqual(to_iso(date(1984, 2, 29)), '1984-02-29')
+        assert to_iso(date(1984, 2, 29)) == '1984-02-29'
 
 
-class RecursiveGetTest(unittest.TestCase):
+class RecursiveGetTest:
     def test_get_root_attribute(self):
         class Tester(object):
             attr = 'value'
 
         tester = Tester()
-        self.assertEqual(recursive_get(tester, 'attr'), 'value')
+        assert recursive_get(tester, 'attr') == 'value'
 
     def test_get_root_key(self):
         tester = {'key': 'value'}
-        self.assertEqual(recursive_get(tester, 'key'), 'value')
+        assert recursive_get(tester, 'key') == 'value'
 
     def test_get_nested_attribute(self):
         class Nested(object):
@@ -165,22 +159,22 @@ class RecursiveGetTest(unittest.TestCase):
                 self.nested = Nested()
 
         tester = Tester()
-        self.assertEqual(recursive_get(tester, 'nested.attr'), 'value')
+        assert recursive_get(tester, 'nested.attr') == 'value'
 
     def test_get_nested_key(self):
         tester = {'nested': {'key': 'value'}}
-        self.assertEqual(recursive_get(tester, 'nested.key'), 'value')
+        assert recursive_get(tester, 'nested.key') == 'value'
 
     def test_attr_not_found(self):
         class Tester(object):
             pass
 
         tester = Tester()
-        self.assertEqual(recursive_get(tester, 'attr'), None)
+        assert recursive_get(tester, 'attr') is None
 
     def test_key_not_found(self):
         tester = {'key': 'value'}
-        self.assertEqual(recursive_get(tester, 'not-found'), None)
+        assert recursive_get(tester, 'not-found') is None
 
     def test_nested_attribute_not_found(self):
         class Nested(object):
@@ -191,16 +185,16 @@ class RecursiveGetTest(unittest.TestCase):
                 self.nested = Nested()
 
         tester = Tester()
-        self.assertEqual(recursive_get(tester, 'nested.not_found'), None)
+        assert recursive_get(tester, 'nested.not_found') is None
 
     def test_nested_key_not_found(self):
         tester = {'nested': {'key': 'value'}}
-        self.assertEqual(recursive_get(tester, 'nested.not_found'), None)
+        assert recursive_get(tester, 'nested.not_found') is None
 
     def test_get_on_none(self):
-        self.assertEqual(recursive_get(None, 'attr'), None)
+        assert recursive_get(None, 'attr') is None
 
     def test_get_key_none(self):
         tester = {'key': 'value'}
-        self.assertEqual(recursive_get(tester, None), None)
-        self.assertEqual(recursive_get(tester, ''), None)
+        assert recursive_get(tester, None) is None
+        assert recursive_get(tester, '') is None


### PR DESCRIPTION
This PR drop nosetests and flask-testing for pytest and some plugins.

- [x] use to pytest as test tool
- [x] drop nose & co dependencies
- [x] drop flask-testing
- [x] make all test pass
- [x] refactor to make use of fixture
- [x] expose some common tools as a pytest plugin

Most of the `udata.tests.{plugin,helpers}` has been extracted from existing base classes (`TestCase`, `FrontTestCase` et `APITestCase`) to allow new tests to make use of pytest easily (no more needs to extend `udata.test.TestCase`).
These base classes are now thin compatibility layers for `pytest` and `fixtures`

This (big) PR will serve as a base for more incremental test tunning (xdist, on demand fixtures, ...) but it's a required first step.