### PR TITLE
CORS everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Bugfixes
 
 - Hide the `resource.type` attribute from JSON-LD output until handled by a dedicated vocabulary/property [#1865](https://github.com/opendatateam/udata/pull/1865)
+- RDFs, CSVs and resource redirect views are now handling CORS properly [#1866](https://github.com/opendatateam/udata/pull/1866)
 
 ### Internal
 

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -126,7 +126,7 @@ class DatasetFollowersView(DatasetView, DetailView):
         return context
 
 
-@blueprint.route('/r/<uuid:id>', endpoint='resource')
+@blueprint.route('/r/<uuid:id>', endpoint='resource', cors=True)
 def resource_redirect(id):
     '''
     Redirect to the latest version of a resource given its identifier.
@@ -135,7 +135,7 @@ def resource_redirect(id):
     return redirect(resource.url.strip()) if resource else abort(404)
 
 
-@blueprint.route('/<dataset:dataset>/rdf', localize=False)
+@blueprint.route('/<dataset:dataset>/rdf', localize=False, cors=True)
 def rdf(dataset):
     '''Root RDF endpoint with content negociation handling'''
     format = RDF_EXTENSIONS[negociate_content()]
@@ -143,7 +143,7 @@ def rdf(dataset):
     return redirect(url)
 
 
-@blueprint.route('/<dataset:dataset>/rdf.<format>', localize=False)
+@blueprint.route('/<dataset:dataset>/rdf.<format>', localize=False, cors=True)
 def rdf_format(dataset, format):
     if not DatasetEditPermission(dataset).can():
         if dataset.private:

--- a/udata/core/organization/views.py
+++ b/udata/core/organization/views.py
@@ -101,14 +101,14 @@ def organization_dashboard(org):
     return redirect('%s#dashboard' % url_for('organizations.show', org=org), code=301)
 
 
-@blueprint.route('/<org:org>/datasets.csv')
+@blueprint.route('/<org:org>/datasets.csv', cors=True)
 def datasets_csv(org):
     datasets = search.iter(Dataset, organization=str(org.id))
     adapter = DatasetCsvAdapter(datasets)
     return csv.stream(adapter, '{0}-datasets'.format(org.slug))
 
 
-@blueprint.route('/<org:org>/issues.csv')
+@blueprint.route('/<org:org>/issues.csv', cors=True)
 def issues_csv(org):
     datasets = Dataset.objects.filter(organization=str(org.id))
     issues = [Issue.objects.filter(subject=dataset)
@@ -118,7 +118,7 @@ def issues_csv(org):
     return csv.stream(adapter, '{0}-issues'.format(org.slug))
 
 
-@blueprint.route('/<org:org>/discussions.csv')
+@blueprint.route('/<org:org>/discussions.csv', cors=True)
 def discussions_csv(org):
     datasets = Dataset.objects.filter(organization=str(org.id))
     discussions = [Discussion.objects.filter(subject=dataset)
@@ -128,7 +128,7 @@ def discussions_csv(org):
     return csv.stream(adapter, '{0}-discussions'.format(org.slug))
 
 
-@blueprint.route('/<org:org>/datasets-resources.csv')
+@blueprint.route('/<org:org>/datasets-resources.csv', cors=True)
 def datasets_resources_csv(org):
     datasets = search.iter(Dataset, organization=str(org.id))
     adapter = ResourcesCsvAdapter(datasets)

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -73,7 +73,7 @@ def map():
     return theme.render('site/map.html')
 
 
-@blueprint.route('/datasets.csv')
+@blueprint.route('/datasets.csv', cors=True)
 def datasets_csv():
     params = multi_to_dict(request.args)
     params['facets'] = False
@@ -82,7 +82,7 @@ def datasets_csv():
     return csv.stream(adapter(datasets), 'datasets')
 
 
-@blueprint.route('/resources.csv')
+@blueprint.route('/resources.csv', cors=True)
 def resources_csv():
     params = multi_to_dict(request.args)
     params['facets'] = False
@@ -90,7 +90,7 @@ def resources_csv():
     return csv.stream(ResourcesCsvAdapter(datasets), 'resources')
 
 
-@blueprint.route('/organizations.csv')
+@blueprint.route('/organizations.csv', cors=True)
 def organizations_csv():
     params = multi_to_dict(request.args)
     params['facets'] = False
@@ -98,7 +98,7 @@ def organizations_csv():
     return csv.stream(OrganizationCsvAdapter(organizations), 'organizations')
 
 
-@blueprint.route('/reuses.csv')
+@blueprint.route('/reuses.csv', cors=True)
 def reuses_csv():
     params = multi_to_dict(request.args)
     params['facets'] = False
@@ -184,20 +184,20 @@ def terms():
     return theme.render('terms.html', terms=content)
 
 
-@blueprint.route('/context.jsonld', localize=False)
+@blueprint.route('/context.jsonld', localize=False, cors=True)
 def jsonld_context():
     '''Expose the JSON-LD context'''
     return json.dumps(CONTEXT), 200, {'Content-Type': 'application/ld+json'}
 
 
-@blueprint.route('/data.<format>', localize=False)
+@blueprint.route('/data.<format>', localize=False, cors=True)
 def dataportal(format):
     '''Root RDF endpoint with content negociation handling'''
     url = url_for('site.rdf_catalog_format', format=format)
     return redirect(url)
 
 
-@blueprint.route('/catalog', localize=False)
+@blueprint.route('/catalog', localize=False, cors=True)
 def rdf_catalog():
     '''Root RDF endpoint with content negociation handling'''
     format = RDF_EXTENSIONS[negociate_content()]
@@ -205,7 +205,7 @@ def rdf_catalog():
     return redirect(url)
 
 
-@blueprint.route('/catalog.<format>', localize=False)
+@blueprint.route('/catalog.<format>', localize=False, cors=True)
 def rdf_catalog_format(format):
     params = multi_to_dict(request.args)
     page = int(params.get('page', 1))

--- a/udata/core/tags/views.py
+++ b/udata/core/tags/views.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 blueprint = I18nBlueprint('tags', __name__)
 
 
-@blueprint.route('/tags.csv', endpoint='csv')
+@blueprint.route('/tags.csv', endpoint='csv', cors=True)
 def tags_csv():
     adapter = TagCsvAdapter(Tag.objects.order_by('-total'))
     return csv.stream(adapter, 'tags')

--- a/udata/i18n.py
+++ b/udata/i18n.py
@@ -22,6 +22,7 @@ from babel.support import NullTranslations, Translations
 from flask_babelex import Babel, Domain, refresh
 from flask_babelex import format_date, format_datetime  # noqa
 from flask_babelex import get_locale as get_current_locale  # noqa
+from flask_restplus import cors
 
 from werkzeug.local import LocalProxy
 
@@ -236,6 +237,18 @@ class I18nBlueprintSetupState(BlueprintSetupState):
         defaults = self.url_defaults
         if 'defaults' in options:
             defaults = dict(defaults, **options.pop('defaults'))
+        # Handle an optionnal cors=True parameter
+        options.setdefault('cors', False)
+        if options.pop('cors', False):
+            methods = options.get('methods', ['GET'])
+            if 'HEAD' not in methods:
+                methods.append('HEAD')
+            if 'OPTIONS' not in methods:
+                methods.append('OPTIONS')
+            decorator = cors.crossdomain('*', headers='*', credentials=True)
+            view_func = decorator(view_func)
+            options['methods'] = methods
+
         if options.pop('localize', True):
             self.app.add_url_rule('/<lang:lang_code>' + rule,
                                   '%s.%s' % (self.blueprint.name, endpoint),


### PR DESCRIPTION
This pull request enable CORS handling on non-html pages:
- RDFs views
- CSVs views
- resource redirect

(API was already handling CORS).

To do so, an optionnal `cors=True` parameter has been added to `I18nBlueprint` (which, by the way, could be extracted to become a `UdataBlueprint`)