### PR TITLE
Prevent cards style to be styled by bootstrap 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Prevent OEmbed card to be styled when loaded in bootstrap 4 [#1569](https://github.com/opendatateam/udata/pull/1569)
 
 ## 1.3.5 (2018-04-03)
 

--- a/less/oembed.less
+++ b/less/oembed.less
@@ -1,4 +1,6 @@
 .udata-oembed {
+    @import "~bootstrap/less/normalize.less";
+
     * {
         box-sizing: border-box;
     }

--- a/less/udata/cards.less
+++ b/less/udata/cards.less
@@ -87,6 +87,7 @@
         line-height: @line-height;
         min-height: 6em;
         margin-left: @card-padding;
+        padding: 0;
 
         .clamp-2 {
             .clamp-sizing(2, @line-height);
@@ -118,6 +119,8 @@
         padding: @card-padding 0 0;
         position: relative;
         white-space: nowrap;
+        background-color: inherit;
+        border: none;
         .clamp-uniline;
 
         &:after {


### PR DESCRIPTION
This PR prevent some side-effets when cards are loaded in page where bootstrap 4 style is loaded.

## Raw

### Before
![screenshot-localhost-8080-2018 04 10-09-22-22](https://user-images.githubusercontent.com/15725/38542101-44ca3b7a-3ca1-11e8-9a1a-6d1d7f3200b0.png)

### After
![screenshot-localhost-8080-2018 04 10-09-20-14](https://user-images.githubusercontent.com/15725/38542112-47dfbe5c-3ca1-11e8-9a7d-7249e21c6057.png)

## Themed
### Before
![screenshot-etalab github io-2018 04 09-18-40-01](https://user-images.githubusercontent.com/15725/38542309-d660e142-3ca1-11e8-9e98-562680d323b4.png)

### After
![screenshot-localhost-8080-2018 04 10-09-19-23](https://user-images.githubusercontent.com/15725/38542116-4baeaeee-3ca1-11e8-90bd-e46f12d9d952.png)

