### PR TITLE
More pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,9 @@ venv
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
+.pytest_cache
 .tox
 cover
 nosetests.xml

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -1,10 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import pytest
 
 from contextlib import contextmanager
 from urlparse import urlparse
 
-from flask import json, template_rendered
+from flask import json, template_rendered, url_for
 from flask.testing import FlaskClient
+from lxml import etree
 from werkzeug.urls import url_encode
 
 from udata import settings
@@ -12,6 +16,8 @@ from udata.app import create_app
 from udata.core.user.factories import UserFactory
 from udata.models import db
 from udata.search import es
+
+from .helpers import assert200
 
 
 class TestClient(FlaskClient):
@@ -255,3 +261,52 @@ def httpretty():
     httpretty.enable()
     yield httpretty
     httpretty.disable()
+
+
+class SitemapClient:
+    # Needed for lxml XPath not supporting default namespace
+    NAMESPACES = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+    MISMATCH = 'URL "{0}" {1} mismatch: expected "{2}" found "{3}"'
+
+    def __init__(self, client):
+        self.client = client
+        self._sitemap = None
+
+    def fetch(self):
+        response = self.client.get('sitemap.xml')
+        assert200(response)
+        self._sitemap = etree.fromstring(response.data)
+        return self._sitemap
+
+    def xpath(self, query):
+        return self._sitemap.xpath(query, namespaces=self.NAMESPACES)
+
+    def get_by_url(self, endpoint, **kwargs):
+        url = url_for(endpoint, _external=True, **kwargs)
+        query = 's:url[s:loc="{url}"]'.format(url=url)
+        result = self.xpath(query)
+        return result[0] if result else None
+
+    def assert_url(self, url, priority, changefreq):
+        '''
+        Check than a URL is present in the sitemap
+        with given `priority` and `changefreq`
+        '''
+        __tracebackhide__ = True
+        r = url.xpath('s:priority', namespaces=self.NAMESPACES)
+        assert len(r) == 1, 'URL "{0}" should have one priority'.format(url)
+        found = r[0].text
+        msg = self.MISMATCH.format(url, 'priority', priority, found)
+        assert found == str(priority), msg
+
+        r = url.xpath('s:changefreq', namespaces=self.NAMESPACES)
+        assert len(r) == 1, 'URL "{0}" should have one changefreq'.format(url)
+        found = r[0].text
+        msg = self.MISMATCH.format(url, 'changefreq', changefreq, found)
+        assert found == changefreq, msg
+
+
+@pytest.fixture
+def sitemap(client):
+    sitemap_client = SitemapClient(client)
+    return sitemap_client

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -263,6 +263,14 @@ def httpretty():
     httpretty.disable()
 
 
+@pytest.fixture
+def m():  # Use m to follow requests-mock doc samples
+    '''A requests-mock fixture'''
+    import requests_mock
+    with requests_mock.Mocker() as m:
+        yield m
+
+
 class SitemapClient:
     # Needed for lxml XPath not supporting default namespace
     NAMESPACES = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}

--- a/udata/tests/test_sitemap.py
+++ b/udata/tests/test_sitemap.py
@@ -1,12 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-
-from flask import url_for
-from lxml import etree
-
-from udata import frontend, api
-from udata.tests import TestCase, WebTestMixin, SearchTestMixin
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.post.factories import PostFactory
@@ -14,127 +8,92 @@ from udata.core.reuse.factories import VisibleReuseFactory
 from udata.core.topic.factories import TopicFactory
 
 
-# Neede for lxml XPath not supporting default namespace
-NAMESPACES = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+class SitemapTest:
+    modules = []
 
-
-class SitemapTestCase(WebTestMixin, SearchTestMixin, TestCase):
-
-    def create_app(self):
-        app = super(SitemapTestCase, self).create_app()
-        frontend.init_app(app)
-        api.init_app(app)
-        return app
-
-    def get_sitemap_tree(self):
-        response = self.get('sitemap.xml')
-        self.assert200(response)
-        self.sitemap = etree.fromstring(response.data)
-        return self.sitemap
-
-    def xpath(self, query):
-        return self.sitemap.xpath(query, namespaces=NAMESPACES)
-
-    def get_by_url(self, endpoint, **kwargs):
-        url = url_for(endpoint, _external=True, **kwargs)
-        query = 's:url[s:loc="{url}"]'.format(url=url)
-        result = self.xpath(query)
-        return result[0] if result else None
-
-    def assert_url(self, url, priority, changefreq):
-        r = url.xpath('s:priority', namespaces=NAMESPACES)
-        self.assertEqual(len(r), 1)
-        self.assertEqual(r[0].text, str(priority))
-
-        r = url.xpath('s:changefreq', namespaces=NAMESPACES)
-        self.assertEqual(len(r), 1)
-        self.assertEqual(r[0].text, changefreq)
-
-
-class SitemapTest(SitemapTestCase):
-
-    def test_topics_within_sitemap(self):
+    def test_topics_within_sitemap(self, sitemap):
         '''It should return a topic list from the sitemap.'''
         topics = TopicFactory.create_batch(3)
 
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
         for topic in topics:
