### PR TITLE
Fix Markdown sanitization

### DIFF
--- a/specs/plugins/markdown.specs.js
+++ b/specs/plugins/markdown.specs.js
@@ -116,6 +116,11 @@ describe('Markdown backend compliance', function() {
         expect(markdown(source)).to.have.html('<p>line 1<br>line 2</p>');
     });
 
+    it('should properly render markdown tags not in allowed tags', function() {
+        const source = '### titre';
+        expect(markdown(source)).to.have.html('<h3>titre</h3>');
+    });
+
     it('should not render github tables', function() {
         const source = [
             '| first | second |',

--- a/specs/polyfills/dom.js
+++ b/specs/polyfills/dom.js
@@ -7,3 +7,49 @@ const createContextualFragment = (html) => {
 };
 
 Range.prototype.createContextualFragment = (html) => createContextualFragment(html);
+
+
+/*
+ * DOMParser HTML extension
+ * 2012-09-04
+ *
+ * By Eli Grey, http://eligrey.com
+ * Public domain.
+ * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+ */
+
+/*! @source https://gist.github.com/1129031 */
+/*global document, DOMParser*/
+
+(function(DOMParser) {
+	"use strict";
+
+	var
+	  DOMParser_proto = DOMParser.prototype
+	, real_parseFromString = DOMParser_proto.parseFromString
+	;
+
+	// Firefox/Opera/IE throw errors on unsupported types
+	try {
+		// WebKit returns null on unsupported types
+		if ((new DOMParser).parseFromString("", "text/html")) {
+			// text/html parsing is natively supported
+			return;
+		}
+	} catch (ex) {}
+
+	DOMParser_proto.parseFromString = function(markup, type) {
+		if (/^\s*text\/html\s*(?:;|$)/i.test(type)) {
+			var doc = document.implementation.createHTMLDocument("");
+	      		if (markup.toLowerCase().indexOf('<!doctype') > -1) {
+        			doc.documentElement.innerHTML = markup;
+      			}
+      			else {
+        			doc.body.innerHTML = markup;
+      			}
+			return doc;
+		} else {
+			return real_parseFromString.apply(this, arguments);
+		}
+	};
+}(DOMParser));


### PR DESCRIPTION
Perform html sanitization on markdown source instead of rendered to only filter raw html tags
ie. `### title` will properly render as `<h3>` even if `<h3>` is not in allowed tags.

(Same as wthat's already in backend)