### PR TITLE
Markdown soft breaks as new lines and client-side security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Switch to pytest as testing tool and expose a `udata` pytest plugin [#1400](https://github.com/opendatateam/udata/pull/1400)
 - Added Geopackage as default allowed file formats [#1425](https://github.com/opendatateam/udata/pull/1425)
 - Added more entrypoints and document them. There is no more automatically enabled plugin by installation. Plugins can now properly contribute translations. [#1431](https://github.com/opendatateam/udata/pull/1431)
+- Soft breaks in markdown is rendered as line return as allowed by the [commonmark specifications](http://spec.commonmark.org/0.28/#soft-line-breaks), client-side rendering follows the same security rules [#1432](https://github.com/opendatateam/udata/pull/1432)
 
 ## 1.2.11 (2018-02-05)
 

--- a/js/config.js
+++ b/js/config.js
@@ -158,6 +158,11 @@ export const tags = {MIN_LENGTH: 3, MAX_LENGTH: 32};
  */
 export const dataset_max_resources_uncollapsed = _jsonMeta('dataset-max-resources-uncollapsed');
 
+/**
+ * Markdown configuration.
+ */
+export const markdown = _jsonMeta('markdown-config');
+
 
 export default {
     user,
@@ -181,4 +186,5 @@ export default {
     tiles_url,
     tiles_config,
     dataset_max_resources_uncollapsed,
+    markdown,
 };

--- a/js/helpers/commonmark.js
+++ b/js/helpers/commonmark.js
@@ -1,9 +1,81 @@
 import markdownit from 'markdown-it';
 import { options, components } from 'markdown-it/lib/presets/commonmark';
 
+const DEFAULTS = {
+    tags: [
+        'a',
+        'abbr',
+        'acronym',
+        'b',
+        'br',
+        'blockquote',
+        'code',
+        'dd',
+        'dl',
+        'dt',
+        'em',
+        'i',
+        'li',
+        'ol',
+        'pre',
+        'small',
+        'strong',
+        'ul',
+        'sup',
+        'sub',
+    ]
+};
+
+function escapeHtml(html) {
+    return html
+         .replace(/&/g, '&amp;')
+         .replace(/</g, '&lt;')
+         .replace(/>/g, '&gt;')
+         .replace(/"/g, '&quot;')
+         .replace(/'/g, '&#039;');
+}
+
+function nodeToStr(node) {
+    const div = document.createElement('div');
+    div.appendChild(node.cloneNode(true));
+    return div.innerHTML;
+}
+
+function escapeTags(content, config) {
+    const doc = document.createRange().createContextualFragment(content);
+    const it = document.createNodeIterator(doc, NodeFilter.SHOW_ELEMENT);
+    let node;
+
+    while (node = it.nextNode()) {
+        // Skip p tags and allowed tags
+        if (node.nodeName === 'P' || config.tags.indexOf(node.nodeName.toLowerCase()) >= 0) continue;
+        const html = nodeToStr(node)
+        const escaped = document.createTextNode(escapeHtml(html));
+        node.parentNode.replaceChild(escaped, node)
+    }
+
+    return nodeToStr(doc);
+}
+
+/**
+ * Sanitize Markdown-it rendered html
+ * @param  {String} html markdown-it rendered html
+ * @return {String}      Sanitized html
+ */
+function sanitize(html, config) {
+    // Markdown-it does not removes the "\n" on soft breaks
+    html = html.replace(/\n/g, '');
+    return escapeTags(html, config);
+}
+
 options.linkify = true;
+// Enable soft breaks as line returns
+options.breaks = true;
 const markdown = markdownit().configure({options, components}).enable('linkify');
 
-export default function(text) {
-    return markdown.render(text);
+// Disable mail linkification
+markdown.linkify.add('mailto:', null)
+
+export default function(text, config) {
+    return sanitize(markdown.render(text), config || DEFAULTS);
 }

--- a/js/plugins/markdown.js
+++ b/js/plugins/markdown.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import $ from 'jquery';
 import commonmark from 'helpers/commonmark';
 import txt from 'helpers/text';
@@ -12,7 +13,7 @@ export function install(Vue, options) {
         },
         update: function(value) {
             this.el.classList.add('markdown');
-            this.el.innerHTML = value ? commonmark(value) : '';
+            this.el.innerHTML = value ? commonmark(value, config.markdown) : '';
         },
         unbind: function() {
             $(this.el).removeClass('markdown');
@@ -26,10 +27,10 @@ export function install(Vue, options) {
         if (max_length) {
             const div = document.createElement('div');
             div.classList.add('markdown');
-            div.innerHTML = commonmark(text);
+            div.innerHTML = commonmark(text, config.markdown);
             return txt.truncate(div.textContent || div.innerText || '', max_length);
         } else {
-            return commonmark(text);
+            return commonmark(text, config.markdown);
         }
     });
 }

--- a/specs/loader.js
+++ b/specs/loader.js
@@ -4,6 +4,7 @@
 // Import polyfills first
 import 'babel-polyfill';
 import 'whatwg-fetch';
+import './polyfills/dom';
 
 import Vue from 'vue';
 
@@ -13,6 +14,8 @@ Vue.config.silent = true;
 chai.use(require('chai-dom'));
 chai.use(require('chai-string'));
 chai.use(require('chai-things'));
+
+
 
 const context = require.context('.', true, /\.specs\.js$/);
 context.keys().forEach(context);

--- a/specs/plugins/markdown.specs.js
+++ b/specs/plugins/markdown.specs.js
@@ -77,3 +77,51 @@ describe('Markdown plugin', function() {
         });
     });
 });
+
+describe('Markdown backend compliance', function() {
+    const commonmark = require('helpers/commonmark').default;
+
+    /**
+    * An expect wrapper rendering the markdown
+    * and then allowing to perform chai-dom expectation on it
+    */
+    function markdown(source) {
+        const div = document.createElement('div');
+        div.innerHTML = commonmark(source);
+        return div;
+    }
+
+    it('should transform urls to anchors', function() {
+        const source = 'http://example.net/';
+        expect(markdown(source)).to.have.html('<p><a href="http://example.net/">http://example.net/</a></p>');
+    });
+
+    it('should not transform emails to anchors', function() {
+        const source = 'coucou@cmoi.fr';
+        expect(markdown(source)).to.have.html('<p>coucou@cmoi.fr</p>');
+    });
+
+    it('should not transform links within pre', function() {
+        const source = '<pre>http://example.net/</pre>';
+        expect(markdown(source)).to.have.html('<pre>http://example.net/</pre>');
+    });
+
+    it('should sanitize evil code', function() {
+        const source = 'an <script>evil()</script>';
+        expect(markdown(source)).to.have.text('an &lt;script&gt;evil()&lt;/script&gt;');
+    });
+
+    it('should handle soft breaks as <br/>', function() {
+        const source = 'line 1\nline 2';
+        expect(markdown(source)).to.have.html('<p>line 1<br>line 2</p>');
+    });
+
+    it('should not render github tables', function() {
+        const source = [
+            '| first | second |',
+            '|-------|--------|',
+            '| value | value  |',
+        ].join('\n');
+        expect(markdown(source)).to.have.html(`<p>${source.replace(/\n/g, '<br>')}</p>`);
+    });
+});

--- a/specs/polyfills/dom.js
+++ b/specs/polyfills/dom.js
@@ -1,0 +1,9 @@
+// global.Range = function Range() {};
+
+const createContextualFragment = (html) => {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.children[0]; // so hokey it's not even funny
+};
+
+Range.prototype.createContextualFragment = (html) => createContextualFragment(html);

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -117,7 +117,7 @@ def mdstrip(value, length=None, end='…'):
 
 def init_app(app):
     parser = CommonMark.Parser  # Not an instance because not thread-safe(?)
-    renderer = CommonMark.HtmlRenderer()
+    renderer = CommonMark.HtmlRenderer({'softbreak': '<br/>'})
     app.extensions['markdown'] = UDataMarkdown(app, parser, renderer)
 
     app.add_template_filter(mdstrip)

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -50,6 +50,11 @@
 <meta name="territory-enabled" content="{{ 'true' if config.ACTIVATE_TERRITORIES else 'false' }}">
 <meta name="delete-me-enabled" content="{{ 'true' if config.DELETE_ME else 'false' }}">
 <meta name="dataset-max-resources-uncollapsed" content="{{ config.DATASET_MAX_RESOURCES_UNCOLLAPSED }}">
+<meta name="markdown-config" content="{{ {
+    'tags': config.MD_ALLOWED_TAGS,
+    'attributes': config.MD_ALLOWED_ATTRIBUTES,
+    'styles': config.MD_ALLOWED_STYLES,
+}|tojson }}" />
 
 {% if json_ld %}
 <script id="json_ld" type="application/ld+json">{{ json_ld|safe }}</script>

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -120,6 +120,14 @@ class MarkdownTestCase(TestCase, WebTestMixin):
             expected = '<p>an &lt;script&gt;evil()&lt;/script&gt;</p>'
             self.assert_md_equal(result, expected)
 
+    def test_soft_break(self):
+        '''Markdown should treat soft breaks as br tag'''
+        text = 'line 1\nline 2'
+        with self.app.test_request_context('/'):
+            result = render_template_string('{{ text|markdown }}', text=text)
+            expected = '<p>line 1<br>line 2</p>'
+            self.assert_md_equal(result, expected)
+
     def test_mdstrip_filter(self):
         '''mdstrip should truncate the text before rendering'''
         text = '1 2 3 4 5 6 7 8 9 0'


### PR DESCRIPTION
This PR:
- handles markdown softbreaks as new lines as allowed by [commonmark specifications](http://spec.commonmark.org/0.28/#soft-line-breaks)
- adds some test to the client-side rendering
- make both backend and client side share the same configuration
- handle html sanitization in client side