### PR TITLE
Fix concurrent upload race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix some search parameters validation [#1601](https://github.com/opendatateam/udata/pull/1601)
 - Prevent API tracking errors with unicode [#1602](https://github.com/opendatateam/udata/pull/1602)
+- Prevent a race condition error when uploading file with concurrent chunking [#1606](https://github.com/opendatateam/udata/pull/1606)
 
 ## 1.3.6 (2018-04-16)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -12,7 +12,7 @@ factory-boy==2.10.0
 Faker==0.8.12
 Flask-BabelEx==0.9.3
 Flask-Caching==1.3.3
-flask-fs==0.6.0
+flask-fs==0.6.1
 Flask-Gravatar==0.5.0
 Flask-Login==0.4.1
 Flask-Mail==0.9.1


### PR DESCRIPTION
This PR prevent a race condition on concurrent chunked upload when multiple chunks try to create the chunk directory.
This has been fixed in `flask-fs 0.6.1`