### PR TITLE
Unpin tlds package

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -41,7 +41,7 @@ rdflib-jsonld==0.4.0
 redis==2.10.6
 requests==2.18.4
 StringDist==1.0.9
-tlds==2018041600
+tlds
 unicodecsv==0.14.1
 voluptuous==0.10.5
 wtforms-json==0.3.3


### PR DESCRIPTION
Avoid daily update from `tlds` as there is no changes between update.
This still allows to have the latest version on fresh install and then manually update the `tlds` package if required.