### PR TITLE
Make the map widget customizable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add resend confirmation email link to login screen [#1653](https://github.com/opendatateam/udata/pull/1653)
 - Refactoring of discussions code base [#1623](https://github.com/opendatateam/udata/pull/1623)
 - Fix Firefox custom error handling, part 2 [#1671](https://github.com/opendatateam/udata/pull/1671)
+- The map widget can now be configured (tiles URL, initial position...) [#1672](https://github.com/opendatateam/udata/pull/1672)
 
 ## 1.3.10 (2018-05-11)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -153,6 +153,50 @@ from udata.settings import Defaults
 URLS_ALLOWED_TLDS = Defaults.URLS_ALLOWED_TLDS + set(['custom', 'company'])
 ```
 
+## Map widget configuration
+
+### MAP_TILES_URL
+
+**default**: `'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'`
+
+Tiles URL for SD displays
+
+### MAP_TILES_URL_HIDPI
+
+**default**: `'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png'`
+
+Tiles URL for HD/HiDPI displays
+
+### MAP_TILES_CONFIG
+
+**default**:
+```python
+{
+    'subdomains': 'abcd',
+    'attribution': (
+        '&copy;'
+        '<a href="http://openstreetmap.org/copyright">OpenStreetMap</a>'
+        '/'
+        '<a href="https://cartodb.com/attributions">CartoDB</a>'
+    )
+}
+```
+
+Tiles configuration object given as Leaflet tile layer parameter,
+see https://leafletjs.com/reference-0.7.7.html#tilelayer
+
+### MAP_INITIAL_CENTER
+
+**default**: `[42, 2.4]`
+
+Initial map center position coordinates
+
+### MAP_INITIAL_ZOOM
+
+**default**: `4`
+
+Initial map zoom level
+
 ## Spatial configuration
 
 ### SPATIAL_SEARCH_EXCLUDE_LEVELS

--- a/js/components/leaflet-map.vue
+++ b/js/components/leaflet-map.vue
@@ -5,8 +5,6 @@
 import L from 'leaflet';
 import config from 'config';
 
-const INITIAL_SETTINGS = {center: [42, 2.4], zoom: 4, zoomControl: false};
-
 export default {
     name: 'leaflet-map',
     props: {
@@ -23,7 +21,11 @@ export default {
         geojson: null
     },
     ready() {
-        this.map = L.map(this.$el, INITIAL_SETTINGS);
+        this.map = L.map(this.$el, {
+            center: config.map.init.center,
+            zoom: config.map.init.zoom,
+            zoomControl: false
+        });
 
         if (this.fixed) {
             // Disable drag and zoom handlers.
@@ -36,7 +38,8 @@ export default {
             if (this.map.tap) this.map.tap.disable();
         }
 
-        L.tileLayer(config.tiles_url, config.tiles_config).addTo(this.map);
+        const tiles_url = config.hidpi ? config.map.tiles.hidpi : config.map.tiles.url;
+        L.tileLayer(tiles_url, config.map.tiles.config).addTo(this.map);
     },
     watch: {
         geojson: function(json) {

--- a/js/config.js
+++ b/js/config.js
@@ -130,22 +130,9 @@ export const hidpi = (window.devicePixelRatio > 1 || (
 );
 
 /**
- * Attributions for map tiles
+ * Map configuration
  */
-export const tiles_attributions = '&copy;' + [
-    '<a href="http://openstreetmap.org/copyright">OpenStreetMap</a>',
-    '<a href="https://cartodb.com/attributions">CartoDB</a>'
-].join('/');
-
-/**
- * Map tiles URL
- */
-export const tiles_url = `https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}${hidpi ? '@2x' : ''}.png`;
-
-/**
- * Leaflet base config
- */
-export const tiles_config = {subdomains: 'abcd', attribution: tiles_attributions};
+export const map = _jsonMeta('map-config');
 
 /**
  * Tags constraints
@@ -181,10 +168,8 @@ export default {
     is_territory_enabled,
     is_delete_me_enabled,
     hidpi,
+    map,
     tags,
-    tiles_attributions,
-    tiles_url,
-    tiles_config,
     dataset_max_resources_uncollapsed,
     markdown,
 };

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -280,6 +280,28 @@ class Defaults(object):
     # List of allowed TLDs.
     URLS_ALLOWED_TLDS = tld_set
 
+    # Map/Tiles configuration
+    ###########################################################################
+    # Tiles URL for SD displays
+    MAP_TILES_URL = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'
+    # Tiles URL for HD/HiDPI displays
+    MAP_TILES_URL_HIDPI = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png'
+    # Leaflet tiles config, see https://leafletjs.com/reference-0.7.7.html#tilelayer
+    MAP_TILES_CONFIG = {
+        'subdomains': 'abcd',
+        'attribution': (
+            '&copy;'
+            '<a href="http://openstreetmap.org/copyright">OpenStreetMap</a>'
+            '/'
+            '<a href="https://cartodb.com/attributions">CartoDB</a>'
+        )
+    }
+    # Initial map center position
+    MAP_INITIAL_CENTER = [42, 2.4]
+    # Initial map zoom level
+    MAP_INITIAL_ZOOM = 4
+
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -56,6 +56,18 @@
     'styles': config.MD_ALLOWED_STYLES,
 }|tojson|urlencode }}" />
 
+<meta name="map-config" content="{{ {
+    'init': {
+        'center': config.MAP_INITIAL_CENTER,
+        'zoom': config.MAP_INITIAL_ZOOM,
+    },
+    'tiles': {
+        'url': config.MAP_TILES_URL,
+        'hidpi': config.MAP_TILES_URL_HIDPI,
+        'config': config.MAP_TILES_CONFIG,
+    }
+}|to_json|urlencode }}" />
+
 {% if json_ld %}
 <script id="json_ld" type="application/ld+json">{{ json_ld|safe }}</script>
 {% endif %}


### PR DESCRIPTION
This PR makes the map widgets customizable.

Tiles layer URL(s) is customizable with `MAP_TILES_URL`, `MAP_TILES_URL_HIDPI` and `MAP_TILES_CONFIG`.
The initial position and zoom can be set with `MAP_INITIAL_CENTER` and `MAP_INITIAL_ZOOM`.

Fix #1427