### PR TITLE
Assets manifest and long-term caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ js-built
 /site/
 /node_modules/
 /udata/static/
+/udata/manifest.json
 /jsdoc/
 *.rdb
 venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### New features
 
 - Harvest sources are now filterable through the harvest source create/edit admin form [#1812](https://github.com/opendatateam/udata/pull/1812)
+- Static assets are now compatible with long-term caching (ie. their hash is present in the filename) [#1826](https://github.com/opendatateam/udata/pull/1826)
 
 ### Breaking changes
 
-None
+- Theme are now responsible for adding their CSS markup on template (no more assumptions on `theme.css` and `admin.css`). Most of the time, overriding `raw.html` and `admin.html` should be sufficient
 
 ### Bugfixes
 

--- a/docs/creating-theme.md
+++ b/docs/creating-theme.md
@@ -140,11 +140,17 @@ To extend a template and change some details, just extend the base template and 
 ```html+jinja
 {% extends "raw.html" %}
 
+{% block theme_css %}
+{{ super() }}
+<link href="{{ theme_static('theme.css') }}" rel="stylesheet">
+{% endblock %}
+
 {% block raw_head %}
 {{ super() }}
 <link rel="shortcut icon" href="{{ theme_static('img/favicon.png') }}">
 {% endblock %}
 ```
+
 You can reference static assets from your theme with the `theme_static` global function.
 
 !!! note
@@ -153,6 +159,46 @@ You can reference static assets from your theme with the `theme_static` global f
 
 You can also rewrite entirely the template, but don't forget you need to have the proper blocks
 for template inheritance and use the proper context variables.
+
+## Assets manifest
+
+Theme can optionnaly provide an asset manifest for long-term caching.
+The manifest is simply a JSON file mapping human-readable names (ie. `theme.css`) to their real path (ie. `/_theme/my-theme/theme.83c45954dd3da90126b5f13d10b547b5.css`).
+
+The theme assets manifest need to be named `manifest.json` at the theme root directory (sibling `info.json`).
+If present, `udata` will automatically detect it and allows you to use the `manifest` jinja global helper and the `in_manifest` jinja test.
+
+```html+jinja
+{% extends "raw.html" %}
+
+{% block theme_css %}
+{{ super() }}
+<link href="{{ manifest('theme', 'theme.css') }}" rel="stylesheet">
+{# Only render tag if asset is present in the manifest #}
+{% if 'my.css' is in_manifest('theme') %}
+<link href="{{ manifest('theme', 'my.css') }}" rel="stylesheet">
+{% endif %}
+{% endblock %}
+```
+
+!!! note
+    The theme manifest is registered with the `theme` key.<br/>
+    You need to use `manfest('theme', <filename>)` and `in_manifest('theme')`
+
+Here a sample theme manifest:
+
+```json
+{
+  "admin.css": "/_themes/gouvfr/admin.10cd3b26d19962df0e6b78cbdcadfe88.css",
+  "admin.js": "/_themes/gouvfr/admin.97515dac30750ec5d315.js",
+  "img/favicon.png": "/_themes/gouvfr/img/favicon.png",
+  "...": "",
+  "oembed.css": "/_themes/gouvfr/oembed.66142920652697e6e1717060154fe3a2.css",
+  "oembed.js": "/_themes/gouvfr/oembed.97515dac30750ec5d315.js",
+  "theme.css": "/_themes/gouvfr/theme.d9adbf77694f2b00063ddc34b61bf8fe.css",
+  "theme.js": "/_themes/gouvfr/theme.97515dac30750ec5d315.js"
+}
+```
 
 ## Hooks
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "vue-loader": "8.5.3",
     "vue-style-loader": "^1.0.0",
     "webpack": "1.13.1",
-    "webpack-fail-plugin": "^2.0.0"
+    "webpack-fail-plugin": "^2.0.0",
+    "webpack-manifest-plugin": "^1.3.2"
   },
   "dependencies": {
     "admin-lte": "2.3.11",

--- a/udata/assets.py
+++ b/udata/assets.py
@@ -56,12 +56,17 @@ def from_manifest(app, filename, **kwargs):
     '''
     Get the path to a static file for a given app entry of a given type
     '''
-    if current_app.config.get('DEBUG', current_app.debug):
+    cfg = current_app.config
+    if cfg.get('DEBUG', current_app.debug):
         # Always read manifest in DEBUG
         manifest = load_manifest(app, _registered_manifests[app])
         return manifest[filename]
 
     path = _manifests[app][filename]
+
+    if cfg.get('CDN_DOMAIN') and not cfg.get('CDN_DEBUG'):
+        prefix = 'https://' if cfg.get('CDN_HTTPS') else '//'
+        return ''.join((prefix, cfg['CDN_DOMAIN'], path))
     return path
 
 

--- a/udata/assets.py
+++ b/udata/assets.py
@@ -26,6 +26,8 @@ def has_manifest(app, filename='manifest.json'):
 
 def register_manifest(app, filename='manifest.json'):
     '''Register an assets json manifest'''
+    if current_app.config.get('TESTING'):
+        return  # Do not spend time here when testing
     if not has_manifest(app, filename):
         msg = '{filename} not found for {app}'.format(**locals())
         raise ValueError(msg)
@@ -56,6 +58,8 @@ def from_manifest(app, filename, **kwargs):
     '''
     Get the path to a static file for a given app entry of a given type
     '''
+    if current_app.config.get('TESTING'):
+        return  # Do not spend time here when testing
     cfg = current_app.config
     if cfg.get('DEBUG', current_app.debug):
         # Always read manifest in DEBUG

--- a/udata/assets.py
+++ b/udata/assets.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import io
+import json
+import os
+import pkg_resources
+
+from flask import current_app, url_for
+from flask_cdn import url_for as cdn_url_for
+
+# Store manifests URLs with the following hierarchy
+# app > filename (without hash) > URL
+_manifests = {}
+
+_registered_manifests = {}  # Here for debug without cache
+
+
+def has_manifest(app, filename='manifest.json'):
+    '''Verify the existance of a JSON assets manifest'''
+    try:
+        return pkg_resources.resource_exists(app, filename)
+    except ImportError:
+        return os.path.isabs(filename) and os.path.exists(filename)
+
+
+def register_manifest(app, filename='manifest.json'):
+    '''Register an assets json manifest'''
+    if not has_manifest(app, filename):
+        msg = '{filename} not found for {app}'.format(**locals())
+        raise ValueError(msg)
+    manifest = _manifests.get(app, {})
+    manifest.update(load_manifest(app, filename))
+    _manifests[app] = manifest
+    _registered_manifests[app] = filename
+
+
+def load_manifest(app, filename='manifest.json'):
+    '''Load an assets json manifest'''
+    if os.path.isabs(filename):
+        with io.open(filename, mode='r', encoding='utf8') as stream:
+            data = json.load(stream)
+    else:
+        data = json.load(pkg_resources.resource_stream(app, filename))
+    return data
+
+
+def exists_in_manifest(app, filename):
+    '''
+    Test wether a static file exists in registered manifests or not
+    '''
+    return app in _manifests and filename in _manifests[app]
+
+
+def from_manifest(app, filename, **kwargs):
+    '''
+    Get the path to a static file for a given app entry of a given type
+    '''
+    if current_app.config.get('DEBUG', current_app.debug):
+        # Always read manifest in DEBUG
+        manifest = load_manifest(app, _registered_manifests[app])
+        return manifest[filename]
+
+    path = _manifests[app][filename]
+    return path
+
+
+def cdn_for(endpoint, **kwargs):
+    '''
+    Get a CDN URL for a static assets.
+
+    Do not use a replacement for all flask.url_for calls
+    as it is only meant for CDN assets URLS.
+    (There is some extra round trip which cost is justified
+    by the CDN assets prformance improvements)
+    '''
+    if current_app.config['CDN_DOMAIN']:
+        if not current_app.config.get('CDN_DEBUG'):
+            kwargs.pop('_external', None)  # Avoid the _external parameter in URL
+        return cdn_url_for(endpoint, **kwargs)
+    return url_for(endpoint, **kwargs)

--- a/udata/commands/serve.py
+++ b/udata/commands/serve.py
@@ -11,6 +11,7 @@ from flask.cli import pass_script_info, DispatchingApp
 
 from werkzeug.serving import run_simple
 
+from udata import assets
 from udata.commands import cli
 
 
@@ -67,6 +68,10 @@ def serve(info, host, port, reload, debugger, eager_loading, with_threads):
 
     settings = os.environ.get('UDATA_SETTINGS',
                               os.path.join(os.getcwd(), 'udata.cfg'))
+    extra_files = [settings]
+    if reload:
+        extra_files.extend(assets.manifests_paths())
+
     run_simple(host, port, app, use_reloader=reload,
                use_debugger=debugger, threaded=with_threads,
-               extra_files=[settings])
+               extra_files=extra_files)

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -61,9 +61,12 @@ def known_dists():
     )
 
 
