### PR TITLE
Test and fix html to markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Protocol-relative URLs support [#1599](https://github.com/opendatateam/udata/pull/1599)
 - Audience metrics: use only `views` [#1607](https://github.com/opendatateam/udata/pull/1607)
 - Fix OAuth authorization screen failing with unicode `SITE_TITLE` [#1624](https://github.com/opendatateam/udata/pull/1624)
+- Fix markdown handling of autolinks with angle brackets and factorize (and test) markdown `parse_html()` [#1625](https://github.com/opendatateam/udata/pull/1625)
 
 ## 1.3.8 (2018-04-25)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 This module centralize dataset helpers for RDF/DCAT serialization and parsing
 '''
 import calendar
-import html2text
 import logging
 
 from datetime import date
@@ -16,6 +15,7 @@ from rdflib.resource import Resource as RdfResource
 from rdflib.namespace import RDF
 
 from udata import i18n
+from udata.frontend.markdown import parse_html
 from udata.models import db
 from udata.core.organization.rdf import organization_to_rdf
 from udata.core.user.rdf import user_to_rdf
@@ -62,7 +62,7 @@ def is_html(text):
 def sanitize_html(text):
     text = text.toPython() if isinstance(text, Literal) else ''
     if is_html(text):
-        return html2text.html2text(text.strip(), bodywidth=0).strip()
+        return parse_html(text)
     else:
         return text.strip()
 

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -2,183 +2,180 @@
 from __future__ import unicode_literals
 
 import html5lib
+import pytest
 
 from flask import render_template_string
 
-from .. import TestCase, WebTestMixin
-
-from udata.frontend.markdown import md, init_app, EXCERPT_TOKEN
+from udata.frontend.markdown import md, EXCERPT_TOKEN
 
 parser = html5lib.HTMLParser(tree=html5lib.getTreeBuilder("dom"))
 
 
-class MarkdownTestCase(TestCase, WebTestMixin):
-    def create_app(self):
-        app = super(MarkdownTestCase, self).create_app()
-        init_app(app)
-        return app
+def assert_md_equal(value, expected):
+    __tracebackhide__ = True
+    expected = '<div class="markdown">{0}</div>'.format(expected)
+    assert value.strip() == expected
 
-    def assert_md_equal(self, value, expected):
-        expected = '<div class="markdown">{0}</div>'.format(expected)
-        self.assertEqual(value.strip(), expected)
 
-    def test_excerpt_is_not_removed(self):
-        with self.app.test_request_context('/'):
-            self.assert_md_equal(md(EXCERPT_TOKEN), EXCERPT_TOKEN)
+@pytest.mark.frontend
+class MarkdownTest:
+    def test_excerpt_is_not_removed(self, app):
+        with app.test_request_context('/'):
+            assert_md_equal(md(EXCERPT_TOKEN), EXCERPT_TOKEN)
 
-    def test_markdown_filter_with_none(self):
+    def test_markdown_filter_with_none(self, app):
         '''Markdown filter should not fails with None'''
         text = None
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
 
-        self.assertEqual(result, '')
+        assert result == ''
 
-    def test_markdown_links_nofollow(self):
+    def test_markdown_links_nofollow(self, app):
         '''Markdown filter should render links as nofollow'''
         text = '[example](http://example.net/ "Title")'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
-            self.assertEqual(el.getAttribute('rel'), 'nofollow')
-            self.assertEqual(el.getAttribute('href'), 'http://example.net/')
-            self.assertEqual(el.getAttribute('title'), 'Title')
-            self.assertEqual(el.firstChild.data, 'example')
+            assert el.getAttribute('rel') == 'nofollow'
+            assert el.getAttribute('href') == 'http://example.net/'
+            assert el.getAttribute('title') == 'Title'
+            assert el.firstChild.data == 'example'
 
-    def test_markdown_linkify(self):
+    def test_markdown_linkify(self, app):
         '''Markdown filter should transform urls to anchors'''
         text = 'http://example.net/'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
-            self.assertEqual(el.getAttribute('rel'), 'nofollow')
-            self.assertEqual(el.getAttribute('href'), 'http://example.net/')
-            self.assertEqual(el.firstChild.data, 'http://example.net/')
+            assert el.getAttribute('rel') == 'nofollow'
+            assert el.getAttribute('href') == 'http://example.net/'
+            assert el.firstChild.data == 'http://example.net/'
 
-    def test_markdown_linkify_relative(self):
+    def test_markdown_linkify_relative(self, app):
         '''Markdown filter should transform relative urls to external ones'''
         text = '[foo](/)'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
-            self.assertEqual(el.getAttribute('rel'), '')
-            self.assertEqual(el.getAttribute('href'), 'http://localhost/')
-            self.assertEqual(el.getAttribute('data-tooltip'), '')
-            self.assertEqual(el.firstChild.data, 'foo')
+            assert el.getAttribute('rel') == ''
+            assert el.getAttribute('href') == 'http://localhost/'
+            assert el.getAttribute('data-tooltip') == ''
+            assert el.firstChild.data == 'foo'
 
-    def test_markdown_linkify_https(self):
+    def test_markdown_linkify_https(self, app):
         '''Markdown filter should transform relative urls with HTTPS'''
         text = '[foo](/foo)'
-        with self.app.test_request_context('/', base_url='https://localhost'):
+        with app.test_request_context('/', base_url='https://localhost'):
             result = render_template_string('{{ text|markdown }}', text=text)
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
-            self.assertEqual(el.getAttribute('rel'), '')
-            self.assertEqual(el.getAttribute('href'), 'https://localhost/foo')
-            self.assertEqual(el.getAttribute('data-tooltip'), '')
-            self.assertEqual(el.firstChild.data, 'foo')
+            assert el.getAttribute('rel') == ''
+            assert el.getAttribute('href') == 'https://localhost/foo'
+            assert el.getAttribute('data-tooltip') == ''
+            assert el.firstChild.data == 'foo'
 
-    def test_markdown_linkify_relative_with_tooltip(self):
+    def test_markdown_linkify_relative_with_tooltip(self, app):
         '''Markdown filter should transform + add tooltip'''
         text = '[foo](/)'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string(
                 '{{ text|markdown(source_tooltip=True) }}', text=text)
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
-            self.assertEqual(el.getAttribute('rel'), '')
-            self.assertEqual(el.getAttribute('href'), 'http://localhost/')
-            self.assertEqual(el.getAttribute('data-tooltip'), 'Source')
-            self.assertEqual(el.firstChild.data, 'foo')
+            assert el.getAttribute('rel') == ''
+            assert el.getAttribute('href') == 'http://localhost/'
+            assert el.getAttribute('data-tooltip') == 'Source'
+            assert el.firstChild.data == 'foo'
 
-    def test_markdown_not_linkify_mails(self):
+    def test_markdown_not_linkify_mails(self, app):
         '''Markdown filter should not transform emails to anchors'''
         text = 'coucou@cmoi.fr'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             parsed = parser.parse(result)
-            self.assertEqual(parsed.getElementsByTagName('a'), [])
-            self.assert_md_equal(result, '<p>coucou@cmoi.fr</p>')
+            assert parsed.getElementsByTagName('a') == []
+            assert_md_equal(result, '<p>coucou@cmoi.fr</p>')
 
-    def test_markdown_linkify_within_pre(self):
+    def test_markdown_linkify_within_pre(self, app):
         '''Markdown filter should not transform urls into <pre> anchors'''
         text = '<pre>http://example.net/</pre>'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
-            self.assert_md_equal(result, '<pre>http://example.net/</pre>')
+            assert_md_equal(result, '<pre>http://example.net/</pre>')
 
-    def test_markdown_linkify_email_within_pre(self):
+    def test_markdown_linkify_email_within_pre(self, app):
         '''Markdown filter should not transform emails into <pre> anchors'''
         text = '<pre>coucou@cmoi.fr</pre>'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
-            self.assert_md_equal(result, '<pre>coucou@cmoi.fr</pre>')
+            assert_md_equal(result, '<pre>coucou@cmoi.fr</pre>')
 
-    def test_bleach_sanitize(self):
+    def test_bleach_sanitize(self, app):
         '''Markdown filter should sanitize evil code'''
         text = 'an <script>evil()</script>'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             expected = '<p>an &lt;script&gt;evil()&lt;/script&gt;</p>'
-            self.assert_md_equal(result, expected)
+            assert_md_equal(result, expected)
 
-    def test_soft_break(self):
+    def test_soft_break(self, app):
         '''Markdown should treat soft breaks as br tag'''
         text = 'line 1\nline 2'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             expected = '<p>line 1<br>line 2</p>'
-            self.assert_md_equal(result, expected)
+            assert_md_equal(result, expected)
 
-    def test_mdstrip_filter(self):
+    def test_mdstrip_filter(self, app):
         '''mdstrip should truncate the text before rendering'''
         text = '1 2 3 4 5 6 7 8 9 0'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|mdstrip(7) }}', text=text)
 
-        self.assertEqual(result, '1 2 3…')
+        assert result == '1 2 3…'
 
-    def test_mdstrip_filter_does_not_truncate_without_size(self):
+    def test_mdstrip_filter_does_not_truncate_without_size(self, app):
         '''mdstrip should not truncate by default'''
         text = 'aaaa ' * 300
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|mdstrip }}', text=text)
 
-        self.assertEqual(result.strip(), text.strip())
+        assert result.strip() == text.strip()
 
-    def test_mdstrip_filter_with_none(self):
+    def test_mdstrip_filter_with_none(self, app):
         '''mdstrip filter should not fails with None'''
         text = None
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|mdstrip }}', text=text)
 
-        self.assertEqual(result, '')
+        assert result == ''
 
-    def test_mdstrip_filter_with_excerpt(self):
+    def test_mdstrip_filter_with_excerpt(self, app):
         '''mdstrip should truncate on token if shorter than required size'''
         text = ''.join(['excerpt', EXCERPT_TOKEN, 'aaaa ' * 10])
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string(
                 '{{ text|mdstrip(20) }}', text=text)
 
-        self.assertEqual(result, 'excerpt')
+        assert result == 'excerpt'
 
-    def test_mdstrip_does_not_truncate_in_tags(self):
+    def test_mdstrip_does_not_truncate_in_tags(self, app):
         '''mdstrip should not truncate in middle of a tag'''
         text = '![Legend](http://www.somewhere.com/image.jpg) Here. aaaaa'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string('{{ text|mdstrip(5) }}', text=text)
 
-        self.assertEqual(result.strip(), 'Here…')
+        assert result.strip() == 'Here…'
 
-    def test_mdstrip_custom_end(self):
+    def test_mdstrip_custom_end(self, app):
         '''mdstrip should allow a custom ending string'''
         text = '1234567890'
         template = '{{ text|mdstrip(5, "$") }}'
-        with self.app.test_request_context('/'):
+        with app.test_request_context('/'):
             result = render_template_string(template, text=text)
 
-        self.assertEqual(result.strip(), '1234$')
+        assert result.strip() == '1234$'


### PR DESCRIPTION
This PR fixes markdown angle brackets autolinks handling avoiding them to be treated as HTML tags and from being sanitized.
See https://www.data.gouv.fr/fr/datasets/localisation-des-arrets-transpole-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-transpole/ as example:

It permit `<http://somelink.com>` to be rendered as `<a href="http://somelink.com">http://somelink.com</a>` instead of `&lt;http:somelink.com&gt;`

It also factorize a `markdown.parse_html()` to be reused by harvesters