### PR TITLE
Add the missing harvester URL in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor change on OEmbed cards to avoid theme to override the cards `font-family` [#1549](https://github.com/opendatateam/udata/pull/1549)
 - Improve cli unicode handling [#1551](https://github.com/opendatateam/udata/pull/1551)
 - Fix DCAT harvester mime type detection [#1552](https://github.com/opendatateam/udata/pull/1552)
+- Add the missing harvester URL in admin [#1554](https://github.com/opendatateam/udata/pull/1554)
 
 ## 1.3.4 (2018-03-28)
 

--- a/js/components/harvest/source.vue
+++ b/js/components/harvest/source.vue
@@ -11,6 +11,8 @@
             <dl class="dl-horizontal">
                 <dt>{{ _('Backend') }}</dt>
                 <dd>{{ source.backend }}</dd>
+                <dt>{{ _('URL') }}</dt>
+                <dd>{{ source.url }}</dd>
                 <dt>{{ _('Scheduling') }}</dt>
                 <dd v-if="source.schedule">{{ source.schedule }}</dd>
                 <dd v-else>{{ _('Not scheduled') }}</dd>

--- a/js/views/harvester-edit.vue
+++ b/js/views/harvester-edit.vue
@@ -24,7 +24,17 @@ import HarvestSource from 'models/harvest/source';
 import ItemModal from 'components/harvest/item.vue';
 import Preview from 'components/harvest/preview.vue';
 
-const MASK = ['id', 'name', 'description', 'owner', 'last_job{status,ended}', 'organization', 'backend', 'validation{state}'];
+const MASK = [
+    'id',
+    'name',
+    'url',
+    'description',
+    'owner',
+    'last_job{status,ended}',
+    'organization',
+    'backend',
+    'validation{state}'
+];
 
 export default {
     name: 'harvester-edit',

--- a/js/views/harvester.vue
+++ b/js/views/harvester.vue
@@ -45,7 +45,7 @@ import SourceWidget from 'components/harvest/source.vue';
 import JobWidget from 'components/harvest/job.vue';
 import Layout from 'components/layout.vue';
 
-const MASK = ['id', 'name', 'owner', 'organization', 'backend', 'validation{state}', 'schedule'];
+const MASK = ['id', 'name', 'url', 'owner', 'organization', 'backend', 'validation{state}', 'schedule'];
 
 export default {
     name: 'HarvestSourceView',


### PR DESCRIPTION
This PR fix the empty URL fields on harvester edition.
This URL is now displayed on harvester view.

## Before
### Form
![screenshot-data xps-2018 03 30-16-01-33](https://user-images.githubusercontent.com/15725/38140357-a9b5facc-3433-11e8-85f7-569e1f24b851.png)

### Details

![screenshot-data xps-2018 03 30-15-55-18](https://user-images.githubusercontent.com/15725/38140369-b443aeda-3433-11e8-8e06-fff3c9b58165.png)


## After
### Form
![screenshot-data xps-2018 03 30-15-56-28](https://user-images.githubusercontent.com/15725/38140375-b7f72b06-3433-11e8-80aa-6d4f47939695.png)

### Details
![screenshot-data xps-2018 03 30-15-54-58](https://user-images.githubusercontent.com/15725/38140370-b6cf10f4-3433-11e8-95ea-3c68dbd39266.png)



