### PR TITLE
Prevent regex special chars to break the site search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add missing email templates [#1647](https://github.com/opendatateam/udata/pull/1647)
 - Polyfill `ChildNode.remove()` for IE11 [#1648](https://github.com/opendatateam/udata/pull/1648)
 - Improve Raven-js/Sentry error handling [#1649](https://github.com/opendatateam/udata/pull/1649)
+- Prevent regex special characters to break site search [#1650](https://github.com/opendatateam/udata/pull/1650)
 
 ## 1.3.8 (2018-04-25)
 

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -44,6 +44,7 @@
 
 <script>
 import { Cache } from 'cache';
+import { escapeRegex } from 'utils';
 import placeholders from 'helpers/placeholders';
 
 function group(id, name, template) {
@@ -149,10 +150,11 @@ export default {
     },
     filters: {
         highlight(value, phrase) {
-            return value.replace(new RegExp('('+phrase+')', 'gi'), '<strong>$1</strong>')
+            const pattern = escapeRegex(phrase);
+            return value.replace(new RegExp(`(${pattern})`, 'gi'), '<strong>$1</strong>')
         },
         stripTags(value) {
-            let regex = /(<([^>]+)>)/ig;
+            const regex = /(<([^>]+)>)/ig;
             return value.replace(regex, '');
         }
     },

--- a/js/utils.js
+++ b/js/utils.js
@@ -64,6 +64,15 @@ export function parseQS(qs) {
     return result;
 }
 
+/**
+ * Escape special characters from a string for usage in a regex
+ * @param  {String} str An unscaped string
+ * @return {String}     The regex escaped string
+ */
+export function escapeRegex(str) {
+    return str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
 
 export default {
     isFunction,
@@ -72,4 +81,5 @@ export default {
     getattr,
     setattr,
     parseQS,
+    escapeRegex,
 };

--- a/specs/utils.specs.js
+++ b/specs/utils.specs.js
@@ -113,4 +113,15 @@ describe('Utils', function() {
             expect(u.parseQS('?key%2Fencoded=value')).to.eql({'key/encoded': 'value'});
         });
     });
+
+    describe('escapeRegex', function() {
+        it('should escape any special chars', function() {
+            expect(u.escapeRegex('Chars: |\\{}()[]^$+*?.'))
+                .to.eql('Chars: \\|\\\\\\{\\}\\(\\)\\[\\]\\^\\$\\+\\*\\?\\.');
+        });
+
+        it('should not touch other chars', function() {
+            expect(u.escapeRegex('noop')).to.eql('noop');
+        });
+    });
 });


### PR DESCRIPTION
This PR prevent the JS RegExp special characters to break the site search.

See: https://sentry.data.gouv.fr/share/issue/229c07d2ce644f3eab93dfaa9e238fa4/