### PR TITLE
Ensure API doc works without data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Allows to clear the dataset form temporal coverage. [#1832](https://github.com/opendatateam/udata/pull/1832)
 - Fix missing dataset title on client-side card listing [#1834](https://github.com/opendatateam/udata/pull/1834)
 - Expose the default spatial granularity in API specs [#1841](https://github.com/opendatateam/udata/pull/1841)
+- Ensure API docs works without data [#1840](https://github.com/opendatateam/udata/pull/1840)
 
 ### Internal
 

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import itertools
 import logging
 import urllib
 
+from bson import ObjectId
 from functools import wraps
 
 from flask import (
@@ -19,6 +21,7 @@ from udata.auth import (
     current_user, login_user, Permission, RoleNeed, PermissionDenied
 )
 from udata.core.user.models import User
+from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Organization
 from udata.sitemap import sitemap
 from udata.utils import safe_unicode
@@ -272,8 +275,18 @@ def default_api():
 
 @apidoc.route('/apidoc/')
 def swaggerui():
+    page_size = 10
     params = {"datasets": "many"}
-    organizations = search.iter(Organization, **params)
+    organizations = search.iter(Organization)
+    organizations = list(itertools.islice(organizations, page_size))
+    if len(organizations) < page_size:
+        # Fill with dummy values
+        needs = page_size - len(organizations)
+        extra_orgs = OrganizationFactory.build_batch(needs)
+        for org in extra_orgs:
+            org.id = ObjectId()
+            Organization.slug.generate()
+        organizations.extend(extra_orgs)
     return theme.render('apidoc.html', specs_url=api.specs_url, organizations=organizations)
 
 

--- a/udata/templates/apidoc.html
+++ b/udata/templates/apidoc.html
@@ -7,8 +7,7 @@
 } %}
 
 {% set bundle = 'apidoc' %}
-{% set org_list = organizations | list %}
-{% set main_org = org_list | first %} 
+{% set main_org = organizations | first %}
 
 {% block extra_head %}
 <meta name="swagger-specs" content="{{ specs_url }}" />
@@ -81,7 +80,7 @@
     "data": [{...}, {...}],
     "page": 1,
     "page_size": 20,
-    "total": {{ org_list|count }},
+    "total": {{ organizations|count }},
     "next_page": "https://{{config.SERVER_NAME}}/api/endpoint/?page=2",
     "previous_page": null
 }</code></pre>
@@ -120,7 +119,7 @@ Access-Control-Allow-Credentials: true
             "name": "{{ main_org.name }}",
             "page": "https://{{config.SERVER_NAME}}/organizations/{{ main_org.slug }}/",
             "slug": "{{ main_org.slug }}",
-            "uri": "https://{{config.SERVER_NAME}}/api/1/organizations/{{ main_org.slug }}/",
+            "uri": "https://{{config.SERVER_NAME}}/api/1/organizations/{{ main_org.id }}/",
             "url": "{{ main_org.url }}"
         }
     ],
@@ -128,7 +127,7 @@ Access-Control-Allow-Credentials: true
     "page": 1,
     "page_size": 1,
     "previous_page": null,
-    "total": "{{ org_list|count }}"
+    "total": "{{ organizations|count }}"
 }
 </code></pre>
 
@@ -169,7 +168,7 @@ Access-Control-Allow-Credentials: true
                 <pre><code class="json">$ http $API'organizations/' | jq '.data[].name'</code></pre>
 
 <pre><code class="json">
-{% for org in org_list[0:20] %}"{{ org.name }}"
+{% for org in organizations[0:20] %}"{{ org.name }}"
 {% endfor %}
 </code></pre>
 
@@ -179,19 +178,19 @@ Access-Control-Allow-Credentials: true
                 <pre><code class="json">$ http $API'organizations/?page_size=5' | jq '.data[].uri'</code></pre>
 
 <pre><code class="json">
-{% for org in org_list[0:5] %}"https://{{config.SERVER_NAME}}/api/1/organizations/{{ org.slug }}/"
+{% for org in organizations[0:5] %}"https://{{config.SERVER_NAME}}/api/1/organizations/{{ org.id }}/"
 {% endfor %}
 </code></pre>
 
                 <p>{% trans %}Now we'll be able to retrieve a unique organization thanks to the returned URI:
                 {% endtrans %}</p>
 
-                <pre><code class="json">$ http $API'organizations/{{main_org.slug}}/' | jq '.'</code></pre>
+                <pre><code class="json">$ http $API'organizations/{{main_org.id}}/' | jq '.'</code></pre>
 
                 <p>{% trans %}That's a lot of data to compute. Let's refine these data, if we want only metrics:
                 {% endtrans %}</p>
 
-                <pre><code class="json">$ http $API'organizations/{{main_org.slug}}/' | jq '.metrics'</code></pre>
+                <pre><code class="json">$ http $API'organizations/{{main_org.id}}/' | jq '.metrics'</code></pre>
 
 <pre><code class="json">
 {
@@ -203,7 +202,7 @@ Access-Control-Allow-Credentials: true
                 <p>{% trans %}Or maybe just the name of the members of that organization:
                 {% endtrans %}</p>
 
-                <pre><code class="json">$ http $API'organizations/{{main_org.slug}}/' | jq '.members[].user.last_name'</code></pre>
+                <pre><code class="json">$ http $API'organizations/{{main_org.id}}/' | jq '.members[].user.last_name'</code></pre>
 
 <pre><code class="json">
 {% for member in main_org.members|list %}"{{member.user.last_name}}"


### PR DESCRIPTION
This PR ensure that API doc works when there is not as many data as required to generate the code snippets by generating the missing data with the factories.

Search criterions have been removed: listing relies on global scoring (and allows to fetch organizations when there isn't a lot of data)

It also fixes some snippets (`id` vs `slug`)

Fixes #1787
Fixes #1741