### PR TITLE
Uploads tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fixes on upload: prevent double upload and bad chunks upload [#1516](https://github.com/opendatateam/udata/pull/1516)
 
 ## 1.3.2 (2018-03-20)
 

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -50,6 +50,15 @@ export default {
         };
     },
     ready() {
+        this.$dnd = new qq.DragAndDrop({
+            dropZoneElements: [this.$el],
+            classes: {
+                dropActive: this.$options.dropActive || 'drop-active'
+            },
+            callbacks: {
+                processingDroppedFilesComplete: this.on_dropped_files_complete
+            }
+        });
         this._build_uploader();
     },
 
@@ -122,16 +131,6 @@ export default {
                 },
                 messages: messages,
                 validation: {allowedExtensions: allowedExtensions.items}
-            });
-
-            this.$dnd = new qq.DragAndDrop({
-                dropZoneElements: [this.$el],
-                classes: {
-                    dropActive: this.$options.dropActive || 'drop-active'
-                },
-                callbacks: {
-                    processingDroppedFilesComplete: this.on_dropped_files_complete
-                }
             });
         },
 


### PR DESCRIPTION
This PR tune/fix some details on chunked upload:
- prevent bad chunks storage
- prevent double upload from drag and drop (prevent `FileExits` on upload)