### PR TITLE
Use all space available to display previews

### DIFF
--- a/js/front/dataset/preview-modal.vue
+++ b/js/front/dataset/preview-modal.vue
@@ -23,3 +23,15 @@ export default {
     components: {Modal}
 };
 </script>
+
+<style lang="less">
+@import "~less/udata/variables.less";
+
+@media (min-width: @screen-sm-min) {
+    .preview-modal {
+        .modal-dialog {
+            width: 99%;
+        }
+    }
+}
+</style>

--- a/js/front/dataset/resource-modal.vue
+++ b/js/front/dataset/resource-modal.vue
@@ -1,6 +1,5 @@
 <template>
-<modal class="resource-modal" v-ref:modal
-    :title="resource.title">
+<modal class="resource-modal" v-ref:modal :title="resource.title">
 
     <div class="modal-body">
         {{{ resource.description|markdown }}}


### PR DESCRIPTION
This PR extend the preview modal to 99% of the viewport for non-mobile devices (modal already take the full width on mobile devices)