### PR TITLE
Extras cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix the temporal coverage facet query string parsing [#1676](https://github.com/opendatateam/udata/pull/1676)
 - Fix search auto-complete hitbox [#1687](https://github.com/opendatateam/udata/pull/1687)
 - Fix search auto-complete loading on new page [#1693](https://github.com/opendatateam/udata/pull/1693)
+- Simplify `ExtrasField` form field signature (no need anymore for the `extras` parameter) [#1698](https://github.com/opendatateam/udata/pull/1698)
 
 ## 1.3.11 (2018-05-29)
 

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -79,7 +79,7 @@ class BaseResourceForm(ModelForm):
     published = fields.DateTimeField(
         _('Publication date'),
         description=_('The publication date of the resource'))
-    extras = fields.ExtrasField(extras=Resource.extras)
+    extras = fields.ExtrasField()
 
 
 class ResourceForm(BaseResourceForm):
@@ -135,7 +135,7 @@ class DatasetForm(ModelForm):
 
     owner = fields.CurrentUserField()
     organization = fields.PublishAsField(_('Publish as'))
-    extras = fields.ExtrasField(extras=Dataset.extras)
+    extras = fields.ExtrasField()
     resources = fields.NestedModelList(ResourceForm)
 
 

--- a/udata/core/discussions/forms.py
+++ b/udata/core/discussions/forms.py
@@ -15,7 +15,7 @@ class DiscussionCreateForm(ModelForm):
     title = fields.StringField(_('Title'), [validators.required()])
     comment = fields.StringField(_('Comment'), [validators.required()])
     subject = fields.ModelField(_('Subject'), [validators.required()])
-    extras = fields.ExtrasField(extras=Discussion.extras)
+    extras = fields.ExtrasField()
 
 
 class DiscussionCommentForm(Form):

--- a/udata/core/organization/forms.py
+++ b/udata/core/organization/forms.py
@@ -30,6 +30,8 @@ class OrganizationForm(ModelForm):
         _('Website'), description=_('The organization website URL'))
     logo = fields.ImageField(_('Logo'), sizes=LOGO_SIZES)
 
+    extras = fields.ExtrasField()
+
     def save(self, commit=True, **kwargs):
         '''Register the current user as admin on creation'''
         org = super(OrganizationForm, self).save(commit=False, **kwargs)

--- a/udata/forms/__init__.py
+++ b/udata/forms/__init__.py
@@ -27,5 +27,7 @@ class Form(CommonFormMixin, FlaskForm):
 
 
 class ModelForm(CommonFormMixin, MEModelForm):
+    model_class = None
+
     def _get_translations(self):
         return i18n.domain.get_translations()

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 
 from werkzeug.datastructures import MultiDict
 
-from udata.forms import Form, fields
+from udata.forms import fields, ModelForm
 from udata.models import db
 
 pytestmark = [
@@ -21,8 +21,9 @@ class ExtrasFieldTest:
         class Fake(db.Document):
             extras = db.ExtrasField()
 
-        class FakeForm(Form):
-            extras = fields.ExtrasField(extras=Fake.extras)
+        class FakeForm(ModelForm):
+            model_class = Fake
+            extras = fields.ExtrasField()
 
         return Fake, FakeForm
 

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -1,16 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from datetime import date, datetime
 
 from werkzeug.datastructures import MultiDict
 
 from udata.forms import Form, fields
 from udata.models import db
-from udata.tests import TestCase
+
+pytestmark = [
+    pytest.mark.usefixtures('app')
+]
 
 
-class ExtrasFieldTest(TestCase):
+class ExtrasFieldTest:
 
     def factory(self):
         class Fake(db.Document):
@@ -28,7 +33,7 @@ class ExtrasFieldTest(TestCase):
         form = FakeForm()
         form.populate_obj(fake)
 
-        self.assertEqual(fake.extras, {})
+        assert fake.extras == {}
 
     def test_with_valid_data(self):
         Fake, FakeForm = self.factory()
@@ -47,18 +52,18 @@ class ExtrasFieldTest(TestCase):
         }}))
 
         form.validate()
