### PR TITLE
Raise 404 on RDF unknown format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Disallow resources dict in API [#1603](https://github.com/opendatateam/udata/pull/1603)
 - Test and fix territories routing [#1611](https://github.com/opendatateam/udata/pull/1611)
 - Fix the client-side Raven/Sentry configuration [#1612](https://github.com/opendatateam/udata/pull/1612)
+- Raise a 404 in case of unknown RDF content type [#1613](https://github.com/opendatateam/udata/pull/1613)
 
 ## 1.3.6 (2018-04-16)
 

--- a/udata/core/site/rdf.py
+++ b/udata/core/site/rdf.py
@@ -7,7 +7,6 @@ from flask import url_for, current_app
 from rdflib import Graph, URIRef, Literal, BNode
 from rdflib.namespace import RDF, FOAF
 
-from udata.core.dataset.models import Dataset
 from udata.core.dataset.rdf import dataset_to_rdf
 from udata.rdf import DCAT, DCT, HYDRA, namespace_manager
 from udata.utils import Paginable

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, print_function
 '''
 This module centralize udata-wide RDF helpers and configuration
 '''
-from flask import request, url_for
+from flask import request, url_for, abort
 
 from rdflib import Graph, Literal, URIRef
 from rdflib.resource import Resource as RdfResource
@@ -237,6 +237,8 @@ def graph_response(graph, format):
     Return a proper flask response for a RDF resource given an expected format.
     '''
     fmt = guess_format(format)
+    if not fmt:
+        abort(404)
     headers = {
         'Content-Type': RDF_MIME_TYPES[fmt]
     }

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import current_app, url_for
+import pytest
+
+from flask import url_for
 
 from rdflib import URIRef, Literal, Graph
 from rdflib.namespace import RDF, FOAF
@@ -14,13 +16,16 @@ from udata.core.site.factories import SiteFactory
 from udata.core.site.rdf import build_catalog
 from udata.core.user.factories import UserFactory
 from udata.rdf import CONTEXT, DCAT, DCT, HYDRA
-from udata.tests.frontend import FrontTestCase
+from udata.tests.helpers import assert200, assert404, assert_redirects
 
 
-class CatalogTest(FrontTestCase):
+pytestmark = pytest.mark.usefixtures('clean_db')
+
+
+class CatalogTest:
     modules = ['core.dataset', 'core.organization', 'core.user', 'core.site']
 
-    def test_minimal(self):
+    def test_minimal(self, app):
         site = SiteFactory()
         home_url = url_for('site.home_redirect', _external=True)
         uri = url_for('site.rdf_catalog', _external=True)
@@ -28,32 +33,29 @@ class CatalogTest(FrontTestCase):
         catalog = build_catalog(site, datasets)
         graph = catalog.graph
 
-        self.assertIsInstance(catalog, Resource)
+        assert isinstance(catalog, Resource)
         catalogs = graph.subjects(RDF.type, DCAT.Catalog)
-        self.assertEqual(len(list(catalogs)), 1)
+        assert len(list(catalogs)) == 1
 
-        self.assertEqual(catalog.value(RDF.type).identifier, DCAT.Catalog)
+        assert catalog.value(RDF.type).identifier == DCAT.Catalog
 
-        self.assertIsInstance(catalog.identifier, URIRef)
-        self.assertEqual(str(catalog.identifier), uri)
-        self.assertEqual(catalog.value(DCT.title), Literal(site.title))
-        self.assertEqual(catalog.value(DCT.language),
-                         Literal(self.app.config['DEFAULT_LANGUAGE']))
+        assert isinstance(catalog.identifier, URIRef)
+        assert str(catalog.identifier) == uri
+        assert catalog.value(DCT.title) == Literal(site.title)
+        lang = app.config['DEFAULT_LANGUAGE']
+        assert catalog.value(DCT.language) == Literal(lang)
 
-        self.assertEqual(len(list(catalog.objects(DCAT.dataset))),
-                         len(datasets))
+        assert len(list(catalog.objects(DCAT.dataset))) == len(datasets)
 
-        self.assertEqual(catalog.value(FOAF.homepage).identifier,
-                         URIRef(home_url))
+        assert catalog.value(FOAF.homepage).identifier == URIRef(home_url)
 
         org = catalog.value(DCT.publisher)
-        self.assertEqual(org.value(RDF.type).identifier, FOAF.Organization)
-        self.assertEqual(org.value(FOAF.name),
-                         Literal(current_app.config['SITE_AUTHOR']))
+        assert org.value(RDF.type).identifier == FOAF.Organization
+        assert org.value(FOAF.name) == Literal(app.config['SITE_AUTHOR'])
 
         graph = catalog.graph
-        self.assertEqual(len(list(graph.subjects(RDF.type, DCAT.Dataset))),
-                         len(datasets))
+        graph_datasets = graph.subjects(RDF.type, DCAT.Dataset)
+        assert len(list(graph_datasets)) == len(datasets)
 
     def test_no_duplicate(self):
         site = SiteFactory()
@@ -65,13 +67,13 @@ class CatalogTest(FrontTestCase):
         graph = catalog.graph
 
         orgs = list(graph.subjects(RDF.type, FOAF.Organization))
-        self.assertEqual(len(orgs), 1 + 1)  # There is the site publisher
+        assert len(orgs) == 1 + 1  # There is the site publisher
         users = list(graph.subjects(RDF.type, FOAF.Person))
-        self.assertEqual(len(users), 1)
+        assert len(users) == 1
         org_names = list(graph.objects(orgs[0], FOAF.name))
-        self.assertEqual(len(org_names), 1)
+        assert len(org_names) == 1
         user_names = list(graph.objects(users[0], FOAF.name))
-        self.assertEqual(len(user_names), 1)
+        assert len(user_names) == 1
 
     def test_pagination(self):
         site = SiteFactory()
@@ -89,150 +91,145 @@ class CatalogTest(FrontTestCase):
         catalog = build_catalog(site, datasets, format='json')
         graph = catalog.graph
 
-        self.assertIsInstance(catalog, Resource)
-        self.assertEqual(catalog.identifier, URIRef(uri))
+        assert isinstance(catalog, Resource)
+        assert catalog.identifier == URIRef(uri)
         types = [o.identifier for o in catalog.objects(RDF.type)]
-        self.assertIn(DCAT.Catalog, types)
-        self.assertIn(HYDRA.Collection, types)
+        assert DCAT.Catalog in types
+        assert HYDRA.Collection in types
 
-        self.assertEqual(catalog.value(HYDRA.totalItems), Literal(total))
+        assert catalog.value(HYDRA.totalItems) == Literal(total)
 
-        self.assertEqual(len(list(catalog.objects(DCAT.dataset))),
-                         page_size)
+        assert len(list(catalog.objects(DCAT.dataset))) == page_size
 
-        paginations = list(graph.subjects(RDF.type, HYDRA.PartialCollectionView))
-        self.assertEqual(len(paginations), 1)
+        paginations = list(graph.subjects(RDF.type,
+                                          HYDRA.PartialCollectionView))
+        assert len(paginations) == 1
         pagination = graph.resource(paginations[0])
-        self.assertEqual(pagination.identifier, URIRef(uri_first))
-        self.assertEqual(pagination.value(HYDRA.first).identifier,
-                         URIRef(uri_first))
-        self.assertEqual(pagination.value(HYDRA.next).identifier,
-                         URIRef(uri_last))
-        self.assertEqual(pagination.value(HYDRA.last).identifier,
-                         URIRef(uri_last))
-        self.assertNotIn(HYDRA.previous, pagination)
+        assert pagination.identifier == URIRef(uri_first)
+        assert pagination.value(HYDRA.first).identifier == URIRef(uri_first)
+        assert pagination.value(HYDRA.next).identifier == URIRef(uri_last)
+        assert pagination.value(HYDRA.last).identifier == URIRef(uri_last)
+        assert HYDRA.previous not in pagination
 
         # Second page
         datasets = Dataset.objects.paginate(2, page_size)
         catalog = build_catalog(site, datasets, format='json')
         graph = catalog.graph
 
-        self.assertIsInstance(catalog, Resource)
-        self.assertEqual(catalog.identifier, URIRef(uri))
+        assert isinstance(catalog, Resource)
+        assert catalog.identifier == URIRef(uri)
         types = [o.identifier for o in catalog.objects(RDF.type)]
-        self.assertIn(DCAT.Catalog, types)
-        self.assertIn(HYDRA.Collection, types)
+        assert DCAT.Catalog in types
+        assert HYDRA.Collection in types
 
-        self.assertEqual(catalog.value(HYDRA.totalItems), Literal(total))
+        assert catalog.value(HYDRA.totalItems) == Literal(total)
 
-        self.assertEqual(len(list(catalog.objects(DCAT.dataset))),
-                         1)
+        assert len(list(catalog.objects(DCAT.dataset))) == 1
 
-        paginations = list(graph.subjects(RDF.type, HYDRA.PartialCollectionView))
-        self.assertEqual(len(paginations), 1)
+        paginations = list(graph.subjects(RDF.type,
+                                          HYDRA.PartialCollectionView))
+        assert len(paginations) == 1
         pagination = graph.resource(paginations[0])
-        self.assertEqual(pagination.identifier, URIRef(uri_last))
-        self.assertEqual(pagination.value(HYDRA.first).identifier,
-                         URIRef(uri_first))
-        self.assertEqual(pagination.value(HYDRA.previous).identifier,
-                         URIRef(uri_first))
-        self.assertEqual(pagination.value(HYDRA.last).identifier,
-                         URIRef(uri_last))
-        self.assertNotIn(HYDRA.next, pagination)
+        assert pagination.identifier == URIRef(uri_last)
+        assert pagination.value(HYDRA.first).identifier == URIRef(uri_first)
+        assert pagination.value(HYDRA.previous).identifier == URIRef(uri_first)
+        assert pagination.value(HYDRA.last).identifier == URIRef(uri_last)
+        assert HYDRA.next not in pagination
 
 
-class SiteRdfViewsTest(FrontTestCase):
-    modules = ['admin', 'search', 'core.site', 'core.dataset', 'core.reuse', 'core.organization']
+class SiteRdfViewsTest:
+    modules = ['core.site', 'core.dataset']
 
-    def test_expose_jsonld_context(self):
+    def test_expose_jsonld_context(self, client):
         url = url_for('site.jsonld_context')
-        self.assertEqual(url, '/context.jsonld')
+        assert url == '/context.jsonld'
 
-        response = self.get(url)
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/ld+json')
-        self.assertEqual(response.json, CONTEXT)
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'application/ld+json'
+        assert response.json == CONTEXT
 
-    def test_catalog_default_to_jsonld(self):
+    def test_catalog_default_to_jsonld(self, client):
         expected = url_for('site.rdf_catalog_format', format='json')
-        response = self.get(url_for('site.rdf_catalog'))
-        self.assertRedirects(response, expected)
+        response = client.get(url_for('site.rdf_catalog'))
+        assert_redirects(response, expected)
 
-    def test_rdf_perform_content_negociation(self):
+    def test_rdf_perform_content_negociation(self, client):
         expected = url_for('site.rdf_catalog_format', format='xml')
         url = url_for('site.rdf_catalog')
         headers = {'accept': 'application/xml'}
-        response = self.get(url, headers=headers)
-        self.assertRedirects(response, expected)
+        response = client.get(url, headers=headers)
+        assert_redirects(response, expected)
 
-    def test_catalog_rdf_json_ld(self):
-        for fmt in 'json', 'jsonld':
-            url = url_for('site.rdf_catalog_format', format=fmt)
-            response = self.get(url)
-            self.assert200(response)
-            self.assertEqual(response.content_type, 'application/ld+json')
-            context_url = url_for('site.jsonld_context', _external=True)
-            self.assertEqual(response.json['@context'], context_url)
+    @pytest.mark.parametrize('fmt', ('json', 'jsonld'))
+    def test_catalog_rdf_json_ld(self, fmt, client):
+        url = url_for('site.rdf_catalog_format', format=fmt)
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'application/ld+json'
+        context_url = url_for('site.jsonld_context', _external=True)
+        assert response.json['@context'] == context_url
 
-    def test_catalog_rdf_n3(self):
+    def test_catalog_rdf_n3(self, client):
         url = url_for('site.rdf_catalog_format', format='n3')
-        response = self.get(url)
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'text/n3')
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'text/n3'
 
-    def test_catalog_rdf_turtle(self):
+    def test_catalog_rdf_turtle(self, client):
         url = url_for('site.rdf_catalog_format', format='ttl')
-        response = self.get(url)
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/x-turtle')
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'application/x-turtle'
 
-    def test_catalog_rdf_rdfxml(self):
-        for fmt in 'xml', 'rdf', 'rdfs', 'owl':
-            url = url_for('site.rdf_catalog_format', format=fmt)
-            response = self.get(url)
-            self.assert200(response)
-            self.assertEqual(response.content_type, 'application/rdf+xml')
+    @pytest.mark.parametrize('fmt', ('xml', 'rdf', 'rdfs', 'owl'))
+    def test_catalog_rdf_rdfxml(self, fmt, client):
+        url = url_for('site.rdf_catalog_format', format=fmt)
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'application/rdf+xml'
 
-    def test_catalog_rdf_n_triples(self):
+    def test_catalog_rdf_n_triples(self, client):
         url = url_for('site.rdf_catalog_format', format='nt')
-        response = self.get(url)
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/n-triples')
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'application/n-triples'
 
-    def test_catalog_rdf_trig(self):
+    def test_catalog_rdf_trig(self, client):
         url = url_for('site.rdf_catalog_format', format='trig')
-        response = self.get(url)
-        self.assert200(response)
-        self.assertEqual(response.content_type, 'application/trig')
+        response = client.get(url)
+        assert200(response)
+        assert response.content_type == 'application/trig'
 
-    def test_dataportal_compliance(self):
-        for fmt in 'json', 'xml', 'ttl':
-            url = url_for('site.dataportal', format=fmt)
-            self.assertEqual(url, '/data.{0}'.format(fmt))
-            expected_url = url_for('site.rdf_catalog_format', format=fmt)
+    @pytest.mark.parametrize('fmt', ('json', 'xml', 'ttl'))
+    def test_dataportal_compliance(self, fmt, client):
+        url = url_for('site.dataportal', format=fmt)
+        assert url == '/data.{0}'.format(fmt)
+        expected_url = url_for('site.rdf_catalog_format', format=fmt)
 
-            response = self.get(url)
-            self.assertRedirects(response, expected_url)
+        response = client.get(url)
+        assert_redirects(response, expected_url)
 
-    def test_catalog_rdf_paginate(self):
+    def test_catalog_rdf_paginate(self, client):
         VisibleDatasetFactory.create_batch(4)
         url = url_for('site.rdf_catalog_format', format='n3', page_size=3)
         next_url = url_for('site.rdf_catalog_format', format='n3',
                            page=2, page_size=3, _external=True)
 
-        response = self.get(url)
-        self.assert200(response)
+        response = client.get(url)
+        assert200(response)
 
         graph = Graph().parse(data=response.data, format='n3')
         pagination = graph.value(predicate=RDF.type,
                                  object=HYDRA.PartialCollectionView)
-        self.assertIsNotNone(pagination)
+        assert pagination is not None
         pagination = graph.resource(pagination)
-        self.assertFalse(pagination.value(HYDRA.previous))
-        self.assertEqual(pagination.value(HYDRA.next).identifier,
-                         URIRef(next_url))
+        assert not pagination.value(HYDRA.previous)
+        assert pagination.value(HYDRA.next).identifier == URIRef(next_url)
 
-    def test_catalog_format_unknown(self):
+    # 404 page requires these modules to render metadata
+    @pytest.mark.frontend(['admin', 'search', 'core.reuse', 'core.organization'])
+    def test_catalog_format_unknown(self, client):
         url = url_for('site.rdf_catalog_format', format='unknown')
-        response = self.get(url)
-        self.assert404(response)
+        response = client.get(url)
+        assert404(response)

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -142,7 +142,7 @@ class CatalogTest(FrontTestCase):
 
 
 class SiteRdfViewsTest(FrontTestCase):
-    modules = ['core.site', 'core.dataset']
+    modules = ['admin', 'search', 'core.site', 'core.dataset', 'core.reuse', 'core.organization']
 
     def test_expose_jsonld_context(self):
         url = url_for('site.jsonld_context')
@@ -231,3 +231,8 @@ class SiteRdfViewsTest(FrontTestCase):
         self.assertFalse(pagination.value(HYDRA.previous))
         self.assertEqual(pagination.value(HYDRA.next).identifier,
                          URIRef(next_url))
+
+    def test_catalog_format_unknown(self):
+        url = url_for('site.rdf_catalog_format', format='unknown')
+        response = self.get(url)
+        self.assert404(response)


### PR DESCRIPTION
This PR raise a 404 on unknown catalog format and prevent a server error.

See: https://sentry.data.gouv.fr/share/issue/986ffb80f0ca47f4862574cda03ac165/