### PR TITLE
Lazy Mongo connexion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix oauth scopes serialization in authorization template [#1506](https://github.com/opendatateam/udata/pull/1506)
 - Prevent error on site ressources metric [#1507](https://github.com/opendatateam/udata/pull/1507)
 - Fix some routing errors [#1508](https://github.com/opendatateam/udata/pull/1508)
+- Mongo connection is now lazy by default, preventing non fork-safe usage in celery as well as preventing commands not using the database to hit it [#1509](https://github.com/opendatateam/udata/pull/1509)
 
 ## 1.3.0 (2018-03-13)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -27,6 +27,7 @@ class Defaults(object):
     TERRITORIES_EMAIL = 'territories@example.org'
 
     MONGODB_HOST = 'mongodb://localhost:27017/udata'
+    MONGODB_CONNECT = False  # Lazy connexion for Fork-safe usage
 
     # Elasticsearch configuration
     ELASTICSEARCH_URL = 'localhost:9200'


### PR DESCRIPTION
This PR delay the MongoDB conneection to the first real access.
This will:
- prevent warning on Celery start (and prevent non fork-safe usage in Celery)
- prevent the need to have MongoDB running for every commands, they will fail only on first real access if any