### PR TITLE
Jobs commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - High priority for sendmail tasks [#1484](https://github.com/opendatateam/udata/pull/1484)
 - Improve tasks/jobs queues routing [#1487](https://github.com/opendatateam/udata/pull/1487)
 - Add security.send_confirmation template [#1475](https://github.com/opendatateam/udata/pull/1475)
+- Add the `udata schedule|unschedule|scheduled` commands [#1497](https://github.com/opendatateam/udata/pull/1497)
 
 ## 1.2.11 (2018-02-05)
 

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -82,16 +82,16 @@ You can list available jobs with:
 
 ```shell
 $ udata job list
--> log-test
--> purge-organizations
--> purge-datasets
--> bump-metrics
--> purge-reuses
--> error-test
--> harvest
--> send-frequency-reminder
--> crawl-resources
--> count-tags
+log-test
+purge-organizations
+purge-datasets
+bump-metrics
+purge-reuses
+error-test
+harvest
+send-frequency-reminder
+crawl-resources
+count-tags
 ```
 
 You can launch a job with:
@@ -114,6 +114,37 @@ $ udata job run job-name arg1 arg2 key1=value key2=value
 Most of the time, you won't need it because there will be a dedicated command
 to perform the task you need.
 
+You can also schedule or unschedule jobs (and list scheduled jobs):
+
+```shell
+$ udata job scheduled
+# No scheduled jobs
+$ udata job schedule "0 * * * *" count-tags
+➢ Scheduled Job count-tags with the following crontab: 0 * * * *
+$ udata job scheduled
+Count tags: count-tags ↦ 0 * * * *
+# Same command to reschedule
+$ udata job schedule "1 * * * *" count-tags
+➢ Scheduled Job count-tags with the following crontab: 1 * * * *
+$ udata job scheduled
+Count tags: count-tags ↦ 1 * * * *
+$ udata job unschedule count-tags
+➢ Unscheduled Job count-tags with the following crontab: 0 * * * *
+$ udata job scheduled
+# No scheduled jobs
+```
+
+Because a job can be scheduled multiple time with different parameters,
+you need to provide the same parameters to unschedule:
+
+```shell
+$ udata job schedule my-job "0 * * * *" arg key=value
+➢ Scheduled Job my-job(arg, key=value) with the following crontab: 0 * * * *
+$ udata job unschedule my-job
+✘ No scheduled job match Job my-job
+$ udata job unschedule my-job arg key=value
+➢ Unscheduled Job my-job(arg, key=value) with the following crontab: 0 * * * *
+```
 
 ## Reindexing data
 

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -134,7 +134,7 @@ $ udata job scheduled
 # No scheduled jobs
 ```
 
-Because a job can be scheduled multiple time with different parameters,
+Because a job can be scheduled multiple times with different parameters,
 you need to provide the same parameters to unschedule:
 
 ```shell

--- a/udata/core/jobs/commands.py
+++ b/udata/core/jobs/commands.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 
-from udata.commands import cli, exit_with_error, echo
+from udata.commands import cli, exit_with_error, echo, white
 from udata.tasks import schedulables, celery
 
 from .models import PeriodicTask
@@ -99,3 +99,21 @@ def schedule(name, cron, params):
 
     msg = 'Scheduled {label} with the following crontab: {cron}'
     log.info(msg.format(label=label, cron=periodic_task.crontab))
+
+
+SCHEDULE_LINE = '{name}: {label} ↦ {schedule}'
+
+
+@grp.command()
+def scheduled():
+    '''
+    List scheduled jobs.
+    '''
+    for job in sorted(schedulables()):
+        for task in PeriodicTask.objects(task=job.name):
+            label = job_label(task.task, task.args, task.kwargs)
+            echo(SCHEDULE_LINE.format(
+                name=white(task.name.encode('utf8')),
+                label=label,
+                schedule=task.schedule_display
+            ).encode('utf8'))

--- a/udata/core/jobs/commands.py
+++ b/udata/core/jobs/commands.py
@@ -5,10 +5,21 @@ import logging
 
 import click
 
-from udata.commands import cli, exit_with_error
+from udata.commands import cli, exit_with_error, echo
 from udata.tasks import schedulables, celery
 
+from .models import PeriodicTask
+
 log = logging.getLogger(__name__)
+
+
+def job_label(name, args, kwargs):
+    label = name
+    params = args[:]
+    params += ['='.join((k, v)) for k, v in sorted(kwargs.items())]
+    if params:
+        label += '(' + ', '.join(params) + ')'
+    return label
 
 
 @cli.group('job')
@@ -38,9 +49,7 @@ def run(name, params, delay):
     if name not in celery.tasks:
         exit_with_error('Job %s not found', name)
     job = celery.tasks[name]
-    label = name
-    if params:
-        label += '(' + ', '.join(params) + ')'
+    label = job_label(name, args, kwargs)
     if delay:
         log.info('Sending job %s', label)
         job.delay(*args, **kwargs)
@@ -54,5 +63,39 @@ def run(name, params, delay):
 @grp.command()
 def list():
     '''List all availables jobs'''
-    for job in schedulables():
-        log.info(job.name)
+    for job in sorted(schedulables()):
+        echo(job.name)
+
+
+@grp.command()
+@click.argument('name', metavar='<name>')
+@click.argument('cron', metavar='<cron>')
+@click.argument('params', nargs=-1,  metavar='<arg key=value ...>')
+def schedule(name, cron, params):
+    '''
+    Schedule the job <name> to run periodically given the <cron> expression.
+
+    Jobs args and kwargs are given as parameters without dashes.
+
+    Ex:
+        udata job schedule my-job "* * 0 * *" arg1 arg2 key1=value key2=value
+    '''
+    if name not in celery.tasks:
+        exit_with_error('Job %s not found', name)
+
+    args = [p for p in params if '=' not in p]
+    kwargs = dict(p.split('=') for p in params if '=' in p)
+    label = 'Job {0}'.format(job_label(name, args, kwargs))
+
+    periodic_task = PeriodicTask.objects.create(
+        task=name,
+        name=label,
+        description='Periodic {0} job'.format(name),
+        enabled=True,
+        args=args,
+        kwargs=kwargs,
+        crontab=PeriodicTask.Crontab.parse(cron),
+    )
+
+    msg = 'Scheduled {label} with the following crontab: {cron}'
+    log.info(msg.format(label=label, cron=periodic_task.crontab))

--- a/udata/core/jobs/commands.py
+++ b/udata/core/jobs/commands.py
@@ -112,7 +112,7 @@ def schedule(cron, name, params):
 @click.argument('params', nargs=-1,  metavar='<arg key=value ...>')
 def unschedule(name, params):
     '''
-    Unschedule the job <name> with the given given parameters.
+    Unschedule the job <name> with the given parameters.
 
     Jobs args and kwargs are given as parameters without dashes.
 

--- a/udata/core/jobs/models.py
+++ b/udata/core/jobs/models.py
@@ -25,6 +25,17 @@ class PeriodicTask(BasePeriodicTask):
         def __unicode__(self):
             return CRON.format(**self._data)
 
+        @classmethod
+        def parse(cls, cron):
+            m, h, d, M, W = cron.split()
+            return cls(
+                minute=m,
+                hour=h,
+                day_of_month=d,
+                month_of_year=M,
+                day_of_week=W,
+            )
+
     @property
     def schedule_display(self):
         if self.interval:

--- a/udata/harvest/commands.py
+++ b/udata/harvest/commands.py
@@ -90,11 +90,6 @@ def backends():
 
 
 @grp.command()
-def jobs():
-    '''List started harvest jobs'''
-
-
-@grp.command()
 @click.argument('identifier')
 def launch(identifier):
     '''Launch a source harvesting on the workers'''

--- a/udata/tests/cli/test_db_cli.py
+++ b/udata/tests/cli/test_db_cli.py
@@ -47,12 +47,12 @@ def test_unrecord_with_single_parameter_without_extension(cli, migrations):
 
 def test_unrecord_without_parameters(cli, migrations):
     '''Should display help without errors'''
-    result = cli('db unrecord')
+    result = cli('db unrecord', check=False)
     assert result.exit_code != 0
     assert migrations.count() == 1
 
 def test_unrecord_with_too_many_parameters(cli, migrations):
     '''Should display help without errors'''
-    result = cli('db unrecord udata test.js too many')
+    result = cli('db unrecord udata test.js too many', check=False)
     assert result.exit_code != 0
     assert migrations.count() == 1

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -198,3 +198,9 @@ def full_url(*args, **kwargs):
 def data_path(filename):
     '''Get a test data path'''
     return os.path.join(os.path.dirname(__file__), 'data', filename)
+
+
+def assert_command_ok(result):
+    __tracebackhide__ = True
+    msg = 'Command failed with exit code {0.exit_code} and output:\n{0.output}'
+    assert result.exit_code == 0, msg.format(result)

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -234,7 +234,7 @@ def cli_fixture(mocker, app):
         # Avoid instanciating another app and reuse the app fixture
         with mocker.patch.object(cli, 'create_app', return_value=app):
             result = runner.invoke(cli, args, catch_exceptions=False)
-        if kwargs.get('assert', True):
+        if kwargs.get('check', True):
             assert_command_ok(result)
         return result
 

--- a/udata/tests/workers/test_jobs_commands.py
+++ b/udata/tests/workers/test_jobs_commands.py
@@ -47,7 +47,7 @@ class JobsCommandsTest:
         job_run.assert_called_with('arg', key='value')
 
     def test_schedule_job(self, cli):
-        cli('job schedule fake-job "0 1 2 3 sunday"')
+        cli('job schedule "0 1 2 3 sunday" fake-job')
 
         tasks = PeriodicTask.objects(task=JOB_NAME)
         assert len(tasks) == 1
@@ -64,7 +64,7 @@ class JobsCommandsTest:
         assert task.name == 'Job {0}'.format(JOB_NAME)
 
     def test_schedule_job_with_parameters(self, cli):
-        cli('job schedule fake-job "0 1 2 3 sunday" '
+        cli('job schedule "0 1 2 3 sunday" fake-job '
             'arg0 arg1 key1=value1 key0=value0')
 
         tasks = PeriodicTask.objects(task=JOB_NAME)
@@ -112,3 +112,61 @@ class JobsCommandsTest:
             assert label in result.output
             assert task.name in result.output
             assert task.schedule_display in result.output
+
+    def test_unschedule_job(self, cli):
+        PeriodicTask.objects.create(
+            task=JOB_NAME,
+            name='job',
+            description='I\'m a scheduled job',
+            enabled=True,
+            crontab=PeriodicTask.Crontab.parse('0 0 0 0 0'),
+        )
+        cli('job unschedule {0}'.format(JOB_NAME))
+
+        assert len(PeriodicTask.objects(task=JOB_NAME)) == 0
+
+    def test_unschedule_job_with_parameters(self, cli):
+        PeriodicTask.objects.create(
+            task=JOB_NAME,
+            name='job',
+            description='I\'m a scheduled job',
+            enabled=True,
+            args=['arg'],
+            kwargs={'key': 'value'},
+            crontab=PeriodicTask.Crontab.parse('0 0 0 0 0'),
+        )
+        cli('job unschedule {0} arg key=value'.format(JOB_NAME))
+
+        assert len(PeriodicTask.objects(task=JOB_NAME)) == 0
+
+    def test_unschedule_job_different_parameters(self, cli):
+        PeriodicTask.objects.create(
+            task=JOB_NAME,
+            name='job',
+            description='I\'m a scheduled job',
+            enabled=True,
+            crontab=PeriodicTask.Crontab.parse('0 0 0 0 0'),
+        )
+        result = cli('job unschedule {0} arg'.format(JOB_NAME),
+                     check=False)
+
+        assert result.exit_code != 0
+        assert len(PeriodicTask.objects(task=JOB_NAME)) == 1
+
+    def test_reschedule_job(self, cli):
+        cli('job schedule "0 1 2 3 sunday" {0}'.format(JOB_NAME))
+        cli('job schedule "1 0 0 0 *" {0}'.format(JOB_NAME))
+
+        tasks = PeriodicTask.objects(task=JOB_NAME)
+        assert len(tasks) == 1
+
+        task = tasks[0]
+        assert task.args == []
+        assert task.kwargs == {}
+        assert task.crontab.minute == '1'
+        assert task.crontab.hour == '0'
+        assert task.crontab.day_of_month == '0'
+        assert task.crontab.month_of_year == '0'
+        assert task.crontab.day_of_week == '*'
+        assert task.enabled
+        assert task.name == 'Job {0}'.format(JOB_NAME)

--- a/udata/tests/workers/test_jobs_commands.py
+++ b/udata/tests/workers/test_jobs_commands.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+import pytest
+
+from udata.core.jobs.models import PeriodicTask
+from udata.tasks import job
+
+log = logging.getLogger(__name__)
+
+JOB_NAME = 'fake-job'
+
+
+@job(JOB_NAME)
+def do_nothing(self, *args, **kwargs):
+    log.info('Fake is running')
+
+
+@pytest.fixture
+def job_run(mocker):
+    return mocker.patch.object(do_nothing, 'run')
+
+
+@pytest.mark.usefixtures('clean_db')
+class JobsCommandsTest:
+    def test_list_jobs(self, cli):
+        result = cli('job list')
+        assert JOB_NAME in result.output
+
+    def test_run_job(self, cli, job_run):
+        cli('job run fake-job')
+        job_run.assert_called()
+
+    def test_delay_job(self, cli, job_run):
+        cli('job run -d fake-job')
+        job_run.assert_called()
+
+    def test_run_job_kwargs(self, cli, job_run):
+        cli('job run fake-job arg key=value')
+        job_run.assert_called_with('arg', key='value')
+
+    def test_schedule_job(self, cli):
+        cli('job schedule fake-job "0 1 2 3 sunday"')
+
+        tasks = PeriodicTask.objects(task=JOB_NAME)
+        assert len(tasks) == 1
+
+        task = tasks[0]
+        assert task.args == []
+        assert task.kwargs == {}
+        assert task.crontab.minute == '0'
+        assert task.crontab.hour == '1'
+        assert task.crontab.day_of_month == '2'
+        assert task.crontab.month_of_year == '3'
+        assert task.crontab.day_of_week == 'sunday'
+        assert task.enabled
+        assert task.name == 'Job {0}'.format(JOB_NAME)
+
+    def test_schedule_job_with_parameters(self, cli):
+        cli('job schedule fake-job "0 1 2 3 sunday" '
+            'arg0 arg1 key1=value1 key0=value0')
+
+        tasks = PeriodicTask.objects(task=JOB_NAME)
+        assert len(tasks) == 1
+
+        task = tasks[0]
+        assert task.args == ['arg0', 'arg1']  # Arguments order is preserved
+        assert task.kwargs == {'key0': 'value0', 'key1': 'value1'}
+        assert task.crontab.minute == '0'
+        assert task.crontab.hour == '1'
+        assert task.crontab.day_of_month == '2'
+        assert task.crontab.month_of_year == '3'
+        assert task.crontab.day_of_week == 'sunday'
+        assert task.enabled
+        # kwargs are sorted
+        expected = 'Job {0}(arg0, arg1, key0=value0, key1=value1)'
+        assert task.name == expected.format(JOB_NAME)


### PR DESCRIPTION
This PR adds some commands to handle jobs:
- `udata job schedule` to schedule jobs
- `udata job scheduled` to list scheduled jobs
- `udata job unschedule` to unschedule jobs

Job commands are now tested