### PR TITLE
Fix OAuth authorization screen failing with unicode SITE_TITLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Resource modals: use new single resource API call [#1547](https://github.com/opendatateam/udata/pull/1547)
 - Protocol-relative URLs support [#1599](https://github.com/opendatateam/udata/pull/1599)
 - Audience metrics: use only `views` [#1607](https://github.com/opendatateam/udata/pull/1607)
+- Fix OAuth authorization screen failing with unicode `SITE_TITLE` [#1624](https://github.com/opendatateam/udata/pull/1624)
 
 ## 1.3.8 (2018-04-25)
 

--- a/udata/templates/api/oauth_authorize.html
+++ b/udata/templates/api/oauth_authorize.html
@@ -13,8 +13,8 @@
             <p class="lead prompt">
             {{ _(
                 '%(app)s want to access your %(site)s account.',
-                app='<span class="app">{0}</span>'.format(grant.client.name)|safe,
-                site='<span class="site">{0}</span>'.format(config.SITE_TITLE)|safe
+                app='<span class="app">%s</span>'|format(grant.client.name)|safe,
+                site='<span class="site">%s</span>'|format(config.SITE_TITLE)|safe
             ) }}
             </p>
         </div>


### PR DESCRIPTION
This PR fixes OAuth authorization page with unicode `SITE_TITLE`.

I believe the same fix (use `<unicode>|format(<unicode>)`) should be applied everywhere in jinja templates where `<unicode>.format(<unicode>)` is used because the jinja `format` filter take cares of special encoding issues with Jinja