### PR TITLE
Upload cleanup

### DIFF
--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -110,6 +110,9 @@ export default {
                         endpoint: this.upload_endpoint,
                     }
                 },
+                retry: {
+                    enableAuto: true
+                },
                 callbacks: {
                     onUpload: this.on_upload,
                     onSubmitted: this.on_submit,

--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -45,6 +45,17 @@ class UploadStatus(Exception):
         self.error = error
 
 
+class UploadProgress(UploadStatus):
+    '''Raised on successful chunk uploaded'''
+    pass
+
+
+class UploadError(UploadStatus):
+    '''Raised on any upload error'''
+    def __init__(self, error=None):
+        super(UploadError, self).__init__(ok=False, error=error)
+
+
 def on_upload_status(status):
     '''Not an error, just raised when chunk is processed'''
     if status.ok:
@@ -90,11 +101,11 @@ def handle_upload(storage, prefix=None):
     if is_chunk:
         if uploaded_file:
             save_chunk(uploaded_file, args)
-            raise UploadStatus()
+            raise UploadProgress()
         else:
             uploaded_file = combine_chunks(args)
     elif not uploaded_file:
-        raise UploadStatus(False, 'Missing file parameter')
+        raise UploadError('Missing file parameter')
 
     filename = storage.save(uploaded_file, prefix=prefix)
     uploaded_file.seek(0)

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -244,6 +244,13 @@ def instance_path(app, tmpdir):
     from udata.core.storages.views import blueprint
 
     app.instance_path = str(tmpdir)
+    app.config['FS_ROOT'] = str(tmpdir / 'fs')
+    # Force local storage:
+    for s in 'resources', 'avatars', 'logos', 'images', 'chunks', 'tmp':
+        key = '{0}_FS_{{0}}'.format(s.upper())
+        app.config[key.format('BACKEND')] = 'local'
+        app.config.pop(key.format('ROOT'), None)
+
     storages.init_app(app)
     app.register_blueprint(blueprint)
 

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -95,19 +95,20 @@ class StorageUploadViewTest:
     def test_standard_upload(self, client):
         client.login()
         response = client.post(
-            url_for('storage.upload', name='tmp'),
+            url_for('storage.upload', name='resources'),
             {'file': (StringIO(b'aaa'), 'test.txt')})
 
         assert200(response)
         assert response.json['success']
-        assert 'filename' in response.json
         assert 'url' in response.json
         assert 'size' in response.json
         assert 'sha1' in response.json
-        assert response.json['filename'].endswith('test.txt')
-        assert response.json['mime'] == 'text/plain'
-        expected = storages.tmp.url(response.json['filename'], external=True)
+        assert 'filename' in response.json
+        filename = response.json['filename']
+        assert filename.endswith('test.txt')
+        expected = storages.resources.url(filename, external=True)
         assert response.json['url'] == expected
+        assert response.json['mime'] == 'text/plain'
 
     def test_chunked_upload(self, client):
         client.login()
@@ -150,6 +151,7 @@ class StorageUploadViewTest:
         assert response.json['url'] == expected
         assert response.json['mime'] == 'text/plain'
         assert storages.tmp.read(response.json['filename']) == 'aaaa'
+        assert list(storages.chunks.list_files()) == []
 
     def test_upload_resource_bad_request(self, client):
         client.login()


### PR DESCRIPTION
This PR:
- cleanup chunks after a successful upload
- allows fine uploader to retry failed chunks
- make sentry ignore upload progress
- takes advantage of Flask-FS 0.5 new `metadata` methods and so avoid the need for a local file copy (and so twice the upload size available in chunks)
- ensure tests storages are local and properly cleaned up
