### PR TITLE
Fix missing spinners on most datatables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix organization admin pagination [#1372](https://github.com/opendatateam/udata/issues/1372)
 - Switch to `flask-cli` and drop `flask-script`. Deprecated commands have been removed. [#1364](https://github.com/opendatateam/udata/pull/1364) [breaking]
+- Fix missing spinners on loading datatables [#1401](https://github.com/opendatateam/udata/pull/1401)
 
 ## 1.2.10 (2018-01-24)
 

--- a/js/components/datatable/widget.vue
+++ b/js/components/datatable/widget.vue
@@ -96,7 +96,10 @@ export default {
         boxclass: String,
         tint: String,
         empty: String,
-        loading: Boolean,
+        loading: {
+            type: Boolean,
+            default: undefined
+        },
         track: {
             type: null,
             default: 'id'


### PR DESCRIPTION
`loading` prop was never `undefined` cf commit https://github.com/opendatateam/udata/pull/1401/commits/5f8204cb1930722ef74758a50421f89afefefafb message for vue issue and test case

replace #1399 
fix #1321 