### PR TITLE
Refactor resources collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fix resources reorder (registered extras validation logic) [#1796](https://github.com/opendatateam/udata/pull/1796)
 - Fix checksum display on resource modal [#1797](https://github.com/opendatateam/udata/pull/1797)
 - Use metrics.views on resource card [#1778](https://github.com/opendatateam/udata/pull/1778)
-- Fix dataset collapse on ie11
+- Fix dataset collapse on ie11 [#1802](https://github.com/opendatateam/udata/pull/1802)
 
 ## 1.4.1 (2018-06-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
 - Slugs are now redirected on change when changed until old slug are free [#1771](https://github.com/opendatateam/udata/pull/1771)
 - Improve usability of new organization form [#1777](https://github.com/opendatateam/udata/pull/1777)
 - Fix resources reorder (registered extras validation logic) [#1796](https://github.com/opendatateam/udata/pull/1796)
-- Fix dataset collapse on ie11 and card markup [#1792](https://github.com/opendatateam/udata/pull/1792)
 - Fix checksum display on resource modal [#1797](https://github.com/opendatateam/udata/pull/1797)
 - Use metrics.views on resource card [#1778](https://github.com/opendatateam/udata/pull/1778)
+- Fix dataset collapse on ie11
 
 ## 1.4.1 (2018-06-15)
 

--- a/js/front/dataset/index.js
+++ b/js/front/dataset/index.js
@@ -45,6 +45,7 @@ new Vue({
             dataset: this.extractDataset(),
             userReuses: [],
             checkUrlEnabled: config.check_urls,
+            visibleTypeLists: [],
         };
     },
     ready() {
@@ -58,6 +59,15 @@ new Vue({
         log.debug('Dataset display page ready');
     },
     methods: {
+        /**
+         * Is a resource type list collapsed
+         * @type {String}
+         * @return {Boolean}
+         */
+        isTypeListVisible(type) {
+            return this.visibleTypeLists.indexOf(type) !== -1;
+        },
+
         /**
          * Extract the current dataset metadatas from JSON-LD script
          * @return {Object} The parsed dataset
@@ -131,6 +141,7 @@ new Vue({
             new Velocity(e.target, {height: 0, opacity: 0}, {complete(els) {
                 els[0].remove();
             }});
+            this.visibleTypeLists.push(type);
         },
 
         /**

--- a/less/site.less
+++ b/less/site.less
@@ -372,3 +372,7 @@ small.deleted {
       max-width: 450px;
     }
 }
+
+[v-cloak] {
+  display: none;
+}

--- a/less/udata/resource.less
+++ b/less/udata/resource.less
@@ -1,4 +1,14 @@
 .resources-list {
+
+    .expand-transition {
+      transition: all .3s ease;
+      height: auto;
+    }
+    .expand-enter, .expand-leave {
+      height: 0;
+      opacity: 0;
+    }
+
     .resources-list-header {
         margin-top: 20px;
         margin-bottom: 10px;

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -106,16 +106,14 @@
                         {% if nb_groups > 1 %}<h4 class="resource-type">{{ type_label }}</h4>{% endif %}
                         {% for resource in resources %}
                             {% if loop.index0 == max_resources %}
-                            <div id="collapsed-resources-{{ type }}" class="collapse">
+                            <div v-if="isTypeListVisible('{{ type }}')" v-cloak transition="expand">
                             {% endif %}
                             {% include theme('dataset/resource/card.html') %}
                         {% endfor %}
                         {% if resources|length > max_resources %}
                             </div>
                             <p class="text-center expander">
-                                <button type="button" class="btn btn-default"
-                                    data-toggle="collapse" href="#collapsed-resources-{{ type }}"
-                                    @click.prevent="expandResources($event, '{{ type }}')">
+                                <button type="button" class="btn btn-default" @click.prevent="expandResources($event, '{{ type }}')">
                                     <span class="fa fa-list" ></span>
                                     {{ _('See the %(nb)d resources of type %(type)s', nb=resources|length, type=type_label) }}
                                 </button>


### PR DESCRIPTION
#1792 introduced a regression: link checker checks were triggered for all resources, even those hidden. This PR introduces a new approach to fix ie11 collapse problem: get rid of bootstrap collapse and use `v-if`. #testedonie11