### PR TITLE
Fix dataset collapse on ie11 and card markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
     - use `next()` instead of `.next()` to iterate
     - unhide some implicit casts (in particular search weight)
 - Slugs are now redirected on change when changed until old slug are free [#1771](https://github.com/opendatateam/udata/pull/1771)
-- improve usability of new organization form [#1777](https://github.com/opendatateam/udata/pull/1777) 
+- Improve usability of new organization form [#1777](https://github.com/opendatateam/udata/pull/1777)
+- Fix dataset collapse on ie11 and card markup [#1792](https://github.com/opendatateam/udata/pull/1792)
 
 ## 1.4.1 (2018-06-15)
 

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -45,7 +45,6 @@ new Vue({
             dataset: this.extractDataset(),
             userReuses: [],
             checkUrlEnabled: config.check_urls,
-            visibleTypeLists: [],
         };
     },
     ready() {
@@ -59,15 +58,6 @@ new Vue({
         log.debug('Dataset display page ready');
     },
     methods: {
-        /**
-         * Is a resource type list collapsed
-         * @type {String}
-         * @return {Boolean}
-         */
-        isTypeListVisible(type) {
-            return this.visibleTypeLists.indexOf(type) !== -1;
-        },
-
         /**
          * Extract the current dataset metadatas from JSON-LD script
          * @return {Object} The parsed dataset
@@ -141,7 +131,6 @@ new Vue({
             new Velocity(e.target, {height: 0, opacity: 0}, {complete(els) {
                 els[0].remove();
             }});
-            this.visibleTypeLists.push(type);
         },
 
         /**

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -106,7 +106,7 @@
                         {% if nb_groups > 1 %}<h4 class="resource-type">{{ type_label }}</h4>{% endif %}
                         {% for resource in resources %}
                             {% if loop.index0 == max_resources %}
-                            <div v-if="isTypeListVisible('{{ type }}')" id="collapsed-resources-{{ type }}" class="collapse">
+                            <div id="collapsed-resources-{{ type }}" class="collapse">
                             {% endif %}
                             {% include theme('dataset/resource/card.html') %}
                         {% endfor %}

--- a/udata/templates/dataset/resource/card.html
+++ b/udata/templates/dataset/resource/card.html
@@ -67,8 +67,8 @@
                     href="{{ url_for('admin.index', path=edit_path.format(id=dataset.id, rid=resource.id)) }}">
                     <span class="fa fa-pencil"></span>
                 </a>
+            {% endif %}
             </div>
-        {% endif %}
         </div>
     </footer>
 </article>


### PR DESCRIPTION
This removes the tentative enhancement of `isTypeListVisible` that breaks the `collapse` mechanism on ie11 (at least). Cf https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/#discussion-5b4315e788ee385d44bbff98-1.

It also fixes the anonymous markup of the resource card (missing closing tag).