### PR TITLE
I18n fix extraction

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ directory = udata/translations
 statistics = true
 
 [extract_messages]
-keywords = _ N_ P_ L_ gettext ngettext pgettext npgettext lazy_gettext lazy_pgettext
+keywords = _ N_:1,2 P_:1c,2 L_ gettext ngettext:1,2 pgettext:1c,2 npgettext:1c,2,3 lazy_gettext lazy_pgettext:1c,2
 mapping_file = babel.cfg
 add_comments = TRANSLATORS:
 output_file = udata/translations/udata.pot

--- a/udata/translations/udata.pot
+++ b/udata/translations/udata.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata 1.2.10\n"
+"Project-Id-Version: udata 1.3.0.dev0\n"
 "Report-Msgid-Bugs-To: i18n@opendata.team\n"
-"POT-Creation-Date: 2018-02-01 16:16+0100\n"
-"PO-Revision-Date: 2018-02-01 16:16+0100\n"
+"POT-Creation-Date: 2018-02-06 15:59+0100\n"
+"PO-Revision-Date: 2018-02-06 15:59+0100\n"
 "Last-Translator: Open Data Team <i18n@opendata.team>\n"
 "Language: en\n"
 "Language-Team: Open Data Team <i18n@opendata.team>\n"
@@ -19,27 +19,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.0\n"
 
-#: udata/settings.py:109
+#: udata/settings.py:110
 msgid "Welcome"
 msgstr ""
 
-#: udata/settings.py:110
+#: udata/settings.py:111
 msgid "Please confirm your email"
 msgstr ""
 
-#: udata/settings.py:111
+#: udata/settings.py:112
 msgid "Login instructions"
 msgstr ""
 
-#: udata/settings.py:112
+#: udata/settings.py:113
 msgid "Your password has been reset"
 msgstr ""
 
-#: udata/settings.py:113
+#: udata/settings.py:114
 msgid "Your password has been changed"
 msgstr ""
 
-#: udata/settings.py:115
+#: udata/settings.py:116
 msgid "Password reset instructions"
 msgstr ""
 
@@ -97,19 +97,19 @@ msgstr ""
 msgid "System administrator rights"
 msgstr ""
 
-#: udata/commands/init.py:30
+#: udata/commands/init.py:31
 msgid "Do you want to create a superadmin user?"
 msgstr ""
 
-#: udata/commands/init.py:35
+#: udata/commands/init.py:36
 msgid "Do you want to import some data-related license?"
 msgstr ""
 
-#: udata/commands/init.py:39
+#: udata/commands/init.py:40
 msgid "Do you want to create some sample data?"
 msgstr ""
 
-#: udata/commands/init.py:43
+#: udata/commands/init.py:44
 msgid "Your udata instance is ready!"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: udata/core/user/models.py:240 udata/tests/api/test_me_api.py:373
+#: udata/core/user/models.py:240 udata/tests/api/test_me_api.py:374
 msgid "Account deletion"
 msgstr ""
 
@@ -1133,11 +1133,13 @@ msgid "Anonymous user"
 msgstr ""
 
 #: udata/frontend/helpers.py:269
-msgid "month-format"
+msgctxt "month-format"
+msgid "yyyy/MM"
 msgstr ""
 
 #: udata/frontend/helpers.py:273
-msgid "day-format"
+msgctxt "day-format"
+msgid "yyyy/MM/dd"
 msgstr ""
 
 #: udata/frontend/helpers.py:296
@@ -1633,7 +1635,7 @@ msgstr ""
 msgid "Recent reuses"
 msgstr ""
 
-#: udata/templates/macros/search.html:217 udata/templates/post/subnav.html:13
+#: udata/templates/macros/search.html:215 udata/templates/post/subnav.html:13
 #: udata/templates/search.html:8
 msgid "Search"
 msgstr ""
@@ -1655,24 +1657,32 @@ msgstr ""
 #: udata/templates/user/base.html:79
 #, python-format
 msgid "%(num)d dataset"
-msgstr ""
+msgid_plural "%(num)d datasets"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/display.html:52
 #: udata/templates/organization/display_base.html:87 udata/templates/search.html:34
 #: udata/templates/user/base.html:85
 #, python-format
 msgid "%(num)d reuse"
-msgstr ""
+msgid_plural "%(num)d reuses"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/search.html:41
 #, python-format
 msgid "%(num)d organization"
-msgstr ""
+msgid_plural "%(num)d organizations"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/search.html:49
 #, python-format
 msgid "Territory: %(name)s"
-msgstr ""
+msgid_plural "%(num)d territories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/dataset/search-labels.html:6
 #: udata/templates/reuse/search-labels.html:9 udata/templates/search.html:56
@@ -1927,7 +1937,9 @@ msgstr ""
 #: udata/templates/user/followers.html:15
 #, python-format
 msgid "%(num)d follower"
-msgstr ""
+msgid_plural "%(num)d followers"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/dataset/list.html:9
 #, python-format
