### PR TITLE
Remove the type property from the resource JSON-LD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Bugfixes
 
-- Not yet
+- Hide the `resource.type` attribute from JSON-LD output until handled by a dedicated vocabulary/property [#1864](https://github.com/opendatateam/udata/pull/1864)
 
 ### Internal
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -313,7 +313,6 @@ class ResourceMixin(object):
             'datePublished': self.published.isoformat(),
             'extras': [get_json_ld_extra(*item)
                        for item in self.extras.items()],
-            'type': self.type,
         }
 
         if 'views' in self.metrics:


### PR DESCRIPTION
This PR removes the `type` attribute from the resource `JSON-LD` until a better solution is found.