### PR TITLE
Upgrade to latest fineuploader version to benefit from bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Prevent UnicodeError on unicode URL validation error [#1844](https://github.com/opendatateam/udata/pull/1844)
 - Hide save button in "Add resource" modal until form is visible (and prevent error) [#1846](https://github.com/opendatateam/udata/pull/1846)
 - The purge chunks tasks also remove the directory [#1845](https://github.com/opendatateam/udata/pull/1845)
+- Upgrade to latest Fine-Uploader version to benefit from bug fixes [#1849](https://github.com/opendatateam/udata/pull/1849)
 
 ## 1.5.2 (2018-08-08)
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "chart.js": "^2.7.1",
     "clipboard-copy": "^2.0.0",
     "diff": "^2.2.3",
-    "fine-uploader": "~5.15.6",
+    "fine-uploader": "5.16.2",
     "font-awesome": "^4.7.0",
     "highlight.js": "^9.9.0",
     "i18next": "11.5.0",


### PR DESCRIPTION
This PR upgrade Fine-Uploader to its latest version (`5.16.2`) to benefit from bug fixes