### PR TITLE
Upgrade to flask-restplus 0.11.0 and make use of ujson

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -18,7 +18,7 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 flask-mongoengine==0.9.5
 Flask-Navigation==0.2.0
-flask-restplus==0.10.1
+flask-restplus==0.11.0
 Flask-Security==3.0.0
 Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
@@ -43,6 +43,7 @@ requests==2.18.4
 StringDist==1.0.9
 tlds
 unicodecsv==0.14.1
+ujson==1.35
 voluptuous==0.10.5
 wtforms-json==0.3.3
 wtforms==2.1

--- a/udata/api/fields.py
+++ b/udata/api/fields.py
@@ -35,12 +35,12 @@ class UrlFor(String):
     def default_mapper(self, obj):
         return {'id': str(obj.id)}
 
-    def output(self, key, obj):
+    def output(self, key, obj, **kwargs):
         return url_for(self.endpoint, _external=True, **self.mapper(obj))
 
 
 class NextPageUrl(String):
-    def output(self, key, obj):
+    def output(self, key, obj, **kwargs):
         if not getattr(obj, 'has_next', None):
             return None
         args = multi_to_dict(request.args)
@@ -50,7 +50,7 @@ class NextPageUrl(String):
 
 
 class PreviousPageUrl(String):
-    def output(self, key, obj):
+    def output(self, key, obj, **kwargs):
         if not getattr(obj, 'has_prev', None):
             return None
         args = multi_to_dict(request.args)


### PR DESCRIPTION
This PR upgrade Flask-RESTPlus to the latest 0.11.0 version (and apply custom fields API changes) and adds `ujson` as a depdency for improved performances.

Supersedes #1674