### PR TITLE
prevent autocomple to open on new page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - The map widget can now be configured (tiles URL, initial position...) [#1672](https://github.com/opendatateam/udata/pull/1672)
 - Fix the temporal coverage facet query string parsing [#1676](https://github.com/opendatateam/udata/pull/1676)
 - Fix search auto-complete hitbox [#1687](https://github.com/opendatateam/udata/pull/1687)
+- Fix search auto-complete loading on new page [#1693](https://github.com/opendatateam/udata/pull/1693)
 
 ## 1.3.10 (2018-05-11)
 

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -18,6 +18,7 @@
         <input name="q" type="search" class="form-control" autocomplete="off"
             :placeholder="placeholder || _('Search')"
             v-model="query" debounce="200"
+            @keydown="show = true"
             @keydown.up.prevent="up"
             @keydown.down.prevent="down"
             @keydown.enter="hit"
@@ -168,7 +169,6 @@ export default {
             }
 
             this.current = -1;
-            this.show = true;
 
             this.groups.forEach(group => {
                 const cached = this.cache.get(`${group.id}-${query}`);


### PR DESCRIPTION
Currently if you use the search input, autocomplete will stay open after having loaded the new page because of a watcher on `this.query`.