### PR TITLE
Routing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix some geozones/geoids bugs [#1505](https://github.com/opendatateam/udata/pull/1505)
 - Fix oauth scopes serialization in authorization template [#1506](https://github.com/opendatateam/udata/pull/1506)
 - Prevent error on site ressources metric [#1507](https://github.com/opendatateam/udata/pull/1507)
+- Fix some routing errors
 
 ## 1.3.0 (2018-03-13)
 

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from flask import request
 from mongoengine.errors import InvalidQueryError
 from werkzeug.routing import BaseConverter, NotFound, PathConverter
+from werkzeug.urls import url_quote
 
 from udata import models
 from udata.i18n import ISO_639_1_CODES
@@ -70,10 +71,12 @@ class ModelConverter(BaseConverter):
             return e
 
     def to_url(self, obj):
-        if isinstance(obj, (basestring, ObjectId, UUID)):
+        if isinstance(obj, basestring):
+            return url_quote(obj)
+        elif isinstance(obj, (ObjectId, UUID)):
             return str(obj)
         elif getattr(obj, 'slug', None):
-            return obj.slug
+            return url_quote(obj.slug)
         elif getattr(obj, 'id', None):
             return str(obj.id)
         else:

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -38,7 +38,7 @@ class PathListConverter(PathConverter):
 
 class UUIDConverter(BaseConverter):
     def to_python(self, value):
-        return value if isinstance(value, UUID) else UUID(value)
+        return value if isinstance(value, UUID) else UUID(value.strip())
 
 
 class ModelConverter(BaseConverter):

--- a/udata/tests/test_routing.py
+++ b/udata/tests/test_routing.py
@@ -3,9 +3,13 @@ from __future__ import unicode_literals
 
 import pytest
 
-from uuid import uuid4, UUID
+from bson import ObjectId
+from uuid import uuid4
 
 from flask import url_for
+
+from udata import routing
+from udata.models import db
 
 
 class UUIDConverterTest:
@@ -35,3 +39,75 @@ class UUIDConverterTest:
         uuid = uuid4()
         url = '/uuid/{0} '.format(str(uuid))
         assert client.get(url).data == 'ok'
+
+
+class Tester(db.Document):
+    slug = db.StringField()
+
+
+class TesterConverter(routing.ModelConverter):
+    model = Tester
+
+
+@pytest.mark.usefixtures('clean_db')
+class ObjectIdModelConverterTest:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app):
+        app.url_map.converters['tester'] = TesterConverter
+
+        @app.route('/model/<tester:model>')
+        def model_tester(model):
+            assert isinstance(model, Tester)
+            return 'ok'
+
+    def test_serialize_model_id_to_url(self):
+        tester = Tester.objects.create()
+        url = url_for('model_tester', model=tester)
+        assert url == '/model/{0}'.format(str(tester.id))
+
+    def test_serialize_model_slug_to_url(self):
+        tester = Tester.objects.create(slug='slug')
+        url = url_for('model_tester', model=tester)
+        assert url == '/model/slug'
+
+    def test_serialize_model_slug_with_unicode_to_url(self):
+        tester = Tester.objects.create(slug='slüg')
+        url = url_for('model_tester', model=tester)
+        assert url == '/model/sl%C3%BCg'
+
+    def test_serialize_object_id_to_url(self):
+        id = ObjectId()
+        url = url_for('model_tester', model=id)
+        assert url == '/model/{0}'.format(str(id))
+
+    def test_serialize_string_to_url(self):
+        slug = 'slug'
+        url = url_for('model_tester', model=slug)
+        assert url == '/model/slug'
+
+    def test_serialize_unicode_string_to_url(self):
+        slug = 'slüg'
+        url = url_for('model_tester', model=slug)
+        assert url == '/model/sl%C3%BCg'
+
+    def test_cant_serialize_model_to_url(self):
+        tester = Tester()
+        with pytest.raises(ValueError):
+            url_for('model_tester', model=tester)
+
+    def test_resolve_model_from_id(self, client):
+        tester = Tester.objects.create(slug='slug')
+        url = '/model/{0}'.format(str(tester.id))
+        assert client.get(url).data == 'ok'
+
+    def test_resolve_model_from_slug(self, client):
+        Tester.objects.create(slug='slug')
+        assert client.get('/model/slug').data == 'ok'
+
+    def test_resolve_model_from_utf8_slug(self, client):
+        Tester.objects.create(slug='slüg')
+        assert client.get('/model/slüg').data == 'ok'
+
+    def test_model_not_found(self, client):
+        assert client.get('/model/not-found').status_code == 404

--- a/udata/tests/test_routing.py
+++ b/udata/tests/test_routing.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from uuid import uuid4, UUID
+
+from flask import url_for
+
+
+class UUIDConverterTest:
+    @pytest.fixture(autouse=True)
+    def setup(self, app):
+
+        @app.route('/uuid/<uuid:uuid>')
+        def uuid_tester(uuid):
+            return 'ok'
+
+    def test_serialize_uuid_to_url(self):
+        uuid = uuid4()
+        url = url_for('uuid_tester', uuid=uuid)
+        assert url == '/uuid/{0}'.format(str(uuid))
+
+    def test_serialize_string_uuid_to_url(self):
+        uuid = uuid4()
+        url = url_for('uuid_tester', uuid=str(uuid))
+        assert url == '/uuid/{0}'.format(str(uuid))
+
+    def test_resolve_uuid(self, client):
+        uuid = uuid4()
+        url = '/uuid/{0}'.format(str(uuid))
+        assert client.get(url).data == 'ok'
+
+    def test_resolve_uuid_with_spaces(self, client):
+        uuid = uuid4()
+        url = '/uuid/{0} '.format(str(uuid))
+        assert client.get(url).data == 'ok'


### PR DESCRIPTION
This PR adds some url converters tests and prevent 2 recurrent bugs:
- An extra space in uuid converter break the UUID casting
- Event if the URL is wrong (we don't have unicode slug), prevent unicde in slug resolution to return 400 instead of 404