-def get_plugins_dists(app):
+def get_plugins_dists(app, name=None):
     '''Return a list of Distributions with enabled udata plugins'''
-    plugins = set(app.config['PLUGINS'])
+    if name:
+        plugins = set(e.name for e in get_all(name) if e.name in app.config['PLUGINS'])
+    else:
+        plugins = set(app.config['PLUGINS'])
     return [
         d for d in known_dists()
         if any(set(v.keys()) & plugins for v in d.get_entry_map().values())

--- a/udata/entrypoints.py
+++ b/udata/entrypoints.py
@@ -64,7 +64,7 @@ def known_dists():
 def get_plugins_dists(app, name=None):
     '''Return a list of Distributions with enabled udata plugins'''
     if name:
-        plugins = set(e.name for e in get_all(name) if e.name in app.config['PLUGINS'])
+        plugins = set(e.name for e in iter_all(name) if e.name in app.config['PLUGINS'])
     else:
         plugins = set(app.config['PLUGINS'])
     return [

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -84,6 +84,9 @@ def init_app(app, views=None):
     # Load all plugins views and blueprints
     for module in entrypoints.get_enabled('udata.views', app).values():
         _load_views(app, module)
+    for dist in entrypoints.get_plugins_dists(app, 'udata.views'):
+        if assets.has_manifest(dist):
+            assets.register_manifest(dist)
 
     # Optionnaly register debug views
     if app.config.get('DEBUG'):

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 
 from flask import abort, current_app
 
-from udata import entrypoints
+from udata import assets, entrypoints
 from udata.i18n import I18nBlueprint
 
 from .markdown import init_app as init_markdown
@@ -75,6 +75,8 @@ def init_app(app, views=None):
     init_markdown(app)
 
     from . import helpers, error_handlers  # noqa
+
+    assets.register_manifest('udata')
 
     for view in views:
         _load_views(app, 'udata.{}.views'.format(view))

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -76,17 +76,19 @@ def init_app(app, views=None):
 
     from . import helpers, error_handlers  # noqa
 
-    assets.register_manifest('udata')
-
     for view in views:
         _load_views(app, 'udata.{}.views'.format(view))
 
     # Load all plugins views and blueprints
     for module in entrypoints.get_enabled('udata.views', app).values():
         _load_views(app, module)
-    for dist in entrypoints.get_plugins_dists(app, 'udata.views'):
-        if assets.has_manifest(dist):
-            assets.register_manifest(dist)
+
+    # Load core manifest
+    with app.app_context():
+        assets.register_manifest('udata')
+        for dist in entrypoints.get_plugins_dists(app, 'udata.views'):
+            if assets.has_manifest(dist.project_name):
+                assets.register_manifest(dist.project_name)
 
     # Optionnaly register debug views
     if app.config.get('DEBUG'):

--- a/udata/templates/admin.html
+++ b/udata/templates/admin.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ g.lang_code }}">
     <head>
+        {% block raw_head %}
         {% from theme('macros/metadata.html') import metadata with context %}
         {{ metadata({
             'title': _('Admin'),
@@ -9,13 +10,16 @@
             'robots': 'noindex',
         }) }}
         <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport' />
-        <link href="{{ static('common.css') }}" rel="stylesheet">
-        <link href="{{ static('admin.css') }}" rel="stylesheet">
-        <link href="{{ theme_static('admin.css') }}" rel="stylesheet">
+        <link href="{{ manifest('udata', 'common.css') }}" rel="stylesheet" />
+        <link href="{{ manifest('udata', 'admin.css') }}" rel="stylesheet" />
+        {% block theme_css %}{% endblock %}
+        {% block extra_head %}{% endblock %}
+        {% endblock raw_head %}
     </head>
     <body class="skin-blue fixed sidebar-mini">
         <div id="app"></div>
-        <script src="{{ static('common.js') }}"></script>
-        <script src="{{ static('admin.js') }}"></script>
+        <script src="{{ manifest('udata', 'common.js') }}"></script>
+        <script src="{{ manifest('udata', 'admin.js') }}"></script>
+        {% block theme_js %}{% endblock %}
     </body>
 </html>

--- a/udata/templates/raw.html
+++ b/udata/templates/raw.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
 {%- set bundle = bundle|default('site') -%}
