### PR TITLE
Small fixes on search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Switch to `flask-cli` and drop `flask-script`. Deprecated commands have been removed. [#1364](https://github.com/opendatateam/udata/pull/1364) [breaking]
 - Fix missing spinners on loading datatables [#1401](https://github.com/opendatateam/udata/pull/1401)
 - Switch to pytest as testing tool and expose a `udata` pytest plugin [#1400](https://github.com/opendatateam/udata/pull/1400)
+- Fixes on the search facets [#1410](https://github.com/opendatateam/udata/pull/1410)
 
 ## 1.2.10 (2018-01-24)
 

--- a/less/udata/search.less
+++ b/less/udata/search.less
@@ -5,7 +5,6 @@ ul.search-results {
 
     .search-result {
         position: relative;
-        background: white;
         border-bottom: 1px solid #F0F0F0;
         overflow: hidden;
         zoom: 1;
@@ -136,6 +135,34 @@ ul.search-results {
 .advanced-search-panel {
     .list-group {
         margin-bottom: 0;
+
+        .list-group-item {
+            // Fix the badge position on long facet labels
+            &:not(.more) {
+                @padding:15px; // Hard coded in bootstrap list-group component
+                padding-right: @padding + 37px;
+                position: relative;
+
+                .badge {
+                    position: absolute;
+                    top: 50%;
+                    right: @padding;
+                    transform: translateY(-50%);
+                }
+            }
+
+            // Center the more button
+            &.more {
+                text-align: center;
+            }
+        }
+
+        .list-group-more {
+            // Fix bootstrap hiding first border
+            .list-group-item:first-child {
+                border-top-width: 1px;
+            }
+        }
     }
 
     .btn-remove:hover {

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -108,21 +108,20 @@
     {% for term, count, selected in terms[:nb_displayed_aggregations] %}
         <a href="{{ result.query.to_url(url, **{name: term}) }}"
             class="list-group-item">
+            <span class="badge">{{ count }}</span>
             {{ result.query.facets[name].labelize(term) }}
-            <span class="badge pull-right">{{ count }}</span>
         </a>
     {% endfor %}
     {% if terms|length > nb_displayed_aggregations %}
-        <button class="list-group-item" @click="expandPanel('{{result.class_name}}-{{name}}', $event)">
+        <button class="list-group-item more" @click="expandPanel('{{result.class_name}}-{{name}}', $event)">
             {{ _('More results…') }}
-            <span class="fa fa-chevron-right pull-right"></span>
         </button>
         <div id="facet-{{result.class_name}}-{{name}}-more" class="list-group collapse list-group-more">
         {% for term, count, selected in terms[nb_displayed_aggregations:] %}
             <a href="{{ result.query.to_url(url, **{name: term}) }}"
                 class="list-group-item">
+                <span class="badge">{{ count }}</span>
                 {{ result.query.facets[name].labelize(term) }}
-                <span class="badge pull-right">{{ count }}</span>
             </a>
         {% endfor %}
         </div>
@@ -139,21 +138,20 @@
     {% for obj, count, selected in objects[:nb_displayed_aggregations] %}
         <a href="{{ result.query.to_url(url, **{name: obj.id|string}) }}"
             class="list-group-item">
+            <span class="badge">{{ count }}</span>
             {{ result.query.facets[name].labelize(obj) }}
-            <span class="badge pull-right">{{ count }}</span>
         </a>
     {% endfor %}
     {% if objects|length > nb_displayed_aggregations %}
-        <button class="list-group-item list-group-more" @click="expandPanel('{{result.class_name}}-{{name}}', $event)">
+        <button class="list-group-item more" @click="expandPanel('{{result.class_name}}-{{name}}', $event)">
             {{ _('More results…') }}
-            <span class="fa fa-chevron-right pull-right"></span>
         </button>
         <div id="facet-{{result.class_name}}-{{name}}-more" class="list-group collapse list-group-more">
         {% for obj, count, selected in objects[nb_displayed_aggregations:] %}
             <a href="{{ result.query.to_url(url, **{name: obj.id|string}) }}"
                 class="list-group-item">
+                <span class="badge">{{ count }}</span>
                 {{ result.query.facets[name].labelize(obj) }}
-                <span class="badge pull-right">{{ count }}</span>
             </a>
         {% endfor %}
         </div>
@@ -169,8 +167,8 @@
     {% for key, count, selected in ranges %}
         <a href="{{ result.query.to_url(url, **{name: key}) }}"
             class="list-group-item">
+            <span class="badge">{{ count }}</span>
             {{ result.query.facets[name].labelize(key) }}
-            <span class="badge pull-right">{{ count }}</span>
         </a>
     {% endfor %}
     {% endcall %}


### PR DESCRIPTION
This PR apply small fixes on search:
- facets right counters are vertically centered and ensure they do not overlap with text
- differentiate the "more result button": centered and no more right picto (which as the same as facet header)
- fix the missing separator between the initial facet result and the extra ones
- remove the hardcoded white background color, just reuse the body color

## Unexpanded

| Before | After |
|-----------|--------|
| ![screenshot-data xps-2018-01-29-21-43-31-554](https://user-images.githubusercontent.com/15725/35554337-9f974d46-059b-11e8-84ad-26ae5a6b7c4b.png) | ![screenshot-data xps-2018-01-29-21-40-49-236](https://user-images.githubusercontent.com/15725/35554343-a757e3ba-059b-11e8-86b8-8a32dd178602.png) |

## Expanded

| Before | After |
|-----------|--------|
| ![screenshot-data xps-2018-01-29-21-43-57-495](https://user-images.githubusercontent.com/15725/35554338-9fb715f4-059b-11e8-8be7-b9cd1b4e9935.png) | ![screenshot-data xps-2018-01-29-21-41-24-353](https://user-images.githubusercontent.com/15725/35554344-a7724ef8-059b-11e8-9a57-af7fb9376fb2.png) |
