### PR TITLE
Prepare for legacy PyPI closure and PyPI warehouse supporting markdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           command: |
             source venv/bin/activate
             # Check long description renders properly
-            python setup.py check -r -s
+            python setup.py check -m -s
             # Build a wheel release
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Typed resources [#1398](https://github.com/opendatateam/udata/issues/1398)
 - [breaking] Enforce a domain whitelist when resource.filetype is file [#1567](https://github.com/opendatateam/udata/issues/1567)
 - Initial data preview implementation [#1581](https://github.com/opendatateam/udata/pull/1581)
+- Switch to PyPI.org for package links [#1583](https://github.com/opendatateam/udata/pull/1583)
 
 ## 1.3.5 (2018-04-03)
 
@@ -375,7 +376,7 @@
   [#871](https://github.com/opendatateam/udata/pull/871)
   [#903](https://github.com/opendatateam/udata/pull/903)
 - Upgrade to Flask-Login 0.4.0 and switch from Flask-Security to the latest
-  [Flask-Security-Fork](https://pypi.python.org/pypi/Flask-Security-Fork)
+  [Flask-Security-Fork](https://pypi.org/project/Flask-Security-Fork)
   [#813](https://github.com/opendatateam/udata/pull/813)
 - Migrated remaining widgets to Vue.js [#828](https://github.com/opendatateam/udata/pull/828):
 

--- a/docs/creating-theme.md
+++ b/docs/creating-theme.md
@@ -302,7 +302,7 @@ Please report any difficulty you encounter with a dedicated [Github issue][githu
 [github-new-issue]: https://github.com/opendatateam/udata/issues/new
 [cookiecutter-template]: https://github.com/opendatateam/cookiecutter-udata-theme
 [Babel]: http://babel.pocoo.org/
-[PyPI]: https://pypi.python.org/
+[PyPI]: https://pypi.org/
 [gitter-chan]: https://gitter.im/opendatateam/udata
 [gouvfr-hooks]: https://github.com/etalab/udata-gouvfr/blob/master/udata_gouvfr/theme/__init__.py
 [Poedit]: https://poedit.net/

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -149,7 +149,7 @@ $ watai specs/integration/  --config '{"ignore":[1,2,3,5,6,7], "email":"name@exa
 Check out the [Watai tutorial][] to add your own tests!
 
 [nosetest]: https://nose.readthedocs.org/en/latest/
-[nose-mocha-reporter]: https://pypi.python.org/pypi/nose-mocha-reporter
+[nose-mocha-reporter]: https://pypi.org/project/nose-mocha-reporter
 [watai]: https://github.com/MattiSG/Watai
 [webdriver api]: https://github.com/admc/wd/blob/master/doc/api.md
 [selenium]: http://docs.seleniumhq.org/

--- a/docs/versionning.md
+++ b/docs/versionning.md
@@ -64,7 +64,7 @@ The step to perform a release are:
     - push (commits and tags)
 7. check on [github][] that everything has been pushed
 8. wait for [CircleCI][] tagged build to succeed
-9. check on [PyPI](https://pypi.python.org/pypi/udata) that the new release is present
+9. check on [PyPI](https://pypi.org/project/udata/#history) that the new release is present
 10. celebrate
 
 ## Branching

--- a/setup.py
+++ b/setup.py
@@ -8,27 +8,12 @@ import re
 from setuptools import setup, find_packages
 
 RE_REQUIREMENT = re.compile(r'^\s*-r\s*(?P<filename>.*)$')
-RE_MD_CODE_BLOCK = re.compile(r'```(?P<language>\w+)?\n(?P<lines>.+?)```', re.S)
-RE_CODE = re.compile(r'`(?P<code>[^`]+)`')
-RE_SELF_LINK = re.compile(r'\[([^\]]+)\]\[\]')
-RE_LINK_TO_URL = re.compile(r'\[(?P<text>[^\]]+)\]\((?P<url>[^\)]+)\)')
-RE_LINK_TO_REF = re.compile(r'\[(?P<text>[^\]]+)\]\[(?P<ref>[^\]]+)\]')
-RE_LINK_REF = re.compile(r'^\[(?P<key>[^!].+?)\]:\s*(?P<url>.*)$', re.M)
 RE_BADGE = re.compile(r'^\[\!\[(?P<text>[^\]]+)\]\[(?P<badge>[^\]]+)\]\]\[(?P<target>[^\]]+)\]$', re.M)
-RE_TITLE = re.compile(r'^(?P<level>#+)\s*(?P<title>.+)$', re.M)
 
 BADGES_TO_KEEP = ['gitter-badge', 'readthedocs-badge']
 
-RST_TITLE_LEVELS = ['=', '-', '*']
 
-RST_BADGE = '''\
-.. image:: {badge}
-    :target: {target}
-    :alt: {text}
-'''
-
-
-def md2pypi(filename):
+def md(filename):
     '''
     Load .md (markdown) file and sanitize it for PyPI.
     Remove unsupported github tags:
@@ -37,53 +22,15 @@ def md2pypi(filename):
     '''
     content = io.open(filename).read()
 
-    for match in RE_CODE.finditer(content):
-        rst_code = '``{code}``'.format(**match.groupdict())
-        content = content.replace(match.group(0), rst_code)
-
-    for match in RE_MD_CODE_BLOCK.finditer(content):
-        rst_block = '\n'.join(
-            ['.. code-block:: {language}'.format(**match.groupdict()), ''] +
-            ['    {0}'.format(l) for l in match.group('lines').split('\n')] +
-            ['']
-        )
-        content = content.replace(match.group(0), rst_block)
-
-    refs = dict(RE_LINK_REF.findall(content))
-    content = RE_LINK_REF.sub('.. _\g<key>: \g<url>', content)
-    content = RE_SELF_LINK.sub('`\g<1>`_', content)
-    content = RE_LINK_TO_URL.sub('`\g<text> <\g<url>>`__', content)
-
     for match in RE_BADGE.finditer(content):
         if match.group('badge') not in BADGES_TO_KEEP:
             content = content.replace(match.group(0), '')
-        else:
-            params = match.groupdict()
-            params['badge'] = refs[match.group('badge')]
-            params['target'] = refs[match.group('target')]
-            content = content.replace(match.group(0),
-                                      RST_BADGE.format(**params))
-    # Must occur after badges
-    for match in RE_LINK_TO_REF.finditer(content):
-        content = content.replace(match.group(0), '`{text} <{url}>`_'.format(
-            text=match.group('text'),
-            url=refs[match.group('ref')]
-        ))
-
-    for match in RE_TITLE.finditer(content):
-        underchar = RST_TITLE_LEVELS[len(match.group('level')) - 1]
-        title = match.group('title')
-        underline = underchar * len(title)
-
-        full_title = '\n'.join((title, underline))
-        content = content.replace(match.group(0), full_title)
-
     return content
 
 
 long_description = '\n'.join((
-    md2pypi('README.md'),
-    md2pypi('CHANGELOG.md'),
+    md('README.md'),
+    md('CHANGELOG.md'),
     ''
 ))
 
@@ -111,12 +58,14 @@ setup(
     version=__import__('udata').__version__,
     description=__import__('udata').__description__,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/opendatateam/udata',
     author='Opendata Team',
     author_email='opendatateam@data.gouv.fr',
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
+    setup_requires=['setuptools>=38.6.0'],
     tests_require=tests_require,
     extras_require={
         'test': tests_require,

--- a/udata/templates/footer.html
+++ b/udata/templates/footer.html
@@ -6,7 +6,7 @@
       <div class="col-lg-12">
         <p>
           <a href="https://github.com/opendatateam/udata/">UData</a>
-          <a href="https://pypi.python.org/pypi/udata/{{ package_version('udata') }}/">v{{ package_version('udata') }}</a>
+          <a href="https://pypi.org/project/udata/{{ package_version('udata') }}/">v{{ package_version('udata') }}</a>
           - Copyright &copy; Opendata Team {{ now()|dateformat(format='yyyy') }}
         </p>
       </div>


### PR DESCRIPTION
This PR:
- update the `setup.py` file to support markdown description
- update PyPI links to `pypi.org` to ensure everything is ready for PyPI Legacy closure on 30 April 2018

See for reference:
- [The PyPI migration roadmap](https://wiki.python.org/psf/WarehouseRoadmap)
- [Markdown Descriptions on PyPI](https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi)