### PR TITLE
Ensure OEmbed works with CDN and fixes some static serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Ensure OEmbed compatibility with external CDN [#1815](https://github.com/opendatateam/udata/pull/1815)
+- Fixes some static URL serialization [#1815](https://github.com/opendatateam/udata/pull/1815)
 
 ## 1.5.0 (2018-07-30)
 

--- a/js/components/buttons/integrate.vue
+++ b/js/components/buttons/integrate.vue
@@ -29,6 +29,7 @@ export default {
         objectType: {type: String, required: true},
         objectId: {type: String, required: true},
         widgetUrl: {type: String, required: true},
+        rootUrl: String,
         documentationUrl: String
     },
     data() {
@@ -41,8 +42,9 @@ export default {
     computed: {
         snippet() {
             const tag = 'script'; // Due to vue-loader failing on closing script tag, we interpolate it
+            const root = this.rootUrl && !this.widgetUrl.startsWith(this.rootUrl) ? ` data-udata="${this.rootUrl}"` : '';
             return `<div data-udata-${this.objectType}="${this.objectId}"></div>
-<${tag} src="${this.widgetUrl}" async defer></${tag}>`;
+<${tag}${root} src="${this.widgetUrl}" async defer></${tag}>`;
         }
     },
     methods: {

--- a/js/oembed.js
+++ b/js/oembed.js
@@ -21,7 +21,7 @@ import '../less/oembed.less';
 function getBaseUrl() {
     const script =  document.currentScript || document.querySelector('script[src$="oembed.js"]');
     const parser = document.createElement('a');
-    parser.href = script.src;
+    parser.href = script.dataset.udata || script.src;
     return `${parser.protocol}//${parser.host}`;
 }
 

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -44,7 +44,8 @@ const _MAX_SIZE = 50
  */
 function extractURLs (selector) {
   const parser = document.createElement('a')
-  const scriptURL = document.querySelector(selector).src
+  const script = document.querySelector(selector)
+  const scriptURL = script.dataset.udata || script.src
   parser.href = scriptURL
   const baseURL = `${parser.protocol}//${parser.host}`
   return [scriptURL, baseURL]

--- a/udata/frontend/helpers.py
+++ b/udata/frontend/helpers.py
@@ -46,6 +46,8 @@ def cdn_for(endpoint, **kwargs):
     by the CDN assets prformance improvements)
     '''
     if current_app.config['CDN_DOMAIN']:
+        if not current_app.config.get('CDN_DEBUG'):
+            kwargs.pop('_external', None)  # Avoid the _external parameter in URL
         return cdn_url_for(endpoint, **kwargs)
     return url_for(endpoint, **kwargs)
 

--- a/udata/templates/macros/integrate.html
+++ b/udata/templates/macros/integrate.html
@@ -3,6 +3,8 @@
 {% set widget_url = static('oembed.js', _burst=False, _external=True) %}
 <integrate-button title="{{ _('Integrate') }}"
     object-type="{{ basename }}" object-id="{{ obj.id }}"
-    widget-url="{{ widget_url }}">
+    widget-url="{{ widget_url }}"
+    {% if config.CDN_DOMAIN %}root-url="{{ url_for('site.home_redirect', _external=True) }}"{% endif %}
+    >
 </integrate-button>
 {% endmacro %}

--- a/udata/templates/territories/territory.html
+++ b/udata/templates/territories/territory.html
@@ -61,5 +61,8 @@
 {% endblock %}
 
 {% block extra_js %}
-    <script src="{{ static('widgets.js', _burst=False) }}" id="udata" async defer onload="udataScript.loadDatasets()"></script>
+    <script src="{{ static('widgets.js', _burst=False) }}" id="udata"
+        async defer onload="udataScript.loadDatasets()"
+        {% if config.CDN_DOMAIN %}data-udata="{{ url_for('site.home_redirect', _external=True) }}"{% endif %}
+    ></script>
 {% endblock %}

--- a/udata/theme/__init__.py
+++ b/udata/theme/__init__.py
@@ -49,13 +49,11 @@ def theme_static_with_version(ctx, filename, external=False):
     from udata.frontend.helpers import cdn_for
     if current_app.theme_manager.static_folder:
         url = cdn_for('_themes.static',
-                      filename=current.identifier + '/' + filename,
-                      _external=external)
+                      filename=current.identifier + '/' + filename)
     else:
         url = cdn_for('_themes.static',
                       themeid=current.identifier,
-                      filename=filename,
-                      _external=external)
+                      filename=filename)
     if url.endswith('/'):  # this is a directory, no need for cache burst
         return url
     if current_app.config['DEBUG']:


### PR DESCRIPTION
This PR:
- ensures OEmbed (and legacy widget) compatibility with external CDN
- fixes some static URL serialization cases

By the way, every existing OEmbed/legacy widget integration still works because the assets are still reachable on the old URL.