### PR TITLE
Make it easier to read sentry configuration

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -477,6 +477,43 @@ The default page size for post listing
 
 Max number of resources to display uncollapsed in dataset view.
 
+## Sentry configuration
+
+### SENTRY_DSN
+
+**default**: `None`
+
+The Sentry DSN associated to this udata instance.
+If defined, the Sentry support is automatically activated.
+
+### SENTRY_TAGS
+
+**default**: `{}`
+
+A key-value map of extra tags to pass as Sentry context.
+See: <https://docs.sentry.io/learn/context/>
+
+### SENTRY_USER_ATTRS
+
+**default**: `['slug', 'email', 'fullname']`
+
+Extra user attributes to add the Sentry context.
+See: <https://docs.sentry.io/learn/context/>
+
+### SENTRY_LOGGING
+
+**default**: `'WARNING'`
+
+Minimum log level to be reported to Sentry.
+
+### SENTRY_IGNORE_EXCEPTIONS
+
+**default**: `[]`
+
+A list of extra exceptions to ignore.
+udata already ignores Werkzeug `HTTPException` and some internal ones
+that don't need to be listed here.
+
 
 ## Example configuration file
 

--- a/udata/sentry.py
+++ b/udata/sentry.py
@@ -32,24 +32,19 @@ def public_dsn(dsn):
 
 
 def init_app(app):
-    if 'SENTRY_DSN' in app.config:
+    if app.config['SENTRY_DSN']:
         try:
             from raven.contrib.celery import (
                 register_signal, register_logger_signal
             )
             from raven.contrib.flask import Sentry
         except ImportError:
-            log.error('raven[flask] is required to use sentry')
+            log.error('raven is required to use Sentry')
             return
 
         sentry = Sentry()
-        tags = app.config['SENTRY_TAGS'] = app.config.get('SENTRY_TAGS', {})
-
-        app.config.setdefault('SENTRY_USER_ATTRS',
-                              ['slug', 'email', 'fullname'])
-        app.config.setdefault('SENTRY_LOGGING', 'WARNING')
-
-        log_level_name = app.config.get('SENTRY_LOGGING')
+        tags = app.config['SENTRY_TAGS']
+        log_level_name = app.config['SENTRY_LOGGING']
         if log_level_name:
             log_level = getattr(logging, log_level_name.upper())
             if log_level:
@@ -57,10 +52,10 @@ def init_app(app):
                 sentry.level = log_level
 
         # Do not send HTTPExceptions
-        exceptions = set(app.config.get('RAVEN_IGNORE_EXCEPTIONS', []))
+        exceptions = set(app.config['SENTRY_IGNORE_EXCEPTIONS'])
         for exception in IGNORED_EXCEPTIONS:
             exceptions.add(exception)
-        app.config['RAVEN_IGNORE_EXCEPTIONS'] = list(exceptions)
+        app.config['SENTRY_IGNORE_EXCEPTIONS'] = list(exceptions)
 
         app.config['SENTRY_PUBLIC_DSN'] = public_dsn(app.config['SENTRY_DSN'])
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -98,6 +98,13 @@ class Defaults(object):
                                     'Your password has been changed')
     SECURITY_EMAIL_SUBJECT_PASSWORD_RESET = _('Password reset instructions')
 
+    # Sentry configuration
+    SENTRY_DSN = None
+    SENTRY_TAGS = {}
+    SENTRY_USER_ATTRS = ['slug', 'email', 'fullname']
+    SENTRY_LOGGING = 'WARNING'
+    SENTRY_IGNORE_EXCEPTIONS = []
+
     # Flask WTF settings
     CSRF_SESSION_KEY = 'Default uData csrf key'
 


### PR DESCRIPTION
This PR expose the default Sentry configuration the same way than other modules: set default values in `udata.settings.Defaults`.
This avoid some extra `app.config.setdefault()` calls and make it easier to read the default configuration and the Sentry initialization.

The sentry configuration parameters are also documented.