### PR TITLE
Extra license fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [breaking] Enforce a domain whitelist when resource.filetype is file [#1567](https://github.com/opendatateam/udata/issues/1567)
 - Initial data preview implementation [#1581](https://github.com/opendatateam/udata/pull/1581)
 - Switch to PyPI.org for package links [#1583](https://github.com/opendatateam/udata/pull/1583)
+- Handle some alternate titles and alternate URLs on licenses for improved match on harvesting [#1592](https://github.com/opendatateam/udata/pull/1592)
 
 ## 1.3.6 (2018-04-16)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -117,6 +117,7 @@ class License(db.Document):
     title = db.StringField(required=True)
     slug = db.SlugField(required=True, populate_from='title')
     url = db.URLField()
+    alternate_urls = db.ListField(db.URLField())
     maintainer = db.StringField()
     flags = db.ListField(db.StringField())
 
@@ -153,7 +154,10 @@ class License(db.Document):
         qs = cls.objects
         text = text.strip().lower()  # Stored identifiers are lower case
         slug = cls.slug.slugify(text)  # Use slug as it normalize string
-        license = qs(db.Q(id=text) | db.Q(slug=slug) | db.Q(url=text)).first()
+        license = qs(
+            db.Q(id=text) | db.Q(slug=slug) | db.Q(url=text)
+            | db.Q(alternate_urls=text)
+        ).first()
         if license is None:
             # Try to single match with a low Damerau-Levenshtein distance
             computed = ((l, rdlevenshtein(l.slug, slug)) for l in cls.objects)

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -323,6 +323,46 @@ class LicenseModelTest:
         assert isinstance(found, License)
         assert license.id == found.id
 
+    def test_exact_match_by_alternate_title(self):
+        alternate_title = faker.sentence()
+        license = LicenseFactory(alternate_titles=[alternate_title])
+        found = License.guess(alternate_title)
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_exact_match_by_alternate_title_with_spaces(self):
+        alternate_title = faker.sentence()
+        license = LicenseFactory(alternate_titles=[alternate_title])
+        found = License.guess(' {0} '.format(alternate_title))
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_match_by_alternate_title_with_low_edit_distance(self):
+        license = LicenseFactory(alternate_titles=['License'])
+        found = License.guess('Licence')
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_match_by_alternate_title_with_extra_inner_space(self):
+        license = LicenseFactory(alternate_titles=['License ODBl'])
+        found = License.guess('License  ODBl')  # 2 spaces instead of 1
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_match_by_alternate_title_with_mismatching_case(self):
+        license = LicenseFactory(alternate_titles=['License ODBl'])
+        found = License.guess('License ODBL')
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_prioritize_title_over_alternate_title(self):
+        title = faker.sentence()
+        license = LicenseFactory(title=title)
+        LicenseFactory(alternate_titles=[title])
+        found = License.guess(title)
+        assert isinstance(found, License)
+        assert license.id == found.id
+
     def test_multiple_strings(self):
         license = LicenseFactory()
         found = License.guess('should not match', license.id)

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -14,6 +14,7 @@ from udata.core.discussions.factories import (
     MessageDiscussionFactory, DiscussionFactory
 )
 from udata.core.user.factories import UserFactory
+from udata.utils import faker
 from udata.tests.helpers import assert_emit, assert_equal_dates
 
 
@@ -282,6 +283,13 @@ class LicenseModelTest:
     def test_exact_match_by_url(self):
         license = LicenseFactory()
         found = License.guess(license.url)
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_exact_match_by_alternate_url(self):
+        alternate_url = faker.uri()
+        license = LicenseFactory(alternate_urls=[alternate_url])
+        found = License.guess(alternate_url)
         assert isinstance(found, License)
         assert license.id == found.id
 


### PR DESCRIPTION
This PR adds `alternate_titles` and `alternate_urls` fields on license to improve matching on harvesting.
This allow to fill licenses with common mistakes (ie. `Licence Etalab` instead of `Open Licence` or license pdf URL instead of license page URL)