### PR TITLE
Ensure 'publish as" screen properly hide admin only widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixes the search result vertical cut off [#1530](https://github.com/opendatateam/udata/pull/1530)
 - Prevent visually disabled pagination buttons from being clicked [#1539](https://github.com/opendatateam/udata/pull/1539)
 - Fixes "sort organization by name" not working [#1537](https://github.com/opendatateam/udata/pull/1537)
+- Non-admin users should not see the "publish as anyone" filter field on "publish as" screen [#1538](https://github.com/opendatateam/udata/pull/1538)
 
 ## 1.3.3 (2018-03-20)
 

--- a/js/components/widgets/publish-as.vue
+++ b/js/components/widgets/publish-as.vue
@@ -7,7 +7,7 @@
 </div>
 <div class="row" v-if="$root.me.organizations && $root.me.organizations.length">
     <p class="col-xs-12">{{ _('Publish as an organization') }}</p>
-    
+
     <div v-for="organization in $root.me.organizations" :key="organization.id"
         class="col-xs-12 col-sm-6 col-lg-4">
         <org-card clickable :organization="organization"
@@ -37,7 +37,9 @@
        {{ _('As administrator you can choose any organization to publish') }}
     </p>
 </div>
-<org-filter cardclass="col-xs-12 col-sm-6 col-lg-4" :selected="selected"></org-filter>
+<org-filter v-if="$root.me.is_admin"
+    cardclass="col-xs-12 col-sm-6 col-lg-4" :selected="selected">
+</org-filter>
 </div>
 </template>
 


### PR DESCRIPTION
This PR fixes the "publish as" screen partially hiding the admin-only "publish as anyone" field.