### PR TITLE
Resource modals: use API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 dist
 build
 eggs
+.eggs/
 parts
 bin
 var

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Initial data preview implementation [#1581](https://github.com/opendatateam/udata/pull/1581)
 - Switch to PyPI.org for package links [#1583](https://github.com/opendatateam/udata/pull/1583)
 - Handle some alternate titles and alternate URLs on licenses for improved match on harvesting [#1592](https://github.com/opendatateam/udata/pull/1592)
+- Resource modals: use new single resource API call [#1547](https://github.com/opendatateam/udata/pull/1547)
 
 ## 1.3.6 (2018-04-16)
 

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -132,7 +132,7 @@ export default {
         return {
             edit: false,
             confirm: false,
-            dataset: new Dataset(),
+            dataset: this.$parent.$parent.dataset,
             resource: new Resource(),
             next_route: null
         };
@@ -167,10 +167,11 @@ export default {
                     params: parent.params
                 };
             }
-            this.dataset.fetch(this.$route.params.oid);
             if (this.$route.name.includes('community')) {
                 this.resource = new CommunityResource();
                 this.resource.fetch(this.$route.params.rid);
+            } else {
+                this.resource.fetch(this.$route.params.oid, this.$route.params.rid);
             }
         }
     },

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -90,7 +90,7 @@ new Vue({
             const resource = this.dataset[attr].find(resource => resource['@id'] === id);
             const communityPrefix = isCommunity ? '-community' : '';
             location.hash = `resource${communityPrefix}-${id}`;
-            const modal = this.$modal(ResourceModal, {resource});
+            const modal = this.$modal(ResourceModal, {datasetId: this.dataset['@id'], resourceId: id, resourceJsonLd: resource});
             modal.$on('modal:closed', () => {
                 // prevent scrolling to top
                 location.hash = '_';

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -83,14 +83,45 @@ new Vue({
         },
 
         /**
+         * Get a resource object conform to model (but not a Model instance) from JSON-LD
+         * @param  {Object} resourceJsonLd  Resource as in JSON-LD
+         * @return {Object}                 Resource object as it would be in model
+         */
+        resourceFromJsonLd(resourceJsonLd) {
+            const resource = {
+                id: resourceJsonLd['@id'],
+                url: resourceJsonLd.contentUrl,
+                latest: resourceJsonLd.url,
+                title: resourceJsonLd.name,
+                format: resourceJsonLd.encodingFormat,
+                mime: resourceJsonLd.fileFormat,
+                filesize: resourceJsonLd.contentSize,
+                created_at: resourceJsonLd.dateCreated,
+                modified: resourceJsonLd.dateModified,
+                published: resourceJsonLd.datePublished,
+                description: resourceJsonLd.description,
+            };
+            if (resourceJsonLd.interactionStatistic) {
+                resource.metrics = {
+                    views: resourceJsonLd.interactionStatistic.userInteractionCount,
+                }
+            }
+            resource.extras = {};
+            return resource;
+        },
+
+        /**
          * Display a resource or a community ressource in a modal
          */
         showResource(id, isCommunity) {
             const attr = isCommunity ? 'communityResources' : 'resources';
-            const resource = this.dataset[attr].find(resource => resource['@id'] === id);
+            const resourceJsonLd = this.dataset[attr].find(resource => resource['@id'] === id);
             const communityPrefix = isCommunity ? '-community' : '';
             location.hash = `resource${communityPrefix}-${id}`;
-            const modal = this.$modal(ResourceModal, {datasetId: this.dataset['@id'], resourceId: id, resourceJsonLd: resource});
+            const modal = this.$modal(
+                ResourceModal,
+                {datasetId: this.dataset['@id'], resource: this.resourceFromJsonLd(resourceJsonLd)}
+            );
             modal.$on('modal:closed', () => {
                 // prevent scrolling to top
                 location.hash = '_';

--- a/js/front/dataset/resource-modal.vue
+++ b/js/front/dataset/resource-modal.vue
@@ -1,36 +1,36 @@
 <template>
 <modal class="resource-modal" v-ref:modal
-    :title="resource.name">
+    :title="resource.title">
 
     <div class="modal-body">
-        {{{ resource.description }}}
+        {{{ resource.description|markdown }}}
 
         <dl class="dl-horizontal dl-wide">
           <dt>{{ _('URL') }}</dt>
-          <dd><a :href="resource.contentUrl" @click="onClick">{{resource.contentUrl}}</a></dd>
+          <dd><a :href="resourceJsonLd.contentUrl" @click="onClick">{{resourceJsonLd.contentUrl}}</a></dd>
           <dt>{{ _('Latest URL') }}</dt>
-          <dd><a :href="resource.url" @click="onClick">{{resource.url}}</a></dd>
-          <dt v-if="resource.encodingFormat">{{ _('Format') }}</dt>
-          <dd v-if="resource.encodingFormat">{{resource.encodingFormat}}</dd>
-          <dt v-if="resource.fileFormat">{{ _('MimeType') }}</dt>
-          <dd v-if="resource.fileFormat">{{resource.fileFormat}}</dd>
-          <dt v-if="resource.contentSize">{{ _('Size') }}</dt>
-          <dd v-if="resource.contentSize">{{ resource.contentSize|size }}</dd>
-          <dt v-if="resource.checksum">{{ resource.checksumType || 'sha1'}}</dt>
-          <dd v-if="resource.checksum">{{ resource.checksum }}</dd>
-          <dt v-if="resource.dateCreated">{{ _('Created on') }}</dt>
-          <dd v-if="resource.dateCreated"> {{ resource.dateCreated|dt }}</dd>
-          <dt v-if="resource.dateModified">{{ _('Modified on') }}</dt>
-          <dd v-if="resource.dateModified"> {{ resource.dateModified|dt }}</dd>
-          <dt v-if="resource.datePublished">{{ _('Published on') }}</dt>
-          <dd v-if="resource.datePublished"> {{ resource.datePublished|dt }}</dd>
-          <dt v-if="resource.interactionStatistic && resource.interactionStatistic.userInteractionCount">{{ _('Downloads') }}</dt>
-          <dd v-if="resource.interactionStatistic && resource.interactionStatistic.userInteractionCount"> {{ resource.interactionStatistic.userInteractionCount }}</dd>
-          <dt v-if="checkResults['check:date']">{{ _('Last checked on') }}</dt>
-          <dd v-if="checkResults['check:date']"> {{ checkResults['check:date']|dt }}</dd>
-          <dt v-if="checkResults['check:status']">{{ _('Last checked result') }}</dt>
-          <dd v-if="checkResults['check:status']">
-              <availability :status="checkResults['check:status']"></availability>
+          <dd><a :href="resourceJsonLd.url" @click="onClick">{{resourceJsonLd.url}}</a></dd>
+          <dt v-if="resourceJsonLd.encodingFormat">{{ _('Format') }}</dt>
+          <dd v-if="resourceJsonLd.encodingFormat">{{resourceJsonLd.encodingFormat}}</dd>
+          <dt v-if="resourceJsonLd.fileFormat">{{ _('MimeType') }}</dt>
+          <dd v-if="resourceJsonLd.fileFormat">{{resourceJsonLd.fileFormat}}</dd>
+          <dt v-if="resourceJsonLd.contentSize">{{ _('Size') }}</dt>
+          <dd v-if="resourceJsonLd.contentSize">{{ resourceJsonLd.contentSize|size }}</dd>
+          <dt v-if="resourceJsonLd.checksum">{{ resourceJsonLd.checksumType || 'sha1'}}</dt>
+          <dd v-if="resourceJsonLd.checksum">{{ resourceJsonLd.checksum }}</dd>
+          <dt v-if="resourceJsonLd.dateCreated">{{ _('Created on') }}</dt>
+          <dd v-if="resourceJsonLd.dateCreated"> {{ resourceJsonLd.dateCreated|dt }}</dd>
+          <dt v-if="resourceJsonLd.dateModified">{{ _('Modified on') }}</dt>
+          <dd v-if="resourceJsonLd.dateModified"> {{ resourceJsonLd.dateModified|dt }}</dd>
+          <dt v-if="resourceJsonLd.datePublished">{{ _('Published on') }}</dt>
+          <dd v-if="resourceJsonLd.datePublished"> {{ resourceJsonLd.datePublished|dt }}</dd>
+          <dt v-if="resourceJsonLd.interactionStatistic && resourceJsonLd.interactionStatistic.userInteractionCount">{{ _('Downloads') }}</dt>
+          <dd v-if="resourceJsonLd.interactionStatistic && resourceJsonLd.interactionStatistic.userInteractionCount"> {{ resourceJsonLd.interactionStatistic.userInteractionCount }}</dd>
+          <dt v-if="resource.extras && resource.extras['check:date']">{{ _('Last checked on') }}</dt>
+          <dd v-if="resource.extras && resource.extras['check:date']"> {{ resource.extras['check:date']|dt }}</dd>
+          <dt v-if="resource.extras && resource.extras['check:status']">{{ _('Last checked result') }}</dt>
+          <dd v-if="resource.extras && resource.extras['check:status']">
+                <availability :status="resource.extras['check:status']"></availability>
           </dd>
         </dl>
     </div>
@@ -45,23 +45,33 @@
 
 <script>
 import Modal from 'components/modal.vue';
+import Resource from 'models/resource';
 import Availability from './resource/availability.vue';
 import pubsub from 'pubsub';
 
 export default {
     props: {
-        resource: Object
+        datasetId: {
+            type: String,
+            required: true,
+        },
+        resourceId: {
+            type: String,
+            required: true,
+        },
+        resourceJsonLd: {
+            type: Object,
+            required: true,
+        }
+    },
+    data() {
+        return {
+            resource: new Resource(),
+        }
     },
     components: {Modal, Availability},
-    computed: {
-        checkResults() {
-            return this.resource.extras.reduce((obj, extra) => {
-                if (extra.name.startsWith('check:')) {
-                    obj[extra.name] = extra.value;
-                }
-                return obj;
-            }, {});
-        },
+    created() {
+        this.resource.fetch(this.datasetId, this.resourceId);
     },
     methods: {
         onClick() {

--- a/js/front/dataset/resource-modal.vue
+++ b/js/front/dataset/resource-modal.vue
@@ -7,25 +7,25 @@
 
         <dl class="dl-horizontal dl-wide">
           <dt>{{ _('URL') }}</dt>
-          <dd><a :href="resourceJsonLd.contentUrl" @click="onClick">{{resourceJsonLd.contentUrl}}</a></dd>
+          <dd><a :href="resource.url" @click="onClick">{{resource.url}}</a></dd>
           <dt>{{ _('Latest URL') }}</dt>
-          <dd><a :href="resourceJsonLd.url" @click="onClick">{{resourceJsonLd.url}}</a></dd>
-          <dt v-if="resourceJsonLd.encodingFormat">{{ _('Format') }}</dt>
-          <dd v-if="resourceJsonLd.encodingFormat">{{resourceJsonLd.encodingFormat}}</dd>
-          <dt v-if="resourceJsonLd.fileFormat">{{ _('MimeType') }}</dt>
-          <dd v-if="resourceJsonLd.fileFormat">{{resourceJsonLd.fileFormat}}</dd>
-          <dt v-if="resourceJsonLd.contentSize">{{ _('Size') }}</dt>
-          <dd v-if="resourceJsonLd.contentSize">{{ resourceJsonLd.contentSize|size }}</dd>
-          <dt v-if="resourceJsonLd.checksum">{{ resourceJsonLd.checksumType || 'sha1'}}</dt>
-          <dd v-if="resourceJsonLd.checksum">{{ resourceJsonLd.checksum }}</dd>
-          <dt v-if="resourceJsonLd.dateCreated">{{ _('Created on') }}</dt>
-          <dd v-if="resourceJsonLd.dateCreated"> {{ resourceJsonLd.dateCreated|dt }}</dd>
-          <dt v-if="resourceJsonLd.dateModified">{{ _('Modified on') }}</dt>
-          <dd v-if="resourceJsonLd.dateModified"> {{ resourceJsonLd.dateModified|dt }}</dd>
-          <dt v-if="resourceJsonLd.datePublished">{{ _('Published on') }}</dt>
-          <dd v-if="resourceJsonLd.datePublished"> {{ resourceJsonLd.datePublished|dt }}</dd>
-          <dt v-if="resourceJsonLd.interactionStatistic && resourceJsonLd.interactionStatistic.userInteractionCount">{{ _('Downloads') }}</dt>
-          <dd v-if="resourceJsonLd.interactionStatistic && resourceJsonLd.interactionStatistic.userInteractionCount"> {{ resourceJsonLd.interactionStatistic.userInteractionCount }}</dd>
+          <dd><a :href="resource.latest" @click="onClick">{{resource.latest}}</a></dd>
+          <dt v-if="resource.format">{{ _('Format') }}</dt>
+          <dd v-if="resource.format">{{resource.format}}</dd>
+          <dt v-if="resource.mime">{{ _('MimeType') }}</dt>
+          <dd v-if="resource.mime">{{resource.mime}}</dd>
+          <dt v-if="resource.filesize">{{ _('Size') }}</dt>
+          <dd v-if="resource.filesize">{{ resource.filesize|size }}</dd>
+          <dt v-if="resource.checksum">{{ resource.checksumType || 'sha1'}}</dt>
+          <dd v-if="resource.checksum">{{ resource.checksum }}</dd>
+          <dt v-if="resource.created_at">{{ _('Created on') }}</dt>
+          <dd v-if="resource.created_at"> {{ resource.created_at|dt }}</dd>
+          <dt v-if="resource.modified">{{ _('Modified on') }}</dt>
+          <dd v-if="resource.modified"> {{ resource.modified|dt }}</dd>
+          <dt v-if="resource.published">{{ _('Published on') }}</dt>
+          <dd v-if="resource.published"> {{ resource.published|dt }}</dd>
+          <dt v-if="resource.metrics && resource.metrics.views">{{ _('Downloads') }}</dt>
+          <dd v-if="resource.metrics && resource.metrics.views"> {{ resource.metrics.views }}</dd>
           <dt v-if="resource.extras && resource.extras['check:date']">{{ _('Last checked on') }}</dt>
           <dd v-if="resource.extras && resource.extras['check:date']"> {{ resource.extras['check:date']|dt }}</dd>
           <dt v-if="resource.extras && resource.extras['check:status']">{{ _('Last checked result') }}</dt>
@@ -55,23 +55,17 @@ export default {
             type: String,
             required: true,
         },
-        resourceId: {
-            type: String,
-            required: true,
-        },
-        resourceJsonLd: {
+        resource: {
             type: Object,
             required: true,
         }
     },
-    data() {
-        return {
-            resource: new Resource(),
-        }
-    },
     components: {Modal, Availability},
     created() {
-        this.resource.fetch(this.datasetId, this.resourceId);
+        const url = `datasets/${this.datasetId}/resources/${this.resource.id}/`;
+        this.$api.get(url).then(resource => {
+            Object.assign(this.resource, resource);
+        });
     },
     methods: {
         onClick() {

--- a/js/front/dataset/resource/availability.vue
+++ b/js/front/dataset/resource/availability.vue
@@ -24,7 +24,13 @@ export default {
          */
         status: {
             type: Number,
-        }
+        },
+        /**
+         * Does the resource need a refreshed check?
+         */
+        needCheck: {
+            type: Boolean,
+        },
     },
     data() {
         return {
@@ -81,7 +87,7 @@ export default {
          * @param  {Object} resource A resource as extracted from JSON-LD
          */
         getCachedCheck(resource) {
-            if (!resource.needCheck) {
+            if (!this.needCheck) {
                 const extras = this.getCheckExtras(resource.extras || []);
                 if (extras['check:status']) {
                     return extras;

--- a/js/models/resource.js
+++ b/js/models/resource.js
@@ -2,4 +2,20 @@ import {Model} from 'models/base';
 import log from 'logger';
 
 
-export default class Resource extends Model {};
+export default class Resource extends Model {
+    /**
+     * Fetch a resource given its dataset identifier and own identifier.
+     * @param  {String} datasetId  The dataset identifier of the resource to fetch.
+     * @param  {String} resourceId The resource identifier to fetch.
+     * @return {Resource}           The current object itself.
+     */
+    fetch(datasetId, resourceId) {
+        if (datasetId && resourceId) {
+            this.loading = true;
+            this.$api('datasets.get_resource', {dataset: datasetId, rid: resourceId}, this.on_fetched);
+        } else {
+            log.error('Unable to fetch Resource: no identifier(s) specified');
+        }
+        return this;
+    }
+};

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -327,6 +327,15 @@ class ReuploadCommunityResource(ResourceMixin, UploadMixin, API):
           doc=common_doc)
 @api.doc(params={'rid': 'The resource unique identifier'})
 class ResourceAPI(ResourceMixin, API):
+    @api.doc('get_resource')
+    @api.marshal_with(resource_fields)
+    def get(self, dataset, rid):
+        '''Get a resource given its identifier'''
+        if dataset.deleted and not DatasetEditPermission(dataset).can():
+            api.abort(410, 'Dataset has been deleted')
+        resource = self.get_resource_or_404(dataset, rid)
+        return resource
+
     @api.secure
     @api.doc('update_resource', body=resource_fields)
     @api.marshal_with(resource_fields)

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -302,7 +302,6 @@ class ResourceMixin(object):
             'datePublished': self.published.isoformat(),
             'extras': [get_json_ld_extra(*item)
                        for item in self.extras.items()],
-            'needCheck': self.need_check(),
             'type': self.type,
         }
 
@@ -326,11 +325,6 @@ class ResourceMixin(object):
 
         if self.description:
             result['description'] = mdstrip(self.description)
-
-        # These 2 values are not standard
-        if self.checksum:
-            result['checksum'] = self.checksum.value,
-            result['checksumType'] = self.checksum.type or 'sha1'
 
         return result
 

--- a/udata/templates/dataset/resource/card.html
+++ b/udata/templates/dataset/resource/card.html
@@ -30,7 +30,11 @@
                     {{ resource.metrics.nb_hits or 0 }}
                 </li>
                 <li class="healthcheck-container">
-                    <availability v-if="checkUrlEnabled" :resource="getResourceById('{{ resource.id }}')" :checkurl="'{{ url_for('api.check_dataset_resource', dataset=dataset.id, rid=resource.id) }}'"></availability>
+                    <availability v-if="checkUrlEnabled"
+                                  :resource="getResourceById('{{ resource.id }}')"
+                                  :checkurl="'{{ url_for('api.check_dataset_resource', dataset=dataset.id, rid=resource.id) }}'"
+                                  :need-check="{{ resource.need_check()|tojson }}">
+                    </availability>
                 </li>
             </ul>
         </div>

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -548,6 +548,19 @@ class DatasetResourceAPITest(APITestCase):
         self.login()
         self.dataset = DatasetFactory(owner=self.user)
 
+    def test_get(self):
+        '''It should fetch a resource from the API'''
+        with self.autoindex():
+            resource = ResourceFactory()
+            dataset = DatasetFactory(resources=[resource])
+        response = self.get(url_for('api.resource', dataset=dataset,
+                                    rid=resource.id))
+        self.assert200(response)
+        data = json.loads(response.data)
+        assert data['title'] == resource.title
+        assert data['latest'] == resource.latest
+        assert data['url'] == resource.url
+
     def test_create(self):
         data = ResourceFactory.as_dict()
         with self.api_user():

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -550,9 +550,8 @@ class DatasetResourceAPITest(APITestCase):
 
     def test_get(self):
         '''It should fetch a resource from the API'''
-        with self.autoindex():
-            resource = ResourceFactory()
-            dataset = DatasetFactory(resources=[resource])
+        resource = ResourceFactory()
+        dataset = DatasetFactory(resources=[resource])
         response = self.get(url_for('api.resource', dataset=dataset,
                                     rid=resource.id))
         self.assert200(response)


### PR DESCRIPTION
This PR:
- introduces a new API endpoint to get a single resource
- uses this API endpoint to display a markdown formatted description on the the front resource modal
- uses the API endpoint to display check results (parsing is easier than w/ JSON-LD)
- uses the API endpoint to display back resource modal (instead of the whole dataset)

I kept both JSON-LD and API call results in the modal, because the JSON-LD stuff is loaded instantaneously (already present and needed in the markup of the dataset page). This can be discussed.

~I tried to use the new API endpoint on the back resource modal too (as of today we're loading the entire dataset when opening each modal) but there were some dependencies in the modal to the dataset object.~

<img width="636" alt="capture d ecran 2018-03-29 11 51 32" src="https://user-images.githubusercontent.com/119625/38085000-442f0386-334f-11e8-99d8-ee21c24f60a8.png">
