### PR TITLE
Fix missing dataset title on client-side card listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Ensure that admin notifications are displayed once and with a constant width. [#1831](https://github.com/opendatateam/udata/pull/1831)
 - Allows to clear the dataset form temporal coverage. [#1832](https://github.com/opendatateam/udata/pull/1832)
+- Fix missing dataset title on client-side card listing [#1834](https://github.com/opendatateam/udata/pull/1834)
 
 ### Internal
 

--- a/js/components/dataset/card.vue
+++ b/js/components/dataset/card.vue
@@ -59,7 +59,7 @@ import placeholders from 'helpers/placeholders';
 import config from 'config';
 
 const MASK = [
-    'id', 'title', 'description', 'metrics', 'organization',
+    'id', 'title', 'acronym', 'description', 'metrics', 'organization',
     'spatial{zones,granularity}', 'frequency', 'temporal_coverage',
     'page', 'uri'
 ];

--- a/js/models/base.js
+++ b/js/models/base.js
@@ -206,6 +206,7 @@ export class List extends Base {
 
         this.items = this.$options.data || [];
         this.query = this.$options.query || {};
+        this.model = this.$options.model;
 
         this.sorted = null;
         this.reversed = false;
@@ -268,7 +269,7 @@ export class List extends Base {
     }
 
     on_fetched(data) {
-        this.items = data.obj;
+        this.items = this.model ? data.obj.map(o => new this.model({data: o})) : data.obj;
         this.populate();
         this.$emit('updated');
         this.loading = false;

--- a/js/views/editorial.vue
+++ b/js/views/editorial.vue
@@ -25,6 +25,8 @@
 <script>
 import Posts from 'models/posts';
 import Topics from 'models/topics';
+import Reuse from 'models/reuse';
+import Dataset from 'models/dataset';
 import {List} from 'models/base';
 import API from 'api';
 import Layout from 'components/layout.vue';
@@ -40,8 +42,10 @@ export default {
         return {
             posts: new Posts({query: {sort: '-created', page_size: 10}, mask: PostList.MASK}),
             topics: new Topics({query: {sort: '-created', page_size: 10}, mask: TopicList.MASK}),
-            home_datasets: new List({ns: 'site', fetch: 'get_home_datasets', mask: DatasetCardList.MASK}),
-            home_reuses: new List({ns: 'site', fetch: 'get_home_reuses', mask: ReuseCardList.MASK})
+            home_datasets: new List({ns: 'site', fetch: 'get_home_datasets',
+                                     mask: DatasetCardList.MASK, model: Dataset}),
+            home_reuses: new List({ns: 'site', fetch: 'get_home_reuses',
+                                   mask: ReuseCardList.MASK, model: Reuse})
         };
     },
     components: {


### PR DESCRIPTION
This PR fixes the missing dataset title on editorial home datasets.

## Explanation
`full_title` is `Dataset` object computed property (it's `title` + `acronym` if present).
Everywhere but here this is a list of `Dataset` object instances which is given as parameter.

To fix this, this PR allows to cast js `List`objects with an optionnal `model` option in constructor.

## Before
![screenshot-data xps-2018 08 17-19-01-59](https://user-images.githubusercontent.com/15725/44278972-0b91fb80-a250-11e8-8941-ea8ed4fc6b6f.png)


## After
![screenshot-data xps-2018 08 17-18-56-38](https://user-images.githubusercontent.com/15725/44278962-f2894a80-a24f-11e8-8691-d53b7187d820.png)
