### PR TITLE
Resources modals consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Prevent UnicodeError on unicode URL validation error [#1844](https://github.com/opendatateam/udata/pull/1844)
+- Hide save button in "Add resource" modal until form is visible (and prevent error) [#1846](https://github.com/opendatateam/udata/pull/1846)
 
 ## 1.5.2 (2018-08-08)
 

--- a/js/components/dataset/resource/add-modal.vue
+++ b/js/components/dataset/resource/add-modal.vue
@@ -8,15 +8,15 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button"
-            class="btn btn-primary btn-flat pull-left"
-            v-show="$refs.form.hasData"
-            @click="save">
-            {{ _('Save') }}
-        </button>
-        <button type="button" class="btn btn-outline btn-flat"
+        <button type="button" class="btn btn-sm btn-primary btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button"
+            class="btn btn-outline btn-flat"
+            v-show="editing"
+            @click="save">
+            {{ _('Save') }}
         </button>
     </footer>
 </modal>
@@ -37,6 +37,17 @@ export default {
         }
     },
     components: {Modal, ResourceForm},
+    data() {
+        return {ready: false};
+    },
+    computed: {
+        editing() {
+            return this.ready && this.$refs && this.$refs.form && this.$refs.form.hasData;
+        }
+    },
+    ready() {
+        this.ready = true; // Artificially force editing update because $refs is not reactive
+    },
     methods: {
         save() {
             if (this.$refs.form.validate()) {

--- a/js/components/dataset/resource/add-modal.vue
+++ b/js/components/dataset/resource/add-modal.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
 <modal class="modal-primary add-resource-modal" v-ref:modal
-    :title="_('Add a resource')">
+    :title="_('Add a resource')" :large="editing">
 
     <div class="modal-body">
         <resource-form v-ref:form :dataset="dataset"></resource-form>

--- a/js/components/dataset/resource/add-modal.vue
+++ b/js/components/dataset/resource/add-modal.vue
@@ -10,7 +10,7 @@
     <footer class="modal-footer text-center">
         <button type="button"
             class="btn btn-primary btn-flat pull-left"
-            v-show="$refs.form.resource.filetype"
+            v-show="$refs.form.hasData"
             @click="save">
             {{ _('Save') }}
         </button>

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -227,7 +227,7 @@ export default {
     },
     computed: {
         hasData() {
-            return this.hasChosenRemoteFile || this.resource.url;
+            return Boolean(this.resource.url || this.hasChosenRemoteFile);
         },
         showUploadZone() {
             if (this.files.length) return false;

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -99,7 +99,7 @@
 
 <template>
 <div>
-    <form-horizontal v-if="resource.url || hasChosenRemoteFile" class="resource-form file-resource-form"
+    <form-horizontal v-if="hasData" class="resource-form file-resource-form"
         :fields="fields" :model="resource" v-ref:form>
     </form-horizontal>
     <div v-show="files.length" v-for="file in files" class="info-box bg-aqua">
@@ -226,6 +226,9 @@ export default {
         };
     },
     computed: {
+        hasData() {
+            return this.hasChosenRemoteFile || this.resource.url;
+        },
         showUploadZone() {
             if (this.files.length) return false;
             if (this.hasChosenRemoteFile) return false;

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -192,6 +192,7 @@ export default {
                 }, {
                     id: 'description',
                     label: this._('Description'),
+                    rows:3,
                 }, {
                     id: 'published',
                     label: this._('Publication date'),

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -16,7 +16,7 @@
 
 <template>
 <div>
-<modal :title="resource.title" class="resource-modal"
+<modal :title="resource.title" class="resource-modal" :large="edit"
     :class="{ 'modal-danger': confirm, 'modal-primary': !confirm }"
     v-ref:modal>
     <div class="modal-body">

--- a/js/components/form/markdown-editor.vue
+++ b/js/components/form/markdown-editor.vue
@@ -40,7 +40,7 @@
 </style>
 
 <template>
-<textarea class="form-control" :rows="rows || 6"
+<textarea class="form-control" :rows="field.rows || rows || 6"
     :id="field.id"
     :name="field.id"
     :placeholder="placeholder"


### PR DESCRIPTION
This PR adds some consistency to the resources modals:

## Only show save button when form is shown

The "Add resource" modal "Save" button is only shown when the form is shown too, this prevent form validation when the form isn't present yet.

### Before
![screenshot-www data gouv fr-2018 08 23-14-40-42](https://user-images.githubusercontent.com/15725/44525942-d7508c00-a6e2-11e8-89ae-c95272ad3759.png)

### After
![screenshot-data xps-2018 08 23-17-07-27](https://user-images.githubusercontent.com/15725/44534041-27d1e480-a6f7-11e8-97c4-ce6c23d0699b.png)

## Wide modal when editing

The modal become wide when the form shown:
- prevent most fields from spanning on 2 lines
- allow form to fill in the page and avoid scrolling to see buttons

Description fields has also been reduced from 6 to 3 lines

### Before
![screenshot-www data gouv fr-2018 08 23-17-04-30](https://user-images.githubusercontent.com/15725/44533896-ca3d9800-a6f6-11e8-9894-001859f3104b.png)

### After
![screenshot-data xps-2018 08 23-17-03-20](https://user-images.githubusercontent.com/15725/44533901-d0cc0f80-a6f6-11e8-9cf3-8f860c80bcc8.png)

## Same buttons design and order

Both modals have now the buttons design and order: Cancel buttons is on the left and smaller, actions on the right, outlined

### Before
#### Add modal
![screenshot-www data gouv fr-2018 08 23-17-11-45](https://user-images.githubusercontent.com/15725/44534302-bb0b1a00-a6f7-11e8-9d1c-35fbde3370a9.png)
#### Edit modal
![screenshot-www data gouv fr-2018 08 23-17-13-14](https://user-images.githubusercontent.com/15725/44534354-dd9d3300-a6f7-11e8-8cf6-44e6e3f19877.png)

### After
#### Add modal
![screenshot-data xps-2018 08 23-17-14-30](https://user-images.githubusercontent.com/15725/44534502-3e2c7000-a6f8-11e8-9414-d14366ee4525.png)

#### Edit modal
![screenshot-data xps-2018 08 23-17-15-58](https://user-images.githubusercontent.com/15725/44534510-4389ba80-a6f8-11e8-86ad-4d2c9e93d091.png)

