### PR TITLE
Upload errors handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Only display temporal coverage years on cards and search results [#1833](https://github.com/opendatateam/udata/pull/1833)
 - Prevent front views from downloading `swagger.json` [#1838](https://github.com/opendatateam/udata/pull/1838)
+- Improved upload error handling: deduplicate notifications, localized generic error message, sentry identifier... [#1842](https://github.com/opendatateam/udata/pull/1842)
 
 ### Breaking changes
 

--- a/js/components/alert.vue
+++ b/js/components/alert.vue
@@ -5,7 +5,7 @@
             <span class="icon fa fa-{{alert.icon || 'check'}}"></span>
             {{alert.title}}
         </h4>
-        {{alert.details}}
+        {{{ details }}}
     </div>
 </template>
 
@@ -34,6 +34,11 @@ export default {
             };
             classes[`alert-${this.alert.type || 'success'}`] = true;
             return classes;
+        },
+        details() {
+            if (this.alert && this.alert.details) {
+                return this.alert.details.replace(/\n/g, '<br/>');
+            }
         }
     },
     methods: {

--- a/js/locales/udata.en.json
+++ b/js/locales/udata.en.json
@@ -387,6 +387,7 @@
     "Unavailable (maybe temporary)": "Unavailable (maybe temporary)",
     "Unfollow": "Unfollow",
     "Unique visitors": "Unique visitors",
+    "Unknown error while communicating with the server": "Unknown error while communicating with the server",
     "Unrecoverable error - this browser does not permit file uploading of any kind due to serious bugs in iOS8 Safari. Please use iOS8 Chrome until Apple fixes these issues.": "Unrecoverable error - this browser does not permit file uploading of any kind due to serious bugs in iOS8 Safari. Please use iOS8 Chrome until Apple fixes these issues.",
     "Unschedule": "Unschedule",
     "Unsupported ISO-8601 date format": "Unsupported ISO-8601 date format",

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import i18n from 'i18n';
 import log from 'logger';
 import qq from 'fine-uploader';
@@ -230,6 +231,12 @@ export default {
             }
             if (reason === 'XHR returned response code 0') {
                 reason = this._('Unknown error while communicating with the server');
+            }
+            if (xhr && config.sentry.dsn) {
+                const sentryId = xhr.getResponseHeader('X-Sentry-ID');
+                if (sentryId) {
+                    reason = [reason, this._('The error identifier is {id}', {id: sentryId})].join('\n');
+                }
             }
             this.$dispatch('notify', {
                 type: 'error',

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -56,6 +56,7 @@ export default {
     data() {
         return {
             files: [],
+            errors: new Set(),  // Track files ID for which errors has already been advertised
             dropping: false,
             upload_endpoint: null,
             HAS_FILE_API,
@@ -116,9 +117,9 @@ export default {
                     filenameParam: 'filename',
                 },
                 chunking: {
-                    enabled:  this.$options.chunk,
+                    enabled: this.$options.chunk,
                     concurrent: {
-                        enabled:  this.$options.chunk,
+                        enabled: this.$options.chunk,
                     },
                     paramNames: {
                         chunkSize: 'chunksize',
@@ -140,8 +141,8 @@ export default {
                     onComplete: this.on_complete,
                     onError: this.on_error,
                 },
-                messages: messages,
-                validation: {allowedExtensions: allowedExtensions.items}
+                validation: {allowedExtensions: allowedExtensions.items},
+                messages,
             });
         },
 
@@ -217,6 +218,7 @@ export default {
          * See: http://docs.fineuploader.com/branch/master/api/events.html#error
          */
         on_error(id, name, reason, xhr) {
+            if (this.errors.has(id)) return;  // Already notified on first chunk error
             // If there is a JSON message display it instead of the non-explicit default one
             if (xhr) {
                 try {
@@ -233,6 +235,7 @@ export default {
                 details: reason,
             });
             this.$emit('uploader:error', id, name, reason);
+            this.errors.add(id);
         },
 
         clear() {

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -228,6 +228,9 @@ export default {
                     log.error('Unable to parse error', xhr.responseText);
                 }
             }
+            if (reason === 'XHR returned response code 0') {
+                reason = this._('Unknown error while communicating with the server');
+            }
             this.$dispatch('notify', {
                 type: 'error',
                 icon: 'exclamation-triangle',


### PR DESCRIPTION
This PR improves upload errors handling by:
- deduplicating notifications (only one by file instead of one for every chunk)
- localizing the default xhr error
- handling multiline notification details formating
- displaying the Sentry ID if present