### PR TITLE
Normalize resource.format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Normalize resource.format (migration - :warning: need reindexing) [#1563](https://github.com/opendatateam/udata/pull/1563)
 
 ## 1.3.5 (2018-04-03)
 

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -23,6 +23,12 @@ class ChecksumForm(ModelForm):
     value = fields.StringField()
 
 
+def normalize_format(data):
+    '''Normalize format field: strip and lowercase'''
+    if data:
+        return data.strip().lower()
+
+
 class BaseResourceForm(ModelForm):
     title = fields.StringField(_('Title'), [validators.required()])
     description = fields.MarkdownField(_('Description'))
@@ -33,7 +39,10 @@ class BaseResourceForm(ModelForm):
                       'a remote file or an API'))
     url = fields.UploadableURLField(
         _('URL'), [validators.required()], storage=resources)
-    format = fields.StringField(_('Format'))
+    format = fields.StringField(
+        _('Format'),
+        filters=[normalize_format],
+    )
     checksum = fields.FormField(ChecksumForm)
     mime = fields.StringField(
         _('Mime type'),

--- a/udata/migrations/2018-04-03-normalize-resource-format.js
+++ b/udata/migrations/2018-04-03-normalize-resource-format.js
@@ -1,0 +1,24 @@
+/*
+ * resource.format: trim and convert to lower case
+ */
+
+var count = 0;
+
+function normalizeFormat(resource) {
+    if (resource.format) {
+        resource.format = resource.format.trim().toLowerCase();
+    }
+    return resource;
+}
+
+db.dataset.find().forEach(function(dataset) {
+    if (dataset.resources && dataset.resources.length) {
+        const result = db.dataset.update(
+            {_id: dataset._id},
+            {$set: {resources: dataset.resources.map(normalizeFormat)}}
+        );
+        count += result.nModified;
+    }
+});
+
+print(`${count} datasets updated.`);

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -555,6 +555,18 @@ class DatasetResourceAPITest(APITestCase):
         self.dataset.reload()
         self.assertEqual(len(self.dataset.resources), 1)
 
+    def test_create_normalize_format(self):
+        _format = ' FORMAT '
+        data = ResourceFactory.as_dict()
+        data['format'] = _format
+        with self.api_user():
+            response = self.post(url_for('api.resources',
+                                         dataset=self.dataset), data)
+        self.assert201(response)
+        self.dataset.reload()
+        self.assertEqual(self.dataset.resources[0].format,
+                         _format.strip().lower())
+
     def test_create_2nd(self):
         self.dataset.resources.append(ResourceFactory())
         self.dataset.save()


### PR DESCRIPTION
This PR ensures that `resource.format` is unique across resources by casting it to lower case and trimming it.

Fix #986 