### PR TITLE
Delete dataset reference in community resource when deleted

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -673,7 +673,7 @@ class CommunityResource(ResourceMixin, WithMetrics, db.Owned, db.Document):
     Local file, remote file or API added by the community of the users to the
     original dataset
     '''
-    dataset = db.ReferenceField(Dataset)
+    dataset = db.ReferenceField(Dataset, reverse_delete_rule=db.NULLIFY)
 
     meta = {
         'ordering': ['-created_at'],

--- a/udata/migrations/2018-06-07-community-resources-remove-references-to-deleted-datasets.js
+++ b/udata/migrations/2018-06-07-community-resources-remove-references-to-deleted-datasets.js
@@ -1,0 +1,18 @@
+/**
+ * Delete references to deleted datasets from CommunityResources
+ */
+
+var deleted = 0;
+
+db.community_resource.find().forEach(function(resource) {
+    var cursor = db.dataset.find({'_id' : resource.dataset});
+    if (cursor.hasNext() == false) {
+        db.community_resource.update(
+            {_id: resource._id},
+            {$unset: {dataset: true}}
+        );
+        deleted++;
+    }
+});
+
+print(`${deleted} community resources' dataset references removed.`);

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -113,6 +113,13 @@ class DatasetModelTest:
         assert dataset.community_resources[1].id == community_resource1.id
         assert dataset.community_resources[0].id == community_resource2.id
 
+    def test_community_resource_deleted_dataset(self):
+        dataset = DatasetFactory()
+        community_resource = CommunityResourceFactory(dataset=dataset)
+        community_resource.dataset.delete()
+        community_resource.reload()
+        assert community_resource.dataset is None
+
     def test_next_update_empty(self):
         dataset = DatasetFactory()
         assert dataset.next_update is None


### PR DESCRIPTION
Fix [WWW-DATAGOUVFR-74AT](https://sentry.data.gouv.fr/etalab/www-datagouvfr/issues/615128/)

This crashes the community resources list API.

It might be a little strange to leave community resources hanging in the air after their dataset is deleted, but we probably don't want to remove them either.