### PR TITLE
Explicit supported python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     author_email='opendatateam@data.gouv.fr',
     packages=find_packages(),
     include_package_data=True,
+    python_requires='==2.7.*',
     install_requires=install_requires,
     setup_requires=['setuptools>=38.6.0'],
     tests_require=tests_require,


### PR DESCRIPTION
This PR adds a `python_requires` statement to the `setup.py` file to avoid Python 2/3 mismatch (`py3` branch already have the same for Python 3.5+).