### PR TITLE
Fix search API failing on unicode queries

### DIFF
--- a/udata/search/adapter.py
+++ b/udata/search/adapter.py
@@ -95,7 +95,7 @@ class ModelSearchAdapter(DocType):
     def as_request_parser(cls, paginate=True):
         parser = RequestParser()
         # q parameter
-        parser.add_argument('q', type=str, location='args',
+        parser.add_argument('q', type=unicode, location='args',
                             help='The search query')
         # Expected facets
         # (ie. I want all facets or I want both tags and licenses facets)

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -47,6 +47,17 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(len(response.json['data']), len(datasets))
         self.assertFalse('quality' in response.json['data'][0])
 
+    def test_dataset_api_search(self):
+        '''It should search datasets from the API'''
+        with self.autoindex():
+            [VisibleDatasetFactory() for i in range(2)]
+            dataset = VisibleDatasetFactory(title="some spécial chars")
+
+        response = self.get(url_for('api.datasets', q='spécial'))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(dataset.id))
+
     def test_dataset_api_list_filtered_by_org(self):
         '''It should fetch a dataset list for a given org'''
         self.login()

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -1302,7 +1302,7 @@ class SearchAdaptorTest(SearchTestMixin, TestCase):
 
         # query + facets selector + tag and other facets + sorts + pagination
         self.assertEqual(len(parser.args), 7)
-        self.assertHasArgument(parser, 'q', str)
+        self.assertHasArgument(parser, 'q', unicode)
         self.assertHasArgument(parser, 'sort', str)
         self.assertHasArgument(parser, 'facets', str)
         self.assertHasArgument(parser, 'tag', str)
@@ -1316,7 +1316,7 @@ class SearchAdaptorTest(SearchTestMixin, TestCase):
 
         # query + facets selector + boolean facet + sorts + pagination
         self.assertEqual(len(parser.args), 6)
-        self.assertHasArgument(parser, 'q', str)
+        self.assertHasArgument(parser, 'q', unicode)
         self.assertHasArgument(parser, 'sort', str)
         self.assertHasArgument(parser, 'facets', str)
         self.assertHasArgument(parser, 'boolean', inputs.boolean)
@@ -1330,7 +1330,7 @@ class SearchAdaptorTest(SearchTestMixin, TestCase):
 
         # query + facets selector + range facet + sorts + pagination
         self.assertEqual(len(parser.args), 6)
-        self.assertHasArgument(parser, 'q', str)
+        self.assertHasArgument(parser, 'q', unicode)
         self.assertHasArgument(parser, 'sort', str)
         self.assertHasArgument(parser, 'facets', str)
         self.assertHasArgument(parser, 'range', facet.validate_parameter,
@@ -1345,7 +1345,7 @@ class SearchAdaptorTest(SearchTestMixin, TestCase):
 
         # query + facets selector + range facet + sorts + pagination
         self.assertEqual(len(parser.args), 6)
-        self.assertHasArgument(parser, 'q', str)
+        self.assertHasArgument(parser, 'q', unicode)
         self.assertHasArgument(parser, 'sort', str)
         self.assertHasArgument(parser, 'facets', str)
         self.assertHasArgument(parser, 'coverage', facet.validate_parameter)


### PR DESCRIPTION
This PR fix a bug preventing unicode search queries (any model) through the API.