### PR TITLE
Python 3 backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Sort dataset update frequencies by ascending frequency [#1758](https://github.com/opendatateam/udata/pull/1758)
 - Skip gov.uk references tests when site is unreachable [#1767](https://github.com/opendatateam/udata/pull/1767)
 - Tests are now run against `local.test` instead of `localhost` to avoid pytest warnings
+- Backports some Python 3 forward compatible changes and fixes some bugs [#1769](https://github.com/opendatateam/udata/pull/1769):
+    - avoid `filter` and `map` usage instead of list comprehension
+    - explicit encoding handling
+    - avoid comparison to `None`
+    - use `next()` instead of `.next()` to iterate
+    - unhide some implicit casts (in particular search weight)
 
 ## 1.4.1 (2018-06-15)
 

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -22,8 +22,8 @@ __all__ = ('DatasetForm', 'ResourceForm', 'CommunityResourceForm')
 
 class ChecksumForm(ModelForm):
     model_class = Checksum
-    type = fields.SelectField(choices=zip(CHECKSUM_TYPES, CHECKSUM_TYPES),
-                              default='sha1')
+    choices = list(zip(CHECKSUM_TYPES, CHECKSUM_TYPES))
+    type = fields.SelectField(choices=choices, default='sha1')
     value = fields.StringField()
 
 

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -174,7 +174,7 @@ class DatasetSearch(ModelSearchAdapter):
     def get_suggest_weight(cls, temporal_weight, spatial_weight, featured):
         '''Compute the suggest part of the indexation payload'''
         featured_weight = 1 if not featured else FEATURED_WEIGHT
-        return temporal_weight * spatial_weight * featured_weight
+        return int(temporal_weight * spatial_weight * featured_weight * 10)
 
     @classmethod
     def serialize(cls, dataset):
@@ -214,7 +214,7 @@ class DatasetSearch(ModelSearchAdapter):
             'organization': str(organization.id) if organization else None,
             'owner': str(owner.id) if owner else None,
             'dataset_suggest': {
-                'input': cls.completer_tokenize(dataset.title) + [dataset.id],
+                'input': cls.completer_tokenize(dataset.title) + [str(dataset.id)],
                 'output': dataset.title,
                 'payload': {
                     'id': str(dataset.id),

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -171,5 +171,5 @@ def group_resources_by_type(resources):
     ordered = OrderedDict()
     for rtype, rtype_label in RESOURCE_TYPES.items():
         if groups[rtype]:
-            ordered[(rtype, rtype_label)] = groups[rtype]
+            ordered[(rtype, str(rtype_label))] = groups[rtype]
     return ordered

--- a/udata/core/discussions/tasks.py
+++ b/udata/core/discussions/tasks.py
@@ -52,7 +52,7 @@ def notify_new_discussion_comment(discussion, **kwargs):
         comment = kwargs['message']
         recipients = owner_recipients(discussion) + [
             m.posted_by for m in discussion.discussion]
-        recipients = filter(lambda u: u != comment.posted_by, set(recipients))
+        recipients = [u for u in set(recipients) if u != comment.posted_by]
         subject = _('%(user)s commented your discussion',
                     user=comment.posted_by.fullname)
         mail.send(subject, recipients, 'new_discussion_comment',
@@ -68,7 +68,7 @@ def notify_discussion_closed(discussion, **kwargs):
         comment = kwargs['message']
         recipients = owner_recipients(discussion) + [
             m.posted_by for m in discussion.discussion]
-        recipients = filter(lambda u: u != comment.posted_by, set(recipients))
+        recipients = [u for u in set(recipients) if u != comment.posted_by]
         subject = _('A discussion has been closed')
         mail.send(subject, recipients, 'discussion_closed',
                   discussion=discussion, comment=comment)

--- a/udata/core/issues/tasks.py
+++ b/udata/core/issues/tasks.py
@@ -35,7 +35,7 @@ def notify_new_issue_comment(issue, **kwargs):
         comment = kwargs['message']
         recipients = owner_recipients(issue) + [
             m.posted_by for m in issue.discussion]
-        recipients = filter(lambda u: u != comment.posted_by, set(recipients))
+        recipients = [u for u in set(recipients) if u != comment.posted_by]
         subject = _('%(user)s commented your issue',
                     user=comment.posted_by.fullname)
         mail.send(subject, recipients, 'new_issue_comment',
@@ -50,7 +50,7 @@ def notify_issue_closed(issue, **kwargs):
         comment = kwargs['message']
         recipients = owner_recipients(issue) + [
             m.posted_by for m in issue.discussion]
-        recipients = filter(lambda u: u != comment.posted_by, set(recipients))
+        recipients = [u for u in set(recipients) if u != comment.posted_by]
         subject = _('An issue has been closed')
         mail.send(subject, recipients, 'issue_closed',
                   issue=issue, comment=comment)

--- a/udata/core/jobs/commands.py
+++ b/udata/core/jobs/commands.py
@@ -65,8 +65,8 @@ def run(name, params, delay):
 @grp.command()
 def list():
     '''List all availables jobs'''
-    for job in sorted(schedulables()):
-        echo(job.name)
+    for job in sorted([s.name for s in schedulables()]):
+        echo(job)
 
 
 @grp.command()
@@ -141,7 +141,7 @@ def scheduled():
     '''
     List scheduled jobs.
     '''
-    for job in sorted(schedulables()):
+    for job in sorted(schedulables(), key=lambda s: s.name):
         for task in PeriodicTask.objects(task=job.name):
             label = job_label(task.task, task.args, task.kwargs)
             echo(SCHEDULE_LINE.format(

--- a/udata/core/spatial/search.py
+++ b/udata/core/spatial/search.py
@@ -67,7 +67,7 @@ class GeoZoneSearch(ModelSearchAdapter):
         # NB: to be realy progressive, we should take the max population
         # by administrative level but it would either to much time consumption
         # or too much refactoring (storing the max population by level)
-        population = min(max(0, zone.population), MAX_POPULATION)
+        population = min(max(0, zone.population or 0), MAX_POPULATION)
         population_weight = (population / MAX_POPULATION) * PONDERATION_STEP
         return int(level_weight + population_weight)
 

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -118,7 +118,7 @@ def mdstrip(value, length=None, end='…'):
     rendered = md(value, wrap=False)
     text = do_striptags(rendered)
     text = bleach_clean(text)
-    if length > 0:
+    if length and length > 0:
         text = do_truncate(None, text, length, end=end, leeway=2)
     return text
 

--- a/udata/search/fields.py
+++ b/udata/search/fields.py
@@ -142,7 +142,7 @@ class ModelTermsFacet(TermsFacet):
         ids = [key for (key, doc_count, selected) in values]
         # Perform a model resolution: models are feched from DB
         # We use model field to cast IDs
-        ids = map(self.model_field.to_mongo, ids)
+        ids = [self.model_field.to_mongo(id) for id in ids]
         objects = self.model.objects.in_bulk(ids)
 
         return [

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -332,6 +332,7 @@ class Testing(object):
     RESOURCES_FILE_ALLOWED_DOMAINS = ['*']
     URLS_ALLOW_LOCAL = True  # Test server URL is local.test
     URLS_ALLOWED_TLDS = tld_set | set(['test'])
+    URLS_ALLOW_PRIVATE = False
 
 
 class Debug(Defaults):

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -322,9 +322,9 @@ class DatasetAPITest(APITestCase):
         response = self.put(url_for('api.dataset', dataset=dataset), data)
         self.assert200(response)
         dataset.reload()
-        resource = (
+        resource = next((
             r for r in dataset.resources if r.title == resource_data['title']
-        ).next()
+        ))
         self.assertEqual(resource.extras, {'extra:id': 'id'})
 
     def test_dataset_api_update_existing_resource_with_extras(self):

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -22,8 +22,9 @@ class FrontTestCase(WebTestMixin, SearchTestMixin, TestCase):
         pattern = ('<script id="json_ld" type="application/ld\+json">'
                    '(?P<json_ld>[\s\S]*?)'
                    '</script>')
-        search = re.search(pattern, response.data)
-        self.assertIsNotNone(search, (pattern, response.data))
+        data = response.data.decode('utf8')
+        search = re.search(pattern, data)
+        self.assertIsNotNone(search, (pattern, data))
         json_ld = search.group('json_ld')
         return json.loads(json_ld)
 

--- a/udata/tests/frontend/test_frontend_filters.py
+++ b/udata/tests/frontend/test_frontend_filters.py
@@ -10,6 +10,7 @@ from . import FrontTestCase
 from udata.i18n import I18nBlueprint
 from udata.models import db
 from udata.frontend.helpers import in_url
+from udata.tests.helpers import assert_urls_equal
 
 
 def iso2date(string):
@@ -32,7 +33,7 @@ class FrontEndRootTest(FrontTestCase):
             result = render_template_string(
                 "{{ url_rewrite(one='other-value', two=2) }}")
 
-        self.assertEqual(result, expected)
+        assert_urls_equal(result, expected)
 
     def test_rewrite_append(self):
         '''url_rewrite should replace a parameter in the URL if present'''
@@ -42,7 +43,7 @@ class FrontEndRootTest(FrontTestCase):
         with self.app.test_request_context(url):
             result = render_template_string("{{ url_rewrite(one='value') }}")
 
-        self.assertEqual(result, expected)
+        assert_urls_equal(result, expected)
 
     def test_url_add(self):
         '''url_add should add a parameter to the URL'''
@@ -51,8 +52,8 @@ class FrontEndRootTest(FrontTestCase):
         result = render_template_string(
             "{{ url|url_add(two='other') }}", url=url)
 
-        self.assertEqual(result,
-                         url_for('site.home', one='value', two='other'))
+        assert_urls_equal(result,
+                          url_for('site.home', one='value', two='other'))
 
     def test_url_add_append(self):
         '''url_add should add a parameter to the URL even if exists'''
@@ -62,7 +63,7 @@ class FrontEndRootTest(FrontTestCase):
         result = render_template_string(
             "{{ url|url_add(one='other-value') }}", url=url)
 
-        self.assertEqual(result, expected)
+        assert_urls_equal(result, expected)
 
     def test_url_del_by_name(self):
         '''url_del should delete a parameter by name from the URL'''
@@ -71,7 +72,7 @@ class FrontEndRootTest(FrontTestCase):
 
         result = render_template_string("{{ url|url_del('one') }}", url=url)
 
-        self.assertEqual(result, expected)
+        assert_urls_equal(result, expected)
 
     def test_url_del_by_value(self):
         '''url_del should delete a parameter by value from the URL'''
@@ -81,7 +82,7 @@ class FrontEndRootTest(FrontTestCase):
         result = render_template_string(
             "{{ url|url_del(one='other-value') }}", url=url)
 
-        self.assertEqual(result, expected)
+        assert_urls_equal(result, expected)
 
     def test_url_del_by_value_not_string(self):
         '''url_del should delete a parameter by value from the URL'''
@@ -90,7 +91,7 @@ class FrontEndRootTest(FrontTestCase):
 
         result = render_template_string("{{ url|url_del(one=42) }}", url=url)
 
-        self.assertEqual(result, expected)
+        assert_urls_equal(result, expected)
 
     def test_args_in_url(self):
         '''in_url() should test the presence of a key in url'''
@@ -119,17 +120,17 @@ class FrontEndRootTest(FrontTestCase):
         '''URL helpers should exists as filter'''
         url = url_for('site.home', one='value')
 
-        self.assertEqual(
+        assert_urls_equal(
             render_template_string(
                 "{{ url|url_rewrite(one='other-value') }}", url=url),
             url_for('site.home', one='other-value')
         )
-        self.assertEqual(
+        assert_urls_equal(
             render_template_string(
                 "{{ url|url_add(two='other-value') }}", url=url),
             url_for('site.home', one='value', two='other-value')
         )
-        self.assertEqual(
+        assert_urls_equal(
             render_template_string("{{ url|url_del('one') }}", url=url),
             url_for('site.home')
         )
@@ -138,17 +139,17 @@ class FrontEndRootTest(FrontTestCase):
         '''URL helpers should exists as global function'''
         url = url_for('site.home', one='value')
 
-        self.assertEqual(
+        assert_urls_equal(
             render_template_string(
                 "{{ url_rewrite(url, one='other-value') }}", url=url),
             url_for('site.home', one='other-value')
         )
-        self.assertEqual(
+        assert_urls_equal(
             render_template_string(
                 "{{ url_add(url, two='other-value') }}", url=url),
             url_for('site.home', one='value', two='other-value')
         )
-        self.assertEqual(
+        assert_urls_equal(
             render_template_string("{{ url_del(url, 'one') }}", url=url),
             url_for('site.home')
         )
@@ -158,15 +159,15 @@ class FrontEndRootTest(FrontTestCase):
         url = url_for('site.home', one='value')
 
         with self.app.test_request_context(url):
-            self.assertEqual(
+            assert_urls_equal(
                 render_template_string("{{ url_rewrite(one='other-value') }}"),
                 self.full_url('site.home', one='other-value')
             )
-            self.assertEqual(
+            assert_urls_equal(
                 render_template_string("{{ url_add(two='other-value') }}"),
                 self.full_url('site.home', one='value', two='other-value')
             )
-            self.assertEqual(
+            assert_urls_equal(
                 render_template_string("{{ url_del(None, 'one') }}"),
                 self.full_url('site.home')
             )

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -8,7 +8,7 @@ from udata.mail import mail_sent
 
 from contextlib import contextmanager
 from datetime import timedelta
-from urlparse import urljoin, urlparse
+from urlparse import urljoin, urlparse, parse_qs
 
 from flask import request, url_for, json
 
@@ -203,3 +203,16 @@ def assert_command_ok(result):
     __tracebackhide__ = True
     msg = 'Command failed with exit code {0.exit_code} and output:\n{0.output}'
     assert result.exit_code == 0, msg.format(result)
+
+
+def assert_urls_equal(url1, url2):
+    __tracebackhide__ = True
+    p1 = urlparse(url1)
+    p2 = urlparse(url2)
+    assert p1.scheme == p2.scheme, 'Scheme does not match'
+    assert p1.netloc == p2.netloc, 'Network location does not match'
+    assert p1.path == p2.path, 'Path does not match'
+    q1 = parse_qs(p1.query)
+    q2 = parse_qs(p2.query)
+    assert q1 == q2, 'Query does not match'
+    assert p1.fragment == p2.fragment, 'Fragment does not match'

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -410,7 +410,7 @@ class DiscussionCsvTest(FrontTestCase):
         self.assert200(response)
 
         self.assertEqual(
-            response.data,
+            response.data.decode('utf8'),
             ('"id";"user";"subject";"title";"size";"messages";"created";'
              '"closed";"closed_by"\r\n')
         )

--- a/udata/tests/test_i18n.py
+++ b/udata/tests/test_i18n.py
@@ -63,8 +63,8 @@ class I18nBlueprintTest(WebTestMixin, DBTestMixin, TestCase):
         self.assertRedirects(response, '/en/lang/test/?q=test')
 
     def test_do_not_redirect_and_set_lang(self):
-        self.assertEqual(self.get('/fr/lang/test/').data, 'fr')
-        self.assertEqual(self.get('/en/lang/test/').data, 'en')
+        self.assertEqual(self.get('/fr/lang/test/').data, b'fr')
+        self.assertEqual(self.get('/en/lang/test/').data, b'en')
 
     def test_redirect_on_default_lang_for_unknown_lang(self):
         self.assertRedirects(self.get('/sk/lang/test/'), '/en/lang/test/')
@@ -73,8 +73,8 @@ class I18nBlueprintTest(WebTestMixin, DBTestMixin, TestCase):
         self.assert404(self.get('/sk/not-found/'))
 
     def test_language_contact_manager(self):
-        self.assertEqual(self.get('/fr/hardcoded/').data, 'fr-fr')
-        self.assertEqual(self.get('/en/hardcoded/').data, 'en-fr')
+        self.assertEqual(self.get('/fr/hardcoded/').data, b'fr-fr')
+        self.assertEqual(self.get('/en/hardcoded/').data, b'en-fr')
 
     def test_redirect_user_prefered_lang(self):
         self.login(UserFactory(prefered_language='fr'))

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -345,9 +345,9 @@ class IssueCsvTest(FrontTestCase):
         self.assert200(response)
 
         self.assertEqual(
-            response.data,
+            response.data.decode('utf8').strip(),
             ('"id";"user";"subject";"title";"size";"messages";"created";'
-             '"closed";"closed_by"\r\n')
+             '"closed";"closed_by"')
         )
 
     def test_issues_csv_content_filled(self):

--- a/udata/tests/test_routing.py
+++ b/udata/tests/test_routing.py
@@ -36,12 +36,12 @@ class UUIDConverterTest:
     def test_resolve_uuid(self, client):
         uuid = uuid4()
         url = '/uuid/{0}'.format(str(uuid))
-        assert client.get(url).data == 'ok'
+        assert client.get(url).data == b'ok'
 
     def test_resolve_uuid_with_spaces(self, client):
         uuid = uuid4()
         url = '/uuid/{0} '.format(str(uuid))
-        assert client.get(url).data == 'ok'
+        assert client.get(url).data == b'ok'
 
     def test_bad_uuid_is_404(self, client):
         assert client.get('/uuid/bad').status_code == 404
@@ -105,15 +105,15 @@ class ObjectIdModelConverterTest:
     def test_resolve_model_from_id(self, client):
         tester = Tester.objects.create(slug='slug')
         url = '/model/{0}'.format(str(tester.id))
-        assert client.get(url).data == 'ok'
+        assert client.get(url).data == b'ok'
 
     def test_resolve_model_from_slug(self, client):
         Tester.objects.create(slug='slug')
-        assert client.get('/model/slug').data == 'ok'
+        assert client.get('/model/slug').data == b'ok'
 
     def test_resolve_model_from_utf8_slug(self, client):
         Tester.objects.create(slug='slüg')
-        assert client.get('/model/slüg').data == 'ok'
+        assert client.get('/model/slüg').data == b'ok'
 
     def test_model_not_found(self, client):
         assert client.get('/model/not-found').status_code == 404

--- a/udata/tests/workers/test_jobs_commands.py
+++ b/udata/tests/workers/test_jobs_commands.py
@@ -104,7 +104,8 @@ class JobsCommandsTest:
         ]
         result = cli('job scheduled')
 
-        assert len(result.output.splitlines()) == len(tasks)
+        filtered = [l for l in result.output.splitlines() if 'Tip' not in l]
+        assert len(filtered) == len(tasks)
 
         assert 'not-scheduled' not in result.output
         for task in tasks:


### PR DESCRIPTION
This PR backports some Python 3 forward compatible changes.
- avoid `filter` and `map` usage instead of list comprehension
- explicit encoding handling
- avoid comparison to `None`
- use `next()` instead of `.next()` to iterate
- unhide some implicit casts (in particular search weight which was casted as `int` and so loosing some precision)