### PR TITLE
Fix documentation on NGinx proxy pass headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix the client-side Raven/Sentry configuration [#1612](https://github.com/opendatateam/udata/pull/1612)
 - Raise a 404 in case of unknown RDF content type [#1613](https://github.com/opendatateam/udata/pull/1613)
 - Ensure current theme is available to macros requiring it in mails [#1614](https://github.com/opendatateam/udata/pull/1614)
+- Fix documentation about NGinx configuration for https [#1615](https://github.com/opendatateam/udata/pull/1615)
 
 ## 1.3.6 (2018-04-16)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -303,6 +303,7 @@ server {
         proxy_set_header   X-Real-IP $remote_addr;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   X-Forwarded-Proto $scheme;
     }
 }
 ```


### PR DESCRIPTION
This PR fixes the sample NGinx configuration with SSL (missing `X-Forwarded-Proto` header)