### PR TITLE
Use left and right arrows instead of hamburger icon for admin sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add publisher's name on dataset template [#1847](https://github.com/opendatateam/udata/pull/1847)
 - Improved upload error handling: deduplicate notifications, localized generic error message, sentry identifier... [#1842](https://github.com/opendatateam/udata/pull/1842)
 - Allows to filter datasets on resource `type` (needs reindexing) [#1848](https://github.com/opendatateam/udata/pull/1848)
+- Switch the admin sidebar collapse icon from "hamburger"to left and right arrows [#1855](https://github.com/opendatateam/udata/pull/1855)
 
 ### Breaking changes
 

--- a/js/admin.vue
+++ b/js/admin.vue
@@ -2,7 +2,7 @@
 <div>
     <!-- Placeholder for non-routable modals -->
     <div v-el:modal></div>
-    <app-header class="main-header"></app-header>
+    <app-header></app-header>
     <sidebar></sidebar>
     <router-view></router-view>
 </div>
@@ -23,7 +23,7 @@ export default {
     mixins: [ModalMixin],
     data() {
         return {
-            toggled: false,
+            toggled: true,
             notifications: [],
             site, me, config,
         };
@@ -33,6 +33,7 @@ export default {
         'navigation:toggled': function() {
             document.body.classList.toggle('sidebar-collapse');
             document.body.classList.toggle('sidebar-open');
+            this.toggled = !this.toggled;
         },
         notify: function(notification) {
             this.notifications.push(notification);

--- a/js/components/header.vue
+++ b/js/components/header.vue
@@ -1,10 +1,16 @@
 <style lang="less">
-a.sidebar-toggle {
-    cursor: pointer;
+.main-header {
+    a.sidebar-toggle {
+        cursor: pointer;
+
+        &::before {
+            content: '';
+        }
+    }
 }
 </style>
 <template>
-<div>
+<div class="main-header">
     <a href="/" class="logo">
       <!-- Add the class icon to your logo image or logo icon to add the margining -->
       <!-- mini logo for sidebar mini 50x50 pixels -->
@@ -17,9 +23,7 @@ a.sidebar-toggle {
         <!-- Sidebar toggle button-->
         <a class="sidebar-toggle" role="button" @click="click($event)">
             <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+            <span :class="['fa', $root.toggled ? 'fa-angle-double-left' : 'fa-angle-double-right']"></span>
         </a>
       <div class="navbar-custom-menu">
           <ul class="nav navbar-nav">
@@ -43,7 +47,7 @@ module.exports = {
         'add-menu': require('components/add-menu.vue')
     },
     methods: {
-        click: function(e) {
+        click(e) {
             e.preventDefault();
             this.$dispatch('navigation:toggled');
         }


### PR DESCRIPTION
This PR use less confusing visual symbols for admin sidebar collapse button

## Before

| Expanded | Collapsed |
|---------------|---------------|
| ![screenshot-data xps-2018 08 27-10-38-38](https://user-images.githubusercontent.com/15725/44649949-a2e01700-a9e5-11e8-9e57-ad2db555eadc.png) | ![screenshot-data xps-2018 08 27-10-38-55](https://user-images.githubusercontent.com/15725/44649950-a4a9da80-a9e5-11e8-8d6b-5d027001f245.png) |


## After
| Expanded | Collapsed |
|---------------|---------------|
| ![screenshot-data xps-2018 08 27-10-37-26](https://user-images.githubusercontent.com/15725/44649959-a96e8e80-a9e5-11e8-82a7-2a4218e9c0b4.png) | ![screenshot-data xps-2018 08 27-10-37-46](https://user-images.githubusercontent.com/15725/44649954-a70c3480-a9e5-11e8-96e8-bea157146138.png) |


Fixes #1340 