### PR TITLE
API: enforce application/json content-type for forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prevent errors when handling API errors without data/payload [#1743](https://github.com/opendatateam/udata/pull/1743)
 - Improve/fix validation error formatting on harvesting [#1745](https://github.com/opendatateam/udata/pull/1745)
 - Ensure daterange can be parsed from full iso datetime [#1748](https://github.com/opendatateam/udata/pull/1748)
+- API: enforce application/json content-type for forms [#1751](https://github.com/opendatateam/udata/pull/1751)
 
 ## 1.4.0 (2018-06-06)
 

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -135,6 +135,9 @@ class UDataApi(Api):
 
     def validate(self, form_cls, obj=None):
         '''Validate a form from the request and handle errors'''
+        if 'application/json' not in request.headers.get('Content-Type'):
+            errors = {'Content-Type': 'expecting application/json'}
+            self.abort(400, errors=errors)
         form = form_cls.from_json(request.json, obj=obj, instance=obj,
                                   csrf_enabled=False)
         if not form.validate():

--- a/udata/tests/api/test_base_api.py
+++ b/udata/tests/api/test_base_api.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from flask import url_for
 
 from udata.api import api, API
+from udata.forms import Form, fields
 
 from . import APITestCase
 
@@ -16,7 +17,16 @@ class FakeAPI(API):
         return {'success': True}
 
 
-class APIAuthTest(APITestCase):
+@ns.route('/fake-form', endpoint='fake-form')
+class FakeFormAPI(API):
+    def post(self):
+        class FakeForm(Form):
+            pass
+        api.validate(FakeForm)
+        return {'success': True}
+
+
+class OptionsCORSTest(APITestCase):
     def test_should_allow_options_and_cors(self):
         '''Should allow OPTIONS operation and give cors parameters'''
         response = self.client.options(url_for('api.fake-options'))
@@ -27,3 +37,21 @@ class APIAuthTest(APITestCase):
         self.assertIn('HEAD', allowed_methods)
         self.assertIn('OPTIONS', allowed_methods)
         self.assertIn('GET', allowed_methods)
+
+
+class JSONFormRequestTest(APITestCase):
+    def test_non_json_content_type(self):
+        '''We expect JSON requests for forms and enforce it'''
+        response = self.client.post(url_for('api.fake-form'), {}, headers={
+            'Content-Type': 'multipart/form-data'
+        })
+        self.assert400(response)
+        self.assertEquals(
+            response.json,
+            {'errors': {'Content-Type': 'expecting application/json'}}
+        )
+
+    def test_json_content_type(self):
+        '''We expect JSON requests for forms and enforce it'''
+        response = self.post(url_for('api.fake-form'), {})
+        self.assert200(response)


### PR DESCRIPTION
I stumbled into this morning when making a script using the API. I forgot to set the `Content-Type` header and I got some cryptic 500 errors (`ExtrasField` validation failing) which sent me down a rabbit hole until I realized my rookie mistake.

This may not be the best place to enforce this, but I think we should do it somewhere.