### PR TITLE
Support OAuth2 request-body credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Support request-body credential in OAuth2 (Fix a regression introduced in 1.3.0) [#1511](https://github.com/opendatateam/udata/pull/1511)
 
 ## 1.3.1 (2018-03-15)
 

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -230,6 +230,33 @@ class APIAuthTest:
         assert response.content_type == 'application/json'
         assert 'access_token' in response.json
 
+    def test_authorization_grant_token_body_credentials(self, client, oauth):
+        client.login()
+
+        response = client.post(url_for(
+            'oauth.authorize',
+            response_type='code',
+            client_id=oauth.client_id,
+        ), {
+            'scope': 'default',
+            'accept': '',
+        })
+
+        uri, params = response.location.split('?')
+        code = parse_qs(params)['code'][0]
+
+        client.logout()
+        response = client.post(url_for('oauth.token'), {
+            'grant_type': 'authorization_code',
+            'code': code,
+            'client_id': oauth.client_id,
+            'client_secret': oauth.secret,
+        })
+
+        assert200(response)
+        assert response.content_type == 'application/json'
+        assert 'access_token' in response.json
+
     @pytest.mark.oauth(internal=True)
     def test_authorization_redirects_for_internal_clients(self, client, oauth):
         client.login()


### PR DESCRIPTION
This PR allows OAuth2 request-body credentials (ie. you can submit `client_id` and `client_secret` in the POST body when querying `/oauth/token`)