### PR TITLE
Fix DCAT harvester mime detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgrade `jquery-validation` to 1.17.0 and fixes some issues with client-side URL validation [#1550](https://github.com/opendatateam/udata/pull/1550)
 - Minor change on OEmbed cards to avoid theme to override the cards `font-family` [#1549](https://github.com/opendatateam/udata/pull/1549)
 - Improve cli unicode handling [#1551](https://github.com/opendatateam/udata/pull/1551)
+- Fix DCAT harvester mime type detection [#1552](https://github.com/opendatateam/udata/pull/1552)
 
 ## 1.3.4 (2018-03-28)
 

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:dcat="http://www.w3.org/ns/dcat#"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+  xmlns:schema="http://schema.org/"
+>
+  <dcat:Catalog rdf:about="http://data.test.org/">
+    <dcat:dataset>
+      <dcat:Dataset rdf:about="http://data.test.org/datasets/3">
+        <dcterms:title>Dataset 3</dcterms:title>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T19:01:24.184120</dcterms:modified>
+        <owl:versionInfo>1.0</owl:versionInfo>
+        <dcterms:identifier>3</dcterms:identifier>
+        <dcterms:spatial rdf:resource="http://wuEurope.com/"/>
+        <dcat:keyword>Tag 2</dcat:keyword>
+        <dcterms:publisher rdf:resource="http://data.test.org/organizations/1"/>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T18:59:02.737480</dcterms:issued>
+        <dcterms:description>Dataset 3 description</dcterms:description>
+        <dcat:keyword>Tag 1</dcat:keyword>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/3/resources/1"/>
+      </dcat:Dataset>
+    </dcat:dataset>
+    <dcterms:title>Sample DCAT Catalog</dcterms:title>
+    <dcat:dataset>
+      <dcat:Dataset rdf:about="http://data.test.org/datasets/1">
+        <dcat:theme>Theme 2</dcat:theme>
+        <dcat:contactPoint rdf:resource="http://data.test.org/contacts/1"/>
+        <dcat:landingPage>http://data.test.org/datasets/1</dcat:landingPage>
+        <dcat:keyword>Tag 3</dcat:keyword>
+        <dcterms:description>Dataset 1 description</dcterms:description>
+        <dcterms:title>Dataset 1</dcterms:title>
+        <dcterms:temporal rdf:resource="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-1"/>
+        <dcat:theme>Theme 1</dcat:theme>
+        <dcterms:publisher rdf:resource="http://data.test.org/organizations/1"/>
+        <owl:versionInfo>1.0</owl:versionInfo>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/1/resources/2"/>
+        <dcat:keyword>Tag 4</dcat:keyword>
+        <dcterms:spatial rdf:resource="http://wuEurope.com/"/>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T19:01:24.184120</dcterms:modified>
+        <dcat:keyword>Tag 2</dcat:keyword>
+        <dcat:keyword>Tag 1</dcat:keyword>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/1/resources/1"/>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T18:59:02.737480</dcterms:issued>
+        <dcterms:identifier>1</dcterms:identifier>
+      </dcat:Dataset>
+    </dcat:dataset>
+    <dcat:dataset>
+      <dcat:Dataset rdf:about="http://data.test.org/datasets/2">
+        <dcat:keyword>Tag 1</dcat:keyword>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/2/resources/1"/>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T19:01:24.184120</dcterms:modified>
+        <dcterms:description>Dataset 2 description</dcterms:description>
+        <dcterms:publisher rdf:resource="http://data.test.org/organizations/1"/>
+        <dcterms:temporal rdf:resource="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-2"/>
+        <dcat:contactPoint rdf:resource="http://data.test.org/contacts/1"/>
+        <owl:versionInfo>1.0</owl:versionInfo>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T18:59:02.737480</dcterms:issued>
+        <dcat:landingPage>http://data.test.org/datasets/2</dcat:landingPage>
+        <dcat:keyword>Tag 2</dcat:keyword>
+        <dcat:keyword>Tag 3</dcat:keyword>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/2/resources/2"/>
+        <dcterms:title>Dataset 2</dcterms:title>
+        <dcterms:spatial rdf:resource="http://wuEurope.com/"/>
+        <dcterms:identifier>2</dcterms:identifier>
+      </dcat:Dataset>
+    </dcat:dataset>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-15T09:19:51.723691</dcterms:modified>
+    <foaf:homepage>http://data.test.org</foaf:homepage>
+    <dcterms:language>en</dcterms:language>
+  </dcat:Catalog>
+  <dcat:Distribution rdf:about="http://data.test.org/datasets/2/resources/2">
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcterms:title>Resource 2-2</dcterms:title>
+    <dcterms:format>JSON</dcterms:format>
+    <dcat:accessURL>http://data.test.org/datasets/2/resources/2/file.json</dcat:accessURL>
+  </dcat:Distribution>
+  <vcard:Organization rdf:about="http://data.test.org/contacts/1">
+    <vcard:fn>Organization contact</vcard:fn>
+    <vcard:hasEmail>hello@its.me</vcard:hasEmail>
+  </vcard:Organization>
+  <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-2">
+    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-01T00:00:00</schema:startDate>
+    <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-05T00:00:00</schema:endDate>
+  </dcterms:PeriodOfTime>
+  <dcat:Distribution rdf:about="http://data.test.org/datasets/1/resources/1">
+    <dcterms:title>Resource 1-1</dcterms:title>
+    <dcterms:format>JSON</dcterms:format>
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcat:accessURL>http://data.test.org/datasets/1/resources/1/file.json</dcat:accessURL>
+  </dcat:Distribution>
+  <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-1">
+    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-05T00:00:00</schema:startDate>
+  </dcterms:PeriodOfTime>
+  <dcat:Distribution rdf:about="http://data.test.org/datasets/1/resources/2">
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcterms:format>JSON</dcterms:format>
+    <dcterms:title>Resource 1-2</dcterms:title>
+    <dcat:accessURL>http://data.test.org/datasets/1/resources/2/file.json</dcat:accessURL>
+  </dcat:Distribution>
+  <dcat:Distribution rdf:about="http://data.test.org/datasets/2/resources/1">
+    <dcat:accessURL>http://data.test.org/datasets/2/resources/1/file.json</dcat:accessURL>
+    <dcterms:title>Resource 2-1</dcterms:title>
+    <dcterms:format>JSON</dcterms:format>
+    <dcterms:description>A JSON resource</dcterms:description>
+  </dcat:Distribution>
+  <dcat:Distribution rdf:about="http://data.test.org/datasets/3/resources/1">
+    <dcterms:format>JSON</dcterms:format>
+    <dcterms:title>Resource 3-1</dcterms:title>
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcat:accessURL>http://data.test.org/datasets/3/resources/1/file.json</dcat:accessURL>
+  </dcat:Distribution>
+  <dcterms:Location rdf:about="http://wuEurope.com/"/>
+  <foaf:Organization rdf:about="http://data.test.org/organizations/1">
+    <foaf:name>An Organization</foaf:name>
+  </foaf:Organization>
+</rdf:RDF>

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -51,7 +51,7 @@ RDF_MIME_TYPES = {
     'nt': 'application/n-triples',
     'json-ld': 'application/ld+json',
     'trig': 'application/trig',
-    # Available but no activated
+    # Available but not activated
     # 'nquads': 'application/n-quads',
     # 'trix': 'text/xml',
 }
@@ -67,7 +67,7 @@ ACCEPTED_MIME_TYPES = {
     'application/ld+json': 'json-ld',
     'application/json': 'json-ld',
     'application/trig': 'trig',
-    # Available but no activated
+    # Available but not activated
     # 'application/n-quads': 'nquads',
     # 'text/xml': 'trix',
 }
@@ -80,7 +80,7 @@ RDF_EXTENSIONS = {
     'nt': 'nt',
     'trig': 'trig',
     'json-ld': 'json',
-    # Available but no activated
+    # Available but not activated
     # 'nquads': 'nq',
     # 'trix': 'trix',
 }
@@ -88,6 +88,8 @@ RDF_EXTENSIONS = {
 
 def guess_format(string):
     '''Guess format given an extension or a mime-type'''
+    if string in ACCEPTED_MIME_TYPES:
+        return ACCEPTED_MIME_TYPES[string]
     return raw_guess_format(string, FORMAT_MAP)
 
 

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function
 
+import pytest
+
 from udata.tests import TestCase
 
 
-from udata.rdf import negociate_content, want_rdf, ACCEPTED_MIME_TYPES
+from udata.rdf import (
+    guess_format, negociate_content, want_rdf, ACCEPTED_MIME_TYPES, FORMAT_MAP
+)
 
 
 class ContentNegociationTest(TestCase):
@@ -52,3 +56,19 @@ class ContentNegociationTest(TestCase):
 
         with self.app.test_request_context():
             self.assertFalse(want_rdf())
+
+
+class GuessFormatTest(object):
+    @pytest.mark.parametrize('suffix,expected', FORMAT_MAP.items())
+    def test_guess_from_extension(self, suffix, expected):
+        assert guess_format('resource.{0}'.format(suffix)) == expected
+
+    @pytest.mark.parametrize('mime,expected', ACCEPTED_MIME_TYPES.items())
+    def test_guess_from_mime_type(self, mime, expected):
+        assert guess_format(mime) == expected
+
+    def test_unkown_extension(self):
+        assert guess_format('resource.unknonn') is None
+
+    def test_unkown_mime(self):
+        assert guess_format('unknown/mime') is None


### PR DESCRIPTION
This PR adds the missing mime-type detection on `udata.rdf.guess_format()` and so fix the DCAT harvester mime detection from `HEAD`