### PR TITLE
Slug redirections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - avoid comparison to `None`
     - use `next()` instead of `.next()` to iterate
     - unhide some implicit casts (in particular search weight)
+- Slugs are now redirected on change when changed until old slug are free [#1771](https://github.com/opendatateam/udata/pull/1771)
 
 ## 1.4.1 (2018-06-15)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -360,8 +360,8 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
                                   default=datetime.now, required=True)
     title = db.StringField(required=True)
     acronym = db.StringField(max_length=128)
-    slug = db.SlugField(max_length=255, required=True,
-                        populate_from='title', update=True)
+    slug = db.SlugField(max_length=255, required=True, populate_from='title',
+                        update=True, follow=True)
     description = db.StringField(required=True, default='')
     license = db.ReferenceField('License')
 

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -97,8 +97,8 @@ class OrganizationQuerySet(db.BaseQuerySet):
 class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
     name = db.StringField(required=True)
     acronym = db.StringField(max_length=128)
-    slug = db.SlugField(
-        max_length=255, required=True, populate_from='name', update=True)
+    slug = db.SlugField(max_length=255, required=True, populate_from='name',
+                        update=True, follow=True)
     description = db.StringField(required=True)
     url = db.StringField()
     image_url = db.StringField()

--- a/udata/core/post/models.py
+++ b/udata/core/post/models.py
@@ -16,8 +16,8 @@ IMAGE_SIZES = [400, 100, 50]
 
 class Post(db.Datetimed, db.Document):
     name = db.StringField(max_length=255, required=True)
-    slug = db.SlugField(
-        max_length=255, required=True, populate_from='name', update=True)
+    slug = db.SlugField(max_length=255, required=True, populate_from='name',
+                        update=True, follow=True)
     headline = db.StringField()
     content = db.StringField(required=True)
     image_url = db.StringField()

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -43,8 +43,8 @@ class ReuseQuerySet(db.OwnedQuerySet):
 
 class Reuse(db.Datetimed, WithMetrics, BadgeMixin, db.Owned, db.Document):
     title = db.StringField(required=True)
-    slug = db.SlugField(
-        max_length=255, required=True, populate_from='title', update=True)
+    slug = db.SlugField(max_length=255, required=True, populate_from='title',
+                        update=True, follow=True)
     description = db.StringField(required=True)
     type = db.StringField(required=True, choices=REUSE_TYPES.keys())
     url = db.StringField(required=True)

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -11,8 +11,8 @@ __all__ = ('Topic', )
 
 class Topic(db.Document):
     name = db.StringField(required=True)
-    slug = db.SlugField(
-        max_length=255, required=True, populate_from='name', update=True)
+    slug = db.SlugField(max_length=255, required=True, populate_from='name',
+                        update=True, follow=True)
     description = db.StringField()
     tags = db.ListField(db.StringField())
     color = db.IntField()

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -6,6 +6,7 @@ import slugify
 
 from flask_mongoengine import Document
 from mongoengine.fields import StringField
+from mongoengine.signals import post_delete
 
 from .queryset import UDataQuerySet
 
@@ -28,6 +29,9 @@ class SlugField(StringField):
         self.separator = separator
         self.follow = follow
         super(SlugField, self).__init__(**kwargs)
+        if follow:
+            # Can't use sender=self.owner_document which is not yet defined
+            post_delete.connect(self.cleanup_on_delete)
 
     def __get__(self, instance, owner):
         if instance is not None:
@@ -56,6 +60,26 @@ class SlugField(StringField):
                                separator=self.separator,
                                to_lower=self.lower_case)
 
+    def latest(self, value):
+        '''
+        Get the latest object for a given old slug
+        '''
+        namespace = self.owner_document.__name__
+        follow = SlugFollow.objects(namespace=namespace, old_slug=value).first()
+        if follow:
+            return self.owner_document.objects(slug=follow.new_slug).first()
+        return None
+
+    def cleanup_on_delete(self, sender, document):
+        '''
+        Clean up slug redirections on object deletion
+        '''
+        if not self.follow or sender is not self.owner_document:
+            return
+        slug = getattr(document, self.db_field)
+        namespace = self.owner_document.__name__
+        SlugFollow.objects(namespace=namespace, new_slug=slug).delete()
+
 
 class SlugFollow(Document):
     '''
@@ -66,9 +90,9 @@ class SlugFollow(Document):
         * old_slug - Before change slug.
         * new_slug - After change slug
     '''
