### PR TITLE
Allows to serve static asserts on an external CDN domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Use metrics.views on resource card [#1778](https://github.com/opendatateam/udata/pull/1778)
 - Fix dataset collapse on ie11 [#1802](https://github.com/opendatateam/udata/pull/1802)
 - Upgrade i18next (security) [#1803](https://github.com/opendatateam/udata/pull/1803)
+- Allows to serve assets on an external CDN domain using `CDN_DOMAIN` [#1804](https://github.com/opendatateam/udata/pull/1804)
 
 ## 1.4.1 (2018-06-15)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -446,6 +446,16 @@ This activates metrics, this is deactivated for tests
 
 uData use Flask-FS as storage abstraction.
 
+## Flask-CDN options
+
+See [Flask-CDN README](https://github.com/libwilliam/flask-cdn#flask-cdn-options) for detailed options.
+
+### CDN_DOMAIN
+
+**default**: `None`
+
+Set this to a domain name. If defined, udata will serve its static assets from this domain.
+
 ## Avatars/identicon configuration
 
 Theses settings allow you to customize avatar rendering.

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -12,6 +12,7 @@ factory-boy==2.11.1
 Faker==0.8.17
 Flask-BabelEx==0.9.3
 Flask-Caching==1.4.0
+Flask-CDN==1.5.3
 flask-fs==0.6.1
 Flask-Gravatar==0.5.0
 Flask-Login==0.4.1

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -100,6 +100,11 @@ def init_app(app, views=None):
     # Load front only views and helpers
     app.register_blueprint(front)
 
+    # Enable CDN if required
+    if app.config['CDN_DOMAIN'] is not None:
+        from flask_cdn import CDN
+        CDN(app)
+
     # Load debug toolbar if enabled
     if app.config.get('DEBUG_TOOLBAR'):
         from flask_debugtoolbar import DebugToolbarExtension

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -307,6 +307,12 @@ class Defaults(object):
     MAP_INITIAL_ZOOM = 4
     # Initial map territory level
     MAP_INITIAL_LEVEL = 0
+    # Flask-CDN options
+    # See: https://github.com/libwilliam/flask-cdn#flask-cdn-options
+    # If this value is defined, toggle static assets on external domain
+    CDN_DOMAIN = None
+    # Don't check timestamp on assets (and avoid error on missing assets)
+    CDN_TIMESTAMP = False
 
 
 class Testing(object):

--- a/udata/theme/__init__.py
+++ b/udata/theme/__init__.py
@@ -45,7 +45,17 @@ default_menu = nav.Bar('default_menu', [
 @contextfunction
 def theme_static_with_version(ctx, filename, external=False):
     '''Override the default theme static to add cache burst'''
-    url = global_theme_static(ctx, filename, external=external)
+    # Imported here to avoir circular dependencies
+    from udata.frontend.helpers import cdn_for
+    if current_app.theme_manager.static_folder:
+        url = cdn_for('_themes.static',
+                      filename=current.identifier + '/' + filename,
+                      _external=external)
+    else:
+        url = cdn_for('_themes.static',
+                      themeid=current.identifier,
+                      filename=filename,
+                      _external=external)
     if url.endswith('/'):  # this is a directory, no need for cache burst
         return url
     if current_app.config['DEBUG']:


### PR DESCRIPTION
This PR allows to serve static assets from an external CDN defined by `CDN_DOMAIN`.
