### PR TITLE
Apply font family to oembed container instead of cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Upgrade `sifter` to `0.5.3` [#1548](https://github.com/opendatateam/udata/pull/1548)
 - Upgrade `jquery-validation` to 1.17.0 and fixes some issues with client-side URL validation [#1550](https://github.com/opendatateam/udata/pull/1550)
+- Minor change on OEmbed cards to avoid theme to override the cards `font-family` [#1549](https://github.com/opendatateam/udata/pull/1549)
 
 ## 1.3.4 (2018-03-28)
 

--- a/less/oembed.less
+++ b/less/oembed.less
@@ -2,11 +2,13 @@
     * {
         box-sizing: border-box;
     }
+
     @import "oembed-font/style";
     @import "udata/variables";
     @import "udata/mixins";
     @import "udata/cards";
 
+    font-family: @font-family-sans-serif;
 
     // Spin animation extracted from Font Awesome
     .fa-spin {

--- a/less/udata/cards.less
+++ b/less/udata/cards.less
@@ -12,7 +12,6 @@
     border: 1px solid darken(@gray-lighter, 16%);
     border-radius: 3px;
     text-decoration: none;
-    font-family: @font-family-sans-serif;
 
     @card-font-size: 14px;
     @logo-size: 60px;


### PR DESCRIPTION
Very little change to lower the side-effect of oembed `font-family` on themes