### PR TITLE
Ensure info config only display config variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@
 - Ensure harvest previewing is done against current form content [#1888](https://github.com/opendatateam/udata/pull/1888)
 - Ensure deleted objects are unindexed [#1891](https://github.com/opendatateam/udata/pull/1891)
 - Fix the dataset resources list layout wrapping [#1893](https://github.com/opendatateam/udata/pull/1893)
-- Fix wrong behavior for weblinks [#1894](https://github.com/opendatateam/udata/pull/1894) 
+- Fix wrong behavior for weblinks [#1894](https://github.com/opendatateam/udata/pull/1894)
+- Ensure `info config` command only displays configuration variables [#1897](https://github.com/opendatateam/udata/pull/1897)
 
 ### Internal
 

--- a/udata/commands/info.py
+++ b/udata/commands/info.py
@@ -38,6 +38,8 @@ def config():
 
     log.info(white('Current configuration'))
     for key in sorted(current_app.config):
+        if key.startswith('__') or not key.isupper():
+            continue
         echo('{0}: {1}'.format(white(key), current_app.config[key]))
 
 


### PR DESCRIPTION
Fix a small bug in `udata info config` command to prevent non configuration variable to be dispayed (imported modules, builtins...)