### PR TITLE
Fix filter syntax in oauth authorize template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix some geozones/geoids bugs [#1505](https://github.com/opendatateam/udata/pull/1505)
+- Fix oauth scopes serialization in authorization template [#1506](https://github.com/opendatateam/udata/pull/1506)
 
 ## 1.3.0 (2018-03-13)
 

--- a/udata/templates/api/oauth_authorize.html
+++ b/udata/templates/api/oauth_authorize.html
@@ -52,7 +52,7 @@
 <div class="panel-body">
     <form class="form text-center" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="scope" value="{{ grant.scopes or ['default'] | join(' ') }}" />
+        <input type="hidden" name="scope" value="{{ (grant.scopes or ['default']) | join(' ') }}" />
         <input type="submit" name="accept" value="{{ _('Accept') }}"
             class="btn btn-success btn-lg" />
         <input type="submit" name="decline" value="{{ _('Refuse') }}"


### PR DESCRIPTION
This PR ensures scopes array is properly serialized in the authorize template form field