### PR TITLE
Disallow resources dict in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix some search parameters validation [#1601](https://github.com/opendatateam/udata/pull/1601)
 - Prevent API tracking errors with unicode [#1602](https://github.com/opendatateam/udata/pull/1602)
 - Prevent a race condition error when uploading file with concurrent chunking [#1606](https://github.com/opendatateam/udata/pull/1606)
+- Disallow resources dict in API [#1603](https://github.com/opendatateam/udata/pull/1603)
 
 ## 1.3.6 (2018-04-16)
 

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -245,6 +245,20 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(len(dataset.resources), 3)
 
+    def test_dataset_api_create_with_resources_dict(self):
+        """Create a dataset w/ resources in a dict instead of list,
+        should fail
+        """
+        data = DatasetFactory.as_dict()
+        data['resources'] = {
+            k: v for k, v in enumerate([
+                ResourceFactory.as_dict() for _ in range(3)
+            ])
+        }
+        with self.api_user():
+            response = self.post(url_for('api.datasets'), data)
+        self.assert400(response)
+
     def test_dataset_api_create_with_geom(self):
         '''It should create a dataset with resources from the API'''
         data = DatasetFactory.as_dict()


### PR DESCRIPTION
Tentative fix to avoid resources being created with a `{}` of resources instead of a `[]` through the API.

`wtforms` black magic is quite obscure to me, there may be a better solution.