### PR TITLE
Preview plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Normalize resource.format (migration - :warning: need reindexing) [#1563](https://github.com/opendatateam/udata/pull/1563)
 - Typed resources [#1398](https://github.com/opendatateam/udata/issues/1398)
 - [breaking] Enforce a domain whitelist when resource.filetype is file [#1567](https://github.com/opendatateam/udata/issues/1567)
-- Initial data preview implementation [#1581](https://github.com/opendatateam/udata/pull/1581)
+- Initial data preview implementation [#1581](https://github.com/opendatateam/udata/pull/1581) [#1632](https://github.com/opendatateam/udata/pull/1632)
 - Switch to PyPI.org for package links [#1583](https://github.com/opendatateam/udata/pull/1583)
 - Handle some alternate titles and alternate URLs on licenses for improved match on harvesting [#1592](https://github.com/opendatateam/udata/pull/1592)
 - Resource modals: use new single resource API call [#1547](https://github.com/opendatateam/udata/pull/1547)

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -205,3 +205,12 @@ $ udata worker status --munin-config -q default
 ```
 
 [munin-plugin]: https://github.com/etalab/munin-plugins/tree/master/udata-worker-status
+
+
+## Cache
+
+Flush the cache with:
+
+```shell
+$ udata cache flush
+```

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -85,6 +85,10 @@ class MyGenericPreview(PreviewPlugin):
     default = True
 ```
 
+Enabled plugins are cached so don't forget to flush cache when:
+- you change your `PLUGINS` configuration
+- you deliver new plugin versions
+
 
 ### Generic plugins (`udata.plugins`)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -65,27 +65,28 @@ from udata.core.dataset.preview import PreviewPlugin
 class MyPreview(PreviewPlugin):
     def can_preview(self, resource):
         # Check whether or not you can display a preview
-        # You can access the resource or its dataset (trough resource.dataset)
+        # You can access the resource or its dataset (through resource.dataset)
         # to check your requirements
 
     def preview_url(self, resource):
         # Return the absolute preview URL for the given resource.
-        # You can access the resource to check or its dataset (trough resource.dataset)
+        # You can access the resource or its dataset (through resource.dataset)
         # to build your preview URL
 ```
 
-You can mark a preview plugin as `default`, meaning it will only be a candidates
+You can mark a preview plugin as `fallback`, meaning it will only be a candidate
 if other plugins can't provide a preview.
-This is typically for plugin displaying generic preview (ie. only relying on mimetype by example):
+This is typically for plugin displaying generic preview (ie. only relying on mimetype for example):
 
 ```python
 from udata.core.dataset.preview import PreviewPlugin
 
 class MyGenericPreview(PreviewPlugin):
-    default = True
+    fallback = True
 ```
 
-Enabled plugins are cached so don't forget to flush cache when:
+Enabled plugins are cached so don't forget to [flush cache](administrative-tasks.md#cache) when:
+
 - you change your `PLUGINS` configuration
 - you deliver new plugin versions
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -51,6 +51,41 @@ This class entrypoint allows to register new link checkers that udata will recog
 
 This module entrypoint allows to register new asynchronous tasks and schedulable jobs.
 
+### Previews (`udata.preview`)
+
+A class entrypoint for preview providers.
+
+These plugins should extend `udata.core.dataset.preview.PreviewPlugin`.
+
+*Example:*
+
+```python
+from udata.core.dataset.preview import PreviewPlugin
+
+class MyPreview(PreviewPlugin):
+    def can_preview(self, resource):
+        # Check whether or not you can display a preview
+        # You can access the resource or its dataset (trough resource.dataset)
+        # to check your requirements
+
+    def preview_url(self, resource):
+        # Return the absolute preview URL for the given resource.
+        # You can access the resource to check or its dataset (trough resource.dataset)
+        # to build your preview URL
+```
+
+You can mark a preview plugin as `default`, meaning it will only be a candidates
+if other plugins can't provide a preview.
+This is typically for plugin displaying generic preview (ie. only relying on mimetype by example):
+
+```python
+from udata.core.dataset.preview import PreviewPlugin
+
+class MyGenericPreview(PreviewPlugin):
+    default = True
+```
+
+
 ### Generic plugins (`udata.plugins`)
 
 A module entrypoint for generic plugins. They just have to expose a `init_app(app)` function

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -66,8 +66,10 @@ resource_fields = api.model('Resource', {
         description='The resource last modification date'),
     'metrics': fields.Raw(description='The resource metrics', readonly=True),
     'extras': fields.Raw(description='Extra attributes as key-value pairs'),
-    'preview_url': fields.String(description='An optionnal preview URL to be loaded '
-                                 'as a standalone page (ie. iframe or new page'),
+    'preview_url': fields.String(description='An optionnal preview URL to be '
+                                 'loaded as a standalone page (ie. iframe or '
+                                 'new page)',
+                                 readonly=True),
 })
 
 upload_fields = api.inherit('UploadedResource', resource_fields, {

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -79,7 +79,6 @@ class BaseResourceForm(ModelForm):
     published = fields.DateTimeField(
         _('Publication date'),
         description=_('The publication date of the resource'))
-    preview_url = fields.URLField(_('Preview URL'))
 
 
 class ResourceForm(BaseResourceForm):

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -233,7 +233,7 @@ class ResourceMixin(object):
         if not self.urlhash or 'url' in self._get_changed_fields():
             self.urlhash = hash_url(self.url)
 
-    @property
+    @cached_property  # Accessed at least 2 times in front rendering
     def preview_url(self):
         return get_preview_url(self)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -16,6 +16,8 @@ from udata.models import db, WithMetrics, BadgeMixin, SpatialCoverage
 from udata.i18n import lazy_gettext as _
 from udata.utils import get_by, hash_url
 
+from .preview import get_preview_url
+
 __all__ = (
     'License', 'Resource', 'Dataset', 'Checksum', 'CommunityResource',
     'UPDATE_FREQUENCIES', 'LEGACY_FREQUENCIES', 'RESOURCE_FILETYPES',
@@ -221,8 +223,6 @@ class ResourceMixin(object):
     filesize = db.IntField()  # `size` is a reserved keyword for mongoengine.
     extras = db.ExtrasField()
 
-    preview_url = db.URLField()
-
     created_at = db.DateTimeField(default=datetime.now, required=True)
     modified = db.DateTimeField(default=datetime.now, required=True)
     published = db.DateTimeField(default=datetime.now, required=True)
@@ -232,6 +232,10 @@ class ResourceMixin(object):
         super(ResourceMixin, self).clean()
         if not self.urlhash or 'url' in self._get_changed_fields():
             self.urlhash = hash_url(self.url)
+
+    @property
+    def preview_url(self):
+        return get_preview_url(self)
 
     @property
     def closed_or_no_format(self):
@@ -336,6 +340,10 @@ class Resource(ResourceMixin, WithMetrics, db.EmbeddedDocument):
     '''
     on_added = signal('Resource.on_added')
     on_deleted = signal('Resource.on_deleted')
+
+    @property
+    def dataset(self):
+        return self._instance
 
 
 class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):

--- a/udata/core/dataset/preview.py
+++ b/udata/core/dataset/preview.py
@@ -21,7 +21,7 @@ class PreviewPlugin:
     An abstract preview plugin.
 
     In order to register a functionnal PreviewPlugin,
-    extension developpers needs to:
+    extension developpers need to:
     - inherit this class
     - implement abstract methods
     - expose the class on the ``udata.preview`` endpoint
@@ -30,8 +30,8 @@ class PreviewPlugin:
 
     #: Default previews are given only if no specific preview match.
     #: Typically plugins only relying on mimetype or format
-    #: should have `default = True`
-    default = False
+    #: should have `fallback = True`
+    fallback = False
 
     @abstractmethod
     def can_preview(self, resource):
@@ -51,7 +51,7 @@ class PreviewPlugin:
 
         :param ResourceMixin resource: the (community) resource to preview
         :return: a preview url to be displayed into an iframe or a new window
-        :rtype: HttpResponse
+        :rtype: str
         '''
         pass
 
@@ -69,7 +69,7 @@ def get_enabled_plugins():
         if plugin not in valid:
             clsname = plugin.__name__
             warnings.warn('{0} is not a valid preview plugin'.format(clsname))
-    return [p() for p in sorted(valid, key=lambda p: 1 if p.default else 0)]
+    return [p() for p in sorted(valid, key=lambda p: 1 if p.fallback else 0)]
 
 
 def get_preview_url(resource):

--- a/udata/core/dataset/preview.py
+++ b/udata/core/dataset/preview.py
@@ -8,6 +8,12 @@ from abc import ABCMeta, abstractmethod
 from flask import current_app
 
 from udata import entrypoints
+from udata.app import cache
+
+# Cache available plugins for a day
+# Don't forget to flush cache on new configuration or plugin
+CACHE_DURATION = 60 * 60 * 24
+CACHE_KEY = 'udata.preview.enabled_plugins'
 
 
 class PreviewPlugin:
@@ -50,6 +56,7 @@ class PreviewPlugin:
         pass
 
 
+@cache.cached(timeout=CACHE_DURATION, key_prefix=CACHE_KEY)
 def get_enabled_plugins():
     '''
     Returns enabled preview plugins.

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -10,6 +10,7 @@ ENTRYPOINTS = {
     'udata.linkcheckers': 'Link checker backends',
     'udata.metrics': 'Extra metrics',
     'udata.models': 'Models and migrations',
+    'udata.preview': 'Displays preview for resources',
     'udata.plugins': 'Generic plugin',
     'udata.tasks': 'Tasks and jobs',
     'udata.themes': 'Themes',

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -36,6 +36,7 @@ class DatasetModelTest:
             dataset.add_resource(resource)
         assert len(dataset.resources) == 2
         assert dataset.resources[0].id == resource.id
+        assert dataset.resources[0].dataset == dataset
 
     def test_add_resource_without_checksum(self):
         user = UserFactory()

--- a/udata/tests/dataset/test_resource_preview.py
+++ b/udata/tests/dataset/test_resource_preview.py
@@ -11,7 +11,7 @@ pytestmark = [
 ]
 
 PREVIEW_URL = 'http://preview'
-DEFAULT_PREVIEW_URL = 'http://preview/default'
+FALLBACK_PREVIEW_URL = 'http://preview/default'
 
 
 class AlwaysPreview(PreviewPlugin):
@@ -38,18 +38,18 @@ class PreviewFromDataset(PreviewPlugin):
         return resource.dataset.extras['preview']
 
 
-class DefaultPreview(PreviewPlugin):
-    default = True
+class FallbackPreview(PreviewPlugin):
+    fallback = True
 
     def can_preview(self, resource):
         return True
 
     def preview_url(self, resource):
-        return DEFAULT_PREVIEW_URL
+        return FALLBACK_PREVIEW_URL
 
 
 class NotAValidPlugin(object):
-    default = False
+    fallback = False
 
     def can_preview(self, resource):
         return True
@@ -105,17 +105,17 @@ class ResourcePreviewTest:
         assert resource.preview_url == PREVIEW_URL
 
     # order matters to ensure test is failing
-    @pytest.mark.preview([NeverPreview, DefaultPreview, AlwaysPreview])
-    def test_default_preview_comes_after(self):
+    @pytest.mark.preview([NeverPreview, FallbackPreview, AlwaysPreview])
+    def test_fallback_preview_comes_after(self):
         dataset = DatasetFactory(visible=True)
         resource = dataset.resources[0]
         assert resource.preview_url == PREVIEW_URL
 
-    @pytest.mark.preview([NeverPreview, DefaultPreview])
+    @pytest.mark.preview([NeverPreview, FallbackPreview])
     def test_fallback_on_default_preview(self):
         dataset = DatasetFactory(visible=True)
         resource = dataset.resources[0]
-        assert resource.preview_url == DEFAULT_PREVIEW_URL
+        assert resource.preview_url == FALLBACK_PREVIEW_URL
 
     @pytest.mark.preview([NotAValidPlugin])
     def test_warn_but_ignore_invalid_plugins(self, recwarn):

--- a/udata/tests/dataset/test_resource_preview.py
+++ b/udata/tests/dataset/test_resource_preview.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from udata.core.dataset.preview import PreviewPlugin
+from udata.core.dataset.factories import DatasetFactory, ResourceFactory
+
+from udata.utils import faker
+
+
+pytestmark = [
+    pytest.mark.usefixtures('clean_db')
+]
+
+PREVIEW_URL = 'http://preview'
+DEFAULT_PREVIEW_URL = 'http://preview/default'
+
+
+class AlwaysPreview(PreviewPlugin):
+    def can_preview(self, resource):
+        return True
+
+    def preview_url(self, resource):
+        return PREVIEW_URL
+
+
+class NeverPreview(PreviewPlugin):
+    def can_preview(self, resource):
+        return False
+
+    def preview_url(self, resource):
+        return PREVIEW_URL
+
+
+class PreviewFromDataset(PreviewPlugin):
+    def can_preview(self, resource):
+        return True
+
+    def preview_url(self, resource):
+        return resource.dataset.extras['preview']
+
+
+class DefaultPreview(PreviewPlugin):
+    default = True
+
+    def can_preview(self, resource):
+        return True
+
+    def preview_url(self, resource):
+        return DEFAULT_PREVIEW_URL
+
+
+class ResourcePreviewTest:
+    @pytest.fixture(autouse=True)
+    def patch_entrypoint(self, request, mocker, app):
+        marker = request.node.get_marker('preview')
+        plugins = marker.args[0] if marker else []
+        m = mocker.patch('udata.entrypoints.get_enabled')
+        m.return_value.values.return_value = plugins  # Keep order
+        yield
+        m.assert_called_with('udata.preview', app)
+
+    def test_preview_is_none_by_default(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url is None
+
+    @pytest.mark.preview([NeverPreview])
+    def test_resource_has_no_preview(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url == None
+
+    @pytest.mark.preview([AlwaysPreview])
+    def test_resource_has_preview(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url == PREVIEW_URL
+
+    @pytest.mark.preview([AlwaysPreview, NeverPreview, NeverPreview])
+    def test_resource_has_one_preview_with_multiple_plugins(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url == PREVIEW_URL
+
+    @pytest.mark.preview([PreviewFromDataset])
+    def test_can_access_dataset_metadata(self):
+        dataset = DatasetFactory(visible=True,
+                                 extras={'preview': PREVIEW_URL})
+        resource = dataset.resources[0]
+        assert resource.preview_url == PREVIEW_URL
+
+    @pytest.mark.preview([AlwaysPreview, AlwaysPreview])
+    def test_can_have_multiple_candidates(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url == PREVIEW_URL
+
+    # order matters to ensure test is failing
+    @pytest.mark.preview([NeverPreview, DefaultPreview, AlwaysPreview])
+    def test_default_preview_comes_after(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url == PREVIEW_URL
+
+    @pytest.mark.preview([NeverPreview, DefaultPreview])
+    def test_fallback_on_default_preview(self):
+        dataset = DatasetFactory(visible=True)
+        resource = dataset.resources[0]
+        assert resource.preview_url == DEFAULT_PREVIEW_URL


### PR DESCRIPTION
This PR makes `Resource.preview_url` a property relying `udata.preview` entrypoint plugins.

For security considerations, the `preview_url` is not user writable and rely on `udata.preview` plugins providing (or not) a preview URL.

Preview plugins should inherit from `udata.core.dataset.preview:PreviewPlugin` and implement both `can_preview(resource)` and `preview_url(resource)` methods.

To resolve cases where multiple plugins match, we introduced 2 levels of preview plugins. When the `default` attribute is set to `True` on a `PreviewPlugin`, this plugin will match only if none of the non-default plugin matched.
In case of multiple non default match or multiple default match, the `preview_url` will be any of the candidates.