### PR TITLE
Fix client-side temporal coverage rendering (fix etalab/data.gouv.fr#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix client-side temporal coverage rendering [#1821](https://github.com/opendatateam/udata/pull/1821)
 
 ## 1.5.1 (2018-08-03)
 

--- a/js/components/dataset/filters.js
+++ b/js/components/dataset/filters.js
@@ -17,7 +17,7 @@ export default {
             const start_label = start.format('L');
             const end_label = end.format('L');
             return end_label
-                ? this._('{start} to {end}', {start:start_label, end:end_label})
+                ? this._('{start} to {end}', {start: start_label, end: end_label, interpolation: { escapeValue: false }})
                 : start_label;
         },
         frequency_label(dataset) {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "fine-uploader": "~5.15.6",
     "font-awesome": "^4.7.0",
     "highlight.js": "^9.9.0",
-    "i18next": "3.4.4",
+    "i18next": "11.5.0",
     "icheck": "^1.0.2",
     "jquery": "~3.0.0",
     "jquery-jcrop": "^0.9.13",


### PR DESCRIPTION
Fix an `i18next` upgrade (security fix) side-effect: interpolated strings are now escaped unless `interpolation: { escapeValue: false }` variable is set