### PR TITLE
Harvest backend helpers

### DIFF
--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -109,6 +109,13 @@ class BaseBackend(object):
             'User-Agent': 'uData/0.1 {0.name}'.format(self),
         }
 
+    def has_feature(self, key):
+        try:
+            feature = next(f for f in self.features if f.key == key)
+        except StopIteration:
+            raise HarvestException('Unkown feature {}'.format(key))
+        return self.config.get('features', {}).get(key, feature.default)
+
     def harvest(self):
         '''Start the harvesting process'''
         if self.perform_initialization() is not None:

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -113,8 +113,11 @@ class BaseBackend(object):
         try:
             feature = next(f for f in self.features if f.key == key)
         except StopIteration:
-            raise HarvestException('Unkown feature {}'.format(key))
+            raise HarvestException('Unknown feature {}'.format(key))
         return self.config.get('features', {}).get(key, feature.default)
+
+    def get_filters(self):
+        return self.config.get('filters', [])
 
     def harvest(self):
         '''Start the harvesting process'''

--- a/udata/harvest/tests/test_base_backend.py
+++ b/udata/harvest/tests/test_base_backend.py
@@ -22,6 +22,10 @@ class Unknown:
 
 
 class FakeBackend(BaseBackend):
+    filters = (
+        HarvestFilter('First filter', 'first', basestring),
+        HarvestFilter('Second filter', 'second', basestring),
+    )
     features = (
         HarvestFeature('feature', 'A test feature'),
         HarvestFeature('enabled', 'A test feature enabled by default', default=True),
@@ -101,6 +105,23 @@ class BaseBackendTest:
 
         with pytest.raises(HarvestException):
             backend.has_feature('unknown')
+
+    def test_get_filters_empty(self):
+        source = HarvestSourceFactory()
+        backend = FakeBackend(source)
+
+        assert backend.get_filters() == []
+
+    def test_get_filters(self):
+        source = HarvestSourceFactory(config={
+            'filters': [
+                {'key': 'second', 'value': ''},
+                {'key': 'first', 'value': ''},
+            ]
+        })
+        backend = FakeBackend(source)
+
+        assert [f['key'] for f in backend.get_filters()] == ['second', 'first']
 
 
 @pytest.mark.usefixtures('clean_db')


### PR DESCRIPTION
This PR adds 2 harvest Backend helpers:
- `has_feature` to easily test if a feature is enabled or not
- `get_filters` to easily loop over filters