-            url = self.get_by_url('topics.display_redirect', topic=topic)
-            self.assertIsNotNone(url)
-            self.assert_url(url, 0.8, 'weekly')
+            url = sitemap.get_by_url('topics.display_redirect', topic=topic)
+            assert url is not None
+            # assert url is not None
+            sitemap.assert_url(url, 0.8, 'weekly')
 
-    def test_organizations_within_sitemap(self):
+    def test_organizations_within_sitemap(self, sitemap):
         '''It should return an organization list from the sitemap.'''
         organizations = OrganizationFactory.create_batch(3)
 
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
         for org in organizations:
-            url = self.get_by_url('organizations.show_redirect', org=org)
-            self.assertIsNotNone(url)
-            self.assert_url(url, 0.7, 'weekly')
+            url = sitemap.get_by_url('organizations.show_redirect', org=org)
+            assert url is not None
+            sitemap.assert_url(url, 0.7, 'weekly')
 
-    def test_reuses_within_sitemap(self):
+    def test_reuses_within_sitemap(self, sitemap):
         '''It should return a reuse list from the sitemap.'''
         reuses = VisibleReuseFactory.create_batch(3)
 
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
         for reuse in reuses:
-            url = self.get_by_url('reuses.show_redirect', reuse=reuse)
-            self.assertIsNotNone(url)
-            self.assert_url(url, 0.8, 'weekly')
+            url = sitemap.get_by_url('reuses.show_redirect', reuse=reuse)
+            assert url is not None
+            sitemap.assert_url(url, 0.8, 'weekly')
 
-    def test_datasets_within_sitemap(self):
+    def test_datasets_within_sitemap(self, sitemap):
         '''It should return a dataset list from the sitemap.'''
         datasets = VisibleDatasetFactory.create_batch(3)
 
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
         for dataset in datasets:
-            url = self.get_by_url('datasets.show_redirect', dataset=dataset)
-            self.assertIsNotNone(url)
-            self.assert_url(url, 0.8, 'weekly')
+            url = sitemap.get_by_url('datasets.show_redirect', dataset=dataset)
+            assert url is not None
+            sitemap.assert_url(url, 0.8, 'weekly')
 
-    def test_posts_within_sitemap(self):
+    def test_posts_within_sitemap(self, sitemap):
         '''It should return a post list from the sitemap.'''
         posts = PostFactory.create_batch(3)
 
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
         for post in posts:
-            url = self.get_by_url('posts.show_redirect', post=post)
-            self.assertIsNotNone(url)
-            self.assert_url(url, 0.6, 'weekly')
+            url = sitemap.get_by_url('posts.show_redirect', post=post)
+            assert url is not None
+            sitemap.assert_url(url, 0.6, 'weekly')
 
-    def test_home_within_sitemap(self):
+    def test_home_within_sitemap(self, sitemap):
         '''It should return the home page from the sitemap.'''
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
-        url = self.get_by_url('site.home_redirect')
-        self.assertIsNotNone(url)
-        self.assert_url(url, 1, 'daily')
+        url = sitemap.get_by_url('site.home_redirect')
+        assert url is not None
+        sitemap.assert_url(url, 1, 'daily')
 
-    def test_dashboard_within_sitemap(self):
+    def test_dashboard_within_sitemap(self, sitemap):
         '''It should return the dashoard page from the sitemap.'''
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
-        url = self.get_by_url('site.dashboard_redirect')
-        self.assertIsNotNone(url)
-        self.assert_url(url, 0.6, 'weekly')
+        url = sitemap.get_by_url('site.dashboard_redirect')
+        assert url is not None
+        sitemap.assert_url(url, 0.6, 'weekly')
 
-    def test_apidoc_within_sitemap(self):
+    def test_apidoc_within_sitemap(self, sitemap):
         '''It should return the API Doc page from the sitemap.'''
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
-        url = self.get_by_url('apidoc.swaggerui_redirect')
-        self.assertIsNotNone(url)
-        self.assert_url(url, 0.9, 'weekly')
+        url = sitemap.get_by_url('apidoc.swaggerui_redirect')
+        assert url is not None
+        sitemap.assert_url(url, 0.9, 'weekly')
 
-    def test_terms_within_sitemap(self):
+    def test_terms_within_sitemap(self, sitemap):
         '''It should return the terms page from the sitemap.'''
-        self.get_sitemap_tree()
+        sitemap.fetch()
 
-        url = self.get_by_url('site.terms_redirect')
-        self.assertIsNotNone(url)
+        url = sitemap.get_by_url('site.terms_redirect')
+        assert url is not None


### PR DESCRIPTION
This PR:
- factorize a `sitemap` fixture
- adds a `m` fixture for `requests-mock` (name `m` follows the documentation syntax)
- allows to use both `with autoindex:` and `with autoindex()`