### PR TITLE
Added resource.preview_url and display it (fix #1564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Normalize resource.format (migration - :warning: need reindexing) [#1563](https://github.com/opendatateam/udata/pull/1563)
 - Typed resources [#1398](https://github.com/opendatateam/udata/issues/1398)
 - [breaking] Enforce a domain whitelist when resource.filetype is file [#1567](https://github.com/opendatateam/udata/issues/1567)
+- Initial data preview implementation [#1581](https://github.com/opendatateam/udata/pull/1581)
 
 ## 1.3.5 (2018-04-03)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -103,6 +103,16 @@ Whitelist of urls domains allowed for resources with `filetype` equals to `file`
 
 `*` is a supported value as a wildcard allowing all domains.
 
+### PREVIEW_MODE
+
+**default**: `'iframe'`
+
+Define the resources preview mode. Can be one of:
+- `'iframe'`: preview are displayed into an iframe modal
+- `'page'`: preview is displayed into a new page
+
+If you want to disable preview, set `PREVIEW_MODE` to `None`
+
 ## Spatial configuration
 
 ### SPATIAL_SEARCH_EXCLUDE_LEVELS

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -12,6 +12,7 @@ import Velocity from 'velocity-animate';
 // Components
 import AddReuseModal from './add-reuse-modal.vue';
 import DetailsModal from './details-modal.vue';
+import PreviewModal from './preview-modal.vue';
 import ResourceModal from './resource-modal.vue';
 import Availability from './resource/availability.vue';
 import LeafletMap from 'components/leaflet-map.vue';
@@ -36,7 +37,7 @@ new Vue({
     mixins: [FrontMixin],
     components: {
         LeafletMap, DiscussionThreads, FeaturedButton, IntegrateButton, IssuesButton,
-        ShareButton, FollowButton, Availability,
+        ShareButton, FollowButton, Availability, PreviewModal,
     },
     data() {
         return {
@@ -111,6 +112,13 @@ new Vue({
          */
         showDetails() {
             this.$modal(DetailsModal, {dataset: this.dataset});
+        },
+
+        /**
+         * Display a preview URL
+         */
+        showPreview(url) {
+            this.$modal(PreviewModal, {url});
         },
 
         /**

--- a/js/front/dataset/preview-modal.vue
+++ b/js/front/dataset/preview-modal.vue
@@ -1,0 +1,25 @@
+<template>
+<modal class="preview-modal" v-ref:modal :title="_('Preview')" large>
+
+    <div class="modal-body">
+        <iframe :src="url" width="100%" height="600" frameborder="0"></iframe>
+    </div>
+
+    <footer class="modal-footer text-center">
+        <button class="btn btn-default" @click="$refs.modal.close">
+            {{ _('Close') }}
+        </button>
+    </footer>
+</modal>
+</template>
+
+<script>
+import Modal from 'components/modal.vue';
+
+export default {
+    props: {
+        url: String
+    },
+    components: {Modal}
+};
+</script>

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -66,6 +66,8 @@ resource_fields = api.model('Resource', {
         description='The resource last modification date'),
     'metrics': fields.Raw(description='The resource metrics', readonly=True),
     'extras': fields.Raw(description='Extra attributes as key-value pairs'),
+    'preview_url': fields.String(description='An optionnal preview URL to be loaded '
+                                 'as a standalone page (ie. iframe or new page'),
 })
 
 upload_fields = api.inherit('UploadedResource', resource_fields, {

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -79,6 +79,7 @@ class BaseResourceForm(ModelForm):
     published = fields.DateTimeField(
         _('Publication date'),
         description=_('The publication date of the resource'))
+    preview_url = fields.URLField(_('Preview URL'))
 
 
 class ResourceForm(BaseResourceForm):

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -14,7 +14,7 @@ from werkzeug import cached_property
 from udata.frontend.markdown import mdstrip
 from udata.models import db, WithMetrics, BadgeMixin, SpatialCoverage
 from udata.i18n import lazy_gettext as _
-from udata.utils import hash_url
+from udata.utils import get_by, hash_url
 
 __all__ = (
     'License', 'Resource', 'Dataset', 'Checksum', 'CommunityResource',
@@ -203,6 +203,8 @@ class ResourceMixin(object):
     mime = db.StringField()
     filesize = db.IntField()  # `size` is a reserved keyword for mongoengine.
     extras = db.ExtrasField()
+
+    preview_url = db.URLField()
 
     created_at = db.DateTimeField(default=datetime.now, required=True)
     modified = db.DateTimeField(default=datetime.now, required=True)
@@ -646,3 +648,12 @@ class CommunityResource(ResourceMixin, WithMetrics, db.Owned, db.Document):
     @property
     def from_community(self):
         return True
+
+
+def get_resource(id):
+    '''Fetch a resource given its UUID'''
+    dataset = Dataset.objects(resources__id=id).first()
+    if dataset:
+        return get_by(dataset.resources, 'id', id)
+    else:
+        return CommunityResource.objects(id=id).first()

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -9,16 +9,15 @@ from werkzeug.contrib.atom import AtomFeed
 from udata.core.site.models import current_site
 from udata.frontend.views import DetailView, SearchView
 from udata.i18n import I18nBlueprint, lazy_gettext as _
-from udata.models import (Dataset, Follow, Reuse, CommunityResource,
-                          RESOURCE_TYPES)
+from udata.models import Follow, Reuse
 from udata.rdf import (
     RDF_MIME_TYPES, RDF_EXTENSIONS,
     negociate_content, want_rdf, graph_response
 )
 from udata.sitemap import sitemap
 from udata.theme import render as render_template
-from udata.utils import get_by
 
+from .models import Dataset, RESOURCE_TYPES, get_resource
 from .rdf import dataset_to_rdf
 from .search import DatasetSearch
 from .permissions import ResourceEditPermission, DatasetEditPermission
@@ -132,11 +131,7 @@ def resource_redirect(id):
     '''
     Redirect to the latest version of a resource given its identifier.
     '''
-    dataset = Dataset.objects(resources__id=id).first()
-    if dataset:
-        resource = get_by(dataset.resources, 'id', id)
-    else:
-        resource = CommunityResource.objects(id=id).first()
+    resource = get_resource(id)
     return redirect(resource.url.strip()) if resource else abort(404)
 
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -254,6 +254,11 @@ class Defaults(object):
     # Max number of resources to display uncollapsed in dataset view
     DATASET_MAX_RESOURCES_UNCOLLAPSED = 6
 
+    # Preview settings
+    ###########################################################################
+    # Preview mode can be either `iframe` or `page` or `None`
+    PREVIEW_MODE = 'iframe'
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/templates/dataset/resource/card.html
+++ b/udata/templates/dataset/resource/card.html
@@ -34,21 +34,36 @@
                 </li>
             </ul>
         </div>
-        <div class="resource-card-actions btn-group">
-            <a @click.stop href="{{ resource.latest }}" class="btn btn-sm btn-primary" download>{{ _('Download') }}</a>
-            <button @click.stop class="btn btn-sm btn-default" v-tooltip title="{{ _('Copy permalink to clipboard') }}" v-clipboard="{{ resource.latest }}">
-                <span class="fa fa-clipboard"></span>
-            </button>
-        {% if can_edit_resource(resource if resource.from_community else dataset) %}
-            {% if resource.from_community %}
-                {% set edit_path = 'dataset/{id}/community-resource/{rid}' %}
-            {% else %}
-                {% set edit_path = 'dataset/{id}/resource/{rid}' %}
+        <div class="resource-card-actions btn-toolbar">
+            {% if config.PREVIEW_MODE and resource.preview_url %}
+            <div class="btn-group">
+                <a class="btn btn-sm btn-primary"
+                    {% if config.PREVIEW_MODE == 'iframe' %}
+                    @click.stop="showPreview('{{ resource.preview_url }}')"
+                    {% else %}
+                    @click.stop href="{{ resource.preview_url }}" target="_blank"
+                    {% endif %}
+                    >
+                    {{ _('Preview') }}
+                </a>
+            </div>
             {% endif %}
-            <a @click.stop class="btn btn-sm btn-default" v-tooltip title="{{ _('Edit this resource') }}"
-                href="{{ url_for('admin.index', path=edit_path.format(id=dataset.id, rid=resource.id)) }}">
-                <span class="fa fa-pencil"></span>
-            </a>
+            <div class="btn-group">
+                <a @click.stop href="{{ resource.latest }}" class="btn btn-sm btn-primary" download>{{ _('Download') }}</a>
+                <button @click.stop class="btn btn-sm btn-default" v-tooltip title="{{ _('Copy permalink to clipboard') }}" v-clipboard="{{ resource.latest }}">
+                    <span class="fa fa-clipboard"></span>
+                </button>
+            {% if can_edit_resource(resource if resource.from_community else dataset) %}
+                {% if resource.from_community %}
+                    {% set edit_path = 'dataset/{id}/community-resource/{rid}' %}
+                {% else %}
+                    {% set edit_path = 'dataset/{id}/resource/{rid}' %}
+                {% endif %}
+                <a @click.stop class="btn btn-sm btn-default" v-tooltip title="{{ _('Edit this resource') }}"
+                    href="{{ url_for('admin.index', path=edit_path.format(id=dataset.id, rid=resource.id)) }}">
+                    <span class="fa fa-pencil"></span>
+                </a>
+            </div>
         {% endif %}
         </div>
     </footer>


### PR DESCRIPTION
This PR adds initial data preview support through the `resource.preview_url`.

The behavior is configurable with the `PREVIEW_MODE` parameter:
- `'iframe'` (*default*): displays the preview into a modal iframe
- `'page'`: displays the preview into a blank new page
- `None`: previewing is disabled

## Resource card with preview button

![screenshot-data xps-2018 04 12-12-36-59](https://user-images.githubusercontent.com/15725/38674366-8dd7e38a-3e54-11e8-8888-177ac6135a21.png)

## `iframe` mode

![screenshot-data xps-2018 04 12-12-34-56](https://user-images.githubusercontent.com/15725/38674384-9aa5d400-3e54-11e8-879d-5179b1f6f74f.png)
