### PR TITLE
Can parse iso datetime in daterange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Failsafe JS cache storage: use a custom in-memory storage as fallback when access to `sessionStorage` is not allowed [#1742](https://github.com/opendatateam/udata/pull/1742)
 - Prevent errors when handling API errors without data/payload [#1743](https://github.com/opendatateam/udata/pull/1743)
 - Improve/fix validation error formatting on harvesting [#1745](https://github.com/opendatateam/udata/pull/1745)
+- Ensure daterange can be parsed from full iso datetime [#1748](https://github.com/opendatateam/udata/pull/1748)
 
 ## 1.4.0 (2018-06-06)
 

--- a/udata/tests/test_utils.py
+++ b/udata/tests/test_utils.py
@@ -51,6 +51,28 @@ class DateRangeTest:
         assert daterange_end(None) is None
         assert daterange_end('') is None
 
+    def test_parse_daterange_start_date(self):
+        today = date.today()
+        assert daterange_start(today) == today
+
+    def test_parse_daterange_end_date(self):
+        today = date.today()
+        assert daterange_end(today) == today
+
+    def test_parse_daterange_start_datetime(self):
+        now = datetime.now()
+        assert daterange_start(now) == now.date()
+
+    def test_parse_daterange_end_datetime(self):
+        now = datetime.now()
+        assert daterange_end(now) == now.date()
+
+    def test_parse_daterange_start_full_iso(self):
+        assert daterange_start('1984-06-07T00:00:00+00:00') == date(1984, 6, 7)
+
+    def test_parse_daterange_end_full_iso(self):
+        assert daterange_end('1984-06-07T00:00:00+00:00') == date(1984, 6, 7)
+
     def test_parse_daterange_start_full(self):
         assert daterange_start('1984-06-07') == date(1984, 6, 7)
 


### PR DESCRIPTION
This PR improve daterange parsing to handle iso datetimes.

See https://sentry.data.gouv.fr/share/issue/bcc9e83697b34fed82f4bde84695d879/ for an example of harvested iso daterange failing.

Parser also properly handle `date` and `datetime` values.