+{%- set bundle_js = '{0}.js'.format(bundle)-%}
+{%- set bundle_css = '{0}.css'.format(bundle)-%}
 <html lang="{{ g.lang_code }}">
   <head>
     {% block raw_head %}
     {% from theme('macros/metadata.html') import metadata with context %}
     {{ metadata(meta or {}) }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="{{ static('common.css') }}">
-    <link rel="stylesheet" href="{{ static('{0}.css'.format(bundle)) }}">
+    <link rel="stylesheet" href="{{ manifest('udata', 'common.css') }}">
+    {% if bundle_css is in_manifest %}
+    <link rel="stylesheet" href="{{ manifest('udata', '{0}.css'.format(bundle)) }}">
+    {% endif %}
     {% block extra_css %}{% endblock %}
-    <link href="{{ theme_static('theme.css') }}" rel="stylesheet">
+    {% block theme_css %}{% endblock %}
     {# ATOM Feeds #}
     <link href="{{ url_for('datasets.recent_feed') }}"
         rel="alternate" type="application/atom+xml"
@@ -28,8 +32,10 @@
   <body class="{{body_class}} theme-{{current_theme.variant}}">
     {% block body %}{% endblock %}
 
-    <script src="{{ static('common.js') }}"></script>
-    <script src="{{ static('{0}.js'.format(bundle)) }}"></script>
+    <script src="{{ manifest('udata', 'common.js') }}"></script>
+    {% if bundle_js is in_manifest %}
+    <script src="{{ manifest('udata', '{0}.js'.format(bundle)) }}"></script>
+    {% endif %}
     {% block extra_js %}{% endblock %}
 
     {% for snippet in footer_snippets %}

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -18,7 +18,6 @@
 
 {% block extra_head %}
 <link rel="canonical" href="{{ url_for('reuses.show', reuse=reuse) }}" />
-<link rel="stylesheet" type="text/css" href="{{ static('reuse.css') }}">
 <link rel="alternate" type="application/json+oembed"
     href="{{ url_for('api.oembed', url=reuse.external_url) }}"
     title="{{ reuse.title | urlencode }}" />

--- a/udata/theme/__init__.py
+++ b/udata/theme/__init__.py
@@ -118,7 +118,6 @@ class ConfigurableTheme(Theme):
         if self._configured:
             return
         self.entrypoint.load()
-        assets.register_manifest('theme', self.manifest)
         if self.defaults and self.identifier not in self.site.themes:
             self.site.themes[self.identifier] = self.defaults
             try:
@@ -174,6 +173,11 @@ def init_app(app):
 
     # Override the default theme_static
     app.jinja_env.globals['theme_static'] = theme_static_with_version
+
+    # Load manifest if necessary
+    if theme.manifest:
+        with app.app_context():
+            assets.register_manifest('theme', theme.manifest)
 
     # Hook into flask security to user themed auth pages
     app.config.setdefault('SECURITY_RENDER', 'udata.theme:render')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,15 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const node_path = path.join(__dirname, 'node_modules');
+const ManifestPlugin = require('webpack-manifest-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const css_loader = ExtractTextPlugin.extract('vue-style?sourceMap', 'css?sourceMap');
 const less_loader = ExtractTextPlugin.extract('vue-style?sourceMap', 'css?sourceMap!less?sourceMap=source-map-less-inline');
 
 const languages = ['en', 'es', 'fr', 'pt'];
+const public_path = '/static/';
 
 module.exports = {
     entry: {
@@ -28,9 +30,9 @@ module.exports = {
     },
     output: {
         path: path.join(__dirname, 'udata', 'static'),
-        publicPath: '/static/',
-        filename: '[name].js',
-        chunkFilename: 'chunks/[id].[hash].js'
+        publicPath: public_path,
+        filename: '[name].[hash].js',
+        chunkFilename: 'chunks/[id].[chunkhash].js'
     },
     resolve: {
         root: [
@@ -89,13 +91,18 @@ module.exports = {
             jQuery: 'jquery',  // Required by bootstrap.js
             'window.jQuery': 'jquery',  // Required by swagger.js jquery client
         }),
-        new ExtractTextPlugin('[name].css'),
+        new ManifestPlugin({
+            fileName: path.join(__dirname, 'udata', 'manifest.json'),
+            // Filter out chunks and source maps
+            filter: ({name, isInitial, isChunk}) => !name.endsWith('.map') && (isInitial || !isChunk),
+            publicPath: public_path,
+        }),
+        new ExtractTextPlugin('[name].[contenthash].css'),
         // Only include needed translations
         new webpack.ContextReplacementPlugin(/moment\/locale$/, new RegExp('^' + languages.join('|') + '$')),
         new webpack.ContextReplacementPlugin(/locales$/, new RegExp(languages.join('|'))),
         new webpack.optimize.CommonsChunkPlugin({
             name: 'common',
-            filename: 'common.js',
             minChunks: 10,  // (Modules must be shared between 10 entries)
         })
     ],


### PR DESCRIPTION
This pull request adds support for assets manifests as JSON files.

## Assets Manifest

An assets manifest is simply a json file mapping the assets human-readable names to their cacheable (ie. hashed) one.

**A sample manifest file**
```json
{
  "admin.css": "/_themes/gouvfr/admin.10cd3b26d19962df0e6b78cbdcadfe88.css",
  "admin.js": "/_themes/gouvfr/admin.97515dac30750ec5d315.js",
  "img/favicon.png": "/_themes/gouvfr/img/favicon.png",
  "...": "",
  "oembed.css": "/_themes/gouvfr/oembed.66142920652697e6e1717060154fe3a2.css",
  "oembed.js": "/_themes/gouvfr/oembed.97515dac30750ec5d315.js",
  "theme.css": "/_themes/gouvfr/theme.d9adbf77694f2b00063ddc34b61bf8fe.css",
  "theme.js": "/_themes/gouvfr/theme.97515dac30750ec5d315.js"
}
```

## Templates

This pull request adds a new `manifest` global helper as well as a `in_manifest` jinja test.

This allow to serialize assets URLs like this:
```html+jinja
{# Always rendered #}
<link href="{{ manifest('udata', 'common.css') }}" rel="stylesheet">
{# Only render tag if asset is present in the udata manifest #}
{% if 'my.css' is in_manifest %}
<link href="{{ manifest('udata', 'my.css') }}" rel="stylesheet">
{% endif %}
{# Only render tag if asset is present in the udata-xxx manifest #}
{% if 'my.css' is in_manifest('udata-xxx') %}
<link href="{{ manifest('udata-xxx', 'my.css') }}" rel="stylesheet">
{% endif %}
```

`udata` template make use of `in_manifest` to prevent a lot of 404 on bundles without style.

## Webpack, core assets

This PR makes uses of [danethurber/webpack-manifest-plugin](https://github.com/danethurber/webpack-manifest-plugin) to generate the `udata core assets manifest.
All generated assets have their hash in their filename and so won't conflict with previous assets versions.

## Theming

Themes can provide a `manifest.json` in their root dirctory (sibling `info.json`) and it will be automatically loaded by `udata` and available under the `theme` manifest.

```html+jinja
{% block theme_css %}
{{ super() }}
<link href="{{ manifest('theme', 'theme.css') }}" rel="stylesheet">
{% endblock %}
```

### Breaking change

Theme are now entirely responsible for adding their style or script markup in the template.

To maintain compatibility, theme should provide the following templates:

**raw.html**
```html+jinja
{% extends "raw.html" %}
{% block theme_css %}
{{ super() }}
<link href="{{ theme_static('theme.css') }}" rel="stylesheet">
{% endblock %}
```

**admin.html**
```html+jinja
{% extends "admin.html" %}
{% block theme_css %}
{{ super() }}
<link href="{{ theme_static('admin.css') }}" rel="stylesheet">
{% endblock %}
```
This allows theme to optionnaly use assets manifests and this also avoid 404 errors on missing style (ie. `admin.css` when admin is not customized and there is no `admin.css` in the theme)

## Extensions

Extensions exporting `udata.views` plugins can also provide a `manifest.json` in their root package, it will be automatically loaded if extension is active.
The manifest will be available under the package distribution name (ie. `udata-xxx`).

Generic plugins can manually register any manifest with the appropriate helpers:

```python
from udata import assets

def init_app(app):
    # Absolute path be loaded on any key
    assets.register_manifest('key', `absolute_path_to_manifest')
    # Relative path is relative to the distribution root package
    # and must use the distribution name as key (ie. `udata-xx`)
    assets.register_manifest('my-udata-ext', `package_root_relative_path_to_manifest')
    # You can register multiple manifest on a single key
    # They will be merged (older key are overwritten)
    assets.register_manifest('key', `absolute_path_to_another_manifest')
```

## Debug and assets reloading

~~To allows assets reloading when using the `assets-watch`, the manifest is read each time an URL is needed. In production, the manifest is read once.~~

~~A possible alternative implementation is to add the manifests to the flask development server watch list. It will be more performant be will trigger a server reload after each webpack build. (Don't hesitate to tell if you prefer this second implementation, I can switch it easily)~~

When using the `serve` command with auto-reload, manifest files are watched and will trigger reload on any change.

## Testing

Manifests files reading is disabled during test to:
- allow to run tests without the need for compiled assets
- avoid file read on each test

## Internals

Assets helpers have been grouped together into the `udata.assets` module for coherence, maintainability and to break a circular dependency on `cdn_for()` helper.

## Not handled

Legacy embed widgets and the oembed cards are not using using hash in URL because they are referenced respectively by `widgets.js` and `oembed.js` in the copy-paste snippet.
This might need another pull request.
