### PR TITLE
Prevent word breaking when wrapping discussions messages (fix #1820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix client-side temporal coverage rendering [#1821](https://github.com/opendatateam/udata/pull/1821)
+- Prevent word breaking when wrapping discussions messages [#1822](https://github.com/opendatateam/udata/pull/1822)
 
 ## 1.5.1 (2018-08-03)
 

--- a/js/components/discussions/message.vue
+++ b/js/components/discussions/message.vue
@@ -1,37 +1,61 @@
-<style scoped lang="less">
-.message {
+<style lang="less">
+/* Warning:
+    As markdown content is not rendered by Vue.js,
+    scoped style doesn't work for styling markdown content
+*/
+
+.discussion-message {
     display: flex;
     flex-direction: row;
-    
+
     padding-top: 1.25em;
 
-    & > div {
-        display: flex;
-        flex-grow: 1;
-        flex-flow: row wrap;
-        justify-content: space-between;
-        flex-basis: 100%;
-    }
-    
-    & > .avatar {
+    > .avatar {
         margin-right: 1em;
         flex-basis: auto;
     }
 
-    div.author {
-        font-weight: bold;
-        margin-bottom: 0.5em;
-    }
+    .message-content {
+        display: flex;
+        flex-direction: column;
+        min-width: 0; // Override Flex default to auto
 
-    div.posted_on {
-        text-align: right;
-    }
+        .message-header {
+            display: flex;
+            flex: 0 0 auto;
+            margin-bottom: 0.5em;
 
-    div.body {
-        overflow-wrap: break-word;
-        word-wrap: break-word;
-        word-break: break-all;
-        flex-basis: 100%;
+            .author {
+                flex: 1 0 auto;
+                font-weight: bold;
+            }
+
+            .posted_on {
+                flex: 0 0 auto;
+                text-align: right;
+
+                .fa {
+                    // Space before anchor
+                    margin-left: 5px;
+                }
+            }
+        }
+
+        .body {
+            flex: 1 0 auto;
+
+            a, code {
+                word-wrap: break-word;
+                word-break: break-all;
+            }
+
+            pre {
+                code {
+                    word-wrap: normal;
+                    word-break: normal;
+                }
+            }
+        }
     }
 }
 
@@ -44,23 +68,25 @@
 
 </style>
 <template>
-    <div class="message">
+    <div class="discussion-message">
         <div class="avatar">
             <a href="{{ message.posted_by.page }}"><avatar :user="message.posted_by"></avatar></a>
         </div>
-        <div>
-            <div class="author">
-                <a href="{{ message.posted_by.page }}">{{ message.posted_by.first_name }} {{ message.posted_by.last_name }}</a>
-            </div>
-           
-            <div class="posted_on">
-                {{ formatDate(message.posted_on) }} 
-                <a href="#{{ discussion }}-{{ index }}"><span class="fa fa-link"></span></a>
+        <div class="message-content">
+            <div class="message-header">
+                <div class="author">
+                    <a href="{{ message.posted_by.page }}">{{ message.posted_by.first_name }} {{ message.posted_by.last_name }}</a>
+                </div>
+
+                <div class="posted_on">
+                    {{ formatDate(message.posted_on) }}
+                    <a href="#{{ discussion }}-{{ index }}"><span class="fa fa-link"></span></a>
+                </div>
             </div>
 
             <div class="body">
                 {{{ message.content | markdown }}}
-            </div> 
+            </div>
        </div>
     </div>
 </template>


### PR DESCRIPTION
This PR change the discussions word wrapping rule and prevent word to be breaked:
- layout has been a little bit refactored so all flexbox constraints apply (width in particular)
- `scoped` style attribute has been removed allowing style to apply on Markdown
- `word-wrap` and `word-break` are back to `normal` in the message body
- set `word-wrap: break-word` and `word-break: break-all` on message body anchors
- make `pre > code` scroll horizontal in case of overflow

## Desktop
![screenshot-data xps-2018 08 06-18-34-37](https://user-images.githubusercontent.com/15725/43729354-59199620-99a8-11e8-8289-0322594ed49f.png)

## Mobile
![screenshot-data xps-2018 08 06-17-52-37](https://user-images.githubusercontent.com/15725/43727307-d80ebb6a-99a1-11e8-8367-42ab27e2514f.png)


## Notes
Fixes #1820 
Fixes #1747 