### PR TITLE
Show resource type in modal (front)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Register known extras types [#1700](https://github.com/opendatateam/udata/pull/1700)
 - Fix 404/missing css on front pages [#1709](https://github.com/opendatateam/udata/pull/1709)
 - Fix markdown max image width (front) [#1707](https://github.com/opendatateam/udata/pull/1707)
+- Show resource type in modal (front) [#1714](https://github.com/opendatateam/udata/pull/1714)
 
 ## 1.3.12 (2018-05-31)
 

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -24,7 +24,6 @@ import ShareButton from 'components/buttons/share.vue';
 import IntegrateButton from 'components/buttons/integrate.vue';
 import IssuesButton from 'components/buttons/issues.vue';
 import DiscussionThreads from 'components/discussions/threads.vue';
-import resource_types from 'models/resource_types';
 
 
 function parseUrl(url) {
@@ -102,6 +101,7 @@ new Vue({
                 modified: resourceJsonLd.dateModified,
                 published: resourceJsonLd.datePublished,
                 description: resourceJsonLd.description,
+                type: resourceJsonLd.type,
             };
             if (resourceJsonLd.interactionStatistic) {
                 resource.metrics = {


### PR DESCRIPTION
I had to do some very convoluted stuff (https://github.com/opendatateam/udata/pull/1714/files#diff-a2d75a95cf3f2bde33208a75029b76a9R76) to make sure it shows up both when opening the modal from the dataset page and via a deeplink.

Ideally there is a way to make this filter await on the loading of `resource_types` but I did not find how: https://github.com/opendatateam/udata/blob/master/js/components/dataset/filters.js#L28.