### PR TITLE
[Nice to have] Add map initial territory level

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -197,6 +197,12 @@ Initial map center position coordinates
 
 Initial map zoom level
 
+### MAP_INITIAL_LEVEL
+
+**default**: `0`
+
+Initial map territory level
+
 ## Spatial configuration
 
 ### SPATIAL_SEARCH_EXCLUDE_LEVELS

--- a/js/front/covermap/index.js
+++ b/js/front/covermap/index.js
@@ -8,6 +8,7 @@ import Vue from 'vue';
 import log from 'logger';
 
 import L from 'leaflet';
+import config from 'config';
 import 'leaflet-spin';
 
 import LeafletMap from 'components/leaflet-map.vue';
@@ -83,7 +84,7 @@ new Vue({
                 this.switchLevel(ev.layer.level);
             });
 
-            this.switchLevel(this.levels[0]);
+            this.switchLevel(this.levels[config.map.init.level]);
         },
 
         /**

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -300,7 +300,8 @@ class Defaults(object):
     MAP_INITIAL_CENTER = [42, 2.4]
     # Initial map zoom level
     MAP_INITIAL_ZOOM = 4
-
+    # Initial map territory level
+    MAP_INITIAL_LEVEL = 0
 
 
 class Testing(object):

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -60,6 +60,7 @@
     'init': {
         'center': config.MAP_INITIAL_CENTER,
         'zoom': config.MAP_INITIAL_ZOOM,
+        'level': config.MAP_INITIAL_LEVEL,
     },
     'tiles': {
         'url': config.MAP_TILES_URL,


### PR DESCRIPTION
This is an extension to PR #1672.
We would like to control the initial territory level as well.

For example if I'm a user from France I would like to see at first the territories from France and then have the possibility to choose other territorial levels when I open the coverage map.