### PR TITLE
Tasks routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - udata is now protocol (`http`/`https`) agnostic. This is now fully the reverse-proxy responsibility (please ensure that you are using SSL only in production for security purpose). [#1463](https://github.com/opendatateam/udata/pull/1463) [breaking]
 - Fix organization widget (embed) [#1474](https://github.com/opendatateam/udata/pull/1474)
 - High priority for sendmail tasks [#1484](https://github.com/opendatateam/udata/pull/1484)
+- Improve tasks/jobs queues routing [#1487](https://github.com/opendatateam/udata/pull/1487)
 
 ## 1.2.11 (2018-02-05)
 

--- a/udata/core/organization/tasks.py
+++ b/udata/core/organization/tasks.py
@@ -30,7 +30,7 @@ def purge_organizations(self):
             reindex(dataset)
 
 
-@task
+@task(route='high.mail')
 def notify_membership_request(org, request):
     recipients = [m.user for m in org.by_role('admin')]
     mail.send(
@@ -38,7 +38,7 @@ def notify_membership_request(org, request):
         org=org, request=request)
 
 
-@task
+@task(route='high.mail')
 def notify_membership_response(org, request):
     if request.status == 'accepted':
         subject = _('You are now a member of the organization "%(org)s"',

--- a/udata/core/user/tasks.py
+++ b/udata/core/user/tasks.py
@@ -10,6 +10,6 @@ from udata.tasks import task
 log = logging.getLogger(__name__)
 
 
-@task
+@task(route='high.mail')
 def send_test_mail(user):
     mail.send(_('Test mail'), user, 'test')

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -12,7 +12,7 @@ from .models import HarvestSource
 log = get_logger(__name__)
 
 
-@job('harvest')
+@job('harvest', route='low.harvest')
 def harvest(self, ident):
     log.info('Launching harvest job for source "%s"', ident)
 
@@ -30,7 +30,7 @@ def harvest(self, ident):
         backend.finalize()
 
 
-@task(ignore_result=False)
+@task(ignore_result=False, route='low.harvest')
 def harvest_item(source_id, item_id):
     log.info('Harvesting item %s for source "%s"', item_id, source_id)
 
@@ -45,7 +45,7 @@ def harvest_item(source_id, item_id):
     return (item_id, result)
 
 
-@task(ignore_result=False)
+@task(ignore_result=False, route='low.harvest')
 def harvest_finalize(results, source_id):
     log.info('Finalize harvesting for source "%s"', source_id)
     source = HarvestSource.get(source_id)
@@ -55,7 +55,7 @@ def harvest_finalize(results, source_id):
     backend.finalize()
 
 
-@task
+@task(route='low.harvest')
 def purge_harvest_sources():
     log.info('Purging HarvestSources flagged as deleted')
     from .actions import purge_sources

--- a/udata/patch_flask_security.py
+++ b/udata/patch_flask_security.py
@@ -8,7 +8,7 @@ from .tasks import task
 from udata.models import datastore
 
 
-@task
+@task(route='high.mail')
 def sendmail(subject, email, template, **context):
     user = datastore.get_user(email)
     tpl = 'security/{0}'.format(template)

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -15,7 +15,7 @@ from mongoengine.signals import post_save
 from speaklater import is_lazy_string
 from werkzeug.local import LocalProxy
 
-from udata.tasks import celery
+from udata.tasks import task
 
 
 from . import analysis
@@ -121,7 +121,7 @@ def get_i18n_analyzer():
 i18n_analyzer = LocalProxy(lambda: get_i18n_analyzer())
 
 
-@celery.task
+@task(route='high.search')
 def reindex(obj):
     model = obj.__class__
     adapter_class = adapter_catalog.get(model)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -62,30 +62,7 @@ class Defaults(object):
     CELERY_TASK_DEFAULT_EXCHANGE = 'default'
     CELERY_TASK_DEFAULT_EXCHANGE_TYPE = 'topic'
     CELERY_TASK_DEFAULT_ROUTING_KEY = 'task.default'
-    CELERY_TASK_ROUTES = {
-        # High priority for search tasks and mails
-        'udata.search.reindex': {
-            'queue': 'high',
-            'routing_key': 'high.search',
-        },
-        'udata.patch_flask_security.sendmail': {
-            'queue': 'high',
-            'routing_key': 'high.sendmail',
-        },
-        # Low priority for harvest operations
-        'harvest': {
-            'queue': 'low',
-            'routing_key': 'low.harvest',
-        },
-        'udata.harvest.tasks.harvest_item': {
-            'queue': 'low',
-            'routing_key': 'low.harvest',
-        },
-        'udata.harvest.tasks.harvest_finalize': {
-            'queue': 'low',
-            'routing_key': 'low.harvest',
-        },
-    }
+    CELERY_TASK_ROUTES = 'udata.tasks.router'
 
     CACHE_KEY_PREFIX = 'udata-cache'
     CACHE_TYPE = 'redis'

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -18,6 +18,9 @@ class ContextTask(Task):
     abstract = True
     schedulable = None
     current_app = None
+    route = None
+    default_queue = None
+    default_routing_key = None
 
     def __call__(self, *args, **kwargs):
         with self.current_app.app_context():
@@ -26,6 +29,7 @@ class ContextTask(Task):
 
 class JobTask(ContextTask):
     abstract = True
+    default_queue = 'low'
 
     @property
     def log(self):
@@ -43,14 +47,40 @@ class Scheduler(MongoScheduler):
 celery = Celery(task_cls=ContextTask)
 
 
+def router(name, args, kwargs, options, task=None, **kw):
+    '''
+    A celery router using the predeclared :class:`ContextTask`
+    attributes (`router` or `default_queue` and/or `default routing_key`).
+    '''
+    # Fetch task by name if necessary
+    task = task or celery.tasks.get(name)
+    if not task:
+        return
+    # Single route param override everything
+    if task.route:
+        queue = task.route.split('.', 1)[0]
+        return {'queue': queue, 'routing_key': task.route}
+    # queue parameter, routing_key computed if not present
+    if task.default_queue:
+        key = task.default_routing_key
+        key = key or '{0.default_queue}.{0.name}'.format(task)
+        return {'queue': task.default_queue, 'routing_key': key}
+    # only routing_key, queue should not be returned to fallback on default
+    elif task.default_routing_key:
+        return {'routing_key': task.default_routing_key}
+
+
 def task(*args, **kwargs):
+    for arg in 'queue', 'routing_key':
+        if arg in kwargs:
+            kwargs['default_{0}'.format(arg)] = kwargs.pop(arg)
     return celery.task(*args, **kwargs)
 
 
 def job(name, **kwargs):
     '''A shortcut decorator for declaring jobs'''
-    return celery.task(name=name, schedulable=True, base=JobTask,
-                       bind=True, **kwargs)
+    return task(name=name, schedulable=True, base=JobTask,
+                bind=True, **kwargs)
 
 
 def get_logger(name):
@@ -76,6 +106,19 @@ def log_test(self):
     self.log.info('This is an INFO message')
     self.log.warning('This is a WARNING message')
     self.log.error('This is a ERROR message')
+
+
+@job('test-low-queue', queue='low')
+@job('test-default-queue', queue='default')
+@job('test-high-queue', queue='high')
+def queue_test(self, raises=False):
+    '''
+    An empty task to test the queues.
+    Set raise to True if you want a notification (ie. Sentry)
+    '''
+    self.log.info('Just a test task')
+    if raises:
+        raise Exception('Test task processing')
 
 
 @job('error-test')

--- a/udata/tests/workers/test_tasks_routing.py
+++ b/udata/tests/workers/test_tasks_routing.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from udata.tasks import celery, task, job
+from udata.utils import unique_string
+
+
+TASKS = [
+    ({}, 'default', None),
+    ({'queue': 'low'}, 'low', 'low.{name}'),
+    ({'queue': 'low', 'routing_key': 'key'}, 'low', 'key'),
+    ({'routing_key': 'key'}, None, 'key'),
+    ({'route': 'low.topic'}, 'low', 'low.topic'),
+    ({'route': 'low.topic', 'queue': 'q'}, 'low', 'low.topic'),
+    ({'route': 'low.topic', 'routing_key': 'rk'}, 'low', 'low.topic'),
+]
+
+JOBS = [
+    ({}, 'low', 'low.{name}'),
+    ({'queue': 'high'}, 'high', 'high.{name}'),
+    ({'queue': 'high', 'routing_key': 'key'}, 'high', 'key'),
+    ({'routing_key': 'key'}, 'low', 'key'),
+    ({'route': 'high.topic'}, 'high', 'high.topic'),
+    ({'route': 'high.topic', 'queue': 'q'}, 'high', 'high.topic'),
+    ({'route': 'high.topic', 'routing_key': 'rk'}, 'high', 'high.topic'),
+]
+
+
+def idify(params):
+    '''Proper param display for easier debugging'''
+    return [
+        ', '.join('='.join(tup) for tup in row[0].items())
+        or 'none'
+        for row in params
+    ]
+
+
+def fake_task(*args, **kwargs):
+    pass
+
+
+@pytest.fixture
+def route_to(app, mocker):
+
+    def assertion(func, args, kwargs, queue, key=None):
+        __tracebackhide__ = True
+
+        decorator = func(*args, **kwargs) if args or kwargs else func
+        router = celery.amqp.router
+
+        # Celery instanciate only one task by name so we need unique names
+        suffix = unique_string().replace('-', '_')
+        fake_task.__name__ = b'task_{0}'.format(suffix)
+        t = decorator(fake_task)
+
+        options = t._get_exec_options()
+
+        route = router.route(options, t.name, task_type=t)
+        if queue:
+            assert route['queue'].name == queue, 'queue mismatch'
+        if key:
+            key = key.format(name=t.name)
+            assert route['routing_key'] == key, 'routing_key mismatch'
+        return route
+
+    return assertion
+
+
+@pytest.mark.parametrize('kwargs,queue,key', TASKS, ids=idify(TASKS))
+def test_tasks_routing(route_to, kwargs, queue, key):
+    route_to(task, [], kwargs, queue, key)
+
+
+@pytest.mark.parametrize('kwargs,queue,key', JOBS, ids=idify(JOBS))
+def test_job_routing(route_to, kwargs, queue, key):
+    route_to(job, [unique_string()], kwargs, queue, key)


### PR DESCRIPTION
This PR refactor the task routing: the default route can be defined at declaration time, on both `task` and `job`, by either using:
- `queue` and/or `routing_key` parameters
- `route` parameter from which `queue` and `routing_key` will be computed (`route=high.somewhere` gives `queue=high` and ` routing_key=high.somewhere`)

This also allows extension to define routing on their tasks.

Some route have been added to the existing tasks and jobs.