### PR TITLE
Improve usability at new organization creation

### DIFF
--- a/js/components/organization/card-filter.vue
+++ b/js/components/organization/card-filter.vue
@@ -13,9 +13,9 @@
                 <input type="text" name="search" class="form-control"
                     :placeholder="_('Search')" v-model="search_query" />
                 <div class="input-group-btn">
-                    <button type="submit" name="submit" class="btn btn-warning btn-flat">
+                    <div class="btn btn-warning btn-flat">
                         <span class="fa fa-search"></span>
-                    </button>
+                    </div>
                 </div>
             </div>
         </form>
@@ -33,6 +33,11 @@
     <p class="col-xs-12 lead text-center">
     {{ _('No organization found. You can go to the next step to create your own one.') }}
     </p>
+    <div class="col-xs-12 lead text-center">
+        <a v-link="{name: 'organization-new'}" class="btn btn-flat btn-primary">
+            {{ _('Find or create your organization') }}
+        </a>
+    </div>
 </div>
 </div>
 </template>

--- a/js/components/organization/pre-create.vue
+++ b/js/components/organization/pre-create.vue
@@ -17,9 +17,9 @@
                     :placeholder="_('Search')" v-model="search_query"
                 />
                 <div class="input-group-btn">
-                    <button type="submit" name="submit" class="btn btn-warning btn-flat">
+                    <div class="btn btn-warning btn-flat">
                         <span class="fa fa-search"></span>
-                    </button>
+                    </div>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
This is a PR with a improvement to the search organization button on administration. The search results appear as you type and clicking on the buttons reloads the page unnecessarily causing some confusion to the users, so I've removed this page reloading feature.

It adds also a 'Find or create your organization' button so the user can click on it when no organization results have been found. 

Before:
![image](https://user-images.githubusercontent.com/9539326/42086148-2dfe7abe-7b8a-11e8-9be0-4aebb5a84ad8.png)


After:
![image](https://user-images.githubusercontent.com/9539326/42086236-65a1d54c-7b8a-11e8-82ac-acf98f1641f6.png)


Best!