### PR TITLE
Suppress antagonist btn classes

### DIFF
--- a/udata/templates/organization/sidebar-producer.html
+++ b/udata/templates/organization/sidebar-producer.html
@@ -12,7 +12,7 @@
 <br/>
 {% endif %}
 <a href="{{ url_for('organizations.show', org=organization) }}"
-    class="btn btn-sm btn-block btn-left btn-warning btn-primary">
+    class="btn btn-sm btn-block btn-left btn-warning">
     <span class="fa fa-users"></span>
     {{ _('View Profile') }}
 </a>

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -156,7 +156,7 @@
 
                             <a href="{{ url_for('users.show', user=reuse.owner) }}"
                                 title="{{ _('more') }}"
-                                class="btn btn-block btn-sm btn-left btn-warning btn-primary">
+                                class="btn btn-block btn-sm btn-left btn-warning">
                                 <span class="fa fa-user"></span>
                                 {{ _('View Profile') }}
                             </a>


### PR DESCRIPTION
This pr remove antagonist `btn-*` classes (`btn-warning` and `btn-primary`) on some buttons.
The side-effect is hidden on gouvfr but it prevent theming on these and produce unpredictable rendering.