### PR TITLE
More entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Switch to `flask-cli` and drop `flask-script`. Deprecated commands have been removed. [#1364](https://github.com/opendatateam/udata/pull/1364) [breaking]
 - Switch to pytest as testing tool and expose a `udata` pytest plugin [#1400](https://github.com/opendatateam/udata/pull/1400)
 - Added Geopackage as default allowed file formats [#1425](https://github.com/opendatateam/udata/pull/1425)
+- Added more entrypoints and document them. There is no more automatically enabled plugin by installation. Plugins can now properly contribute translations. [#1431](https://github.com/opendatateam/udata/pull/1431)
 
 ## 1.2.11 (2018-02-05)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,64 @@
+# Extending uData
+
+uData is customizable in many ways, just choose yours.
+
+## Configuration
+
+Before trying to code something specific, take a look at [all the settings](adapting-settings.md),
+there may already be some details you can easily customize with a simple setting.
+
+## Themes
+
+You can totally customize the udata apparence with themes.
+
+See the [dedicated section](creating-theme.md) for more details.
+
+**NB**: A theme is also an [entrypoint](#entrypoints), but a special one.
+
+## Entrypoints
+
+Entrypoints are modules or classes loaded by udata to extends its features.
+
+### Harvesters (`udata.harvesters`)
+
+Plugins can expose extra harvesters via the `udata.harvesters` class entrypoint.
+
+See [the Harvesting section](harvesting.md#custom) for more details
+
+### Views (`udata.views`)
+
+Plugins can expose extra view features via the `udata.views` module entrypoint including:
+
+- a blueprint (should be named `blueprint`)
+- some view filters
+
+### Metrics (`udata.metrics`)
+
+A module entrypoint allowing to register new metrics
+
+### Models (`udata.models`)
+
+This module entrypoint allows you to expose new models or to extend existing ones by adding new badges or new known extras.
+
+Models entrypoints may also expose migrations in the `migrations` folder sibling to the `models` module.
+If you only need to expose migrations, just provide an empty `models` module.
+
+### Link checkers (`udata.linkcheckers`)
+
+This class entrypoint allows to register new link checkers that udata will recognize and use.
+
+### Tasks and jobs (`udata.tasks`)
+
+This module entrypoint allows to register new asynchronous tasks and schedulable jobs.
+
+### Translations
+
+Any registered plugin may also expose translations in its roots module `translations` directory.
+They will automatically discovered and loaded if the plugin is enabled.
+
+## Contributing
+
+At last but not least, if none of hte above match your needs,
+you can also contribute to the core udata project and submit some contributions.
+
+See [the Contributing Guide](contributing-guide)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -9,7 +9,7 @@ there may already be some details you can easily customize with a simple setting
 
 ## Themes
 
-You can totally customize the udata apparence with themes.
+You can totally customize the udata appearence with themes.
 
 See the [dedicated section](creating-theme.md) for more details.
 
@@ -34,7 +34,7 @@ Plugins can expose extra view features via the `udata.views` module entrypoint i
 
 ### Metrics (`udata.metrics`)
 
-A module entrypoint allowing to register new metrics
+A module entrypoint allowing to register new metrics.
 
 ### Models (`udata.models`)
 
@@ -53,12 +53,12 @@ This module entrypoint allows to register new asynchronous tasks and schedulable
 
 ### Translations
 
-Any registered plugin may also expose translations in its roots module `translations` directory.
-They will automatically discovered and loaded if the plugin is enabled.
+Any registered plugin may also expose translations in its root module `translations` directory.
+They will be automatically discovered and loaded if the plugin is enabled.
 
 ## Contributing
 
-At last but not least, if none of hte above match your needs,
+Last but not least, if none of the above match your needs,
 you can also contribute to the core udata project and submit some contributions.
 
 See [the Contributing Guide](contributing-guide)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ pages:
     - Developping:
         - Development environment: development-environment.md
         - Testing your code: testing-code.md
+        - Extending uData: extending.md
         - Adding translations: adding-translations.md
         - Creating a custom theme: creating-theme.md
         - Building the documentation: building-documentation.md

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -5,3 +5,4 @@ pytest==3.4.0
 pytest-flask==0.10.0
 pytest-mock==1.6.3
 pytest-sugar==0.9.1
+requests-mock==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -132,9 +132,6 @@ setup(
             'adorable = udata.features.identicon.backends:adorable',
             'robohash = udata.features.identicon.backends:robohash',
         ],
-        'udata.linkcheckers': [
-            'no_check = udata.linkchecker.backends:NoCheckLinkchecker',
-        ],
         'pytest11': [
             'udata = udata.tests.plugin',
         ],

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -331,16 +331,6 @@ def init_app(app):
     import udata.features.territories.api  # noqa
     import udata.harvest.api  # noqa
 
-    # Load plugins API
-    for plugin in app.config['PLUGINS']:
-        name = 'udata_{0}.api'.format(plugin)
-        try:
-            __import__(name)
-        except ImportError:
-            pass
-        except Exception as e:
-            log.error('Error importing %s: %s', name, e)
-
     # api.init_app(app)
     app.register_blueprint(apidoc)
     app.register_blueprint(apiv1)

--- a/udata/app.py
+++ b/udata/app.py
@@ -176,12 +176,6 @@ def standalone(app):
 
     register_features(app)
 
-    for plugin in app.config['PLUGINS']:
-        name = 'udata_{0}'.format(plugin)
-        plugin = import_module(name)
-        if hasattr(plugin, 'init_app') and callable(plugin.init_app):
-            plugin.init_app(app)
-
     return app
 
 

--- a/udata/app.py
+++ b/udata/app.py
@@ -20,6 +20,8 @@ from flask_navigation import Navigation
 from speaklater import is_lazy_string
 from werkzeug.contrib.fixers import ProxyFix
 
+from udata import entrypoints
+
 
 APP_NAME = __name__.split('.')[0]
 ROOT_DIR = abspath(join(dirname(__file__)))
@@ -134,8 +136,8 @@ def init_logging(app):
     debug = app.debug or app.config.get('TESTING')
     log_level = logging.DEBUG if debug else logging.WARNING
     app.logger.setLevel(log_level)
-    for name in app.config['PLUGINS']:
-        logging.getLogger('udata_{0}'.format(name)).setLevel(log_level)
+    for name in entrypoints.get_roots():  # Entrypoints loggers
+        logging.getLogger(name).setLevel(log_level)
     for logger in VERBOSE_LOGGERS:
         logging.getLogger(logger).setLevel(logging.WARNING)
     return app

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -11,6 +11,7 @@ from glob import iglob
 import click
 
 from flask.cli import FlaskGroup, shell_command, ScriptInfo
+from udata import entrypoints
 from udata.app import create_app, standalone, VERBOSE_LOGGERS
 
 log = logging.getLogger(__name__)
@@ -221,9 +222,7 @@ class UdataGroup(FlaskGroup):
 
         # Load commands from entry points for enabled plugins
         app = ctx.ensure_object(ScriptInfo).load_app()
-        for ep in pkg_resources.iter_entry_points('udata.commands'):
-            if ep.name in app.config['PLUGINS']:
-                ep.load()
+        entrypoints.get_enabled('udata.commands', app)
 
         # Ensure loading happens once
         self._udata_commands_loaded = False

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -139,19 +139,19 @@ def init_logging(app):
     logger = logging.getLogger()
     logger.addHandler(handler)
 
-    app.logger.setLevel(log_level)
-    app.logger.handlers = []
-    app.logger.addHandler(handler)
-
     logger = logging.getLogger('__main__')
     logger.setLevel(log_level)
     logger.handlers = []
     logger.addHandler(handler)
 
-    for name in app.config['PLUGINS']:
-        logger = logging.getLogger('udata_{0}'.format(name))
+    for name in entrypoints.get_roots():  # Entrypoints loggers
+        logger = logging.getLogger(name)
         logger.setLevel(log_level)
         logger.handlers = []
+
+    app.logger.setLevel(log_level)
+    app.logger.handlers = []
+    app.logger.addHandler(handler)
 
     for name in VERBOSE_LOGGERS:
         logger = logging.getLogger(name)

--- a/udata/commands/db.py
+++ b/udata/commands/db.py
@@ -13,6 +13,7 @@ from flask import current_app
 from pymongo.errors import PyMongoError, OperationFailure
 from mongoengine.connection import get_db
 
+from udata import entrypoints
 from udata.commands import cli, green, yellow, cyan, red, magenta
 
 log = logging.getLogger(__name__)
@@ -121,12 +122,12 @@ def available_migrations():
         if filename.endswith('.js'):
             migrations.append(('udata', 'udata', filename))
 
-    for plugin in current_app.config['PLUGINS']:
-        name = 'udata_{0}'.format(plugin)
-        if resource_isdir(name, 'migrations'):
-            for filename in resource_listdir(name, 'migrations'):
+    plugins = entrypoints.get_enabled('udata.models', current_app)
+    for plugin, module in plugins.items():
+        if resource_isdir(module.__name__, 'migrations'):
+            for filename in resource_listdir(module.__name__, 'migrations'):
                 if filename.endswith('.js'):
-                    migrations.append((plugin, name, filename))
+                    migrations.append((plugin, module.__name__, filename))
     return sorted(migrations, key=lambda r: r[2])
 
 

--- a/udata/commands/info.py
+++ b/udata/commands/info.py
@@ -7,18 +7,51 @@ from click import echo
 
 from flask import current_app
 
-from udata.commands import cli, white
+from udata import entrypoints
+from udata.commands import cli, white, OK, KO, green, red
+
+from udata.features.identicon.backends import get_config as avatar_config
 
 
 log = logging.getLogger(__name__)
 
 
-@cli.command()
-def info():
+@cli.group('info')
+def grp():
+    '''Display some details about the local environment'''
+    pass
+
+
+def by_name(e):
+    return e.name
+
+
+def is_active(ep, actives):
+    return green(OK) if ep.name in actives else red(KO)
+
+
+@grp.command()
+def config():
     '''Display some details about the local configuration'''
     if hasattr(current_app, 'settings_file'):
         log.info('Loaded configuration from %s', current_app.settings_file)
 
-    log.info('Current configuration')
+    log.info(white('Current configuration'))
     for key in sorted(current_app.config):
         echo('{0}: {1}'.format(white(key), current_app.config[key]))
+
+
+@grp.command()
+def plugins():
+    '''Display some details about the local plugins'''
+    plugins = current_app.config['PLUGINS']
+    for name, description in entrypoints.ENTRYPOINTS.items():
+        echo('{0} ({1})'.format(white(description), name))
+        if name == 'udata.themes':
+            actives = [current_app.config['THEME']]
+        elif name == 'udata.avatars':
+            actives = [avatar_config('provider')]
+        else:
+            actives = plugins
+        for ep in sorted(entrypoints.iter(name), key=by_name):
+            echo('> {0}: {1}'.format(ep.name, is_active(ep, actives)))

--- a/udata/commands/info.py
+++ b/udata/commands/info.py
@@ -53,5 +53,5 @@ def plugins():
             actives = [avatar_config('provider')]
         else:
             actives = plugins
-        for ep in sorted(entrypoints.iter(name), key=by_name):
+        for ep in sorted(entrypoints.iter_all(name), key=by_name):
             echo('> {0}: {1}'.format(ep.name, is_active(ep, actives)))

--- a/udata/core/activity/__init__.py
+++ b/udata/core/activity/__init__.py
@@ -13,13 +13,3 @@ def init_app(app):
     import udata.core.dataset.activities  # noqa
     import udata.core.reuse.activities  # noqa
     import udata.core.organization.activities  # noqa
-
-    # Load plugins API
-    for plugin in app.config['PLUGINS']:
-        name = 'udata_{0}.activities'.format(plugin)
-        try:
-            __import__(name)
-        except ImportError:
-            pass
-        except Exception as e:
-            log.error('Error importing %s: %s', name, e)

--- a/udata/core/metrics/__init__.py
+++ b/udata/core/metrics/__init__.py
@@ -13,7 +13,7 @@ __all__ = ('Metric', 'MetricMetaClass')
 
 metric_catalog = {}
 
-
+from udata import entrypoints
 from udata.models import db  # noqa: need metrics refactoring
 
 from .tasks import update_metric, archive_metric  # noqa
@@ -146,12 +146,5 @@ def init_app(app):
     import udata.core.organization.metrics  # noqa
     import udata.core.followers.metrics  # noqa
 
-    # Load plugins API
-    for plugin in app.config['PLUGINS']:
-        name = 'udata_{0}.metrics'.format(plugin)
-        try:
-            __import__(name)
-        except ImportError:
-            pass
-        except Exception as e:
-            log.error('Error importing %s: %s', name, e)
+    # Load metrics from plugins
+    entrypoints.get_enabled('udata.metrics', app)

--- a/udata/core/metrics/commands.py
+++ b/udata/core/metrics/commands.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 
-from udata.commands import cli, success
+from udata.commands import cli, success, echo, white
 from udata.models import User, Dataset, Reuse, Organization
 
 from . import metric_catalog
@@ -64,3 +64,13 @@ def update(site=False, organizations=False, users=False, datasets=False,
             update_metrics_for(user)
 
     success('All metrics have been updated')
+
+
+@grp.command()
+def list():
+    '''List all known metrics'''
+    for cls, metrics in metric_catalog.items():
+        echo(white(cls.__name__))
+
+        for metric in metrics.keys():
+            echo('> {0}'.format(metric))

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -7,8 +7,10 @@ import pkg_resources
 ENTRYPOINTS = {
     'udata.avatars': 'Avatar rendering backends',
     'udata.harvesters': 'Harvest backends',
-    'udata.i18n': 'Extra translations',
     'udata.linkcheckers': 'Link checker backends',
+    'udata.metrics': 'Extra metrics',
+    'udata.models': 'Models and migrations',
+    'udata.tasks': 'Tasks and jobs',
     'udata.themes': 'Themes',
     'udata.views': 'Extra views',
 }
@@ -66,12 +68,16 @@ def get_plugins_dists(app):
     ]
 
 
-def get_roots():
+def get_roots(app=None):
     '''
     Returns the list of root packages/modules exposing endpoints.
+
+    If app is provided, only returns those of enabled plugins
     '''
     roots = set()
+    plugins = app.config['PLUGINS'] if app else None
     for name in ENTRYPOINTS.keys():
         for ep in iter(name):
-            roots.add(ep.module_name.split('.', 1)[0])
+            if plugins is None or ep.name in plugins:
+                roots.add(ep.module_name.split('.', 1)[0])
     return list(roots)

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, absolute_import
 
 import pkg_resources
 
-# Here for documention purpose
+# Here for documentation purpose
 ENTRYPOINTS = {
     'udata.avatars': 'Avatar rendering backends',
     'udata.harvesters': 'Harvest backends',
@@ -20,14 +20,14 @@ class EntrypointError(Exception):
     pass
 
 
-def iter(name):
+def iter_all(name):
     '''Iter all entrypoints registered on a given key'''
     return pkg_resources.iter_entry_points(name)
 
 
 def get_all(entrypoint_key):
     '''Load all entrypoints registered on a given key'''
-    return dict(_ep_to_kv(e) for e in iter(entrypoint_key))
+    return dict(_ep_to_kv(e) for e in iter_all(entrypoint_key))
 
 
 def get_enabled(name, app):
@@ -36,7 +36,7 @@ def get_enabled(name, app):
     and enabled for the given app.
     '''
     plugins = app.config['PLUGINS']
-    return dict(_ep_to_kv(e) for e in iter(name) if e.name in plugins)
+    return dict(_ep_to_kv(e) for e in iter_all(name) if e.name in plugins)
 
 
 def _ep_to_kv(entrypoint):
@@ -77,7 +77,7 @@ def get_roots(app=None):
     roots = set()
     plugins = app.config['PLUGINS'] if app else None
     for name in ENTRYPOINTS.keys():
-        for ep in iter(name):
+        for ep in iter_all(name):
             if plugins is None or ep.name in plugins:
                 roots.add(ep.module_name.split('.', 1)[0])
     return list(roots)

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -64,3 +64,14 @@ def get_plugins_dists(app):
         d for d in known_dists()
         if any(set(v.keys()) & plugins for v in d.get_entry_map().values())
     ]
+
+
+def get_roots():
+    '''
+    Returns the list of root packages/modules exposing endpoints.
+    '''
+    roots = set()
+    for name in ENTRYPOINTS.keys():
+        for ep in iter(name):
+            roots.add(ep.module_name.split('.', 1)[0])
+    return list(roots)

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -3,11 +3,38 @@ from __future__ import unicode_literals, absolute_import
 
 import pkg_resources
 
+# Here for documention purpose
+ENTRYPOINTS = {
+    'udata.avatars': 'Avatar rendering backends',
+    'udata.harvesters': 'Harvest backends',
+    'udata.i18n': 'Extra translations',
+    'udata.linkcheckers': 'Link checker backends',
+    'udata.themes': 'Themes',
+    'udata.views': 'Extra views',
+}
+
+
+class EntrypointError(Exception):
+    pass
+
+
+def iter(name):
+    '''Iter all entrypoints registered on a given key'''
+    return pkg_resources.iter_entry_points(name)
+
 
 def get_all(entrypoint_key):
-    return dict(
-        _ep_to_kv(e) for e in pkg_resources.iter_entry_points(entrypoint_key)
-    )
+    '''Load all entrypoints registered on a given key'''
+    return dict(_ep_to_kv(e) for e in iter(entrypoint_key))
+
+
+def get_enabled(name, app):
+    '''
+    Get (and load) entrypoints registered on name
+    and enabled for the given app.
+    '''
+    plugins = app.config['PLUGINS']
+    return dict(_ep_to_kv(e) for e in iter(name) if e.name in plugins)
 
 
 def _ep_to_kv(entrypoint):
@@ -20,3 +47,20 @@ def _ep_to_kv(entrypoint):
     cls = entrypoint.load()
     cls.name = entrypoint.name
     return (entrypoint.name, cls)
+
+
+def known_dists():
+    '''Return a list of all Distributions exporting udata.* entrypoints'''
+    return (
+        dist for dist in pkg_resources.working_set
+        if any(k in ENTRYPOINTS for k in dist.get_entry_map().keys())
+    )
+
+
+def get_plugins_dists(app):
+    '''Return a list of Distributions with enabled udata plugins'''
+    plugins = set(app.config['PLUGINS'])
+    return [
+        d for d in known_dists()
+        if any(set(v.keys()) & plugins for v in d.get_entry_map().values())
+    ]

--- a/udata/features/notifications/__init__.py
+++ b/udata/features/notifications/__init__.py
@@ -17,13 +17,3 @@ def init_app(app):
 
     # Load feature notifications
     import udata.features.transfer.notifications  # noqa
-
-    # Load all plugins views and blueprints
-    for plugin in app.config['PLUGINS']:
-        module = 'udata_{0}.notifications'.format(plugin)
-        try:
-            import_module(module)
-        except ImportError:
-            pass
-        except:
-            log.exception('Error importing %s notifications', module)

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -27,7 +27,7 @@ DEFAULT_PAGE_SIZE = 10
 
 def list_backends():
     '''List all available backends'''
-    return backends.get_all().values()
+    return backends.get_all(current_app).values()
 
 
 def _sources_queryset(owner=None):
@@ -135,7 +135,7 @@ def purge_sources():
 def run(ident):
     '''Launch or resume an harvesting for a given source if none is running'''
     source = get_source(ident)
-    cls = backends.get(source.backend)
+    cls = backends.get(current_app, source.backend)
     backend = cls(source)
     backend.harvest()
 
@@ -148,7 +148,7 @@ def launch(ident):
 def preview(ident):
     '''Launch or resume an harvesting for a given source if none is running'''
     source = get_source(ident)
-    cls = backends.get(source.backend)
+    cls = backends.get(current_app, source.backend)
     max_items = current_app.config['HARVEST_PREVIEW_MAX_ITEMS']
     backend = cls(source, dryrun=True, max_items=max_items)
     return backend.harvest()

--- a/udata/harvest/backends/__init__.py
+++ b/udata/harvest/backends/__init__.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-import pkg_resources
-
-from udata.entrypoints import get_all as get_all_entrypoints
+from udata.entrypoints import get_enabled, EntrypointError
 
 
-def get(name):
+def get(app, name):
     '''Get a backend given its name'''
-    return get_all().get(name)
+    backend = get_all(app).get(name)
+    if not backend:
+        msg = 'Harvest backend "{0}" is not registered'.format(name)
+        raise EntrypointError(msg)
+    return backend
 
 
-def get_all():
-    return get_all_entrypoints('udata.harvesters')
+def get_all(app):
+    return get_enabled('udata.harvesters', app)
 
 
 from .base import BaseBackend  # flake8: noqa

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -67,7 +67,7 @@ class DcatBackend(BaseBackend):
 
     def parse_graph(self, url, fmt):
         graph = Graph(namespace_manager=namespace_manager)
-        graph.parse(url, format=fmt)
+        graph.parse(data=requests.get(url).text, format=fmt)
         for id, data in self.dcat_datasets(graph):
             self.add_item(id, graph=data)
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from celery import chord
+from flask import current_app
 
 from udata.tasks import job, get_logger, task
 
@@ -16,7 +17,7 @@ def harvest(self, ident):
     log.info('Launching harvest job for source "%s"', ident)
 
     source = HarvestSource.get(ident)
-    Backend = backends.get(source.backend)
+    Backend = backends.get(current_app, source.backend)
     backend = Backend(source)
     items = backend.perform_initialization()
     if items > 0:
@@ -35,7 +36,7 @@ def harvest_item(source_id, item_id):
 
     source = HarvestSource.get(source_id)
     job = source.get_last_job()
-    Backend = backends.get(source.backend)
+    Backend = backends.get(current_app, source.backend)
     backend = Backend(source, job)
 
     item = filter(lambda i: i.remote_id == item_id, job.items)[0]
@@ -49,7 +50,7 @@ def harvest_finalize(results, source_id):
     log.info('Finalize harvesting for source "%s"', source_id)
     source = HarvestSource.get(source_id)
     job = source.get_last_job()
-    Backend = backends.get(source.backend)
+    Backend = backends.get(current_app, source.backend)
     backend = Backend(source, job)
     backend.finalize()
 

--- a/udata/linkchecker/backends.py
+++ b/udata/linkchecker/backends.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from flask import current_app
 
-from udata.entrypoints import get_all
+from udata.entrypoints import get_enabled
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +27,8 @@ class NoCheckLinkchecker(object):
 
 def get(name):
     '''Get a linkchecker given its name or fallback on default'''
-    linkcheckers = get_all(ENTRYPOINT)
+    linkcheckers = get_enabled(ENTRYPOINT, current_app)
+    linkcheckers.update(no_check=NoCheckLinkchecker)  # no_check always enabled
     selected_linkchecker = linkcheckers.get(name)
     if not selected_linkchecker:
         default_linkchecker = current_app.config.get(

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -14,6 +14,7 @@ from mongoengine.signals import pre_save, post_save
 
 from flask_fs.mongo import FileField, ImageField
 
+from udata import entrypoints
 from udata.errors import ConfigError
 
 from .badges_field import BadgesField
@@ -143,11 +144,4 @@ def init_app(app):
     if app.config['TESTING']:
         build_test_config(app.config)
     db.init_app(app)
-    for plugin in app.config['PLUGINS']:
-        name = 'udata_{0}.models'.format(plugin)
-        try:
-            importlib.import_module(name)
-        except ImportError as e:
-            pass
-        except Exception as e:
-            log.error('Error during import of %s: %s', name, e)
+    entrypoints.get_enabled('udata.models', app)

--- a/udata/sentry.py
+++ b/udata/sentry.py
@@ -33,7 +33,7 @@ def init_app(app):
                 register_signal, register_logger_signal
             )
             from raven.contrib.flask import Sentry
-        except Exception:
+        except ImportError:
             log.error('raven[flask] is required to use sentry')
             return
 

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -9,6 +9,8 @@ from celery import Celery, Task
 from celery.utils.log import get_task_logger
 from celerybeatmongo.schedulers import MongoScheduler
 
+from udata import entrypoints
+
 log = logging.getLogger(__name__)
 
 
@@ -122,14 +124,6 @@ def init_app(app):
     import udata.core.badges.tasks  # noqa
     import udata.harvest.tasks  # noqa
 
-    # Load plugins tasks
-    for plugin in app.config['PLUGINS']:
-        name = 'udata_{0}.tasks'.format(plugin)
-        try:
-            __import__(name)
-        except ImportError:
-            pass
-        except Exception as e:
-            log.error('Error importing %s: %s', name, e)
+    entrypoints.get_enabled('udata.tasks', app)
 
     return celery

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -282,6 +282,7 @@ def rmock():
     '''A requests-mock fixture'''
     import requests_mock
     with requests_mock.Mocker() as m:
+        m.ANY = requests_mock.ANY
         yield m
 
 


### PR DESCRIPTION
This PR cleanups plugins magic import and switch the necessary ones to entrypoints. (`udata.views`, `udata.metrics`, `udata.models` and `udata.tasks`)
Their usage has been rationalized and all necessary functions grouped into the `udata.entrypoints` module.

This introduce the following changes:
- harvesters are only available if the plugin is enabled (avoid adding features/content with just installing a package)
- default `no_check` linkchecker is always available (not entrypoint anymore), others need to be activated in `PLUGINS`
- migrations are associated to `udata.models` entrypoint
- sentry can now detect all plugins and will report every versions
- plugin logging is now properly handled
- each enabled plugin can provide translations which are automatically loaded
- the `info` command is now splitted in two commands `info config` which allows to inspect the config and `info plugins` to inspect plugins
- the `metrics list` command has been added

This PR also adds an entrypoints documentation (ie. extending udata)