### PR TITLE
Test are run against local.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Sort dataset update frequencies by ascending frequency [#1758](https://github.com/opendatateam/udata/pull/1758)
 - Skip gov.uk references tests when site is unreachable [#1767](https://github.com/opendatateam/udata/pull/1767)
+- Tests are now run against `local.test` instead of `localhost` to avoid pytest warnings
 
 ## 1.4.1 (2018-06-15)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -323,14 +323,15 @@ class Testing(object):
     CACHE_TYPE = 'null'
     CACHE_NO_NULL_WARNING = True
     DEBUG_TOOLBAR = False
-    SERVER_NAME = 'localhost'
+    SERVER_NAME = 'local.test'
     DEFAULT_LANGUAGE = 'en'
     ACTIVATE_TERRITORIES = False
     LOGGER_HANDLER_POLICY = 'never'
     CELERYD_HIJACK_ROOT_LOGGER = False
     USE_METRICS = False
     RESOURCES_FILE_ALLOWED_DOMAINS = ['*']
-    URLS_ALLOW_LOCAL = True  # Test server URL is localhost
+    URLS_ALLOW_LOCAL = True  # Test server URL is local.test
+    URLS_ALLOWED_TLDS = tld_set | set(['test'])
 
 
 class Debug(Defaults):

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -111,18 +111,18 @@ class OEmbedAPITest:
 
     def test_oembed_with_an_unknown_url(self, api):
         '''It should fail at fetching an oembed with an invalid URL.'''
-        url = url_for('api.oembed', url='http://localhost/somewhere')
+        url = url_for('api.oembed', url='http://local.test/somewhere')
         response = api.get(url)
         assert404(response)
 
     def test_oembed_with_port_in_https_url(self, api):
         '''It should works on HTTPS URLs with explicit port.'''
         dataset = DatasetFactory()
-        url = dataset.external_url.replace('http://localhost/',
-                                           'https://localhost:443/')
+        url = dataset.external_url.replace('http://local.test/',
+                                           'https://local.test:443/')
         api_url = url_for('api.oembed', url=url)
 
-        assert200(api.get(api_url, base_url='https://localhost:443/'))
+        assert200(api.get(api_url, base_url='https://local.test:443/'))
 
     def test_oembed_does_not_support_xml(self, api):
         '''It does not support xml format.'''

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -109,7 +109,7 @@ class DatasetBlueprintTest(FrontTestCase):
                           dataset.created_at.isoformat()[:16])
         self.assertEquals(json_ld['dateModified'][:16],
                           dataset.last_modified.isoformat()[:16])
-        self.assertEquals(json_ld['url'], 'http://localhost{}'.format(url))
+        self.assertEquals(json_ld['url'], 'http://local.test{}'.format(url))
         self.assertEquals(json_ld['name'], dataset.title)
         self.assertEquals(json_ld['keywords'], 'bar,foo')
         self.assertEquals(len(json_ld['distribution']), 1)

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -74,19 +74,19 @@ class MarkdownTest:
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
             assert el.getAttribute('rel') == ''
-            assert el.getAttribute('href') == 'http://localhost/'
+            assert el.getAttribute('href') == 'http://local.test/'
             assert el.getAttribute('data-tooltip') == ''
             assert el.firstChild.data == 'foo'
 
     def test_markdown_linkify_https(self, app):
         '''Markdown filter should transform relative urls with HTTPS'''
         text = '[foo](/foo)'
-        with app.test_request_context('/', base_url='https://localhost'):
+        with app.test_request_context('/', base_url='https://local.test'):
             result = render_template_string('{{ text|markdown }}', text=text)
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
             assert el.getAttribute('rel') == ''
-            assert el.getAttribute('href') == 'https://localhost/foo'
+            assert el.getAttribute('href') == 'https://local.test/foo'
             assert el.getAttribute('data-tooltip') == ''
             assert el.firstChild.data == 'foo'
 
@@ -99,7 +99,7 @@ class MarkdownTest:
             parsed = parser.parse(result)
             el = parsed.getElementsByTagName('a')[0]
             assert el.getAttribute('rel') == ''
-            assert el.getAttribute('href') == 'http://localhost/'
+            assert el.getAttribute('href') == 'http://local.test/'
             assert el.getAttribute('data-tooltip') == 'Source'
             assert el.firstChild.data == 'foo'
 

--- a/udata/tests/frontend/test_organization_frontend.py
+++ b/udata/tests/frontend/test_organization_frontend.py
@@ -52,7 +52,7 @@ class OrganizationBlueprintTest(FrontTestCase):
         self.assertEquals(json_ld['@context'], 'http://schema.org')
         self.assertEquals(json_ld['@type'], 'Organization')
         self.assertEquals(json_ld['alternateName'], organization.slug)
-        self.assertEquals(json_ld['url'], 'http://localhost{}'.format(url))
+        self.assertEquals(json_ld['url'], 'http://local.test{}'.format(url))
         self.assertEquals(json_ld['name'], organization.name)
         self.assertEquals(json_ld['description'], 'Title 1 Title 2')
 

--- a/udata/tests/frontend/test_reuse_frontend.py
+++ b/udata/tests/frontend/test_reuse_frontend.py
@@ -67,7 +67,7 @@ class ReuseBlueprintTest(FrontTestCase):
                           reuse.created_at.isoformat()[:16])
         self.assertEquals(json_ld['dateModified'][:16],
                           reuse.last_modified.isoformat()[:16])
-        self.assertEquals(json_ld['url'], 'http://localhost{}'.format(url))
+        self.assertEquals(json_ld['url'], 'http://local.test{}'.format(url))
         self.assertEquals(json_ld['name'], reuse.title)
         self.assertEquals(json_ld['description'], 'Title 1 Title 2')
         self.assertEquals(json_ld['isBasedOnUrl'], reuse.url)

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -115,7 +115,7 @@ def assert_redirects(response, location, message=None):
     if parts.netloc:
         expected_location = location
     else:
-        expected_location = urljoin('http://localhost', location)
+        expected_location = urljoin('http://local.test', location)
     not_redirect = REDIRECT_MSG.format(response.status_code)
     assert response.status_code in REDIRECT_CODES, message or not_redirect
     assert response.location == expected_location, message

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -345,7 +345,7 @@ class SitemapClient:
         self._sitemap = None
 
     def fetch(self, secure=False):
-        base_url = '{0}://localhost'.format('https' if secure else 'http')
+        base_url = '{0}://local.test'.format('https' if secure else 'http')
         response = self.client.get('sitemap.xml', base_url=base_url)
         assert200(response)
         self._sitemap = etree.fromstring(response.data)


### PR DESCRIPTION
This PR change the tests `SERVER_NAME` from `localhost` to `local.test` to avoid a lot of warnings in the pytest output (making difficult to use test output in case of error)