### PR TITLE
Cleaner harvest validation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix community resource creation and display [#1733](https://github.com/opendatateam/udata/pull/1733)
 - Failsafe JS cache storage: use a custom in-memory storage as fallback when access to `sessionStorage` is not allowed [#1742](https://github.com/opendatateam/udata/pull/1742)
 - Prevent errors when handling API errors without data/payload [#1743](https://github.com/opendatateam/udata/pull/1743)
+- Improve/fix validation error formatting on harvesting [#1745](https://github.com/opendatateam/udata/pull/1745)
 
 ## 1.4.0 (2018-06-06)
 

--- a/udata/harvest/tests/test_base_backend.py
+++ b/udata/harvest/tests/test_base_backend.py
@@ -5,6 +5,8 @@ import pytest
 
 from datetime import datetime
 
+from voluptuous import Schema
+
 from udata.utils import faker
 from udata.core.dataset.factories import DatasetFactory
 from udata.models import Dataset
@@ -12,6 +14,7 @@ from udata.models import Dataset
 from .factories import HarvestSourceFactory
 
 from ..backends import BaseBackend, HarvestFilter
+from ..exceptions import HarvestException
 
 
 class Unknown:
@@ -50,6 +53,7 @@ class HarvestFilterTest:
             HarvestFilter(faker.word(), faker.word(), type, faker.sentence())
 
 
+@pytest.mark.usefixtures('clean_db')
 class BaseBackendTest:
     def test_simple_harvest(self):
         nb_datasets = 3
@@ -66,3 +70,83 @@ class BaseBackendTest:
             assert dataset.extras['harvest:remote_id'].startswith('fake-')
             datetime.strptime(dataset.extras['harvest:last_update'],
                               '%Y-%m-%dT%H:%M:%S.%f')
+
+
+@pytest.mark.usefixtures('clean_db')
+class BaseBackendValidateTest:
+    @pytest.fixture
+    def validate(self):
+        return FakeBackend(HarvestSourceFactory()).validate
+
+    def test_valid_data(self, validate):
+        schema = Schema({'key': basestring})
+        data = {'key': 'value'}
+        assert validate(data, schema) == data
+
+    def test_handle_basic_error(self, validate):
+        schema = Schema({'bad-value': basestring})
+        data = {'bad-value': 42}
+        with pytest.raises(HarvestException) as excinfo:
+            validate(data, schema)
+        msg = str(excinfo.value)
+        assert '[bad-value] expected basestring: 42' in msg
+
+    def test_handle_required_values(self, validate):
+        schema = Schema({'missing': basestring}, required=True)
+        data = {}
+        with pytest.raises(HarvestException) as excinfo:
+            validate(data, schema)
+        msg = str(excinfo.value)
+        assert '[missing] required key not provided' in msg
+        assert '[missing] required key not provided: None' not in msg
+
+    def test_handle_multiple_errors_on_object(self, validate):
+        schema = Schema({'bad-value': basestring, 'other-bad-value': int})
+        data = {'bad-value': 42, 'other-bad-value': 'wrong'}
+        with pytest.raises(HarvestException) as excinfo:
+            validate(data, schema)
+        msg = str(excinfo.value)
+        assert '[bad-value] expected basestring: 42' in msg
+        assert '[other-bad-value] expected int: wrong' in msg
+
+    def test_handle_multiple_error_on_nested_object(self, validate):
+        schema = Schema({'nested': {
+            'bad-value': basestring, 'other-bad-value': int
+        }})
+        data = {'nested': {'bad-value': 42, 'other-bad-value': 'wrong'}}
+        with pytest.raises(HarvestException) as excinfo:
+            validate(data, schema)
+        msg = str(excinfo.value)
+        assert '[nested.bad-value] expected basestring: 42' in msg
+        assert '[nested.other-bad-value] expected int: wrong' in msg
+
+    def test_handle_multiple_error_on_nested_list(self, validate):
+        schema = Schema({'nested': [
+            {'bad-value': basestring, 'other-bad-value': int}
+        ]})
+        data = {'nested': [
+            {'bad-value': 42, 'other-bad-value': 'wrong'},
+        ]}
+        with pytest.raises(HarvestException) as excinfo:
+            validate(data, schema)
+        msg = str(excinfo.value)
+        assert '[nested.0.bad-value] expected basestring: 42' in msg
+        assert '[nested.0.other-bad-value] expected int: wrong' in msg
+
+    # See: https://github.com/alecthomas/voluptuous/pull/330
+    @pytest.mark.skip(reason='Not yet supported by Voluptuous')
+    def test_handle_multiple_error_on_nested_list_items(self, validate):
+        schema = Schema({'nested': [
+            {'bad-value': basestring, 'other-bad-value': int}
+        ]})
+        data = {'nested': [
+            {'bad-value': 42, 'other-bad-value': 'wrong'},
+            {'bad-value': 43, 'other-bad-value': 'bad'},
+        ]}
+        with pytest.raises(HarvestException) as excinfo:
+            validate(data, schema)
+        msg = str(excinfo.value)
+        assert '[nested.0.bad-value] expected basestring: 42' in msg
+        assert '[nested.0.other-bad-value] expected int: wrong' in msg
+        assert '[nested.1.bad-value] expected basestring: 43' in msg
+        assert '[nested.1.other-bad-value] expected int: bad' in msg


### PR DESCRIPTION
This PR fixes and cleanup harvest messages:
- Validation is now tested
- Multiple validation errors are properly serialized with their field name
- Missing required field is now properly formatted

The validation error was always formatted like this:
```
Validation error:
- [field] expected basestring for dictionnary key: 42
- expected basestring for dictionnary key: 42
- expected basestring for dictionnary key: 42
- required key not provided: None
```
they will now be formatted like this:
```
Validation error:
- [field] expected basestring: 42
- [other] expected basestring: 43
- [nested.key] expected int: wrong
- [nested.missing] required key not provided
```