### PR TITLE
Skip gov.uk references when unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Sort dataset update frequencies by ascending frequency [#1758](https://github.com/opendatateam/udata/pull/1758)
+- Skip gov.uk references tests when site is unreachable [#1767](https://github.com/opendatateam/udata/pull/1767)
 
 ## 1.4.1 (2018-06-15)
 

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import requests
 import pytest
 
 from datetime import date
@@ -36,6 +37,15 @@ FREQ_SAMPLE = [
     (FREQ.daily, 'daily'),
     (FREQ.continuous, 'continuous'),
 ]
+
+GOV_UK_REF = 'http://reference.data.gov.uk/id/year/2017'
+
+try:
+    requests.head(GOV_UK_REF, timeout=0.1)
+except requests.exceptions.RequestException:
+    GOV_UK_REF_IS_UP = False
+else:
+    GOV_UK_REF_IS_UP = True
 
 
 @pytest.mark.frontend
@@ -702,6 +712,8 @@ class RdfToDatasetTest:
         assert daterange.start, date(2017, 6 == 1)
         assert daterange.end, date(2017, 6 == 30)
 
+    @pytest.mark.skipif(not GOV_UK_REF_IS_UP,
+                        reason='Gov.uk references is unreachable')
     def test_parse_temporal_as_gov_uk_format(self):
         node = URIRef('http://reference.data.gov.uk/id/year/2017')
         g = Graph()


### PR DESCRIPTION
This PR prevents test suite to fail when references.gov.uk pages are not reachable.