-        self.assertEqual(form.errors, {})
+        assert form.errors == {}
 
         form.populate_obj(fake)
 
-        self.assertEqual(fake.extras, {
+        assert fake.extras == {
             'integer': 42,
             'float': 42.0,
             'string': 'value',
             'datetime': now,
             'date': today,
             'bool': True
-        })
+        }
 
     def test_with_invalid_data(self):
         Fake, FakeForm = self.factory()
@@ -72,8 +77,8 @@ class ExtrasFieldTest(TestCase):
         }}))
 
         form.validate()
-        self.assertIn('extras', form.errors)
-        self.assertEqual(len(form.errors['extras']), 1)
+        assert 'extras' in form.errors
+        assert len(form.errors['extras']) == 1
 
     def test_with_valid_registered_data(self):
         Fake, FakeForm = self.factory()
@@ -94,16 +99,16 @@ class ExtrasFieldTest(TestCase):
         }}))
 
         form.validate()
-        self.assertEqual(form.errors, {})
+        assert form.errors == {}
 
         form.populate_obj(fake)
-        self.assertEqual(fake.extras, {
+        assert fake.extras == {
             'dict': {
                 'integer': 42,
                 'float': 42.0,
                 'string': 'value',
             }
-        })
+        }
 
     def test_with_invalid_registered_data(self):
         Fake, FakeForm = self.factory()
@@ -119,5 +124,5 @@ class ExtrasFieldTest(TestCase):
         }}))
 
         form.validate()
-        self.assertIn('extras', form.errors)
-        self.assertEqual(len(form.errors['extras']), 1)
+        assert 'extras' in form.errors
+        assert len(form.errors['extras']) == 1

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import json
 import mock
 import os
 
@@ -11,7 +10,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 from urlparse import urljoin, urlparse
 
-from flask import request, url_for
+from flask import request, url_for, json
 
 
 def assert_equal_dates(datetime1, datetime2, limit=1):  # Seconds.

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -319,7 +319,7 @@ class ExtrasFieldTest:
         })
         tester.validate()
 
-    def test_validate_unregistered_type(self):
+    def test_default_dont_validate_complex_types(self):
         class Tester(db.Document):
             extras = db.ExtrasField()
 

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -328,6 +328,37 @@ class ExtrasFieldTest:
         with pytest.raises(ValidationError):
             tester.validate()
 
+    @pytest.mark.parametrize('dbtype,value', [
+        (db.IntField, 42),
+        (db.FloatField, 0.42),
+        (db.BooleanField, True),
+        (db.DateTimeField, datetime.now()),
+        (db.DateField, date.today()),
+    ])
+    def test_validate_registered_db_type(self, dbtype, value):
+        class Tester(db.Document):
+            extras = db.ExtrasField()
+
+        Tester.extras.register('test', dbtype)
+
+        Tester(extras={'test': value}).validate()
+
+    @pytest.mark.parametrize('dbtype,value', [
+        (db.IntField, datetime.now()),
+        (db.FloatField, datetime.now()),
+        (db.BooleanField, 42),
+        (db.DateTimeField, 42),
+        (db.DateField, 42),
+    ])
+    def test_fail_to_validate_wrong_type(self, dbtype, value):
+        class Tester(db.Document):
+            extras = db.ExtrasField()
+
+        Tester.extras.register('test', dbtype)
+
+        with pytest.raises(db.ValidationError):
+            Tester(extras={'test': value}).validate()
+
     def test_validate_registered_type(self):
         class Tester(db.Document):
             extras = db.ExtrasField()


### PR DESCRIPTION
This PR prepare the `ExtrasField`s refactoring (will be easier to read in multiple PR):
- port related tests to pytest syntax
- adds some missing form fields: `DateField` and `FloatField`
- fix the `assert_json_equal` by using the udata JSON serializer
- adds some missing `ExtrasField` model tests
- simplify the `ExtraField` form field signature by removing the need to pass the `extras` parameter