### PR TITLE
Polyfill ChildNode.remove() for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix markdown rendering on IE11 [#1645](https://github.com/opendatateam/udata/pull/1645)
 - Consider bad UUID as 404 in routing [#1646](https://github.com/opendatateam/udata/pull/1646)
 - Add missing email templates [#1647](https://github.com/opendatateam/udata/pull/1647)
+- Polyfill `ChildNode.remove()` for IE11 [#1648](https://github.com/opendatateam/udata/pull/1648)
 
 ## 1.3.8 (2018-04-25)
 

--- a/js/dom-polyfills.js
+++ b/js/dom-polyfills.js
@@ -12,3 +12,21 @@ if (window.Element && !Element.prototype.closest) {
         return el;
     };
 }
+
+// ChildNode.remove
+// taken from https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove
+(function(arr) {
+    arr.forEach(function(item) {
+        if (item.hasOwnProperty('remove')) {
+            return;
+        }
+        Object.defineProperty(item, 'remove', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: function remove() {
+                if (this.parentNode !== null) this.parentNode.removeChild(this);
+            }
+        });
+    });
+})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);

--- a/js/front/mixin.js
+++ b/js/front/mixin.js
@@ -15,6 +15,7 @@ import 'raven';
 import 'babel-polyfill';
 import 'whatwg-fetch';
 import 'url-search-params-polyfill';
+import 'dom-polyfills';
 
 import config from 'config';
 import Vue from 'vue';


### PR DESCRIPTION
This PR polyfill `ChildNode.remove()` for IE11 (expanders, facets...)

See:
- https://sentry.data.gouv.fr/share/issue/21ded7ff40ba47f0a8d8208b47304ce7/
- https://sentry.data.gouv.fr/share/issue/180634b33e034d8aa54fed44360d2818/