### PR TITLE
Fixes on issues and discussions mails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix client-side temporal coverage rendering [#1821](https://github.com/opendatateam/udata/pull/1821)
 - Prevent word breaking when wrapping discussions messages [#1822](https://github.com/opendatateam/udata/pull/1822)
+- Properly render message content on issues and discussions mails
 
 ## 1.5.1 (2018-08-03)
 

--- a/udata/core/discussions/tasks.py
+++ b/udata/core/discussions/tasks.py
@@ -40,7 +40,8 @@ def notify_new_discussion(discussion):
         recipients = owner_recipients(discussion)
         subject = _('Your %(type)s have a new discussion',
                     type=discussion.subject.verbose_name)
-        mail.send(subject, recipients, 'new_discussion', discussion=discussion)
+        mail.send(subject, recipients, 'new_discussion',
+                  discussion=discussion, message=discussion.discussion[0])
     else:
         log.warning('Unrecognized discussion subject type %s',
                     type(discussion.subject))
@@ -49,14 +50,14 @@ def notify_new_discussion(discussion):
 @connect(on_new_discussion_comment)
 def notify_new_discussion_comment(discussion, **kwargs):
     if isinstance(discussion.subject, (Dataset, Reuse, Post)):
-        comment = kwargs['message']
+        message = kwargs['message']
         recipients = owner_recipients(discussion) + [
             m.posted_by for m in discussion.discussion]
-        recipients = [u for u in set(recipients) if u != comment.posted_by]
+        recipients = [u for u in set(recipients) if u != message.posted_by]
         subject = _('%(user)s commented your discussion',
-                    user=comment.posted_by.fullname)
+                    user=message.posted_by.fullname)
         mail.send(subject, recipients, 'new_discussion_comment',
-                  discussion=discussion, comment=comment)
+                  discussion=discussion, message=message)
     else:
         log.warning('Unrecognized discussion subject type %s',
                     type(discussion.subject))
@@ -65,13 +66,13 @@ def notify_new_discussion_comment(discussion, **kwargs):
 @connect(on_discussion_closed)
 def notify_discussion_closed(discussion, **kwargs):
     if isinstance(discussion.subject, (Dataset, Reuse, Post)):
-        comment = kwargs['message']
+        message = kwargs['message']
         recipients = owner_recipients(discussion) + [
             m.posted_by for m in discussion.discussion]
-        recipients = [u for u in set(recipients) if u != comment.posted_by]
+        recipients = [u for u in set(recipients) if u != message.posted_by]
         subject = _('A discussion has been closed')
         mail.send(subject, recipients, 'discussion_closed',
-                  discussion=discussion, comment=comment)
+                  discussion=discussion, message=message)
     else:
         log.warning('Unrecognized discussion subject type %s',
                     type(discussion.subject))

--- a/udata/core/issues/tasks.py
+++ b/udata/core/issues/tasks.py
@@ -24,7 +24,8 @@ def notify_new_issue(issue):
         recipients = owner_recipients(issue)
         subject = _('Your %(type)s have a new issue',
                     type=issue.subject.verbose_name)
-        mail.send(subject, recipients, 'new_issue', issue=issue)
+        mail.send(subject, recipients, 'new_issue', issue=issue,
+                  message=issue.discussion[0])
     else:
         log.warning('Unrecognized issue subject type %s', type(issue.subject))
 
@@ -32,14 +33,14 @@ def notify_new_issue(issue):
 @connect(on_new_issue_comment)
 def notify_new_issue_comment(issue, **kwargs):
     if isinstance(issue.subject, (Dataset, Reuse)):
-        comment = kwargs['message']
+        message = kwargs['message']
         recipients = owner_recipients(issue) + [
             m.posted_by for m in issue.discussion]
-        recipients = [u for u in set(recipients) if u != comment.posted_by]
+        recipients = [u for u in set(recipients) if u != message.posted_by]
         subject = _('%(user)s commented your issue',
-                    user=comment.posted_by.fullname)
+                    user=message.posted_by.fullname)
         mail.send(subject, recipients, 'new_issue_comment',
-                  issue=issue, comment=comment)
+                  issue=issue, message=message)
     else:
         log.warning('Unrecognized issue subject type %s', type(issue.subject))
 
