### PR TITLE
Fix resources reorder (registered extras validation logic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
     - use `next()` instead of `.next()` to iterate
     - unhide some implicit casts (in particular search weight)
 - Slugs are now redirected on change when changed until old slug are free [#1771](https://github.com/opendatateam/udata/pull/1771)
-- improve usability of new organization form [#1777](https://github.com/opendatateam/udata/pull/1777) 
+- improve usability of new organization form [#1777](https://github.com/opendatateam/udata/pull/1777)
+- Fix resources reorder (registered extras validation logic) [#1796](https://github.com/opendatateam/udata/pull/1796)
 
 ## 1.4.1 (2018-06-15)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -665,7 +665,7 @@ class PublishAsField(ModelFieldMixin, Field):
 
 
 def field_parse(cls, value, *args, **kwargs):
-    kwargs['_form'] = Form()
+    kwargs['_form'] = WTForm()
     kwargs['_name'] = 'extra'
     field = cls(*args, **kwargs)
     field.process_formdata([value])

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -9,20 +9,19 @@ from uuid import uuid4
 
 from flask import url_for
 
-from udata.models import (
-    CommunityResource, Dataset, Follow, Member, UPDATE_FREQUENCIES,
-    LEGACY_FREQUENCIES, RESOURCE_TYPES
-)
-
 from . import APITestCase
 
 from udata.core.dataset.factories import (
     DatasetFactory, VisibleDatasetFactory, CommunityResourceFactory,
     LicenseFactory, ResourceFactory)
-from udata.core.dataset.models import RESOURCE_FILETYPE_FILE
+from udata.core.dataset.models import RESOURCE_FILETYPE_FILE, ResourceMixin
 from udata.core.user.factories import UserFactory, AdminFactory
 from udata.core.badges.factories import badge_factory
 from udata.core.organization.factories import OrganizationFactory
+from udata.models import (
+    CommunityResource, Dataset, Follow, Member, UPDATE_FREQUENCIES,
+    LEGACY_FREQUENCIES, RESOURCE_TYPES, db
+)
 from udata.tags import MIN_TAG_LENGTH, MAX_TAG_LENGTH
 from udata.utils import unique_string, faker
 
@@ -733,7 +732,13 @@ class DatasetResourceAPITest(APITestCase):
         self.assert201(response)
 
     def test_reorder(self):
+        # Register an extra field in order to test
+        # https://github.com/opendatateam/udata/issues/1794
+        ResourceMixin.extras.register('my:register', db.BooleanField)
         self.dataset.resources = ResourceFactory.build_batch(3)
+        self.dataset.resources[0].extras = {
+            'my:register': True,
+        }
         self.dataset.save()
         self.dataset.reload()  # Otherwise `last_modified` date is inaccurate.
         initial_last_modified = self.dataset.last_modified


### PR DESCRIPTION
Fix #1794 

Well, this was a hell of a bug hunt 😅 

I finally fixed it by using a bare `WTForm` for registered extras validation instead of one from `flask-wtf` which would run into this logic https://github.com/lepture/flask-wtf/blob/9cb0ac619f79a702254e1ad248ea8e15e5691d92/flask_wtf/form.py#L64 and fail because we have a list of ids on this route.