### PR TITLE
Fix client-side markdown rendering XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Prevent OEmbed card to be styled when loaded in bootstrap 4 [#1569](https://github.com/opendatateam/udata/pull/1569)
 - Fix organizations sort by last_modified [#1576](https://github.com/opendatateam/udata/pull/1576)
 - Fix dataset creation form (and any other form) [#1584](https://github.com/opendatateam/udata/pull/1584)
+- Fix an XSS on client-side markdown parsing [#1585](https://github.com/opendatateam/udata/pull/1585)
 
 ## 1.3.5 (2018-04-03)
 

--- a/js/helpers/commonmark.js
+++ b/js/helpers/commonmark.js
@@ -35,11 +35,6 @@ function escapeHtml(html) {
          .replace(/'/g, '&#039;');
 }
 
-function nodeToStr(node) {
-    const div = document.createElement('div');
-    div.appendChild(node.cloneNode(true));
-    return div.innerHTML;
-}
 
 /**
  * Sanitize Markdown-it source tags
@@ -47,18 +42,17 @@ function nodeToStr(node) {
  * @return {String}      Sanitized html
  */
 function escapeTags(content, config) {
-    const fragment = new DOMParser().parseFromString(content, 'text/html')
+    const fragment = new DOMParser().parseFromString(content, 'text/html');
     const it = document.createNodeIterator(fragment.body, NodeFilter.SHOW_ELEMENT);
     let node;
 
-    while (node = it.nextNode()) {
+    while (node = it.nextNode()) { // eslint-disable-line no-cond-assign
         // Skip body tag and allowed tags
         if (node.nodeName === 'BODY' || config.tags.indexOf(node.nodeName.toLowerCase()) >= 0) continue;
-        const html = nodeToStr(node)
+        const html = node.outerHTML;
         const escaped = document.createTextNode(escapeHtml(html));
-        node.parentNode.replaceChild(escaped, node)
+        node.parentNode.replaceChild(escaped, node);
     }
-
     return fragment.body.innerHTML;
 }
 


### PR DESCRIPTION
This PR prevent DOM scripts from being interpreted during escape (yes, it is a funny and paradoxal XSS) and so prevent those kind of hacks in markdown fields:

```markdown
Some text
<img src="" onerror=console.log(/XSS/)>
Some text
```

This should also speed up a little bit the client-side markdown rendering.