### PR TITLE
Do not send Dataset.on_save signal on linkchecking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Prevent linkchecker to pollute timeline as a side-effect. (migration). **Warning, the migration will delete all dataset update activities** [#1643](https://github.com/opendatateam/udata/pull/1643)
 
 ## 1.3.8 (2018-04-25)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -374,6 +374,8 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
 
     @classmethod
     def post_save(cls, sender, document, **kwargs):
+        if kwargs.get('ignore'):
+            return
         cls.after_save.send(document)
         if kwargs.get('created'):
             cls.on_create.send(document)

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -374,7 +374,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
 
     @classmethod
     def post_save(cls, sender, document, **kwargs):
-        if kwargs.get('ignore'):
+        if 'post_save' in kwargs.get('ignores', []):
             return
         cls.after_save.send(document)
         if kwargs.get('created'):

--- a/udata/linkchecker/checker.py
+++ b/udata/linkchecker/checker.py
@@ -70,5 +70,5 @@ def check_resource(resource):
     previous_status = resource.extras.get('check:available')
     check_keys = _get_check_keys(result, resource, previous_status)
     resource.extras.update(check_keys)
-    resource.save(signal_kwargs={'ignore': True})  # Prevent signal triggering on dataset
+    resource.save(signal_kwargs={'ignores': ['post_save']})  # Prevent signal triggering on dataset
     return result

--- a/udata/linkchecker/checker.py
+++ b/udata/linkchecker/checker.py
@@ -70,5 +70,5 @@ def check_resource(resource):
     previous_status = resource.extras.get('check:available')
     check_keys = _get_check_keys(result, resource, previous_status)
     resource.extras.update(check_keys)
-    resource.save()
+    resource.save(signal_kwargs={'ignore': True})  # Prevent signal triggering on dataset
     return result

--- a/udata/migrations/2018-05-04-remove-userupdateddataset-activities.js
+++ b/udata/migrations/2018-05-04-remove-userupdateddataset-activities.js
@@ -1,0 +1,7 @@
+/**
+ * Delete all activities of type `Activity.UserUpdatedDataset`
+ */
+
+var res = db.activity.deleteMany({_cls: "Activity.UserUpdatedDataset"});
+
+print(`${res.deletedCount} activities removed.`);

--- a/udata/models/datetime_fields.py
+++ b/udata/models/datetime_fields.py
@@ -62,6 +62,6 @@ class Datetimed(object):
 
 
 @pre_save.connect
-def set_modified_datetime(sender, document):
+def set_modified_datetime(sender, document, **kwargs):
     if isinstance(document, Datetimed):
         document.last_modified = datetime.now()


### PR DESCRIPTION
This PR fix bug on the linkchecker creating activities each time an user visit a page as a side-effect of checking resources (even with the default linkchecker).

:warning: The fix comes with a migration dropping all "dataset updated" activities because they were not relevant before this PR. 