### PR TITLE
Prevent error on site resources metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix some geozones/geoids bugs [#1505](https://github.com/opendatateam/udata/pull/1505)
 - Fix oauth scopes serialization in authorization template [#1506](https://github.com/opendatateam/udata/pull/1506)
+- Prevent error on site ressources metric [#1507](https://github.com/opendatateam/udata/pull/1507)
 
 ## 1.3.0 (2018-03-13)
 

--- a/udata/core/site/metrics.py
+++ b/udata/core/site/metrics.py
@@ -67,7 +67,9 @@ class ResourcesMetric(SiteMetric):
         function() {
             var total = 0
             db[collection].find(query).forEach(function(doc) {
-                total += doc.resources.length;
+                if (doc.resources && doc.resources.length) {
+                    total += doc.resources.length;
+                }
             });
             return total;
         }


### PR DESCRIPTION
Prevent site resource metric from return `NaN`