### PR TITLE
Migrate resources {} to []

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Prevent API tracking errors with unicode [#1602](https://github.com/opendatateam/udata/pull/1602)
 - Prevent a race condition error when uploading file with concurrent chunking [#1606](https://github.com/opendatateam/udata/pull/1606)
 - Disallow resources dict in API [#1603](https://github.com/opendatateam/udata/pull/1603)
+- Migrate resources {} to [] (migration) [#1610](https://github.com/opendatateam/udata/pull/1610)
 
 ## 1.3.6 (2018-04-16)
 

--- a/udata/migrations/2018-04-23-resources-dict.js
+++ b/udata/migrations/2018-04-23-resources-dict.js
@@ -1,0 +1,16 @@
+/*
+ * Migrate faulty `dataset.resources` from {} to []
+ * Ensure migrated resources are valid (url && title)
+ */
+
+var count = 0;
+
+db.dataset.find().forEach(d => {
+    if (d.resources && !(d.resources instanceof Array)) {
+        d.resources = Object.keys(d.resources).map(k => d.resources[k]).filter(r => r.url && r.title);
+        db.dataset.save(d);
+        count++;
+    }
+});
+
+print(`Migrated ${count} dataset(s).`);


### PR DESCRIPTION
This is not necessary in our case (data.gouv.fr) because the resources we have in DB are faulty (only metrics attached). But since it was possible to upload a dict through the API, there may be some faulty resources out there.

Fix #1608 

Edit: after more investigation, if we could indeed pass a `{}` of resources to the API, it wouldn't create any resources (resource creation fails silently). This migration is then probably useless.