### PR TITLE
Normalize uploaded filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Allows to clear the dataset form temporal coverage. [#1832](https://github.com/opendatateam/udata/pull/1832)
 - Ensure that admin notifications are displayed once and with a constant width. [#1831](https://github.com/opendatateam/udata/pull/1831)
 - Fix broken date range picker date parsing (ie. manual keyboard input) [#1863](https://github.com/opendatateam/udata/pull/1853)
+- Normalize uploaded filenames to avoid encoding issues, filesystem incompatibilities... [#1852](https://github.com/opendatateam/udata/pull/1852)
 
 ## 1.5.2 (2018-08-08)
 

--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -114,7 +114,8 @@ def combine_chunks(storage, args, prefix=None):
     Chunks are stored in the chunks storage.
     '''
     uuid = args['uuid']
-    target = args['filename']
+    # Normalize filename including extension
+    target = utils.normalize(args['filename'])
     if prefix:
         target = os.path.join(prefix, target)
     with storage.open(target, 'wb') as out:
@@ -139,7 +140,10 @@ def handle_upload(storage, prefix=None):
     elif not uploaded_file:
         raise UploadError('Missing file parameter')
     else:
-        filename = storage.save(uploaded_file, prefix=prefix)
+        # Normalize filename including extension
+        filename = utils.normalize(uploaded_file.filename)
+        filename = storage.save(uploaded_file, prefix=prefix,
+                                filename=filename)
 
     metadata = storage.metadata(filename)
     checksum = metadata.pop('checksum')

--- a/udata/core/storages/utils.py
+++ b/udata/core/storages/utils.py
@@ -6,8 +6,12 @@ import mimetypes
 import os
 import zlib
 
+from slugify import Slugify
 
 CHUNK_SIZE = 2 ** 16
+
+
+slugify = Slugify(separator='-', to_lower=True, safe_chars='.')
 
 
 def hash(file, hasher):
@@ -53,3 +57,7 @@ def extension(filename):
         extension = ext if not extension else ext + '.' + extension
 
     return extension
+
+
+def normalize(filename):
+    return slugify(filename)

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -73,6 +73,19 @@ class StorageUtilsTest:
         assert utils.extension('test') is None
         assert utils.extension('prefix/test') is None
 
+    def test_normalize_no_changes(self):
+        assert utils.normalize('test.txt') == 'test.txt'
+
+    def test_normalize_spaces(self):
+        expected = 'test-with-spaces.txt'
+        assert utils.normalize('test with  spaces.txt') == expected
+
+    def test_normalize_to_lower(self):
+        assert utils.normalize('Test.TXT') == 'test.txt'
+
+    def test_normalize_special_chars(self):
+        assert utils.normalize('éàü@€.txt') == 'eau-eur.txt'
+
 
 @pytest.mark.usefixtures('app')
 class ConfigurableAllowedExtensionsTest:
@@ -98,7 +111,7 @@ class StorageUploadViewTest:
         client.login()
         response = client.post(
             url_for('storage.upload', name='resources'),
-            {'file': (StringIO(b'aaa'), 'test.txt')})
+            {'file': (StringIO(b'aaa'), 'Test with  spaces.TXT')})
 
         assert200(response)
         assert response.json['success']
@@ -107,7 +120,7 @@ class StorageUploadViewTest:
         assert 'sha1' in response.json
         assert 'filename' in response.json
         filename = response.json['filename']
-        assert filename.endswith('test.txt')
+        assert filename.endswith('test-with-spaces.txt')
         expected = storages.resources.url(filename, external=True)
         assert response.json['url'] == expected
         assert response.json['mime'] == 'text/plain'
@@ -122,7 +135,7 @@ class StorageUploadViewTest:
             response = client.post(url, {
                 'file': (StringIO(b'a'), 'blob'),
                 'uuid': uuid,
-                'filename': 'test.txt',
+                'filename': 'Test with  spaces.TXT',
                 'partindex': i,
                 'partbyteoffset': 0,
                 'totalfilesize': parts,
@@ -140,7 +153,7 @@ class StorageUploadViewTest:
 
         response = client.post(url, {
             'uuid': uuid,
-            'filename': 'test.txt',
+            'filename': 'Test with  spaces.TXT',
             'totalfilesize': parts,
             'totalparts': parts,
         })
@@ -149,10 +162,13 @@ class StorageUploadViewTest:
         assert 'size' in response.json
         assert response.json['size'] == parts
         assert 'sha1' in response.json
-        expected = storages.tmp.url(response.json['filename'], external=True)
-        assert response.json['url'] == expected
+        expected_filename = 'test-with-spaces.txt'
+        filename = response.json['filename']
+        assert filename.endswith(expected_filename)
+        expected_url = storages.tmp.url(filename, external=True)
+        assert response.json['url'] == expected_url
         assert response.json['mime'] == 'text/plain'
-        assert storages.tmp.read(response.json['filename']) == 'aaaa'
+        assert storages.tmp.read(filename) == 'aaaa'
         assert list(storages.chunks.list_files()) == []
 
     def test_chunked_upload_bad_chunk(self, client):


### PR DESCRIPTION
This PR normalizes uploaded files names to avoid:
- encoding issues in udata (or elsewhere)
- filesystem incompatibilities
- ugly URLs

So an uploaded file named `My  Ügly  Nämé.TXT` will be stored and visible as `my-ugly-name.txt`, no encoding issue on anywhere (only ASCII), no issue with filesystem (no spaces, no special chars), same filename on filesystem and in URL.