### PR TITLE
Switch discussion.posted_by from user ID to embedded user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Breaking changes
 
 - Theme are now responsible for adding their CSS markup on template (no more assumptions on `theme.css` and `admin.css`). Most of the time, overriding `raw.html` and `admin.html` should be sufficient
+- The discussions API `posted_by` attribute is now an embedded user instead of an user ID to avoid extra API calls [#1839](https://github.com/opendatateam/udata/pull/1839)
 
 ### Bugfixes
 

--- a/js/components/discussions/message.vue
+++ b/js/components/discussions/message.vue
@@ -75,7 +75,7 @@
         <div class="message-content">
             <div class="message-header">
                 <div class="author">
-                    <a href="{{ message.posted_by.page }}">{{ message.posted_by.first_name }} {{ message.posted_by.last_name }}</a>
+                    <a href="{{ message.posted_by.page }}">{{ message.posted_by | display }}</a>
                 </div>
 
                 <div class="posted_on">

--- a/js/components/discussions/thread.vue
+++ b/js/components/discussions/thread.vue
@@ -10,9 +10,9 @@
 }
 
 .add-comment {
-    
+
     padding: 10px 15px;
-    
+
     & > button.btn {
         margin: 0 auto;
         display: block;
@@ -23,7 +23,7 @@
 <div class="discussion-thread panel panel-default">
     <div class="panel-heading" @click="toggleDiscussions">
         <div>
-            <a href="#{{ discussionIdAttr }}" class="pull-right" v-on:click.stop><span class="fa fa-link"></span></a> 
+            <a href="#{{ discussionIdAttr }}" class="pull-right" v-on:click.stop><span class="fa fa-link"></span></a>
             <strong>{{ discussion.title }}</strong>
             <span class="label label-warning" v-if="discussion.closed"><i class="fa fa-minus-circle" aria-hidden="true"></i> {{ _('closed discussion') }}</span>
         </div>
@@ -56,10 +56,10 @@
         <span class="text-muted">{{ discussion.discussion.length }} {{ _('messages') }}</span>
     </div>
 
-    <div class="panel-footer" v-show="discussion.closed">
+    <div class="panel-footer" v-if="discussion.closed">
         <div class="text-muted">
             {{ _('Discussion has been closed') }}
-            {{ _('by') }} <a href="{{ closed_by_url}}">{{ closed_by_name }}</a>
+            {{ _('by') }} <a href="{{ discussion.closed_by.page }}">{{ discussion.closed_by | display }}</a>
             {{ _('on') }} {{ closedDate }}
         </div>
     </div>
@@ -84,8 +84,6 @@ export default {
             detailed: true,
             formDisplayed: false,
             currentUser: config.user,
-            closed_by_name: null,
-            closed_by_url: null
         }
     },
     events: {
@@ -104,18 +102,6 @@ export default {
         },
         closedDate() {
             return moment(this.discussion.closed).format('LL');
-        }
-    },
-    ready() {
-        if( this.discussion.closed_by ){
-            const user_id = this.discussion.closed_by;
-
-            this.detailed = false;
-
-            this.$api.get(`users/${user_id}`).then(response => {
-                this.closed_by_url = response.page;
-                this.closed_by_name = `${response.first_name} ${response.last_name}`;
-            });
         }
     },
     methods: {

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -38,9 +38,8 @@ discussion_fields = api.model('Discussion', {
         user_ref_fields, description='The discussion author'),
     'created': fields.ISODateTime(description='The discussion creation date'),
     'closed': fields.ISODateTime(description='The discussion closing date'),
-    'closed_by': fields.String(
-        attribute='closed_by.id',
-        description='The user who closed the discussion'),
+    'closed_by': fields.Nested(user_ref_fields, allow_null=True,
+                               description='The user who closed the discussion'),
     'discussion': fields.Nested(message_fields),
     'url': fields.UrlFor('api.discussion',
                          description='The discussion API URI'),

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -324,7 +324,7 @@ class DiscussionsTest(APITestCase):
         self.assertEqual(data['title'], 'test discussion')
         self.assertIsNotNone(data['created'])
         self.assertIsNotNone(data['closed'])
-        self.assertEqual(data['closed_by'], str(owner.id))
+        self.assertEqual(data['closed_by']['id'], str(owner.id))
         self.assertEqual(len(data['discussion']), 2)
         self.assertEqual(data['discussion'][1]['content'], 'close bla bla')
         self.assertEqual(


### PR DESCRIPTION
This PR switch the discussion API `posted_by` attribute from being a user ID to an embedded user.
This avoid extra API calls to fetch user data on display.