### PR TITLE
Discussion add card style coherence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Improved upload error handling: deduplicate notifications, localized generic error message, sentry identifier... [#1842](https://github.com/opendatateam/udata/pull/1842)
 - Allows to filter datasets on resource `type` (needs reindexing) [#1848](https://github.com/opendatateam/udata/pull/1848)
 - Switch the admin sidebar collapse icon from "hamburger"to left and right arrows [#1855](https://github.com/opendatateam/udata/pull/1855)
-- Discussion add card style coherence
+- Discussion add card style coherence [#1884](https://github.com/opendatateam/udata/pull/1884)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improved upload error handling: deduplicate notifications, localized generic error message, sentry identifier... [#1842](https://github.com/opendatateam/udata/pull/1842)
 - Allows to filter datasets on resource `type` (needs reindexing) [#1848](https://github.com/opendatateam/udata/pull/1848)
 - Switch the admin sidebar collapse icon from "hamburger"to left and right arrows [#1855](https://github.com/opendatateam/udata/pull/1855)
+- Discussion add card style coherence
 
 ### Breaking changes
 

--- a/js/components/discussions/threads.vue
+++ b/js/components/discussions/threads.vue
@@ -1,6 +1,8 @@
 <style scoped lang="less">
 .sort {
     margin-top: -32px;
+    margin-bottom: 1em;
+    text-align: right;
 }
 
 .loading {
@@ -8,18 +10,22 @@
     text-align: center;
 }
 
-.sort {
-    margin-bottom: 1em;
-    text-align: right;
-}
-
-.add {
-    h4 {
-        line-height: 30px;
-        margin-top: 9px;
-        margin-left: 60px;
-        font-size: 14px;
-        font-weight: bold;
+.discussion-card.add {
+    cursor: pointer;
+    .card-logo {
+        background-color: #eeeeee;
+        font-size: 2em;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 60px;
+    }
+    .card-body {
+        min-height: auto;
+        justify-content: left;
+        h4 {
+            margin-bottom: 0;
+        }
     }
 }
 
@@ -64,7 +70,7 @@
             </ul>
         </div>
     </div>
-    
+
     <discussion-thread
         v-ref:threads
         v-for="discussion in discussions"
@@ -74,9 +80,11 @@
     </discussion-thread>
 
     <!-- New discussion -->
-    <a class="list-group-item add new-discussion" @click="displayForm" v-show="!formDisplayed">
-        <div class="format-label pull-left">+</div>
-        <h4 class="list-group-item-heading">{{ _('Start a new discussion') }}</h4>
+    <a class="card discussion-card add" @click="displayForm" v-show="!formDisplayed">
+        <div class="card-logo"><span>+</span></div>
+        <div class="card-body">
+            <h4>{{ _('Start a new discussion') }}</h4>
+        </div>
     </a>
 
     <div v-el:form id="discussion-create" v-show="formDisplayed" v-if="currentUser"
@@ -95,7 +103,7 @@
                 <h4 class="list-group-item-heading">
                     {{ _('Starting a new discussion thread') }}
                 </h4>
-                
+
                 <p class="list-group-item-text">
                     {{ _("You're about to start a new discussion thread. Make sure that a thread about the same topic doesn't exist yet just above.") }}
                 </p>
@@ -159,7 +167,7 @@ export default {
     },
     ready() {
         this.$api.get('discussions/', {for: this.subjectId}).then(response => {
-            
+
             this.loading = false;
             this.discussions = response.data;
 
@@ -244,7 +252,7 @@ export default {
 .discussion-threads {
     .list-group-form {
         height: inherit;
-        
+
         form {
             padding: 1em;
         }

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -196,7 +196,7 @@
                 <div class="panel panel-default text-center">
                     <div class="panel-body">
                         <h3 class="text-left">{{ _('Author') }}</h3>
-                        
+
                         {% with user=dataset.owner %}
                             {% include theme('user/sidebar-user.html') %}
                         {% endwith %}
@@ -395,7 +395,7 @@
                     href="{{ url_for('admin.index', path='community-resource/new/', **{'dataset_id': dataset.id}) }}">
                     <div class="card-logo"><span>+</span></div>
                     <div class="card-body">
-                        <h4>{{ _('New community resource') }}</h4>
+                        <h4>{{ _('Add a community resource') }}</h4>
                     </div>
                 </a>
                 </div>

--- a/udata/translations/udata.pot
+++ b/udata/translations/udata.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata 1.6.0.dev0\n"
 "Report-Msgid-Bugs-To: i18n@opendata.team\n"
-"POT-Creation-Date: 2018-09-07 11:01+0200\n"
-"PO-Revision-Date: 2018-09-07 11:01+0200\n"
+"POT-Creation-Date: 2018-09-11 11:57+0200\n"
+"PO-Revision-Date: 2018-09-11 11:57+0200\n"
 "Last-Translator: Open Data Team <i18n@opendata.team>\n"
 "Language: en\n"
 "Language-Team: Open Data Team <i18n@opendata.team>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.5.0\n"
+"Generated-By: Babel 2.5.3\n"
 
 #: udata/settings.py:93
 msgid "Welcome"
@@ -1929,7 +1929,7 @@ msgid "Community resources"
 msgstr ""
 
 #: udata/templates/dataset/display.html:398
-msgid "New community resource"
+msgid "Add a community resource"
 msgstr ""
 
 #: udata/templates/dataset/display.html:405


### PR DESCRIPTION
Make the style coherent with the rest of the page. Also change the wording of community resource add box, with a verb like the rest of the page.

## Before

<img width="615" alt="capture d ecran 2018-09-11 11 01 51" src="https://user-images.githubusercontent.com/119625/45351648-f5f5c480-b5b6-11e8-8159-b3f54ebecd79.png">

## After

<img width="808" alt="capture d ecran 2018-09-11 11 16 58" src="https://user-images.githubusercontent.com/119625/45351655-fb530f00-b5b6-11e8-9e63-5fd42cda039d.png">


Cf https://github.com/etalab/udata-gouvfr/pull/339