### PR TITLE
Backport 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Upgrade to latest Fine-Uploader version to benefit from bug fixes [#1849](https://github.com/opendatateam/udata/pull/1849)
 - Prevent front views from downloading `swagger.json` [#1838](https://github.com/opendatateam/udata/pull/1838)
 - Ensure API docs works without data [#1840](https://github.com/opendatateam/udata/pull/1840)
+- Expose the default spatial granularity in API specs [#1841](https://github.com/opendatateam/udata/pull/1841)
 
 ## 1.5.2 (2018-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Hide save button in "Add resource" modal until form is visible (and prevent error) [#1846](https://github.com/opendatateam/udata/pull/1846)
 - The purge chunks tasks also remove the directory [#1845](https://github.com/opendatateam/udata/pull/1845)
 - Upgrade to latest Fine-Uploader version to benefit from bug fixes [#1849](https://github.com/opendatateam/udata/pull/1849)
+- Prevent front views from downloading `swagger.json` [#1838](https://github.com/opendatateam/udata/pull/1838)
 
 ## 1.5.2 (2018-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Prevent front views from downloading `swagger.json` [#1838](https://github.com/opendatateam/udata/pull/1838)
 - Ensure API docs works without data [#1840](https://github.com/opendatateam/udata/pull/1840)
 - Expose the default spatial granularity in API specs [#1841](https://github.com/opendatateam/udata/pull/1841)
+- Fix missing dataset title on client-side card listing [#1834](https://github.com/opendatateam/udata/pull/1834)
 
 ## 1.5.2 (2018-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The purge chunks tasks also remove the directory [#1845](https://github.com/opendatateam/udata/pull/1845)
 - Upgrade to latest Fine-Uploader version to benefit from bug fixes [#1849](https://github.com/opendatateam/udata/pull/1849)
 - Prevent front views from downloading `swagger.json` [#1838](https://github.com/opendatateam/udata/pull/1838)
+- Ensure API docs works without data [#1840](https://github.com/opendatateam/udata/pull/1840)
 
 ## 1.5.2 (2018-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Expose the default spatial granularity in API specs [#1841](https://github.com/opendatateam/udata/pull/1841)
 - Fix missing dataset title on client-side card listing [#1834](https://github.com/opendatateam/udata/pull/1834)
 - Allows to clear the dataset form temporal coverage. [#1832](https://github.com/opendatateam/udata/pull/1832)
+- Ensure that admin notifications are displayed once and with a constant width. [#1831](https://github.com/opendatateam/udata/pull/1831)
 
 ## 1.5.2 (2018-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Ensure API docs works without data [#1840](https://github.com/opendatateam/udata/pull/1840)
 - Expose the default spatial granularity in API specs [#1841](https://github.com/opendatateam/udata/pull/1841)
 - Fix missing dataset title on client-side card listing [#1834](https://github.com/opendatateam/udata/pull/1834)
+- Allows to clear the dataset form temporal coverage. [#1832](https://github.com/opendatateam/udata/pull/1832)
 
 ## 1.5.2 (2018-08-08)
 

--- a/js/components/dataset/card.vue
+++ b/js/components/dataset/card.vue
@@ -59,7 +59,7 @@ import placeholders from 'helpers/placeholders';
 import config from 'config';
 
 const MASK = [
-    'id', 'title', 'description', 'metrics', 'organization',
+    'id', 'title', 'acronym', 'description', 'metrics', 'organization',
     'spatial{zones,granularity}', 'frequency', 'temporal_coverage',
     'page', 'uri'
 ];

--- a/js/components/form/daterange-picker.vue
+++ b/js/components/form/daterange-picker.vue
@@ -3,6 +3,14 @@
     .dropdown-menu {
         min-width: auto;
     }
+
+    input.form-control {
+        border-right: none;
+
+        &:nth-of-type(2) {  // End date
+            border-left: none;
+        }
+    }
 }
 </style>
 
@@ -10,19 +18,24 @@
 <div class="input-group dropdown daterange-picker" :class="{ 'open': picking }"
     v-outside="onOutside">
     <span class="input-group-addon"><span class="fa fa-calendar"></span></span>
-    <input type="text" class="input-sm form-control"
+    <input type="text" class="form-control"
         v-el:start-input :placeholder="_('Start')"
         @focus="onFocus" @input="onChange | debounce 500"
         :required="required"
         :value="startValue|dt dateFormat ''"
         :readonly="readonly">
     <span class="input-group-addon">{{ _('to') }}</span>
-    <input type="text" class="input-sm form-control"
+    <input type="text" class="form-control daterange-picker-end"
         v-el:end-input :placeholder="_('End')"
         @focus="onFocus" @input="onChange | debounce 500"
         :required="required"
         :value="endValue|dt dateFormat ''"
         :readonly="readonly">
+    <span class="input-group-btn">
+        <button class="btn btn-danger" type="button" @click.prevent="clear">
+            <span class="fa fa-remove">
+        </button>
+    </span>
     <div class="dropdown-menu" :style="dropdownStyle">
         <calendar v-ref:calendar :selected="currentValue" :min="dateMin" :max="dateMax"></calendar>
     </div>
@@ -126,6 +139,10 @@ export default {
         });
     },
     methods: {
+        clear() {
+            this.startValue = '';
+            this.endValue = '';
+        },
         onFocus(e) {
             if (!this.picking || e.target !== this.pickedField) {
                 this.$nextTick(this.$refs.calendar.focus);

--- a/js/components/modal.vue
+++ b/js/components/modal.vue
@@ -11,8 +11,6 @@
                 </button>
                 <h4 class="modal-title" id="modal-title">{{{title}}}</h4>
             </div>
-            <!-- Notifications -->
-            <notification-zone class="modal-body"></notification-zone>
             <slot></slot>
         </div>
         </slot>
@@ -24,11 +22,8 @@
 import velocity from 'velocity-animate';
 import {getScrollBarWidth} from 'vue-strap/src/utils/utils.js';
 
-import NotificationZone from 'components/notification-zone.vue';
-
 export default {
     name: 'modal',
-    components: {NotificationZone},
     props: {
         title: {type: String, default: ''},
         small: {type: Boolean, default: false},

--- a/js/components/notification-zone.vue
+++ b/js/components/notification-zone.vue
@@ -6,6 +6,7 @@
 
 <script>
 import Alert from 'components/alert.vue';
+
 export default {
     name: 'notification-zone',
     components: {Alert}
@@ -16,10 +17,10 @@ export default {
 .notification-zone {
     padding: 15px 15px 0;
     position: fixed;
-    right: 0;
+    right: 15px;
     bottom: 15px;
-    max-width: 350px;
-    z-index: 1001;
+    width: 350px;
+    z-index: 10000;
 
     .alert {
         &:last-child {

--- a/js/models/base.js
+++ b/js/models/base.js
@@ -206,6 +206,7 @@ export class List extends Base {
 
         this.items = this.$options.data || [];
         this.query = this.$options.query || {};
+        this.model = this.$options.model;
 
         this.sorted = null;
         this.reversed = false;
@@ -268,7 +269,7 @@ export class List extends Base {
     }
 
     on_fetched(data) {
-        this.items = data.obj;
+        this.items = this.model ? data.obj.map(o => new this.model({data: o})) : data.obj;
         this.populate();
         this.$emit('updated');
         this.loading = false;

--- a/js/views/editorial.vue
+++ b/js/views/editorial.vue
@@ -25,6 +25,8 @@
 <script>
 import Posts from 'models/posts';
 import Topics from 'models/topics';
+import Reuse from 'models/reuse';
+import Dataset from 'models/dataset';
 import {List} from 'models/base';
 import API from 'api';
 import Layout from 'components/layout.vue';
@@ -40,8 +42,10 @@ export default {
         return {
             posts: new Posts({query: {sort: '-created', page_size: 10}, mask: PostList.MASK}),
             topics: new Topics({query: {sort: '-created', page_size: 10}, mask: TopicList.MASK}),
-            home_datasets: new List({ns: 'site', fetch: 'get_home_datasets', mask: DatasetCardList.MASK}),
-            home_reuses: new List({ns: 'site', fetch: 'get_home_reuses', mask: ReuseCardList.MASK})
+            home_datasets: new List({ns: 'site', fetch: 'get_home_datasets',
+                                     mask: DatasetCardList.MASK, model: Dataset}),
+            home_reuses: new List({ns: 'site', fetch: 'get_home_reuses',
+                                   mask: ReuseCardList.MASK, model: Reuse})
         };
     },
     components: {

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     author_email='opendatateam@data.gouv.fr',
     packages=find_packages(),
     include_package_data=True,
+    python_requires='==2.7.*',
     install_requires=install_requires,
     setup_requires=['setuptools>=38.6.0'],
     tests_require=tests_require,

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import itertools
 import logging
 import urllib
 
+from bson import ObjectId
 from functools import wraps
 
 from flask import (
@@ -19,6 +21,7 @@ from udata.auth import (
     current_user, login_user, Permission, RoleNeed, PermissionDenied
 )
 from udata.core.user.models import User
+from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Organization
 from udata.sitemap import sitemap
 from udata.utils import safe_unicode
@@ -272,8 +275,18 @@ def default_api():
 
 @apidoc.route('/apidoc/')
 def swaggerui():
+    page_size = 10
     params = {"datasets": "many"}
-    organizations = search.iter(Organization, **params)
+    organizations = search.iter(Organization)
+    organizations = list(itertools.islice(organizations, page_size))
+    if len(organizations) < page_size:
+        # Fill with dummy values
+        needs = page_size - len(organizations)
+        extra_orgs = OrganizationFactory.build_batch(needs)
+        for org in extra_orgs:
+            org.id = ObjectId()
+            Organization.slug.generate()
+        organizations.extend(extra_orgs)
     return theme.render('apidoc.html', specs_url=api.specs_url, organizations=organizations)
 
 

--- a/udata/core/spatial/api_fields.py
+++ b/udata/core/spatial/api_fields.py
@@ -66,7 +66,7 @@ spatial_coverage_fields = api.model('SpatialCoverage', {
         description='A multipolygon for the whole coverage'),
     'zones': fields.List(
         fields.String, description='The covered zones identifiers'),
-    'granularity': fields.String(
+    'granularity': fields.String(default='other',
         description='The spatial/territorial granularity'),
 })
 

--- a/udata/templates/apidoc.html
+++ b/udata/templates/apidoc.html
@@ -7,8 +7,7 @@
 } %}
 
 {% set bundle = 'apidoc' %}
-{% set org_list = organizations | list %}
-{% set main_org = org_list | first %} 
+{% set main_org = organizations | first %}
 
 {% block extra_head %}
 <meta name="swagger-specs" content="{{ specs_url }}" />
@@ -81,7 +80,7 @@
     "data": [{...}, {...}],
     "page": 1,
     "page_size": 20,
-    "total": {{ org_list|count }},
+    "total": {{ organizations|count }},
     "next_page": "https://{{config.SERVER_NAME}}/api/endpoint/?page=2",
     "previous_page": null
 }</code></pre>
@@ -120,7 +119,7 @@ Access-Control-Allow-Credentials: true
             "name": "{{ main_org.name }}",
             "page": "https://{{config.SERVER_NAME}}/organizations/{{ main_org.slug }}/",
             "slug": "{{ main_org.slug }}",
-            "uri": "https://{{config.SERVER_NAME}}/api/1/organizations/{{ main_org.slug }}/",
+            "uri": "https://{{config.SERVER_NAME}}/api/1/organizations/{{ main_org.id }}/",
             "url": "{{ main_org.url }}"
         }
     ],
@@ -128,7 +127,7 @@ Access-Control-Allow-Credentials: true
     "page": 1,
     "page_size": 1,
     "previous_page": null,
-    "total": "{{ org_list|count }}"
+    "total": "{{ organizations|count }}"
 }
 </code></pre>
 
@@ -169,7 +168,7 @@ Access-Control-Allow-Credentials: true
                 <pre><code class="json">$ http $API'organizations/' | jq '.data[].name'</code></pre>
 
 <pre><code class="json">
-{% for org in org_list[0:20] %}"{{ org.name }}"
+{% for org in organizations[0:20] %}"{{ org.name }}"
 {% endfor %}
 </code></pre>
 
@@ -179,19 +178,19 @@ Access-Control-Allow-Credentials: true
                 <pre><code class="json">$ http $API'organizations/?page_size=5' | jq '.data[].uri'</code></pre>
 
 <pre><code class="json">
-{% for org in org_list[0:5] %}"https://{{config.SERVER_NAME}}/api/1/organizations/{{ org.slug }}/"
+{% for org in organizations[0:5] %}"https://{{config.SERVER_NAME}}/api/1/organizations/{{ org.id }}/"
 {% endfor %}
 </code></pre>
 
                 <p>{% trans %}Now we'll be able to retrieve a unique organization thanks to the returned URI:
                 {% endtrans %}</p>
 
-                <pre><code class="json">$ http $API'organizations/{{main_org.slug}}/' | jq '.'</code></pre>
+                <pre><code class="json">$ http $API'organizations/{{main_org.id}}/' | jq '.'</code></pre>
 
                 <p>{% trans %}That's a lot of data to compute. Let's refine these data, if we want only metrics:
                 {% endtrans %}</p>
 
-                <pre><code class="json">$ http $API'organizations/{{main_org.slug}}/' | jq '.metrics'</code></pre>
+                <pre><code class="json">$ http $API'organizations/{{main_org.id}}/' | jq '.metrics'</code></pre>
 
 <pre><code class="json">
 {
@@ -203,7 +202,7 @@ Access-Control-Allow-Credentials: true
                 <p>{% trans %}Or maybe just the name of the members of that organization:
                 {% endtrans %}</p>
 
-                <pre><code class="json">$ http $API'organizations/{{main_org.slug}}/' | jq '.members[].user.last_name'</code></pre>
+                <pre><code class="json">$ http $API'organizations/{{main_org.id}}/' | jq '.members[].user.last_name'</code></pre>
 
 <pre><code class="json">
 {% for member in main_org.members|list %}"{{member.user.last_name}}"


### PR DESCRIPTION
This PR backports some changes from current `master` to the `1.5` branch:
- #1831 Fix admin duplicate notifications
- #1832 Allows to clear dataset temporal coverage
- #1834 Fix missing dataset title on client-side card listing
- #1837 Explicit supported python version in `setup.py`
- #1838 Prevent views from hitting `swagger.json`
- #1840 Ensure API docs works without data
- #1841 Adds missing default spatial granularity
