### PR TITLE
Switch to Authlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added more entrypoints and document them. There is no more automatically enabled plugin by installation. Plugins can now properly contribute translations. [#1431](https://github.com/opendatateam/udata/pull/1431)
 - Soft breaks in markdown is rendered as line return as allowed by the [commonmark specifications](http://spec.commonmark.org/0.28/#soft-line-breaks), client-side rendering follows the same security rules [#1432](https://github.com/opendatateam/udata/pull/1432)
 - Update card components to make them more consistent [#1383](https://github.com/opendatateam/udata/pull/1383)
+- Switch from OAuthlib/Flask-OUAhtlib to Authlib and support all grants type as well as token revocation [#1434](https://github.com/opendatateam/udata/pull/1434)
 
 ## 1.2.11 (2018-02-05)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,4 +1,5 @@
 awesome-slugify==1.6.5
+authlib==0.5.1
 bleach==2.1.2
 blinker==1.4
 celery==4.1.0
@@ -17,7 +18,6 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 flask-mongoengine==0.9.3
 Flask-Navigation==0.2.0
-Flask-OAuthlib==0.9.4
 flask-restplus==0.10.1
 Flask-Security==3.0.0
 Flask-Sitemap==0.2.0
@@ -30,7 +30,6 @@ mongoengine==0.15.0
 msgpack-python==0.4.8
 pillow==5.0.0
 bcrypt==3.1.4
-oauthlib==2.0.6
 pydenticon==0.3.1
 pyliblzma==0.5.3
 python-dateutil==2.6.1

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -2,6 +2,7 @@ feedparser==5.2.1
 httpretty==0.8.14
 mock==2.0.0
 pytest==3.4.0
+pytest-env==0.6.2
 pytest-flask==0.10.0
 pytest-mock==1.6.3
 pytest-sugar==0.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ norecursedirs = .git build .tox specs .cache udata/static udata/templates udata/
 python_files = test_*.py
 python_functions = test_*
 python_classes = *Test
+env =
+    # See: https://docs.authlib.org/en/latest/flask/oauth2.html
+    AUTHLIB_INSECURE_TRANSPORT=true
 
 [flake8]
 exclude =

--- a/udata/api/oauth2.py
+++ b/udata/api/oauth2.py
@@ -141,6 +141,9 @@ class OAuth2Client(ClientMixin, db.Datetimed, db.Document):
         allowed = set(self.scopes)
         return allowed.issuperset(set(scopes))
 
+    def has_client_secret(self):
+        return bool(self.secret)
+
 
 class OAuth2Grant(db.Document):
     user = db.ReferenceField('User', required=True)
@@ -148,7 +151,7 @@ class OAuth2Grant(db.Document):
 
     code = db.StringField(required=True)
 
-    redirect_uri = db.StringField(required=True)
+    redirect_uri = db.StringField()
     expires = db.DateTimeField()
 
     scopes = db.ListField(db.StringField())

--- a/udata/api/oauth2.py
+++ b/udata/api/oauth2.py
@@ -1,13 +1,33 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+'''
+OAuth 2 serveur implementation based on Authlib.
+
+See the documentatiosn here:
+ - https://docs.authlib.org/en/latest/flask/oauth2.html
+ - https://docs.authlib.org/en/latest/spec/rfc6749.html
+ - https://docs.authlib.org/en/latest/spec/rfc6750.html
+ - https://docs.authlib.org/en/latest/spec/rfc7009.html
+
+Authlib provides SqlAlchemny mixins which help understanding:
+ - https://github.com/lepture/authlib/blob/master/authlib/flask/oauth2/sqla.py
+
+As well as a sample application:
+ - https://github.com/authlib/playground
+'''
 
 from bson import ObjectId
+
 from datetime import datetime, timedelta
 
+from authlib.common.security import generate_token
+from authlib.flask.oauth2 import (
+    AuthorizationServer, ResourceProtector, current_token
+)
+from authlib.specs.rfc6749 import grants, ClientMixin
 from flask import abort, request
-from flask_oauthlib.provider import OAuth2Provider
-from werkzeug.security import gen_salt
 from werkzeug.exceptions import Unauthorized
+from werkzeug.security import gen_salt
 
 from udata import theme
 from udata.app import csrf
@@ -17,12 +37,14 @@ from udata.models import db
 from udata.core.storages import images, default_image_basename
 
 
-oauth = OAuth2Provider()
-blueprint = I18nBlueprint('oauth', __name__)
+blueprint = I18nBlueprint('oauth', __name__, url_prefix='/oauth')
+oauth = AuthorizationServer()
 
 
 GRANT_EXPIRATION = 100  # 100 seconds
-TOKEN_EXPIRATION = 30 * 24  # 30 days
+TOKEN_EXPIRATION = 30 * 24 * 60 * 60  # 30 days in seconds
+REFRESH_EXPIRATION = 30  # days
+EPOCH = datetime.fromtimestamp(0)
 
 
 CLIENT_TYPES = {
@@ -32,8 +54,8 @@ CLIENT_TYPES = {
 
 CLIENT_PROFILES = {
     'web': _('Web Application'),
-    'user': _('User Agent'),
-    'native': _('Native'),
+    'user': _('User Agent application (Browser)'),
+    'native': _('Native Application'),
 }
 
 GRANT_TYPES = {
@@ -53,7 +75,7 @@ SCOPES = {
 }
 
 
-class OAuth2Client(db.Datetimed, db.Document):
+class OAuth2Client(ClientMixin, db.Datetimed, db.Document):
     secret = db.StringField(default=lambda: gen_salt(50), required=True)
 
     type = db.StringField(choices=CLIENT_TYPES.keys(), default='public',
@@ -72,7 +94,7 @@ class OAuth2Client(db.Datetimed, db.Document):
                           thumbnails=[150, 25])
 
     redirect_uris = db.ListField(db.StringField())
-    default_scopes = db.ListField(db.StringField(), default=SCOPES.keys())
+    scopes = db.ListField(db.StringField(), default=SCOPES.keys())
 
     meta = {
         'collection': 'oauth2_client'
@@ -93,6 +115,32 @@ class OAuth2Client(db.Datetimed, db.Document):
     def default_redirect_uri(self):
         return self.redirect_uris[0]
 
+    def get_default_redirect_uri(self):
+        '''Implement required ClientMixin method'''
+        return self.default_redirect_uri
+
+    def check_redirect_uri(self, redirect_uri):
+        '''Implement required ClientMixin method'''
+        return redirect_uri in self.redirect_uris
+
+    def check_client_type(self, client_type):
+        if client_type not in CLIENT_TYPES:
+            raise ValueError('Invalid client_type')
+        return client_type == self.type
+
+    def check_client_secret(self, client_secret):
+        return self.secret == client_secret
+
+    def check_response_type(self, response_type):
+        return True
+
+    def check_grant_type(self, grant_type):
+        return True
+
+    def check_requested_scopes(self, scopes):
+        allowed = set(self.scopes)
+        return allowed.issuperset(set(scopes))
+
 
 class OAuth2Grant(db.Document):
     user = db.ReferenceField('User', required=True)
@@ -100,7 +148,7 @@ class OAuth2Grant(db.Document):
 
     code = db.StringField(required=True)
 
-    redirect_uri = db.StringField()
+    redirect_uri = db.StringField(required=True)
     expires = db.DateTimeField()
 
     scopes = db.ListField(db.StringField())
@@ -112,6 +160,15 @@ class OAuth2Grant(db.Document):
     def __unicode__(self):
         return '<OAuth2Grant({0.client.name}, {0.user.fullname})>'.format(self)
 
+    def is_expired(self):
+        return self.expires < datetime.utcnow()
+
+    def get_redirect_uri(self):
+        return self.redirect_uri
+
+    def get_scope(self):
+        return ' '.join(self.scopes)
+
 
 class OAuth2Token(db.Document):
     client = db.ReferenceField('OAuth2Client', required=True)
@@ -122,8 +179,8 @@ class OAuth2Token(db.Document):
 
     access_token = db.StringField(unique=True)
     refresh_token = db.StringField(unique=True)
-    expires = db.DateTimeField(
-        default=lambda: datetime.utcnow() + timedelta(hours=TOKEN_EXPIRATION))
+    created_at = db.DateTimeField(default=datetime.utcnow, required=True)
+    expires_in = db.IntField(required=True, default=TOKEN_EXPIRATION)
     scopes = db.ListField(db.StringField())
 
     meta = {
@@ -133,100 +190,110 @@ class OAuth2Token(db.Document):
     def __unicode__(self):
         return '<OAuth2Token({0.client.name})>'.format(self)
 
+    def get_scope(self):
+        return ' '.join(self.scopes)
 
-@oauth.clientgetter
-def load_client(client_id):
-    try:
-        return OAuth2Client.objects.get(id=ObjectId(client_id))
-    except OAuth2Client.DoesNotExist:
-        pass
+    def get_expires_in(self):
+        return self.expires_in
 
+    def get_expires_at(self):
+        return (self.created_at - EPOCH).total_seconds() + self.expires_in
 
-@oauth.grantgetter
-def load_grant(client_id, code):
-    try:
-        return OAuth2Grant.objects.get(client=ObjectId(client_id), code=code)
-    except OAuth2Grant.DoesNotExist:
-        pass
+    def is_refresh_token_expired(self):
+        expired_at = datetime.fromtimestamp(self.get_expires_at())
+        expired_at += timedelta(days=REFRESH_EXPIRATION)
+        return expired_at < datetime.utcnow()
 
 
-@oauth.grantsetter
-def save_grant(client_id, code, request, *args, **kwargs):
-    # decide the expires time yourself
-    expires = datetime.utcnow() + timedelta(seconds=GRANT_EXPIRATION)
-    return OAuth2Grant.objects.create(
-        client=ObjectId(client_id),
-        code=code['code'],
-        redirect_uri=request.redirect_uri,
-        scopes=request.scopes,
-        user=current_user._get_current_object(),
-        expires=expires
-    )
+class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
+    def create_authorization_code(self, client, grant_user, request):
+        code = generate_token(48)
+        expires = datetime.utcnow() + timedelta(seconds=GRANT_EXPIRATION)
+        OAuth2Grant.objects.create(
+            code=code,
+            client=client,
+            redirect_uri=request.redirect_uri,
+            scopes=request.scope.split(' '),
+            user=ObjectId(grant_user.id),
+            expires=expires,
+        )
+        return code
+
+    def parse_authorization_code(self, code, client):
+        item = OAuth2Grant.objects(code=code, client=client).first()
+        if item and not item.is_expired():
+            return item
+
+    def delete_authorization_code(self, authorization_code):
+        authorization_code.delete()
+
+    def create_access_token(self, token, client, authorization_code):
+        scopes = token.pop('scope').split(' ')
+        OAuth2Token.objects.create(
+            client=client,
+            user=authorization_code.user,
+            scopes=scopes,
+            **token
+        )
 
 
-@oauth.tokengetter
-def load_token(access_token=None, refresh_token=None):
-    try:
-        if access_token:
-            return OAuth2Token.objects.get(access_token=access_token)
-        elif refresh_token:
-            return OAuth2Token.objects.get(refresh_token=refresh_token)
-    except OAuth2Token.DoesNotExist:
-        pass
+class RefreshTokenGrant(grants.RefreshTokenGrant):
+    def authenticate_refresh_token(self, refresh_token):
+        token = OAuth2Token.objects(refresh_token=refresh_token).first()
+        if token and not token.is_refresh_token_expired():
+            return token
+
+    def create_access_token(self, token, client, authenticated_token):
+        authenticated_token.update(**token)
 
 
-@oauth.tokensetter
-def save_token(token, request, *args, **kwargs):
-    # make sure that every client has only one token connected to a user
-    OAuth2Token.objects(client=request.client, user=request.user).delete()
-
-    expires_in = token.pop('expires_in')
-    expires = datetime.utcnow() + timedelta(seconds=expires_in)
-
-    return OAuth2Token.objects.create(
-        access_token=token['access_token'],
-        refresh_token=token['refresh_token'],
-        token_type=token['token_type'],
-        scopes=token['scope'].split(),
-        expires=expires,
-        client=request.client,
-        user=request.user,
-    )
+oauth.register_grant_endpoint(AuthorizationCodeGrant)
+oauth.register_grant_endpoint(RefreshTokenGrant)
 
 
-@blueprint.route('/oauth/token', methods=['POST'], localize=False)
+@blueprint.route('/token', methods=['POST'], localize=False, endpoint='token')
 @csrf.exempt
-@oauth.token_handler
 def access_token():
-    return None
+    return oauth.create_token_response()
 
 
-@blueprint.route('/oauth/authorize', methods=['GET', 'POST'])
-@oauth.authorize_handler
+@blueprint.route('/authorize', methods=['GET', 'POST'])
 @login_required
 def authorize(*args, **kwargs):
     if request.method == 'GET':
-        client_id = kwargs.get('client_id')
-        client = OAuth2Client.objects.get(id=ObjectId(client_id))
-        kwargs['client'] = client
-        return theme.render('api/oauth_authorize.html', oauth=kwargs)
+        grant = oauth.validate_authorization_request()
+        return theme.render('api/oauth_authorize.html', grant=grant)
     elif request.method == 'POST':
         accept = 'accept' in request.form
         decline = 'decline' in request.form
-        return accept and not decline
+        if accept and not decline:
+            return oauth.create_authorization_response(current_user)
+        return oauth.create_authorization_response(None)
     else:
         abort(405)
 
 
-@blueprint.route('/oauth/error')
+@blueprint.route('/error')
 def oauth_error():
     return theme.render('api/oauth_error.html')
 
 
+def query_client(client_id):
+    '''Fetch client by ID'''
+    return OAuth2Client.objects(id=ObjectId(client_id)).first()
+
+
+def query_token(access_token=access_token):
+    return OAuth2Token.objects(access_token=access_token).first()
+
+
+require_oauth = ResourceProtector(query_token)
+
+
 def check_credentials():
-    @oauth.require_oauth()
+    @require_oauth(None)
     def log_user_from_oauth_credentials():
-        login_user(request.oauth.user)
+        login_user(current_token.user)
 
     try:
         log_user_from_oauth_credentials()
@@ -236,5 +303,5 @@ def check_credentials():
 
 
 def init_app(app):
-    oauth.init_app(app)
+    oauth.init_app(app, query_client=query_client)
     app.register_blueprint(blueprint)

--- a/udata/core/user/factories.py
+++ b/udata/core/user/factories.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import factory
 
+from flask_security.utils import hash_password
+
 from udata.factories import ModelFactory
 
 from .models import User, Role
@@ -16,6 +18,13 @@ class UserFactory(ModelFactory):
     last_name = factory.Faker('last_name')
     email = factory.Faker('email')
     active = True
+
+    @classmethod
+    def _adjust_kwargs(cls, **kwargs):
+        if 'password' in kwargs:
+            # Password is stored hashed
+            kwargs['password'] = hash_password(kwargs['password'])
+        return kwargs
 
 
 class AdminFactory(UserFactory):

--- a/udata/migrations/2018-02-12-authlib.js
+++ b/udata/migrations/2018-02-12-authlib.js
@@ -7,20 +7,14 @@ const TOKEN_EXPIRATION = 30 * 24 * 60 * 60;  // 30 days in seconds
 
 var nbClients = 0;
 db.oauth2_client.find({}).forEach(client => {
-    client.scope = client.default_scopes || 'default';
+    client.scopes = client.default_scopes;
     client.confidential = client.type === 'confidential';
     delete client.default_scopes;
     delete client.grant_type;
     delete client.profile;
-    delete clients.type;
+    delete client.type;
     nbClients++;
 })
-
-// const result = db.oauth2_client.update(
-//     {},
-//     {$rename: {'default_scopes': 'scopes'}, $unset: {'grant_type': '', 'profile': ''}},
-//     {multi: true}
-// );
 print(`Updated ${nbClients} OAuth2 clients`);
 
 var nbTokens = 0
@@ -31,5 +25,4 @@ db.oauth2_token.find().forEach(token => {
     db.oauth2_token.save(token);
     nbTokens++;
 });
-
 print(`Updated ${nbTokens} OAuth2 token(s)`);

--- a/udata/migrations/2018-02-12-authlib.js
+++ b/udata/migrations/2018-02-12-authlib.js
@@ -1,0 +1,20 @@
+/*
+ * Migrate Oauth2 clients and Tokens to the new Authlib format
+ * (mostly readability migration)
+ */
+
+const TOKEN_EXPIRATION = 30 * 24 * 60 * 60;  // 30 days in seconds
+
+const result = db.oauth2_client.update({}, {$rename: {'default_scopes': 'scopes'}}, {multi: true});
+print(`Updated ${result.nModified} OAuth2 clients`);
+
+var nbTokens = 0
+db.oauth2_token.find().forEach(token => {
+    token.create_at = new Date().setTime(token.expires.getTime() - TOKEN_EXPIRATION);
+    token.expires_in = token.expires.getTime() - token.create_at.getTime();
+    delete token.expires;
+    db.oauth2_token.save(token);
+    nbTokens++;
+});
+
+print(`Updated ${nbTokens} OAuth2 token(s)`);

--- a/udata/migrations/2018-02-12-authlib.js
+++ b/udata/migrations/2018-02-12-authlib.js
@@ -5,8 +5,23 @@
 
 const TOKEN_EXPIRATION = 30 * 24 * 60 * 60;  // 30 days in seconds
 
-const result = db.oauth2_client.update({}, {$rename: {'default_scopes': 'scopes'}}, {multi: true});
-print(`Updated ${result.nModified} OAuth2 clients`);
+var nbClients = 0;
+db.oauth2_client.find({}).forEach(client => {
+    client.scope = client.default_scopes || 'default';
+    client.confidential = client.type === 'confidential';
+    delete client.default_scopes;
+    delete client.grant_type;
+    delete client.profile;
+    delete clients.type;
+    nbClients++;
+})
+
+// const result = db.oauth2_client.update(
+//     {},
+//     {$rename: {'default_scopes': 'scopes'}, $unset: {'grant_type': '', 'profile': ''}},
+//     {multi: true}
+// );
+print(`Updated ${nbClients} OAuth2 clients`);
 
 var nbTokens = 0
 db.oauth2_token.find().forEach(token => {

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -137,7 +137,9 @@ class Defaults(object):
 
     STATIC_DIRS = []
 
+    # OAuth 2 settings
     OAUTH2_PROVIDER_ERROR_ENDPOINT = 'oauth.oauth_error'
+    OAUTH2_REFRESH_TOKEN_GENERATOR = True
 
     MD_ALLOWED_TAGS = [
         'a',

--- a/udata/templates/api/oauth_authorize.html
+++ b/udata/templates/api/oauth_authorize.html
@@ -9,11 +9,11 @@
 <div class="panel-body oauth-authorize">
     <div class="row">
         <div class="col-xs-12">
-            <img src="{{ oauth.client.image(100) }}" class="pull-left app-logo" width="100" height="100" alt="">
+            <img src="{{ grant.client.image(100) }}" class="pull-left app-logo" width="100" height="100" alt="">
             <p class="lead prompt">
             {{ _(
                 '%(app)s want to access your %(site)s account.',
-                app='<span class="app">{0}</span>'.format(oauth.client.name)|safe,
+                app='<span class="app">{0}</span>'.format(grant.client.name)|safe,
                 site='<span class="site">{0}</span>'.format(config.SITE_TITLE)|safe
             ) }}
             </p>

--- a/udata/templates/api/oauth_authorize.html
+++ b/udata/templates/api/oauth_authorize.html
@@ -52,7 +52,7 @@
 <div class="panel-body">
     <form class="form text-center" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="scopes" value="{{ scopes|join(' ')|default('default') }}" />
+        <input type="hidden" name="scope" value="{{ grant.scopes or ['default'] | join(' ') }}" />
         <input type="submit" name="accept" value="{{ _('Accept') }}"
             class="btn btn-success btn-lg" />
         <input type="submit" name="decline" value="{{ _('Refuse') }}"

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -232,6 +232,23 @@ class APIAuthTest:
         assert response.content_type == 'application/json'
         assert 'access_token' in response.json
 
+    @pytest.mark.oauth(internal=True)
+    def test_authorization_redirects_for_internal_clients(self, client, oauth):
+        client.login()
+
+        response = client.get(url_for(
+            'oauth.authorize',
+            response_type='code',
+            client_id=oauth.client_id,
+            redirect_uri=oauth.default_redirect_uri
+        ))
+
+        assert_status(response, 302)
+        uri, params = response.location.split('?')
+
+        assert uri == oauth.default_redirect_uri
+        assert 'code' in parse_qs(params)
+
     @pytest.mark.oauth(type='confidential')
     def test_refresh_token(self, client, oauth):
         user = UserFactory()

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -249,7 +249,7 @@ class APIAuthTest:
         assert uri == oauth.default_redirect_uri
         assert 'code' in parse_qs(params)
 
-    @pytest.mark.oauth(type='confidential')
+    @pytest.mark.oauth(confidential=True)
     def test_refresh_token(self, client, oauth):
         user = UserFactory()
         token = OAuth2Token.objects.create(

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from base64 import b64encode
 
 from flask import url_for
 
-from udata.auth import PermissionDenied
 from udata.api import api, API
 from udata.api.oauth2 import OAuth2Client, OAuth2Token
-from udata.forms import Form, fields, validators
-
-from . import APITestCase
+from udata.auth import PermissionDenied
 from udata.core.user.factories import UserFactory
+from udata.forms import Form, fields, validators
+from udata.tests.helpers import (
+    assert200, assert400, assert401, assert403, assert_status
+)
 
 ns = api.namespace('fake', 'A Fake namespace')
 
@@ -41,205 +44,200 @@ def basic_header(client):
         return {'Authorization': 'Basic ' + b64encode(payload)}
 
 
-class APIAuthTest(APITestCase):
-    modules = ['admin', 'search', 'core.dataset', 'core.reuse', 'core.site',
-               'core.organization', 'core.user']
+@pytest.fixture
+def oauth(app):
+    return OAuth2Client.objects.create(
+        name='test-client',
+        owner=UserFactory(),
+        type='confidential',
+        redirect_uris=['https://test.org/callback']
+    )
 
-    def oauth_app(self, name='test-client'):
-        owner = UserFactory()
-        return OAuth2Client.objects.create(
-            name=name,
-            owner=owner,
-            type='confidential',
-            redirect_uris=['https://test.org/callback']
-        )
 
-    def test_no_auth(self):
+@pytest.mark.usefixtures('clean_db')
+class APIAuthTest:
+    modules = []
+
+    def test_no_auth(self, api):
         '''Should not return a content type if there is no content on delete'''
-        response = self.get(url_for('api.fake'))
+        response = api.get(url_for('api.fake'))
 
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertEqual(response.json, {'success': True})
+        assert200(response)
+        assert response.content_type == 'application/json'
+        assert response.json == {'success': True}
 
-    def test_session_auth(self):
+    def test_session_auth(self, api):
         '''Should handle session authentication'''
-        self.login()
+        api.client.login()  # Session auth
 
-        response = self.post(url_for('api.fake'))
+        response = api.post(url_for('api.fake'))
 
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertEqual(response.json, {'success': True})
+        assert200(response)
+        assert response.content_type == 'application/json'
+        assert response.json == {'success': True}
 
-    def test_header_auth(self):
+    def test_header_auth(self, api):
         '''Should handle header API Key authentication'''
-        user = UserFactory(apikey='apikey')
-        response = self.post(url_for('api.fake'),
-                             headers={'X-API-KEY': user.apikey})
+        with api.user() as user:  # API Key auth
+            response = api.post(url_for('api.fake'),
+                                headers={'X-API-KEY': user.apikey})
 
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertEqual(response.json, {'success': True})
+        assert200(response)
+        assert response.content_type == 'application/json'
+        assert response.json == {'success': True}
 
-    def test_oauth_auth(self):
+    def test_oauth_auth(self, api, oauth):
         '''Should handle  OAuth header authentication'''
         user = UserFactory()
-        client = self.oauth_app()
         token = OAuth2Token.objects.create(
-            client=client,
+            client=oauth,
             user=user,
             access_token='access-token',
             refresh_token='refresh-token',
         )
 
-        response = self.post(url_for('api.fake'), headers={
+        response = api.post(url_for('api.fake'), headers={
             'Authorization': ' '.join(['Bearer', token.access_token])
         })
 
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertEqual(response.json, {'success': True})
+        assert200(response)
+        assert response.content_type == 'application/json'
+        assert response.json == {'success': True}
 
-    def test_no_apikey(self):
+    def test_no_apikey(self, api):
         '''Should raise a HTTP 401 if no API Key is provided'''
-        response = self.post(url_for('api.fake'))
+        response = api.post(url_for('api.fake'))
 
-        self.assert401(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertIn('message', response.json)
+        assert401(response)
+        assert response.content_type == 'application/json'
+        assert 'message' in response.json
 
-    def test_invalid_apikey(self):
+    def test_invalid_apikey(self, api):
         '''Should raise a HTTP 401 if an invalid API Key is provided'''
-        response = self.post(url_for('api.fake'),
-                             headers={'X-API-KEY': 'fake'})
+        response = api.post(url_for('api.fake'), headers={'X-API-KEY': 'fake'})
 
-        self.assert401(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertIn('message', response.json)
+        assert401(response)
+        assert response.content_type == 'application/json'
+        assert 'message' in response.json
 
-    def test_inactive_user(self):
+    def test_inactive_user(self, api):
         '''Should raise a HTTP 401 if the user is inactive'''
-        user = UserFactory(apikey='apikey', active=False)
-        response = self.post(url_for('api.fake'),
-                             headers={'X-API-KEY': user.apikey})
+        user = UserFactory(active=False)
+        with api.user(user) as user:
+            response = api.post(url_for('api.fake'),
+                                headers={'X-API-KEY': user.apikey})
 
-        self.assert401(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertIn('message', response.json)
+        assert401(response)
+        assert response.content_type == 'application/json'
+        assert 'message' in response.json
 
-    def test_validation_errors(self):
+    def test_validation_errors(self, api):
         '''Should raise a HTTP 400 and returns errors on validation error'''
-        response = self.put(url_for('api.fake'), {'email': 'wrong'})
+        response = api.put(url_for('api.fake'), {'email': 'wrong'})
 
-        self.assert400(response)
-        self.assertEqual(response.content_type, 'application/json')
+        assert400(response)
+        assert response.content_type == 'application/json'
 
         for field in 'required', 'email', 'choices':
-            self.assertIn(field, response.json['errors'])
-            self.assertIsInstance(response.json['errors'][field], list)
+            assert field in response.json['errors']
+            assert isinstance(response.json['errors'][field], list)
 
-    def test_no_validation_error(self):
+    def test_no_validation_error(self, api):
         '''Should pass if no validation error'''
-        response = self.put(url_for('api.fake'), {
+        response = api.put(url_for('api.fake'), {
             'required': 'value',
             'email': 'coucou@cmoi.fr',
             'choices': 'first',
         })
 
-        self.assert200(response)
-        self.assertEqual(response.json, {'success': True})
+        assert200(response)
+        assert response.json == {'success': True}
 
-    def test_authorization_display(self):
+    def test_authorization_display(self, client, oauth):
         '''Should display the OAuth authorization page'''
-        self.login()
+        client.login()
 
-        client = self.oauth_app()
-        response = self.get(url_for(
+        response = client.get(url_for(
             'oauth.authorize',
             response_type='code',
-            client_id=client.client_id,
-            redirect_uri=client.default_redirect_uri
+            client_id=oauth.client_id,
+            redirect_uri=oauth.default_redirect_uri
         ))
 
-        self.assert200(response)
+        assert200(response)
 
-    def test_authorization_decline(self):
+    def test_authorization_decline(self, client, oauth):
         '''Should redirect to the redirect_uri on authorization denied'''
-        self.login()
+        client.login()
 
-        client = self.oauth_app()
-        response = self.post(url_for(
+        response = client.post(url_for(
             'oauth.authorize',
             response_type='code',
-            client_id=client.client_id,
-            redirect_uri=client.default_redirect_uri
+            client_id=oauth.client_id,
+            redirect_uri=oauth.default_redirect_uri
         ), {
-            'scopes': ['default'],
+            'scope': 'default',
             'refuse': '',
         })
 
-        self.assertStatus(response, 302)
+        assert_status(response, 302)
         uri, params = response.location.split('?')
-        self.assertEqual(uri, client.default_redirect_uri)
+        assert uri == oauth.default_redirect_uri
 
-    def test_authorization_accept(self):
+    def test_authorization_accept(self, client, oauth):
         '''Should redirect to the redirect_uri on authorization accepted'''
-        self.login()
+        client.login()
 
-        client = self.oauth_app()
-
-        response = self.post(url_for(
+        response = client.post(url_for(
             'oauth.authorize',
             response_type='code',
-            client_id=client.client_id,
-            redirect_uri=client.default_redirect_uri
+            client_id=oauth.client_id,
+            redirect_uri=oauth.default_redirect_uri
         ), {
-            'scopes': ['default'],
+            'scope': 'default',
             'accept': '',
         })
 
-        self.assertStatus(response, 302)
+        assert_status(response, 302)
         uri, params = response.location.split('?')
-        self.assertEqual(uri, client.default_redirect_uri)
+        assert uri == oauth.default_redirect_uri
 
-    def test_refresh_token(self):
+    def test_refresh_token(self, client, oauth):
         user = UserFactory()
-        client = self.oauth_app()
         token = OAuth2Token.objects.create(
-            client=client,
+            client=oauth,
             user=user,
             access_token='access-token',
             refresh_token='refresh-token',
         )
 
-        response = self.post(url_for('oauth.token'), {
+        response = client.post(url_for('oauth.token'), {
             'grant_type': 'refresh_token',
             'refresh_token': token.refresh_token,
-        }, headers=basic_header(client), json=False)
+        }, headers=basic_header(oauth))
 
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/json')
-        self.assertIn('access_token', response.json)
+        assert200(response)
+        assert response.content_type == 'application/json'
+        assert 'access_token' in response.json
 
-    def test_value_error(self):
+    def test_value_error(self, api):
         @ns.route('/exception', endpoint='exception')
         class ExceptionAPI(API):
             def get(self):
                 raise ValueError('Not working')
 
-        response = self.get(url_for('api.exception'))
+        response = api.get(url_for('api.exception'))
 
-        self.assert400(response)
-        self.assertEqual(response.json['message'], 'Not working')
+        assert400(response)
+        assert response.json['message'] == 'Not working'
 
-    def test_permission_denied(self):
+    def test_permission_denied(self, api):
         @ns.route('/exception', endpoint='exception')
         class ExceptionAPI(API):
             def get(self):
                 raise PermissionDenied('Permission denied')
 
-        response = self.get(url_for('api.exception'))
+        response = api.get(url_for('api.exception'))
 
-        self.assert403(response)
-        self.assertIn('message', response.json)
+        assert403(response)
+        assert 'message' in response.json

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -50,6 +50,11 @@ class TestClient(FlaskClient):
             session['_fresh'] = True
         return user
 
+    def logout(self):
+        with self.session_transaction() as session:
+            del session['user_id']
+            del session['_fresh']
+
 
 @pytest.fixture
 def app(request):


### PR DESCRIPTION
This PR:
- [x] Switch to [Authlib](https://docs.authlib.org/en/latest/index.html) instead of the unmaintained [OAuthlib](https://oauthlib.readthedocs.io/en/latest/)/[Flask-OAuthlib](http://flask-oauthlib.readthedocs.io/en/latest/)
- [x] Ensure refresh tokens are working
- [x] Makes OAuth 2 implementation support all grantypes
- [x] Support token revocation
- [x] Makes `internal` client allowed to bypass authorization screen
- [x] Ports test to Pytest
- [x] Ensures tests cover all cases