### PR TITLE
Prevent XSS in search on TermFacets (Fix OBB-595082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix some search unicode issues [#1555](https://github.com/opendatateam/udata/pull/1555)
 - Small fixes on OEmbed URL detection [#1556](https://github.com/opendatateam/udata/pull/1556)
 - Use nb_hits instead of views to count downloads [#1560](https://github.com/opendatateam/udata/pull/1560)
+- Prevent an XSS in TermFacet [#1561](https://github.com/opendatateam/udata/pull/1561)
 
 ## 1.3.4 (2018-03-28)
 

--- a/udata/frontend/views.py
+++ b/udata/frontend/views.py
@@ -5,7 +5,7 @@ from flask import request, redirect, abort, g, json
 from flask.views import MethodView
 
 from udata import search, auth, theme
-from udata.utils import multi_to_dict
+from udata.utils import not_none_dict
 
 
 class Templated(object):
@@ -96,7 +96,9 @@ class SearchView(Templated, BaseView):
     search_adapter = None
 
     def get_queryset(self):
-        params = multi_to_dict(request.args)
+        adapter = search.adapter_for(self.search_adapter or self.model)
+        parser = adapter.as_request_parser()
+        params = not_none_dict(parser.parse_args())
         params['facets'] = True
         adapter = self.search_adapter or self.model
         result = search.query(adapter, **params)

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -184,14 +184,17 @@ def facets_for(adapter, params):
         ]
 
 
+def adapter_for(model_or_adapter):
+    if issubclass(model_or_adapter, ModelSearchAdapter):
+        return model_or_adapter
+    else:
+        return adapter_catalog[model_or_adapter]
+
+
 def search_for(model_or_adapter, **params):
     if isinstance(model_or_adapter, FacetedSearch):
         return model_or_adapter
-    is_adapter = issubclass(model_or_adapter, ModelSearchAdapter)
-    if is_adapter:
-        adapter = model_or_adapter
-    else:
-        adapter = adapter_catalog[model_or_adapter]
+    adapter = adapter_for(model_or_adapter)
     facets = facets_for(adapter, params)
     facet_search = adapter.facet_search(*facets)
     return facet_search(params)

--- a/udata/search/fields.py
+++ b/udata/search/fields.py
@@ -18,7 +18,7 @@ from jinja2 import Markup
 from speaklater import is_lazy_string
 
 from udata.i18n import lazy_gettext as _, format_date
-from udata.utils import to_bool, safe_unicode
+from udata.utils import to_bool, safe_unicode, clean_string
 
 log = logging.getLogger(__name__)
 
@@ -70,10 +70,10 @@ class Facet(object):
         return Markup(obj_to_string(labelize(value)))
 
     def default_labelizer(self, value):
-        return safe_unicode(value)
+        return clean_string(safe_unicode(value))
 
     def as_request_parser_kwargs(self):
-        return {'type': str}
+        return {'type': clean_string}
 
     def validate_parameter(self, value):
         return value

--- a/udata/search/views.py
+++ b/udata/search/views.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import request
-
 from udata import search, theme
 from udata.models import Dataset, Organization, Reuse
-from udata.utils import multi_to_dict
+from udata.utils import not_none_dict
 from udata.features.territories import check_for_territories
 from udata.i18n import I18nBlueprint
 
@@ -21,15 +19,23 @@ MAPPING = {
 
 @blueprint.route('/search/', endpoint='index')
 def render_search():
-    params = multi_to_dict(request.args)
-    params['facets'] = True
     # We only fetch relevant data for the given filter.
-    if 'tag' in params:
-        types = ['datasets', 'reuses']
-    elif 'badge' in params:
-        types = ['datasets', 'organizations']
-    else:
-        types = ['datasets', 'reuses', 'organizations']
+    # To do so, we parse query for each type
+    # and we only keep types supporting all parameters
+    adapters = {t: search.adapter_for(m) for t, m in MAPPING.items()}
+    type_args = {
+        t: not_none_dict(a.as_request_parser().parse_args())
+        for t, a in adapters.items()
+    }
+    all_args = set.union(*[
+        set(args.keys()) for args in type_args.values()
+    ])
+    types = [
+        typ for typ, args in type_args.items()
+        if set(args.keys()) == all_args
+    ]
+    params = type_args[types[0]]
+    params['facets'] = True
     models = [MAPPING[typ] for typ in types]
     results = search.multisearch(*models, **params)
     context = dict(zip(types, results))

--- a/udata/tests/frontend/test_search_frontend.py
+++ b/udata/tests/frontend/test_search_frontend.py
@@ -29,3 +29,10 @@ class SearchFrontTest:
         '''It should render the search page without data'''
         response = client.get(url_for('search.index'))
         assert200(response)
+
+    def test_render_search_wihtout_xss(self, client, autoindex):
+        '''It should render the search page without data'''
+        xss = '/><script src="whatever.js">'
+        response = client.get(url_for('search.index', tag=xss))
+        assert200(response)
+        assert xss not in response.data.decode('utf8')

--- a/udata/tests/test_search.py
+++ b/udata/tests/test_search.py
@@ -16,11 +16,10 @@ from flask_restplus.reqparse import RequestParser
 
 from udata import search
 from udata.core.metrics import Metric
-from udata.models import db
-from udata.utils import multi_to_dict
 from udata.i18n import gettext as _, format_date
+from udata.models import db
 from udata.tests import TestCase, DBTestMixin, SearchTestMixin
-from udata.utils import faker
+from udata.utils import faker, clean_string, multi_to_dict
 
 
 #############################################################################
@@ -1315,8 +1314,8 @@ class SearchAdaptorTest(SearchTestMixin, TestCase):
         self.assertHasArgument(parser, 'q', unicode)
         self.assertHasArgument(parser, 'sort', str)
         self.assertHasArgument(parser, 'facets', str)
-        self.assertHasArgument(parser, 'tag', str)
-        self.assertHasArgument(parser, 'other', str)
+        self.assertHasArgument(parser, 'tag', clean_string)
+        self.assertHasArgument(parser, 'other', clean_string)
         self.assertHasArgument(parser, 'page', int)
         self.assertHasArgument(parser, 'page_size', int)
 

--- a/udata/utils.py
+++ b/udata/utils.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from datetime import date, datetime
 from calendar import monthrange
 from math import ceil
+from xml.sax.saxutils import escape
 from faker import Faker
 from faker.config import PROVIDERS
 from faker.providers import BaseProvider
@@ -179,6 +180,18 @@ def to_bool(value):
         return value > 0
     else:
         return False
+
+
+def clean_string(value):
+    '''
+    Clean an user input string (Prevent it from containing XSS)
+    '''
+    return escape(value)
+
+
+def not_none_dict(d):
+    '''Filter out None values from a dict'''
+    return {k: v for k, v in d.iteritems() if v is not None}
 
 
 def hash_url(url):


### PR DESCRIPTION
This PR provide a double protection from XSS in search with TermsFacets:
- prevent XSS from being active in udata search frontend
- prevent XSS from being parsed (protected API clients)

Fix [Open Bug Bounty 595082](https://www.openbugbounty.org/reports/595082/)