### PR TITLE
Handle pytest warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ python_classes = *Test
 env =
     # See: https://docs.authlib.org/en/latest/flask/oauth2.html
     AUTHLIB_INSECURE_TRANSPORT=true
+# See: https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning
+filterwarnings =
+    ignore::DeprecationWarning:mongoengine
 
 [flake8]
 exclude =

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -80,7 +80,7 @@ def _load_frontend(request, _configure_application):
         return
 
     app = request.getfixturevalue('app')
-    marker = request.node.get_marker('frontend')
+    marker = request.node.get_closest_marker('frontend')
     modules = set(marker.args[0] if marker and marker.args else [])
 
     if getattr(request.cls, 'modules', None):
@@ -115,7 +115,7 @@ def get_settings(request):
     '''
     Extract settings from the current test request
     '''
-    marker = request.node.get_marker('settings')
+    marker = request.node.get_closest_marker('settings')
     if marker:
         return marker.args[0]
     return getattr(request.cls, 'settings', settings.Testing)


### PR DESCRIPTION
This PR hides warnings during tests (until upstream `pytest-flask` and `mongoengine` fixes theirs).
It also fixes udata test plugin deprecation warnings