### PR TITLE
Generic plugin entrypoint

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -51,6 +51,13 @@ This class entrypoint allows to register new link checkers that udata will recog
 
 This module entrypoint allows to register new asynchronous tasks and schedulable jobs.
 
+### Generic plugins (`udata.plugins`)
+
+A module entrypoint for generic plugins. They just have to expose a `init_app(app)` function
+and can perform any manual initialization.
+
+Use this entrypoint if you want to perform something not handled by previous entrypoints.
+
 ### Translations
 
 Any registered plugin may also expose translations in its root module `translations` directory.

--- a/udata/app.py
+++ b/udata/app.py
@@ -206,3 +206,6 @@ def register_features(app):
     from udata.features import notifications
 
     notifications.init_app(app)
+
+    for ep in entrypoints.get_enabled('udata.plugins', app).values():
+        ep.init_app(app)

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -10,6 +10,7 @@ ENTRYPOINTS = {
     'udata.linkcheckers': 'Link checker backends',
     'udata.metrics': 'Extra metrics',
     'udata.models': 'Models and migrations',
+    'udata.plugins': 'Generic plugin',
     'udata.tasks': 'Tasks and jobs',
     'udata.themes': 'Themes',
     'udata.views': 'Extra views',


### PR DESCRIPTION
This entrypoint is more generic than the other. This will allow easy experimentation and customization without the need for a new udata release.