### PR TITLE
Extras parsing and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix search auto-complete hitbox [#1687](https://github.com/opendatateam/udata/pull/1687)
 - Fix search auto-complete loading on new page [#1693](https://github.com/opendatateam/udata/pull/1693)
 - Simplify `ExtrasField` form field signature (no need anymore for the `extras` parameter) [#1698](https://github.com/opendatateam/udata/pull/1698)
+- Ensure registered extras types are properly parsed from JSON. Remove the need for custom `db.Extra` classes [#1699](https://github.com/opendatateam/udata/pull/1699)
 
 ## 1.3.11 (2018-05-29)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -738,5 +738,5 @@ class ExtrasField(Field):
         else:
             self.errors = None
 
-        return bool(self.errors)
+        return not bool(self.errors)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -673,7 +673,7 @@ def field_parse(cls, value, *args, **kwargs):
 
 
 class ExtrasField(Field):
-    TYPES = {
+    KNOWN_TYPES = {
         db.DateTimeField: DateTimeField,
         db.DateField: DateField,
         db.IntField: IntegerField,
@@ -707,9 +707,9 @@ class ExtrasField(Field):
         if key not in self.extras.registered:
             return value
         expected = self.extras.registered[key]
-        if expected in self.TYPES:
+        if expected in self.KNOWN_TYPES:
             try:
-                return field_parse(self.TYPES[expected], value)
+                return field_parse(self.KNOWN_TYPES[expected], value)
             except Exception as e:
                 self.field_errors[key] = getattr(e, 'message', str(e))
         else:

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -710,7 +710,7 @@ class ExtrasField(Field):
         if expected in self.KNOWN_TYPES:
             try:
                 return field_parse(self.KNOWN_TYPES[expected], value)
-            except Exception as e:
+            except (validators.ValidationError, ValueError) as e:
                 self.field_errors[key] = getattr(e, 'message', str(e))
         else:
             return value

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import importlib
 import logging
 import warnings
 
@@ -20,7 +19,7 @@ from udata.errors import ConfigError
 from .badges_field import BadgesField
 from .taglist_field import TagListField
 from .datetime_fields import DateField, DateRange, Datetimed
-from .extras_fields import ExtrasField, Extra
+from .extras_fields import ExtrasField
 from .slug_fields import SlugField
 from .url_field import URLField
 from .uuid_fields import AutoUUIDField
@@ -39,7 +38,6 @@ class UDataMongoEngine(MongoEngine):
         self.TagListField = TagListField
         self.DateField = DateField
         self.Datetimed = Datetimed
-        self.Extra = Extra
         self.ExtrasField = ExtrasField
         self.SlugField = SlugField
         self.AutoUUIDField = AutoUUIDField

--- a/udata/models/extras_fields.py
+++ b/udata/models/extras_fields.py
@@ -6,8 +6,7 @@ import logging
 from datetime import date, datetime
 
 from mongoengine import EmbeddedDocument
-from mongoengine.errors import ValidationError
-from mongoengine.fields import DictField
+from mongoengine.fields import DictField, BaseField
 
 log = logging.getLogger(__name__)
 
@@ -20,15 +19,26 @@ class ExtrasField(DictField):
         self.registered = {}
         super(ExtrasField, self).__init__()
 
-    def register(self, key, extra):
-        self.registered[key] = extra
+    def register(self, key, dbtype):
+        '''Register a DB type to add constraint on a given extra key'''
+        if not issubclass(dbtype, (BaseField, EmbeddedDocument)):
+            msg = 'ExtrasField can only register MongoEngine fields'
+            raise TypeError(msg)
+        self.registered[key] = dbtype
 
     def validate(self, value):
         super(ExtrasField, self).validate(value)
 
         errors = {}
         for key, value in value.items():
-            extra_cls = self.registered.get(key, DefaultExtra)
+            extra_cls = self.registered.get(key)
+
+            if not extra_cls:
+                if not isinstance(value, ALLOWED_TYPES):
+                    types = ', '.join(t.__name__ for t in ALLOWED_TYPES)
+                    msg = 'Value should be an instance of: {types}'
+                    errors[key] = msg.format(types=types)
+                continue
 
             try:
                 if issubclass(extra_cls, EmbeddedDocument):
@@ -53,19 +63,3 @@ class ExtrasField(DictField):
         if isinstance(value, EmbeddedDocument):
             return value
         return super(ExtrasField, self).to_python(value)
-
-
-class Extra(object):
-    def validate(self, value):
-        raise NotImplemented
-
-
-class DefaultExtra(Extra):
-    def validate(self, value):
-        if not isinstance(value, ALLOWED_TYPES):
-            types = ', '.join(t.__name__ for t in ALLOWED_TYPES)
-            raise ValidationError('Value should be an instance of: {types}',
-                                  types=types)
-        if isinstance(value, (list, tuple)):
-            for _value in value:
-                self.validate(_value)

--- a/udata/models/extras_fields.py
+++ b/udata/models/extras_fields.py
@@ -37,8 +37,8 @@ class ExtrasField(DictField):
                      else extra_cls(**value).validate())
                 else:
                     extra_cls().validate(value)
-            except ValidationError as e:
-                errors[key] = e.message
+            except Exception as e:
+                errors[key] = getattr(e, 'message', str(e))
 
         if errors:
             self.error('Unsupported types', errors=errors)

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -111,6 +111,32 @@ class ExtrasFieldTest:
             }
         }
 
+    @pytest.mark.parametrize('dbfield,value,type,expected', [
+        pytest.param(*p, id=p[0].__name__) for p in [
+            (db.DateTimeField, '2018-05-29T13:15:04.397603', datetime,
+                datetime(2018, 5, 29, 13, 15, 4, 397603)),
+            (db.DateField, '2018-05-29', date, date(2018, 5, 29)),
+            (db.BooleanField, 'true', bool, True),
+            (db.IntField, 42, int, 42),
+            (db.StringField, '42', basestring, '42'),
+            (db.FloatField, '42.0', float, 42.0),
+    ]])
+    def test_can_parse_registered_data(self, dbfield, value, type, expected):
+        Fake, FakeForm = self.factory()
+
+        Fake.extras.register('my:extra', dbfield)
+
+        fake = Fake()
+        form = FakeForm(MultiDict({'extras': {'my:extra': value}}))
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(fake)
+
+        assert isinstance(fake.extras['my:extra'], type)
+        assert fake.extras['my:extra'] == expected
+
     def test_with_invalid_registered_data(self):
         Fake, FakeForm = self.factory()
 

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -85,10 +85,8 @@ class ExtrasFieldTest:
         Fake, FakeForm = self.factory()
 
         @Fake.extras('dict')
-        class ExtraDict(db.Extra):
-            def validate(self, value):
-                if not isinstance(value, dict):
-                    raise db.ValidationError('Should be a dict instance')
+        class Custom(db.DictField):
+            pass
 
         fake = Fake()
         form = FakeForm(MultiDict({'extras': {
@@ -155,20 +153,3 @@ class ExtrasFieldTest:
         form.validate()
         assert 'extras' in form.errors
         assert 'my:extra' in form.errors['extras']
-
-    def test_with_invalid_registered_data(self):
-        Fake, FakeForm = self.factory()
-
-        @Fake.extras('dict')
-        class ExtraDict(db.Extra):
-            def validate(self, value):
-                if not isinstance(value, dict):
-                    raise db.ValidationError('Should be a dict instance')
-
-        form = FakeForm(MultiDict({'extras': {
-            'dict': 42
-        }}))
-
-        form.validate()
-        assert 'extras' in form.errors
-        assert len(form.errors['extras']) == 1

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -137,6 +137,25 @@ class ExtrasFieldTest:
         assert isinstance(fake.extras['my:extra'], type)
         assert fake.extras['my:extra'] == expected
 
+    @pytest.mark.parametrize('dbfield,value', [
+        pytest.param(*p, id=p[0].__name__) for p in [
+            (db.DateTimeField, 'xxxx'),
+            (db.DateField, 'xxxx'),
+            (db.IntField, 'xxxx'),
+            (db.StringField, 42),
+            (db.FloatField, 'xxxx'),
+    ]])
+    def test_fail_bad_registered_data(self, dbfield, value):
+        Fake, FakeForm = self.factory()
+
+        Fake.extras.register('my:extra', dbfield)
+
+        form = FakeForm(MultiDict({'extras': {'my:extra': value}}))
+
+        form.validate()
+        assert 'extras' in form.errors
+        assert 'my:extra' in form.errors['extras']
+
     def test_with_invalid_registered_data(self):
         Fake, FakeForm = self.factory()
 


### PR DESCRIPTION
This PR ensures registered extras attributes are properly parsed from JSON (or any forms).
It also remove the need for `db.Extra` as registered types can only be a subclass of Mongoengine `BaseField` or `EmbeddedDocument`.

`EmbeddedDocument` support might lack the advanced parsing part. (Should be in another PR when use cases comes)

Requires #1698 (which is included here)