@@ -47,12 +48,12 @@ def notify_new_issue_comment(issue, **kwargs):
 @connect(on_issue_closed)
 def notify_issue_closed(issue, **kwargs):
     if isinstance(issue.subject, (Dataset, Reuse)):
-        comment = kwargs['message']
+        message = kwargs['message']
         recipients = owner_recipients(issue) + [
             m.posted_by for m in issue.discussion]
-        recipients = [u for u in set(recipients) if u != comment.posted_by]
+        recipients = [u for u in set(recipients) if u != message.posted_by]
         subject = _('An issue has been closed')
         mail.send(subject, recipients, 'issue_closed',
-                  issue=issue, comment=comment)
+                  issue=issue, message=message)
     else:
         log.warning('Unrecognized issue subject type %s', type(issue.subject))

--- a/udata/templates/mail/discussion_closed.html
+++ b/udata/templates/mail/discussion_closed.html
@@ -7,9 +7,9 @@
         type=discussion.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('users.show', user=comment.posted_by, _external=True)
+            + url_for('users.show', user=message.posted_by, _external=True)
             + '">'|safe
-            + comment.posted_by.fullname
+            + message.posted_by.fullname
             + '</a>'|safe
         ),
         subject=(
@@ -23,13 +23,13 @@
 }}.</p>
 <br/>
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Details') }}:</b>
+    <b>{{ _('Title') }}:</b>
     {{ discussion.title }}
 </p>
 
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Comment') }}:</b>
-    {{ comment.content }}
+    <b>{{ _('Message') }}:</b>
+    {{ message.content | markdown }}
 </p>
 
 

--- a/udata/templates/mail/discussion_closed.txt
+++ b/udata/templates/mail/discussion_closed.txt
@@ -3,12 +3,12 @@
 {% block body %}
 {{ _('%(user)s closed an discussion on your %(type)s %(subject)s',
     type=discussion.subject.verbose_name,
-    user=comment.posted_by.fullname,
+    user=message.posted_by.fullname,
     subject=discussion.subject|string
 ) }}.
 
 
-{{ _('Details') }}: {{ discussion.title }}
+{{ _('Title') }}: {{ discussion.title }}
 
 
 {{ _('You can see the discussion on this page:') }}

--- a/udata/templates/mail/issue_closed.html
+++ b/udata/templates/mail/issue_closed.html
@@ -7,9 +7,9 @@
         type=issue.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('users.show', user=comment.posted_by, _external=True)
+            + url_for('users.show', user=message.posted_by, _external=True)
             + '">'|safe
-            + comment.posted_by.fullname
+            + message.posted_by.fullname
             + '</a>'|safe
         ),
         subject=(
@@ -23,13 +23,13 @@
 }}.</p>
 <br/>
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Details') }}:</b>
+    <b>{{ _('Title') }}:</b>
     {{ issue.title }}
 </p>
 
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Comment') }}:</b>
-    {{ comment.content }}
+    <b>{{ _('Message') }}:</b>
+    {{ message.content | markdown }}
 </p>
 
 

--- a/udata/templates/mail/issue_closed.txt
+++ b/udata/templates/mail/issue_closed.txt
@@ -3,12 +3,12 @@
 {% block body %}
 {{ _('%(user)s closed an issue on your %(type)s %(subject)s',
     type=issue.subject.verbose_name,
-    user=comment.posted_by.fullname,
+    user=message.posted_by.fullname,
     subject=issue.subject|string
 ) }}.
 
 
-{{ _('Details') }}: {{ issue.title }}
+{{ _('Title') }}: {{ issue.title }}
 
 
 {{ _('You can see the issue on this page:') }}

--- a/udata/templates/mail/new_discussion.html
+++ b/udata/templates/mail/new_discussion.html
@@ -22,9 +22,15 @@
 ) }}.</p>
 <br/>
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Details') }}:</b>
+    <b>{{ _('Title') }}:</b>
     {{ discussion.title }}
 </p>
+
+<p style="margin: 0;padding: 0;">
+    <b>{{ _('Message') }}:</b>
+    {{ message.content | markdown }}
+</p>
+
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
         <td align="center">

--- a/udata/templates/mail/new_discussion.txt
+++ b/udata/templates/mail/new_discussion.txt
@@ -8,7 +8,7 @@
 ) }}.
 
 
