### PR TITLE
Bad UUID 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix markdown handling of autolinks with angle brackets and factorize (and test) markdown `parse_html()` [#1625](https://github.com/opendatateam/udata/pull/1625)
 - Fix timeline order [#1642](https://github.com/opendatateam/udata/pull/1642)
 - Fix markdown rendering on IE11 [#1645](https://github.com/opendatateam/udata/pull/1645)
+- Consider bad UUID as 404 in routing [#1646](https://github.com/opendatateam/udata/pull/1646)
 
 ## 1.3.8 (2018-04-25)
 

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -40,7 +40,10 @@ class PathListConverter(PathConverter):
 
 class UUIDConverter(BaseConverter):
     def to_python(self, value):
-        return value if isinstance(value, UUID) else UUID(value.strip())
+        try:
+            return value if isinstance(value, UUID) else UUID(value.strip())
+        except ValueError:
+            return NotFound()
 
 
 class ModelConverter(BaseConverter):

--- a/udata/tests/test_routing.py
+++ b/udata/tests/test_routing.py
@@ -43,6 +43,9 @@ class UUIDConverterTest:
         url = '/uuid/{0} '.format(str(uuid))
         assert client.get(url).data == 'ok'
 
+    def test_bad_uuid_is_404(self, client):
+        assert client.get('/uuid/bad').status_code == 404
+
 
 class Tester(db.Document):
     slug = db.StringField()


### PR DESCRIPTION
This PR prevent UUID routin from erroring on bad UUID and consider them as 404 errors.

See: https://sentry.data.gouv.fr/share/issue/d24abc88349c4fa3ae87f2144f1b493e/