### PR TITLE
Failsafe JS cache storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Fix community resource creation and display [#1733](https://github.com/opendatateam/udata/pull/1733)
-- Failsafe JS cache storage: use a custom in-memory storage as fallback when access to `sessionStorage` is not allowed
+- Failsafe JS cache storage: use a custom in-memory storage as fallback when access to `sessionStorage` is not allowed [#1742](https://github.com/opendatateam/udata/pull/1742)
 
 ## 1.4.0 (2018-06-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix community resource creation and display [#1733](https://github.com/opendatateam/udata/pull/1733)
+- Failsafe JS cache storage: use a custom in-memory storage as fallback when access to `sessionStorage` is not allowed
 
 ## 1.4.0 (2018-06-06)
 

--- a/js/cache.js
+++ b/js/cache.js
@@ -60,10 +60,12 @@ export class Cache {
         this.rekey = new RegExp(`^${this.prefix}`);
         try {
             this.storage = sessionStorage;
+            // Force error if sessions storage is simply not defined
+            if (!this.storage) throw Error('Session storage is missing');
         } catch(e) {
             // Session storage access is not allowed (browser privacy settings)
             // A warning is issued in the console
-            const msg = `Access to sessionStorage is not allowed.\
+            const msg = `Access to sessionStorage is not possible.\
             "${namespace}" cache performances will be degraded`;
             console.warn(msg);  // eslint-disable-line no-console
             this.storage = new ShimStorage();

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -75,7 +75,7 @@ export default {
             current: -1,
             query: null,
             show: false,
-            cache: new Cache('site-search', sessionStorage),
+            cache: new Cache('site-search'),
             groups: [
                 group('datasets', this._('Datasets')),
                 group('reuses', this._('Reuses')),

--- a/specs/cache.specs.js
+++ b/specs/cache.specs.js
@@ -10,14 +10,20 @@ describe('Cache', function() {
     });
 
     it('store and retrieve value', function() {
-        const cache = new Cache('cache', sessionStorage);
+        const cache = new Cache('cache');
 
         cache.set('key', 'value');
         expect(cache.get('key')).to.equal('value');
     });
 
+    it('returns undefined if key does not exists', function() {
+        const cache = new Cache('cache');
+
+        expect(cache.get('key')).to.be.undefined;
+    });
+
     it('store and retrieve value with TTL', function() {
-        const cache = new Cache('cache', sessionStorage);
+        const cache = new Cache('cache');
 
         cache.set('key', 'value', 10);
         expect(cache.get('key')).to.equal('value');
@@ -25,7 +31,7 @@ describe('Cache', function() {
 
     it('expire value with default TTL', function(done) {
         const TTL = 1;
-        const cache = new Cache('cache', sessionStorage, TTL);
+        const cache = new Cache('cache', TTL);
 
         cache.set('key', 'value');
 
@@ -37,7 +43,7 @@ describe('Cache', function() {
 
     it('expire value with TTL', function(done) {
         const TTL = 1;
-        const cache = new Cache('cache', sessionStorage);
+        const cache = new Cache('cache');
 
         cache.set('key', 'value', TTL);
 
@@ -48,7 +54,7 @@ describe('Cache', function() {
     });
 
     it('list all keys', function() {
-        const cache = new Cache('cache', sessionStorage);
+        const cache = new Cache('cache');
         const nbkeys = 3;
 
         sessionStorage.setItem('unrelated-key', 'value');
@@ -61,7 +67,7 @@ describe('Cache', function() {
     });
 
     it('remove a value', function() {
-        const cache = new Cache('cache', sessionStorage);
+        const cache = new Cache('cache');
 
         cache.set('key', 'value');
         cache.remove('key');
@@ -69,7 +75,7 @@ describe('Cache', function() {
     });
 
     it('clear/remove all keys', function() {
-        const cache = new Cache('cache', sessionStorage);
+        const cache = new Cache('cache');
         const nbkeys = 3;
 
         sessionStorage.setItem('unrelated-key', 'value');


### PR DESCRIPTION
This PR ensure cache does not fail for the following cases:
- `sessionStorage` access is prevented by the browser privacy settings (`SecurityError` like https://sentry.data.gouv.fr/share/issue/6e2138d8a4744316aefa77ef09b27521/)
- `sessionStorage` is not defined (some mobile browser simply don't have it)

A fallback shim storage is provided with limited performances and it won't survive a page reload or next page display.
A warning message is issued in the console in this case.