-{{ _('Details') }}: {{ discussion.title }}
+{{ _('Title') }}: {{ discussion.title }}
 
 {{ _('You can see the discussion on this page:') }}
 {{ discussion.subject.external_url }}

--- a/udata/templates/mail/new_discussion_comment.html
+++ b/udata/templates/mail/new_discussion_comment.html
@@ -7,9 +7,9 @@
         type=discussion.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('users.show', user=comment.posted_by, _external=True)
+            + url_for('users.show', user=message.posted_by, _external=True)
             + '">'|safe
-            + comment.posted_by.fullname
+            + message.posted_by.fullname
             + '</a>'|safe
         ),
         subject=(
@@ -23,15 +23,14 @@
 }}.</p>
 <br/>
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Details') }}:</b>
+    <b>{{ _('Title') }}:</b>
     {{ discussion.title }}
 </p>
 
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Comment') }}:</b>
-    {{ comment.content }}
+    <b>{{ _('Message') }}:</b>
+    {{ message.content | markdown }}
 </p>
-
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>

--- a/udata/templates/mail/new_discussion_comment.txt
+++ b/udata/templates/mail/new_discussion_comment.txt
@@ -3,12 +3,12 @@
 {% block body %}
 {{ _('%(user)s commented an discussion on your %(type)s %(subject)s',
     type=discussion.subject.verbose_name,
-    user=comment.posted_by.fullname,
+    user=message.posted_by.fullname,
     subject=discussion.subject|string
 ) }}.
 
 
-{{ _('Details') }}: {{ discussion.title }}
+{{ _('Title') }}: {{ discussion.title }}
 
 
 {{ _('You can see the discussion on this page:') }}

--- a/udata/templates/mail/new_issue.html
+++ b/udata/templates/mail/new_issue.html
@@ -22,8 +22,12 @@
 ) }}.</p>
 <br/>
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Details') }}:</b>
+    <b>{{ _('Title') }}:</b>
     {{ issue.title }}
+</p>
+<p style="margin: 0;padding: 0;">
+    <b>{{ _('Message') }}:</b>
+    {{ message.content | markdown }}
 </p>
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>

--- a/udata/templates/mail/new_issue.txt
+++ b/udata/templates/mail/new_issue.txt
@@ -8,7 +8,7 @@
 ) }}.
 
 
-{{ _('Details') }}: {{ issue.title }}
+{{ _('Title') }}: {{ issue.title }}
 
 {{ _('You can see the issue on this page:') }}
 {{ issue.subject.external_url }}

--- a/udata/templates/mail/new_issue_comment.html
+++ b/udata/templates/mail/new_issue_comment.html
@@ -7,9 +7,9 @@
         type=issue.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('users.show', user=comment.posted_by, _external=True)
+            + url_for('users.show', user=message.posted_by, _external=True)
             + '">'|safe
-            + comment.posted_by.fullname
+            + message.posted_by.fullname
             + '</a>'|safe
         ),
         subject=(
@@ -23,15 +23,14 @@
 }}.</p>
 <br/>
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Details') }}:</b>
+    <b>{{ _('Title') }}:</b>
     {{ issue.title }}
 </p>
 
 <p style="margin: 0;padding: 0;">
-    <b>{{ _('Comment') }}:</b>
-    {{ comment.content }}
+    <b>{{ _('Message') }}:</b>
+    {{ message.content | markdown }}
 </p>
-
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>

--- a/udata/templates/mail/new_issue_comment.txt
+++ b/udata/templates/mail/new_issue_comment.txt
@@ -3,12 +3,12 @@
 {% block body %}
 {{ _('%(user)s commented an issue on your %(type)s %(subject)s',
     type=issue.subject.verbose_name,
-    user=comment.posted_by.fullname,
+    user=message.posted_by.fullname,
     subject=issue.subject|string
 ) }}.
 
 
-{{ _('Details') }}: {{ issue.title }}
+{{ _('Title') }}: {{ issue.title }}
 
 
 {{ _('You can see the issue on this page:') }}


### PR DESCRIPTION
This PR ensures the following on discussions and issues mails:
- markdown messages are properly rendered
- make the wording more understandable (Title vs Details...)
- give some coherence by displaying the same content on creation, new comment and closure