### PR TITLE
Add missing default spatial granularity (fix #1790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Ensure that admin notifications are displayed once and with a constant width. [#1831](https://github.com/opendatateam/udata/pull/1831)
 - Allows to clear the dataset form temporal coverage. [#1832](https://github.com/opendatateam/udata/pull/1832)
 - Fix missing dataset title on client-side card listing [#1834](https://github.com/opendatateam/udata/pull/1834)
+- Expose the default spatial granularity in API specs [#1841](https://github.com/opendatateam/udata/pull/1841)
 
 ### Internal
 

--- a/udata/core/spatial/api_fields.py
+++ b/udata/core/spatial/api_fields.py
@@ -66,7 +66,7 @@ spatial_coverage_fields = api.model('SpatialCoverage', {
         description='A multipolygon for the whole coverage'),
     'zones': fields.List(
         fields.String, description='The covered zones identifiers'),
-    'granularity': fields.String(
+    'granularity': fields.String(default='other',
         description='The spatial/territorial granularity'),
 })
 


### PR DESCRIPTION
This PR add the missing `default` attribute in the spatial granularity API specs and as a consequence restablish the preselectionned `other` value in the dataset creation form (granularity was empty).