### PR TITLE
Small fixes on OEmbed URL detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add the missing harvester URL in admin [#1554](https://github.com/opendatateam/udata/pull/1554)
 - Fix harvester preview/job layout [#1553](https://github.com/opendatateam/udata/pull/1553)
 - Fix some search unicode issues [#1555](https://github.com/opendatateam/udata/pull/1555)
+- Small fixes on OEmbed URL detection [#1556](https://github.com/opendatateam/udata/pull/1556)
 
 ## 1.3.4 (2018-03-28)
 

--- a/udata/features/oembed/api.py
+++ b/udata/features/oembed/api.py
@@ -39,10 +39,10 @@ class OEmbedAPI(API):
         'reuses.show': 'reuse',
     }
 
-    @api.doc('oembed', parser=oembeds_parser)
+    @api.doc('oembed', parser=oembed_parser)
     def get(self):
         """
-        En OEmbed compliant API endpoint
+        An OEmbed compliant API endpoint
 
         See: http://oembed.com/
 
@@ -54,7 +54,13 @@ class OEmbedAPI(API):
 
         url = args['url']
 
+        # Fix flask not detecting URL with https://domain:443/
+        if 'https:' in url and ':443/' in url:
+            url = url.replace(':443/', '/')
+
         with current_app.test_request_context(url) as ctx:
+            if not ctx.request.endpoint:
+                api.abort(404, 'Unknown URL')
             endpoint = ctx.request.endpoint.replace('_redirect', '')
             view_args = ctx.request.view_args
 

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -109,6 +109,21 @@ class OEmbedAPITest:
         assert400(response)
         assert 'url' in response.json['errors']
 
+    def test_oembed_with_an_unknown_url(self, api):
+        '''It should fail at fetching an oembed with an invalid URL.'''
+        url = url_for('api.oembed', url='http://localhost/somewhere')
+        response = api.get(url)
+        assert404(response)
+
+    def test_oembed_with_port_in_https_url(self, api):
+        '''It should works on HTTPS URLs with explicit port.'''
+        dataset = DatasetFactory()
+        url = dataset.external_url.replace('http://localhost/',
+                                           'https://localhost:443/')
+        api_url = url_for('api.oembed', url=url)
+
+        assert200(api.get(api_url, base_url='https://localhost:443/'))
+
     def test_oembed_does_not_support_xml(self, api):
         '''It does not support xml format.'''
         dataset = DatasetFactory()


### PR DESCRIPTION
This PR fixes 2 cases:
- URL not found in known URL
- port is specified in HTTPS URL

Fix [WWW-DATAGOUVFR-4RD5](https://sentry.data.gouv.fr/share/issue/d1ee40d116b44a6f831710c82a015d3d/)