### PR TITLE
Add geopackage as default allowed file formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Switch to `flask-cli` and drop `flask-script`. Deprecated commands have been removed. [#1364](https://github.com/opendatateam/udata/pull/1364) [breaking]
 - Switch to pytest as testing tool and expose a `udata` pytest plugin [#1400](https://github.com/opendatateam/udata/pull/1400)
+- Added Geopackage as default allowed file formats [#1425](https://github.com/opendatateam/udata/pull/1425)
 
 ## 1.2.11 (2018-02-05)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -225,7 +225,7 @@ class Defaults(object):
         # Images
         'jpeg', 'jpg', 'jpe', 'gif', 'png', 'dwg', 'svg', 'tiff', 'ecw', 'svgz', 'jp2',
         # Geo
-        'shp', 'kml', 'kmz', 'gpx', 'shx', 'ovr', 'geojson',
+        'shp', 'kml', 'kmz', 'gpx', 'shx', 'ovr', 'geojson', 'gpkg',
         # Meteorology
         'grib2',
         # Misc


### PR DESCRIPTION
This PR adds geopackage (`.gpkg`) as default allowed extension