### PR TITLE
Fix Sentry missing udata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prevent error on site ressources metric [#1507](https://github.com/opendatateam/udata/pull/1507)
 - Fix some routing errors [#1508](https://github.com/opendatateam/udata/pull/1508)
 - Mongo connection is now lazy by default, preventing non fork-safe usage in celery as well as preventing commands not using the database to hit it [#1509](https://github.com/opendatateam/udata/pull/1509)
+- Fix udata version not exposed on Sentry [#1510](https://github.com/opendatateam/udata/pull/1510)
 
 ## 1.3.0 (2018-03-13)
 

--- a/udata/sentry.py
+++ b/udata/sentry.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import logging
+import pkg_resources
 import re
 
 from werkzeug.exceptions import HTTPException
@@ -67,6 +68,8 @@ def init_app(app):
         for dist in entrypoints.get_plugins_dists(app):
             if dist.version:
                 tags[dist.project_name] = dist.version
+        # Do not forget udata itself
+        tags['udata'] = pkg_resources.get_distribution('udata').version
 
         sentry.init_app(app)
 


### PR DESCRIPTION
Sentry stop sending the udata version in 1.3.0. This information has been lost in entrypoint refactoring.
This PR restore it.