### PR TITLE
Fix breadcrumb bar layout on empty search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Small fixes on OEmbed URL detection [#1556](https://github.com/opendatateam/udata/pull/1556)
 - Use nb_hits instead of views to count downloads [#1560](https://github.com/opendatateam/udata/pull/1560)
 - Prevent an XSS in TermFacet [#1561](https://github.com/opendatateam/udata/pull/1561)
+- Fix breadcrumb bar layout on empty search result [#1562](https://github.com/opendatateam/udata/pull/1562)
 
 ## 1.3.4 (2018-03-28)
 

--- a/less/udata/search.less
+++ b/less/udata/search.less
@@ -224,23 +224,13 @@ ul.search-results {
 .multisearch {
 
     section.breadcrumb-bar {
-        height: 42px;
-        // min-height: 42px;
-
-        @media (max-width: @screen-md-min) {
-            height: 84px;
-        }
-
-        @media (max-width: @screen-sm-min) {
-            height: 120px;
-        }
+        @height: 42px;
+        height: @height;
 
         .left-bar {
-            // line-height: 1px;
             background: none;
             padding: 0;
-            // height: 100%;
-            // height: auto;
+            min-height: @height;
         }
 
         .search-toolbar {
@@ -248,6 +238,21 @@ ul.search-results {
             padding-bottom: 9px;
         }
 
+        @media (max-width: @screen-md-min) {
+            @height: 84px;
+            height: @height;
+            .left-bar {
+                min-height: @height;
+            }
+        }
+
+        @media (max-width: @screen-sm-min) {
+            @height: 120px;
+            height: @height;
+            .left-bar {
+                min-height: @height;
+            }
+        }
     }
 
     .nav-tabs {


### PR DESCRIPTION
## Before
### Raw
![screenshot-data xps-2018 04 03-12-41-19](https://user-images.githubusercontent.com/15725/38244932-8a11832e-373c-11e8-88fa-1c2b3ad48878.png)

### Themed
![screenshot-data xps-2018 04 03-12-42-04](https://user-images.githubusercontent.com/15725/38244939-917840b2-373c-11e8-897b-173b2ef9426e.png)

## After

### Raw
![screenshot-data xps-2018 04 03-12-40-12](https://user-images.githubusercontent.com/15725/38244916-7e53923e-373c-11e8-8ad4-1828f64f7576.png)

### Themed
![screenshot-data xps-2018 04 03-12-39-12](https://user-images.githubusercontent.com/15725/38244927-830324a2-373c-11e8-9756-b5f6e8b896ed.png)


