### PR TITLE
Harvest config backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix markdown max image width (front) [#1707](https://github.com/opendatateam/udata/pull/1707)
 - Adds ETag to internal avatar for efficient caching control [#1712](https://github.com/opendatateam/udata/pull/1712)
 - Show resource type in modal (front) [#1714](https://github.com/opendatateam/udata/pull/1714)
+- Starts using harvest backend `config` (validation, API exposition, `HarvestFilters`...) [#1716](https://github.com/opendatateam/udata/pull/1716)
 
 ## 1.3.12 (2018-05-31)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -742,3 +742,12 @@ class ExtrasField(Field):
 
         return not bool(self.errors)
 
+
+class DictField(Field):
+    def process_formdata(self, valuelist):
+        if valuelist:
+            data = valuelist[0]
+            if isinstance(data, dict):
+                self.data = data
+            else:
+                raise ValueError('Unsupported data type')

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -63,7 +63,8 @@ def create_source(name, url, backend,
                   description=None,
                   frequency=DEFAULT_HARVEST_FREQUENCY,
                   owner=None,
-                  organization=None):
+                  organization=None,
+                  config=None):
     '''Create a new harvest source'''
     if owner and not isinstance(owner, User):
         owner = User.get(owner)
@@ -78,7 +79,8 @@ def create_source(name, url, backend,
         description=description,
         frequency=frequency or DEFAULT_HARVEST_FREQUENCY,
         owner=owner,
-        organization=organization
+        organization=organization,
+        config=config,
     )
     signals.harvest_source_created.send(source)
     return source

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -64,7 +64,8 @@ def create_source(name, url, backend,
                   frequency=DEFAULT_HARVEST_FREQUENCY,
                   owner=None,
                   organization=None,
-                  config=None):
+                  config=None,
+                  ):
     '''Create a new harvest source'''
     if owner and not isinstance(owner, User):
         owner = User.get(owner)

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -121,9 +121,19 @@ source_fields = api.model('HarvestSource', {
 source_page_fields = api.model('HarvestSourcePage',
                                fields.pager(source_fields))
 
+
+filter_fields = api.model('HarvestFilter', {
+    'label': fields.String(description='A localized human-readable label'),
+    'key': fields.String(description='The filter key'),
+    'type': fields.String(description='The filter expected type'),
+    'description': fields.String(description='The filter details'),
+})
+
 backend_fields = api.model('HarvestBackend', {
     'id': fields.String(description='The backend identifier'),
-    'label': fields.String(description='The backend display name')
+    'label': fields.String(description='The backend display name'),
+    'filters': fields.List(fields.Nested(filter_fields),
+                           description='The backend supported filters'),
 })
 
 preview_dataset_fields = api.clone('DatasetPreview', dataset_fields, {
@@ -289,8 +299,11 @@ class ListBackendsAPI(API):
     def get(self):
         '''List all available harvest backends'''
         return sorted([
-            {'id': b.name, 'label': b.display_name}
-            for b in actions.list_backends()
+            {
+                'id': b.name,
+                'label': b.display_name,
+                'filters': [f.as_dict() for f in b.filters],
+            } for b in actions.list_backends()
         ], key=lambda b: b['label'])
 
 

--- a/udata/harvest/backends/__init__.py
+++ b/udata/harvest/backends/__init__.py
@@ -17,4 +17,4 @@ def get_all(app):
     return get_enabled('udata.harvesters', app)
 
 
-from .base import BaseBackend  # flake8: noqa
+from .base import BaseBackend, HarvestFilter  # flake8: noqa

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -59,7 +59,7 @@ class BaseBackend(object):
     verify_ssl = True
 
     # Define some allowed filters on the backend
-    # This a  Sequence[HarvestFilter]
+    # This a Sequence[HarvestFilter]
     filters = tuple()
 
     def __init__(self, source, job=None, dryrun=False, max_items=None):

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -26,6 +26,7 @@ requests.packages.urllib3.disable_warnings()
 class HarvestFilter(object):
     TYPES = {
         str: 'string',
+        basestring: 'string',
         int: 'integer',
         bool: 'boolean',
         UUID: 'uuid',
@@ -59,7 +60,7 @@ class BaseBackend(object):
 
     # Define some allowed filters on the backend
     # This a  Sequence[HarvestFilter]
-    filters = []
+    filters = tuple()
 
     def __init__(self, source, job=None, dryrun=False, max_items=None):
         self.source = source

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals, print_function
 import logging
 import traceback
 
-from datetime import datetime
+from datetime import datetime, date
+from uuid import UUID
 
 import requests
 
@@ -22,10 +23,31 @@ log = logging.getLogger(__name__)
 requests.packages.urllib3.disable_warnings()
 
 
-MAPPABLE = (
-    'tags',
-    'license',
-)
+class HarvestFilter(object):
+    TYPES = {
+        str: 'string',
+        int: 'integer',
+        bool: 'boolean',
+        UUID: 'uuid',
+        datetime: 'date-time',
+        date: 'date',
+    }
+
+    def __init__(self, label, key, type, description=None):
+        if type not in self.TYPES:
+            raise TypeError('Unsupported type {0}'.format(type))
+        self.label = label
+        self.key = key
+        self.type = type
+        self.description = description
+
+    def as_dict(self):
+        return {
+            'label': self.label,
+            'key': self.key,
+            'type': self.TYPES[self.type],
+            'description': self.description,
+        }
 
 
 class BaseBackend(object):
@@ -34,6 +56,10 @@ class BaseBackend(object):
     name = None
     display_name = None
     verify_ssl = True
+
+    # Define some allowed filters on the backend
+    # This a  Sequence[HarvestFilter]
+    filters = []
 
     def __init__(self, source, job=None, dryrun=False, max_items=None):
         self.source = source

--- a/udata/harvest/forms.py
+++ b/udata/harvest/forms.py
@@ -11,6 +11,38 @@ from .models import VALIDATION_STATES, VALIDATION_REFUSED
 __all__ = 'HarvestSourceForm', 'HarvestSourceValidationForm'
 
 
+class HarvestConfigField(fields.DictField):
+    '''
+    A DictField with extras validations on known configurations
+    '''
+    def get_backend(self, form):
+        return [
+            b for b in list_backends() if b.name == form.backend.data
+        ][0]
+
+    def get_specs(self, backend, key):
+        candidates = [f for f in backend.filters if f.key == key]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def pre_validate(self, form):
+        if self.data:
+            backend = self.get_backend(form)
+            # Validate filters
+            for f in (self.data.get('filters', None) or []):
+                if not ('key' in f and 'value' in f):
+                    msg = 'A field should have both key and value properties'
+                    raise validators.ValidationError(msg)
+                specs = self.get_specs(backend, f['key'])
+                if not specs:
+                    msg = 'Unknown filter key "{0}" for "{1}" backend'
+                    msg = msg.format(f['key'], backend.name)
+                    raise validators.ValidationError(msg)
+                if not isinstance(f['value'], specs.type):
+                    msg = '"{0}" filter should of type "{1}"'
+                    msg = msg.format(specs.key, specs.type.__name__)
+                    raise validators.ValidationError(msg)
+
+
 class HarvestSourceForm(Form):
     name = fields.StringField(_('Name'), [validators.required()])
     description = fields.MarkdownField(
@@ -22,6 +54,8 @@ class HarvestSourceForm(Form):
     ])
     owner = fields.CurrentUserField()
     organization = fields.PublishAsField(_('Publish as'))
+
+    config = HarvestConfigField()
 
 
 class HarvestSourceValidationForm(Form):

--- a/udata/harvest/forms.py
+++ b/udata/harvest/forms.py
@@ -16,19 +16,17 @@ class HarvestConfigField(fields.DictField):
     A DictField with extras validations on known configurations
     '''
     def get_backend(self, form):
-        return [
-            b for b in list_backends() if b.name == form.backend.data
-        ][0]
+        return next(b for b in list_backends() if b.name == form.backend.data)
 
     def get_specs(self, backend, key):
-        candidates = [f for f in backend.filters if f.key == key]
-        return candidates[0] if len(candidates) == 1 else None
+        candidates = (f for f in backend.filters if f.key == key)
+        return next(candidates, None)
 
     def pre_validate(self, form):
         if self.data:
             backend = self.get_backend(form)
             # Validate filters
-            for f in (self.data.get('filters', None) or []):
+            for f in (self.data.get('filters') or []):
                 if not ('key' in f and 'value' in f):
                     msg = 'A field should have both key and value properties'
                     raise validators.ValidationError(msg)

--- a/udata/harvest/tests/factories.py
+++ b/udata/harvest/tests/factories.py
@@ -49,6 +49,10 @@ DEFAULT_COUNT = 3
 
 class FactoryBackend(backends.BaseBackend):
     name = 'factory'
+    filters = (
+        backends.HarvestFilter('Test', 'test', int),
+        backends.HarvestFilter('Tag', 'tag', basestring),
+    )
 
     def initialize(self):
         mock_initialize.send(self)

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -141,6 +141,18 @@ class HarvestActionsTest:
         assert source.validation.by is None
         assert source.validation.comment is None
 
+    def test_create_source_with_config(self):
+        source_url = faker.url()
+        config = {'filters': [{'key': 'test', 'value': 42}]}
+
+        with assert_emit(signals.harvest_source_created):
+            source = actions.create_source('Test source',
+                                           source_url,
+                                           'factory',
+                                           config=config)
+
+        assert source.config == config
+
     def test_update_source(self):
         source = HarvestSourceFactory()
         data = source.to_dict()

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -34,6 +34,8 @@ class HarvestAPITest(MockBackendsMixin):
         for data in response.json:
             assert 'id' in data
             assert 'label' in data
+            assert 'filters' in data
+            assert isinstance(data['filters'], (list, tuple))
 
     def test_list_sources(self, api):
         sources = HarvestSourceFactory.create_batch(3)

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -119,8 +119,8 @@ class HarvestAPITest(MockBackendsMixin):
 
         assert403(response)
 
-    def test_create_source_with_config(self,api):
-        '''It should create anew source with configuration'''
+    def test_create_source_with_config(self, api):
+        '''It should create a new source with configuration'''
         api.login()
         data = {
             'name': faker.word(),

--- a/udata/tests/forms/test_dict_field.py
+++ b/udata/tests/forms/test_dict_field.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from datetime import date, datetime
+from uuid import UUID
+
+from werkzeug.datastructures import MultiDict
+
+from udata.forms import fields, ModelForm
+from udata.models import db
+
+pytestmark = [
+    pytest.mark.usefixtures('app')
+]
+
+
+class DictFieldTest:
+
+    def factory(self):
+        class Fake(db.Document):
+            raw = db.DictField()
+
+        class FakeForm(ModelForm):
+            model_class = Fake
+            raw = fields.DictField()
+
+        return Fake, FakeForm
+
+    def test_empty_data(self):
+        Fake, FakeForm = self.factory()
+
+        fake = Fake()
+        form = FakeForm()
+        form.populate_obj(fake)
+
+        assert fake.raw == {}
+
+    def test_with_valid_data(self):
+        Fake, FakeForm = self.factory()
+
+        now = datetime.now()
+        today = date.today()
+
+        fake = Fake()
+        form = FakeForm(MultiDict({'raw': {
+            'integer': 42,
+            'float': 42.0,
+            'string': 'value',
+            'datetime': now,
+            'date': today,
+            'bool': True,
+            'dict': {'key': 'value'}
+        }}))
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(fake)
+
+        assert fake.raw == {
+            'integer': 42,
+            'float': 42.0,
+            'string': 'value',
+            'datetime': now,
+            'date': today,
+            'bool': True,
+            'dict': {'key': 'value'}
+        }
+
+    def test_with_invalid_data(self):
+        Fake, FakeForm = self.factory()
+
+        form = FakeForm(MultiDict({'raw': 42}))
+
+        form.validate()
+        assert 'raw' in form.errors
+        assert len(form.errors['raw']) == 1


### PR DESCRIPTION
This PR:
- allows harvest backends to register their allowed filters
- expose backends filters in the API
- ensure the `HarvestSource.config` object is properly writable (with validation)
- Starts testing the base backend class

Requires #1715  (included)