### PR TITLE
Fix broken sorts on organizations datasets list in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Hide the `resource.type` attribute from JSON-LD output until handled by a dedicated vocabulary/property [#1865](https://github.com/opendatateam/udata/pull/1865)
 - RDFs, CSVs and resource redirect views are now handling CORS properly [#1866](https://github.com/opendatateam/udata/pull/1866)
+- Fix broken sorts on organization's datasets list in admin
 
 ### Internal
 


### PR DESCRIPTION
Sort args passed by the `dataset-list` component are made for the search index, not DB. So I created a mapping from one to the other. This feels like a hack, but at least we're not duplicating the component code. Maybe there is a way to this with the arg parser?