@@ -1991,7 +2003,9 @@ msgstr ""
 #: udata/templates/discussion/item.html:13
 #, python-format
 msgid "%(nb)s message"
-msgstr ""
+msgid_plural "%(nb)s messages"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/discussion/item.html:28
 msgid "Deleted message"
@@ -2139,16 +2153,16 @@ msgstr ""
 msgid "Clear filter"
 msgstr ""
 
-#: udata/templates/macros/search.html:117 udata/templates/macros/search.html:148
+#: udata/templates/macros/search.html:117 udata/templates/macros/search.html:147
 msgid "More results…"
 msgstr ""
 
-#: udata/templates/macros/search.html:194
+#: udata/templates/macros/search.html:192
 #, python-format
 msgid "Results %(start)s to %(end)s on %(total)s found"
 msgstr ""
 
-#: udata/templates/macros/search.html:209
+#: udata/templates/macros/search.html:207
 msgid "No result found"
 msgstr ""
 
@@ -2364,7 +2378,9 @@ msgstr ""
 #: udata/templates/reuse/search-result.html:27 udata/templates/user/card.html:23
 #, python-format
 msgid "%(num)s dataset"
-msgstr ""
+msgid_plural "%(num)s datasets"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/card.html:30 udata/templates/user/card.html:29
 msgid "Number of reuses"
@@ -2375,7 +2391,9 @@ msgstr ""
 #: udata/templates/user/card.html:31
 #, python-format
 msgid "%(num)s reuse"
-msgstr ""
+msgid_plural "%(num)s reuses"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/display.html:8
 msgid "organization"
@@ -2390,12 +2408,16 @@ msgstr ""
 #: udata/templates/organization/display.html:49
 #, python-format
 msgid "%(num)d private dataset"
-msgstr ""
+msgid_plural "%(num)d private datasets"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/display.html:53
 #, python-format
 msgid "%(num)d private reuse"
-msgstr ""
+msgid_plural "%(num)d private reuses"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/display.html:80
 #, python-format
@@ -2431,7 +2453,9 @@ msgstr ""
 #: udata/templates/organization/display_base.html:67
 #, python-format
 msgid "%(num)d member"
-msgstr ""
+msgid_plural "%(num)d members"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/display.html:170
 msgid "Display all followers"
@@ -2457,7 +2481,9 @@ msgstr ""
 #: udata/templates/organization/display_base.html:97
 #, python-format
 msgid "%(num)d reappropriation"
-msgstr ""
+msgid_plural "%(num)d reappropriations"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/display_base.html:109
 msgid "I belong to this organization"
@@ -2520,7 +2546,9 @@ msgstr ""
 #: udata/templates/organization/search-result.html:41
 #, python-format
 msgid "%(num)s reappropriation"
-msgstr ""
+msgid_plural "%(num)s reappropriations"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/search-result.html:48
 #: udata/templates/reuse/search-result.html:32
@@ -2531,7 +2559,9 @@ msgstr ""
 #: udata/templates/reuse/search-result.html:34
 #, python-format
 msgid "%(num)s star"
-msgstr ""
+msgid_plural "%(num)s stars"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/search-result.html:57
 msgid "Number of followers"
@@ -2540,7 +2570,9 @@ msgstr ""
 #: udata/templates/organization/search-result.html:59
 #, python-format
 msgid "%(num)s follower"
-msgstr ""
+msgid_plural "%(num)s followers"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/search-result.html:65
 msgid "Number of members"
@@ -2549,7 +2581,9 @@ msgstr ""
 #: udata/templates/organization/search-result.html:67
 #, python-format
 msgid "%(num)s members"
-msgstr ""
+msgid_plural "%(num)s members"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/organization/sidebar-producer.html:17
 #: udata/templates/reuse/display.html:161
@@ -2965,7 +2999,9 @@ msgstr ""
 #: udata/templates/user/base.html:73
 #, python-format
 msgid "%(num)d followed"
-msgstr ""
+msgid_plural "%(num)d followed"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/user/datasets.html:39
 #, python-format
@@ -2980,22 +3016,30 @@ msgstr ""
 #: udata/templates/user/following.html:43
 #, python-format
 msgid "Follow %(num)d dataset"
-msgstr ""
+msgid_plural "Follow %(num)d datasets"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/user/following.html:63
 #, python-format
 msgid "Follow %(num)d reuse"
-msgstr ""
+msgid_plural "Follow %(num)d reuses"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/user/following.html:83
 #, python-format
 msgid "Follow %(num)d organization"
-msgstr ""
+msgid_plural "Follow %(num)d organizations"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/user/following.html:103
 #, python-format
 msgid "Follow %(num)d user"
-msgstr ""
+msgid_plural "Follow %(num)d users"
+msgstr[0] ""
+msgstr[1] ""
 
 #: udata/templates/user/following.html:129
 #, python-format


### PR DESCRIPTION
This PR fix plural and context extraction (the `setup.cfg` `keywords` parameters has undocumented format for `ngettext`, `pgettext` and `npgettext`).

This PR comes with a fixed `.pot` extraction so crowdin can match again plural and contexts