-    namespace = StringField()
-    old_slug = StringField()
-    new_slug = StringField()  # In case slug was changed after a name change.
+    namespace = StringField(required=True)
+    old_slug = StringField(required=True)
+    new_slug = StringField(required=True)
 
     meta = {
         'indexes': [
@@ -89,16 +113,23 @@ def populate_slug(instance, field):
     except Exception:
         previous = None
 
-    manual = (not previous and value or
-              field.db_field in instance._get_changed_fields())
+    # Field value has changed
+    changed = field.db_field in instance._get_changed_fields()
+    # Field initial value has been manually set
+    manual = not previous and value or changed
 
     if not manual and field.populate_from:
+        # value to slugify is extracted from populate_from parameter
         value = getattr(instance, field.populate_from)
         if previous and value == getattr(previous, field.populate_from):
             return value
 
-    if previous and (getattr(previous, field.db_field) == value or
-                     not field.update):
+    if previous and getattr(previous, field.db_field) == value:
+        # value is unchanged from DB
+        return value
+
+    if previous and not changed and not field.update:
+        # Field is not manually set and slug should not update on change
         return value
 
     slug = field.slugify(value)
@@ -109,7 +140,6 @@ def populate_slug(instance, field):
     if slug is None:
         return
 
-    # If previous and slug ==
     old_slug = getattr(previous, field.db_field, None)
 
     if slug == old_slug:
@@ -133,14 +163,23 @@ def populate_slug(instance, field):
             index += 1
 
     # Track old slugs for this class
-    if field.follow and slug != old_slug:
-        slug_follower, created = SlugFollow.objects.get_or_create(
-            namespace=instance.__class__.__name__,
-            old_slug=old_slug
-        )
+    if field.follow and old_slug != slug:
+        ns = instance.__class__.__name__
+        # Destroy redirections from this new slug
+        SlugFollow.objects(namespace=ns, old_slug=slug).delete()
 
-        slug_follower.new_slug = slug
-        slug_follower.save()
+        if old_slug:
+            # Create a redirect for previous slug
+            slug_follower, created = SlugFollow.objects.get_or_create(
+                namespace=ns,
+                old_slug=old_slug,
+                auto_save=False,
+            )
+            slug_follower.new_slug = slug
+            slug_follower.save()
+
+            # Maintain previous redirects
+            SlugFollow.objects(namespace=ns, new_slug=old_slug).update(new_slug=slug)
 
     setattr(instance, field.db_field, slug)
     return slug

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -7,6 +7,8 @@ import slugify
 from flask_mongoengine import Document
 from mongoengine.fields import StringField
 
+from .queryset import UDataQuerySet
+
 log = logging.getLogger(__name__)
 
 
@@ -69,9 +71,10 @@ class SlugFollow(Document):
     new_slug = StringField()  # In case slug was changed after a name change.
 
     meta = {
-        "indexes": [
-            ("namespace", "old_slug"),
-        ]
+        'indexes': [
+            ('namespace', 'old_slug'),
+        ],
+        'queryset_class': UDataQuerySet,
     }
 
 
@@ -83,7 +86,7 @@ def populate_slug(instance, field):
 
     try:
         previous = instance.__class__.objects.get(id=instance.id)
-    except:
+    except Exception:
         previous = None
 
     manual = (not previous and value or
@@ -131,7 +134,7 @@ def populate_slug(instance, field):
 
     # Track old slugs for this class
     if field.follow and slug != old_slug:
-        slug_follower, created = SlugFollow.get_or_create(
+        slug_follower, created = SlugFollow.objects.get_or_create(
             namespace=instance.__class__.__name__,
             old_slug=old_slug
         )

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -4,14 +4,21 @@ from __future__ import unicode_literals
 from bson import ObjectId
 from uuid import UUID
 
-from flask import request
+from flask import request, redirect, url_for
 from mongoengine.errors import InvalidQueryError
 from werkzeug.routing import BaseConverter, NotFound, PathConverter
 from werkzeug.urls import url_quote
 
 from udata import models
+from udata.models import db
 from udata.core.spatial.models import GeoZone
 from udata.i18n import ISO_639_1_CODES
+
+
+class LazyRedirect(object):
+    '''Store location for lazy redirections'''
+    def __init__(self, arg):
+        self.arg = arg
 
 
 class LanguagePrefixConverter(BaseConverter):
@@ -64,11 +71,23 @@ class ModelConverter(BaseConverter):
 
     model = None
 
+    def quote(self, value):
+        if hasattr(self.model, 'slug') and isinstance(self.model.slug, db.SlugField):
+            return self.model.slug.slugify(value)
+        else:
+            return url_quote(value)
+
     def to_python(self, value):
         try:
-            obj = self.model.objects(slug=value).first()
-        except InvalidQueryError:  # If the model doesn't have a slug.
+            quoted = self.quote(value)
+            query = db.Q(slug=value) | db.Q(slug=quoted)
+            obj = self.model.objects(query).get()
+        except (InvalidQueryError, self.model.DoesNotExist):
+            # If the model doesn't have a slug or matching slug doesn't exists.
             obj = None
+        else:
+            if obj.slug != value:
+                return LazyRedirect(quoted)
         try:
             return obj or self.model.objects.get_or_404(id=value)
         except NotFound as e:
@@ -76,11 +95,11 @@ class ModelConverter(BaseConverter):
 
     def to_url(self, obj):
         if isinstance(obj, basestring):
-            return url_quote(obj)
+            return self.quote(obj)
         elif isinstance(obj, (ObjectId, UUID)):
             return str(obj)
         elif getattr(obj, 'slug', None):
-            return url_quote(obj.slug)
+            return self.quote(obj.slug)
         elif getattr(obj, 'id', None):
             return str(obj.id)
         else:
@@ -165,18 +184,26 @@ class TerritoryConverter(PathConverter):
             raise ValueError('Unable to serialize "%s" to url' % obj)
 
 
-def lazy_raise_404():
-    '''Raise 404 lazily to ensure request.endpoint is set'''
+def lazy_raise_or_redirect():
+    '''
+    Raise exception lazily to ensure request.endpoint is set
+    Also perform redirect if needed
+    '''
     if not request.view_args:
         return
-    for arg in request.view_args.values():
-        if isinstance(arg, NotFound):
-            request.routing_exception = arg
+    for name, value in request.view_args.items():
+        if isinstance(value, NotFound):
+            request.routing_exception = value
             break
+        elif isinstance(value, LazyRedirect):
+            new_args = request.view_args
+            new_args[name] = value.arg
+            new_url = url_for(request.endpoint, **new_args)
+            return redirect(new_url)
 
 
 def init_app(app):
-    app.before_request(lazy_raise_404)
+    app.before_request(lazy_raise_or_redirect)
     app.url_map.converters['lang'] = LanguagePrefixConverter
     app.url_map.converters['list'] = ListConverter
     app.url_map.converters['pathlist'] = PathListConverter

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -208,6 +208,10 @@ class SlugFieldTest:
         field = db.SlugField()
         assert field.slugify('  ab  ') == 'ab'
 
+    def test_special_chars_are_normalized(self):
+        field = db.SlugField()
+        assert field.slugify('à-€-ü') == 'a-eur-u'
+
 
 class DateFieldTest:
     def test_none_if_empty_and_not_required(self):

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -151,7 +151,7 @@ class SlugFieldTest:
         assert obj.slug == 'other'
 
     def test_unchanged(self):
-        '''SlugField should not chnage on save if not needed'''
+        '''SlugField should not change on save if not needed'''
         obj = SlugTester(title="A Title")
         assert obj.slug is None
         obj.save()


### PR DESCRIPTION
This PR test, fix and enable slug redirections on any models with a permalink using the slug.

Slug (and their routing) where undertested (tested against `StringField` instead of `SlugField`) with false positive.

The following redirects will be enabled:
- UTF-8 slug redirects to the normalized one
- old slugs are redirected to the new one changes (until another object take the same slug)
- redirections are deleted on object deletion