### PR TITLE
Resources list wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix broken sorts on organization's datasets list in admin [#1873](https://github.com/opendatateam/udata/pull/1873)
 - Ensure harvest previewing is done against current form content [#1888](https://github.com/opendatateam/udata/pull/1888)
 - Ensure deleted objects are unindexed [#1891](https://github.com/opendatateam/udata/pull/1891)
+- Fix the dataset resources list layout wrapping [#1893](https://github.com/opendatateam/udata/pull/1893)
 
 ### Internal
 

--- a/less/udata/resource.less
+++ b/less/udata/resource.less
@@ -57,20 +57,18 @@
     footer {
         // to display resource-card-actions and card-footer side by side
         display: flex;
+        flex-flow: row wrap;
         width: 100%;
         margin-top: 10px;
-        .resource-card-actions {
-            // align right
-            margin-left: auto;
-            // avoid wrap
-            display: flex;
 
-            .btn:first-child {
-                margin-right: 0.5em;
-            }
+        .resource-card-actions {
+            display: flex;
+            flex-flow: row wrap;
+            margin-top: 5px;
         }
+
         .card-footer {
-            flex: 1 1 auto;
+            flex: 1 0 auto;
             // vertical align with action buttons
             align-self: center;
             margin-top: initial;
@@ -79,20 +77,3 @@
     }
 }
 
-@media screen and (max-width: 320px){
-    .resource-card {
-        footer {
-            flex-direction: column;
-
-            .card-footer {
-                flex: 1 0 100%;
-                align-self: normal;
-                padding-bottom: 0.5em;
-            }
-
-            .resource-card-actions {
-                margin-left: -5px;
-            }
-        }
-    }
-}

--- a/less/udata/resource.less
+++ b/less/udata/resource.less
@@ -13,8 +13,11 @@
         margin-top: 20px;
         margin-bottom: 10px;
         display: flex;
+        flex-flow: row wrap;
+
         h3 {
             margin-top: 0;
+            margin-bottom: 0;
             flex-grow: 1;
         }
     }

--- a/udata/templates/dataset/resource/card.html
+++ b/udata/templates/dataset/resource/card.html
@@ -41,22 +41,21 @@
             </ul>
         </div>
         <div class="resource-card-actions btn-toolbar">
-            <div class="btn-group">
-                {% if config.PREVIEW_MODE and resource.preview_url %}
-                <a class="btn btn-sm btn-primary"
-                    {% if config.PREVIEW_MODE == 'iframe' %}
-                    @click.stop="showPreview('{{ resource.preview_url }}')"
-                    {% else %}
-                    @click.stop href="{{ resource.preview_url }}" target="_blank"
-                    {% endif %}
-                    >
-                    {{ _('Preview') }}
-                </a>
+            {% if config.PREVIEW_MODE and resource.preview_url %}
+            <a class="btn btn-sm btn-primary"
+                {% if config.PREVIEW_MODE == 'iframe' %}
+                @click.stop="showPreview('{{ resource.preview_url }}')"
+                {% else %}
+                @click.stop href="{{ resource.preview_url }}" target="_blank"
                 {% endif %}
-                <a @click.stop href="{{ resource.latest }}" class="btn btn-sm btn-primary" download>{{ _('Download') }}</a>
-                <a @click.stop class="btn btn-sm btn-default" v-tooltip title="{{ _('Copy permalink to clipboard') }}" v-clipboard="{{ resource.latest }}">
-                    <span class="fa fa-clipboard"></span>
-                </a>
+                >
+                {{ _('Preview') }}
+            </a>
+            {% endif %}
+            <a @click.stop href="{{ resource.latest }}" class="btn btn-sm btn-primary" download>{{ _('Download') }}</a>
+            <a @click.stop class="btn btn-sm btn-default" v-tooltip title="{{ _('Copy permalink to clipboard') }}" v-clipboard="{{ resource.latest }}">
+                <span class="fa fa-clipboard"></span>
+            </a>
             {% if can_edit_resource(resource if resource.from_community else dataset) %}
                 {% if resource.from_community %}
                     {% set edit_path = 'dataset/{id}/community-resource/{rid}' %}
@@ -68,7 +67,6 @@
                     <span class="fa fa-pencil"></span>
                 </a>
             {% endif %}
-            </div>
         </div>
     </footer>
 </article>


### PR DESCRIPTION
This PR fixes the resources list wrapping:
- proper actions buttons wrapping
- proper community resource anchor wrapping

## Desktop

| Before | After |
|------------|----------|
| ![screenshot-data xps-2018 09 20-15-14-25](https://user-images.githubusercontent.com/15725/45820792-e7f72080-bce7-11e8-8d3e-6ef2f5df58b4.png) | ![screenshot-data xps-2018 09 20-14-41-11](https://user-images.githubusercontent.com/15725/45821015-79ff2900-bce8-11e8-8987-4c751aa11609.png) |

## Large mobile (width > 320)
| Before | After |
|------------|----------|
| ![screenshot-data xps-2018 09 20-15-16-39](https://user-images.githubusercontent.com/15725/45820927-3f958c00-bce8-11e8-83fe-6b00373d8e9a.png) | ![screenshot-data xps-2018 09 20-15-08-55](https://user-images.githubusercontent.com/15725/45820493-2dffb480-bce7-11e8-9335-d6533bef6cfa.png) |

## Small mobile (width <=320)
| Before | After |
|------------|----------|
| ![screenshot-data xps-2018 09 20-15-17-43](https://user-images.githubusercontent.com/15725/45820975-60f67800-bce8-11e8-8ffb-01a7c265a14e.png) | ![screenshot-data xps-2018 09 20-15-10-22](https://user-images.githubusercontent.com/15725/45820635-8931a700-bce7-11e8-880a-df00fc31dce1.png) |