### PR TITLE
GeoZones/GeoIDs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix some geozones/geoids bugs [#1505](https://github.com/opendatateam/udata/pull/1505)
 
 ## 1.3.0 (2018-03-13)
 

--- a/udata/core/spatial/geoids.py
+++ b/udata/core/spatial/geoids.py
@@ -30,7 +30,11 @@ def parse(text):
         validity = 'latest'
     if ':' not in spatial:
         raise GeoIDError('Bad GeoID format: {0}'.format(text))
-    level, code = spatial.rsplit(':', 1)
+    # country-subset is a special case:
+    if spatial.startswith('country-subset:'):
+        level, code = spatial.split(':', 1)
+    else:
+        level, code = spatial.rsplit(':', 1)
     return level, code, validity
 
 

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -135,8 +135,12 @@ class GeoZone(db.Document):
         for value in self.keys.values():
             if isinstance(value, list):
                 keys_values += value
-            elif not str(value).startswith('-'):  # Avoid -99.
+            elif isinstance(value, basestring) and not value.startswith('-'):
+                # Avoid -99. Should be fixed in geozones
                 keys_values.append(value)
+            elif isinstance(value, int) and value >= 0:
+                # Avoid -99. Should be fixed in geozones
+                keys_values.append(str(value))
         return keys_values
 
     @cached_property

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -87,7 +87,7 @@ class GeoZone(db.Document):
     name = db.StringField(required=True)
     level = db.StringField(required=True)
     code = db.StringField(required=True)
-    geom = db.MultiPolygonField()
+    geom = db.MultiPolygonField(null=True)
     parents = db.ListField()
     keys = db.DictField()
     validity = db.EmbeddedDocumentField(db.DateRange)

--- a/udata/core/spatial/tests/test_geoid.py
+++ b/udata/core/spatial/tests/test_geoid.py
@@ -1,46 +1,54 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-
-from udata.tests import TestCase
+import pytest
 
 from .. import geoids
 from ..models import GeoZone
 from udata.utils import faker
 
 
-class GeoIDTests(TestCase):
+class GeoIDTest:
     def test_parse_full_geoid(self):
         geoid = 'level:code@1984-06-07'
 
         level, code, validity = geoids.parse(geoid)
 
-        self.assertEqual(level, 'level')
-        self.assertEqual(code, 'code')
-        self.assertEqual(validity, '1984-06-07')
+        assert level == 'level'
+        assert code == 'code'
+        assert validity == '1984-06-07'
 
     def test_parse_implicit_latest(self):
         geoid = 'level:code'
 
         level, code, validity = geoids.parse(geoid)
 
-        self.assertEqual(level, 'level')
-        self.assertEqual(code, 'code')
-        self.assertEqual(validity, 'latest')
+        assert level == 'level'
+        assert code == 'code'
+        assert validity == 'latest'
 
     def test_parse_nested_levels(self):
         geoid = 'nested:level:code@1984-06-07'
 
         level, code, validity = geoids.parse(geoid)
 
-        self.assertEqual(level, 'nested:level')
-        self.assertEqual(code, 'code')
-        self.assertEqual(validity, '1984-06-07')
+        assert level == 'nested:level'
+        assert code == 'code'
+        assert validity == '1984-06-07'
+
+    def test_parse_country_subset_levels(self):
+        geoid = 'country-subset:country:code@1984-06-07'
+
+        level, code, validity = geoids.parse(geoid)
+
+        assert level == 'country-subset'
+        assert code == 'country:code'
+        assert validity == '1984-06-07'
 
     def test_parse_invalid_geoid(self):
         geoid = 'this-is-not-a-geoid'
 
-        with self.assertRaises(geoids.GeoIDError):
+        with pytest.raises(geoids.GeoIDError):
             geoids.parse(geoid)
 
     def test_build_without_validity(self):
@@ -49,7 +57,7 @@ class GeoIDTests(TestCase):
 
         geoid = geoids.build(level, code)
 
-        self.assertEqual(geoid, 'level:code')
+        assert geoid == 'level:code'
 
     def test_build_with_validity_as_string(self):
         level = 'level'
@@ -58,7 +66,7 @@ class GeoIDTests(TestCase):
 
         geoid = geoids.build(level, code, validity)
 
-        self.assertEqual(geoid, 'level:code@latest')
+        assert geoid == 'level:code@latest'
 
     def test_build_with_validity_as_date(self):
         level = 'level'
@@ -67,7 +75,7 @@ class GeoIDTests(TestCase):
 
         geoid = geoids.build(level, code, validity)
 
-        self.assertEqual(geoid, 'level:code@{0:%Y-%m-%d}'.format(validity))
+        assert geoid == 'level:code@{0:%Y-%m-%d}'.format(validity)
 
     def test_build_with_validity_as_datetime(self):
         level = 'level'
@@ -76,14 +84,14 @@ class GeoIDTests(TestCase):
 
         geoid = geoids.build(level, code, validity)
 
-        self.assertEqual(geoid, 'level:code@{0:%Y-%m-%d}'.format(validity))
+        assert geoid == 'level:code@{0:%Y-%m-%d}'.format(validity)
 
     def test_build_with_invalid_validity_type(self):
         level = 'level'
         code = 'code'
         validity = object()
 
-        with self.assertRaises(geoids.GeoIDError):
+        with pytest.raises(geoids.GeoIDError):
             geoids.build(level, code, validity)
 
     def test_from_zone_with_validity(self):
@@ -95,7 +103,7 @@ class GeoIDTests(TestCase):
 
         geoid = geoids.from_zone(zone)
 
-        self.assertEqual(geoid, 'level:code@{0:%Y-%m-%d}'.format(start))
+        assert geoid == 'level:code@{0:%Y-%m-%d}'.format(start)
 
     def test_from_zone_without_validity(self):
         level = 'level'
@@ -104,4 +112,4 @@ class GeoIDTests(TestCase):
 
         geoid = geoids.from_zone(zone)
 
-        self.assertEqual(geoid, 'level:code')
+        assert geoid == 'level:code'

--- a/udata/core/spatial/tests/test_models.py
+++ b/udata/core/spatial/tests/test_models.py
@@ -182,3 +182,11 @@ class SpatialTemporalResolutionTest(DBTestMixin, TestCase):
         result = GeoZone.objects.resolve(geoid, id_only=True)
 
         self.assertEqual(result, zone.id)
+
+    def test_resolve_latest_without_validity(self):
+        zone = GeoZoneFactory()
+        zone.update(unset__validity=True)
+        geoid = '{0.level}:{0.code}'.format(zone)
+        result = GeoZone.objects.resolve(geoid)
+
+        self.assertEqual(result, zone)

--- a/udata/migrations/2018-03-14-geozones-validity.js
+++ b/udata/migrations/2018-03-14-geozones-validity.js
@@ -1,0 +1,11 @@
+/*
+ * Ensure validityless zones are properly stored
+ */
+
+const result = db.geo_zone.update(
+    {validity: {}},
+    {$unset: {validity: true}},
+    {multi: true}
+);
+
+print(`Updated ${result.nModified} zones`);


### PR DESCRIPTION
This PR ensure:
- `country-subset` (`country-subset:iso:name`) geoids are properly parsed (until a better ID is found in geozones for these zones)
- spatial zones properly load:
  - when not using `--drop`, perform update on existing zones
  - default values are handled
- Geozones with unicode label successfully (re)index

This PR also migrate existing geozones loaded with an incorrect validity (`validity: {}`)