### PR TITLE
Remove unwanted commas in default SECURITY_EMAIL_SUBJECT_* parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Raise a 404 in case of unknown RDF content type [#1613](https://github.com/opendatateam/udata/pull/1613)
 - Ensure current theme is available to macros requiring it in mails [#1614](https://github.com/opendatateam/udata/pull/1614)
 - Fix documentation about NGinx configuration for https [#1615](https://github.com/opendatateam/udata/pull/1615)
+- Remove unwanted commas in default `SECURITY_EMAIL_SUBJECT_*` parameters [#1616](https://github.com/opendatateam/udata/pull/1616)
 
 ## 1.3.6 (2018-04-16)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -9,7 +9,6 @@ from tlds import tld_set
 from udata.i18n import lazy_gettext as _
 
 
-
 HOUR = 60 * 60
 
 
@@ -91,13 +90,13 @@ class Defaults(object):
 
     SECURITY_EMAIL_SENDER = MAIL_DEFAULT_SENDER
 
-    SECURITY_EMAIL_SUBJECT_REGISTER = _('Welcome'),
-    SECURITY_EMAIL_SUBJECT_CONFIRM = _('Please confirm your email'),
-    SECURITY_EMAIL_SUBJECT_PASSWORDLESS = _('Login instructions'),
-    SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE = _('Your password has been reset'),
+    SECURITY_EMAIL_SUBJECT_REGISTER = _('Welcome')
+    SECURITY_EMAIL_SUBJECT_CONFIRM = _('Please confirm your email')
+    SECURITY_EMAIL_SUBJECT_PASSWORDLESS = _('Login instructions')
+    SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE = _('Your password has been reset')
     SECURITY_EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE = _(
-                                    'Your password has been changed'),
-    SECURITY_EMAIL_SUBJECT_PASSWORD_RESET = _('Password reset instructions'),
+                                    'Your password has been changed')
+    SECURITY_EMAIL_SUBJECT_PASSWORD_RESET = _('Password reset instructions')
 
     # Flask WTF settings
     CSRF_SESSION_KEY = 'Default uData csrf key'


### PR DESCRIPTION
This PR removes unwanted commas in default `SECURITY_EMAIL_SUBJECT_*` (which makes it tuples instead of expected strings)