### PR TITLE
Upgrade sifter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Upgrade `sifter` to `0.5.3` [#1548](https://github.com/opendatateam/udata/pull/1548)
 
 ## 1.3.4 (2018-03-28)
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "raven-js": "^3.1.1",
     "respond.js": "^1.4.2",
     "selectize": "^0.12.2",
-    "sifter": "0.5.1",
+    "sifter": "^0.5.3",
     "sortablejs": "^1.4.2",
     "source-sans-pro": "^2.0.10",
     "string_score": "^0.1.22",


### PR DESCRIPTION
This version gets rid of a dependency to `node-csv` on GitHub.