### PR TITLE
Api specs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Switch the admin sidebar collapse icon from "hamburger"to left and right arrows [#1855](https://github.com/opendatateam/udata/pull/1855)
 - Discussion add card style coherence [#1884](https://github.com/opendatateam/udata/pull/1884)
 - `LINKCHECKING_UNCHECKED_TYPES` setting to prevent linkchecking on some ressource types [#1892](https://github.com/opendatateam/udata/pull/1892)
+- `swagger.json` API specifications now pass validation [#1898](https://github.com/opendatateam/udata/pull/1898)
 
 ### Breaking changes
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -19,7 +19,7 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 flask-mongoengine==0.9.5
 Flask-Navigation==0.2.0
-flask-restplus==0.11.0
+flask-restplus==0.12.1
 Flask-Security==3.0.0
 Flask-Sitemap==0.3.0
 Flask-Themes2==0.1.4

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -162,7 +162,7 @@ class DatasetFeaturedAPI(API):
         return dataset
 
     @api.secure(admin_permission)
-    @api.doc('unfeature_reuse')
+    @api.doc('unfeature_dataset')
     @api.marshal_with(dataset_fields)
     def delete(self, dataset):
         '''Unmark the dataset as featured'''
@@ -247,10 +247,11 @@ class UploadMixin(object):
 
 
 @ns.route('/<dataset:dataset>/upload/', endpoint='upload_new_dataset_resource')
-@api.doc(parser=upload_parser, **common_doc)
+@api.doc(**common_doc)
 class UploadNewDatasetResource(UploadMixin, API):
     @api.secure
     @api.doc('upload_new_dataset_resource')
+    @api.expect(upload_parser)
     @api.marshal_with(upload_fields)
     def post(self, dataset):
         '''Upload a new dataset resource'''
@@ -265,10 +266,11 @@ class UploadNewDatasetResource(UploadMixin, API):
 
 @ns.route('/<dataset:dataset>/upload/community/',
           endpoint='upload_new_community_resource')
-@api.doc(parser=upload_parser, **common_doc)
+@api.doc(**common_doc)
 class UploadNewCommunityResources(UploadMixin, API):
     @api.secure
     @api.doc('upload_new_community_resource')
+    @api.expect(upload_parser)
     @api.marshal_with(upload_fields)
     def post(self, dataset):
         '''Upload a new community resource'''

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -437,6 +437,9 @@ class CommunityResourceAPI(API):
 
 
 @ns.route('/<id>/followers/', endpoint='dataset_followers')
+@ns.doc(get={'id': 'list_dataset_followers'},
+        post={'id': 'follow_dataset'},
+        delete={'id': 'unfollow_dataset'})
 class DatasetFollowersAPI(FollowAPI):
     model = Dataset
 

--- a/udata/core/followers/api.py
+++ b/udata/core/followers/api.py
@@ -42,7 +42,7 @@ class FollowAPI(API):
     '''
     model = None
 
-    @api.doc('list_followers', parser=parser)
+    @api.doc(parser=parser)
     @api.marshal_with(follow_page_fields)
     def get(self, id):
         '''List all followers for a given object'''
@@ -52,7 +52,7 @@ class FollowAPI(API):
         return qs.paginate(args['page'], args['page_size'])
 
     @api.secure
-    @api.doc('follow', description=NOTE)
+    @api.doc(description=NOTE)
     def post(self, id):
         '''Follow an object given its ID'''
         model = self.model.objects.only('id').get_or_404(id=id)
@@ -64,7 +64,7 @@ class FollowAPI(API):
         return {'followers': count}, 201 if created else 200
 
     @api.secure
-    @api.doc('unfollow', description=NOTE)
+    @api.doc(description=NOTE)
     def delete(self, id):
         '''Unfollow an object given its ID'''
         model = self.model.objects.only('id').get_or_404(id=id)

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -301,6 +301,9 @@ class MemberAPI(API):
 
 
 @ns.route('/<id>/followers/', endpoint='organization_followers')
+@ns.doc(get={'id': 'list_organization_followers'},
+        post={'id': 'follow_organization'},
+        delete={'id': 'unfollow_organization'})
 class FollowOrgAPI(FollowAPI):
     model = Organization
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -338,10 +338,11 @@ class SuggestOrganizationsAPI(API):
 
 
 @ns.route('/<org:org>/logo', endpoint='organization_logo')
-@api.doc(parser=image_parser, **common_doc)
+@api.doc(**common_doc)
 class AvatarAPI(API):
     @api.secure
     @api.doc('organization_logo')
+    @api.expect(image_parser)  # Swagger 2.0 does not support formData at path level
     @api.marshal_with(uploaded_image_fields)
     def post(self, org):
         '''Upload a new logo'''
@@ -352,6 +353,7 @@ class AvatarAPI(API):
 
     @api.secure
     @api.doc('resize_organization_logo')
+    @api.expect(image_parser)  # Swagger 2.0 does not support formData at path level
     @api.marshal_with(uploaded_image_fields)
     def put(self, org):
         '''Set the logo BBox'''

--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -133,10 +133,10 @@ class PublishPostAPI(API):
 
 
 @ns.route('/<post:post>/image', endpoint='post_image')
-@api.doc(parser=image_parser)
 class PostImageAPI(API):
     @api.secure(admin_permission)
     @api.doc('post_image')
+    @api.expect(image_parser)  # Swagger 2.0 does not support formData at path level
     @api.marshal_with(uploaded_image_fields)
     def post(self, post):
         '''Upload a new image'''
@@ -146,6 +146,7 @@ class PostImageAPI(API):
 
     @api.secure(admin_permission)
     @api.doc('resize_post_image')
+    @api.expect(image_parser)  # Swagger 2.0 does not support formData at path level
     @api.marshal_with(uploaded_image_fields)
     def put(self, post):
         '''Set the image BBox'''

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -164,6 +164,9 @@ class ReuseFeaturedAPI(API):
 
 
 @ns.route('/<id>/followers/', endpoint='reuse_followers')
+@ns.doc(get={'id': 'list_reuse_followers'},
+        post={'id': 'follow_reuse'},
+        delete={'id': 'unfollow_reuse'})
 class FollowReuseAPI(FollowAPI):
     model = Reuse
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -200,10 +200,11 @@ class SuggestReusesAPI(API):
 
 
 @ns.route('/<reuse:reuse>/image', endpoint='reuse_image')
-@api.doc(parser=image_parser, **common_doc)
+@api.doc(**common_doc)
 class ReuseImageAPI(API):
     @api.secure
     @api.doc('reuse_image')
+    @api.expect(image_parser)  # Swagger 2.0 does not support formData at path level
     @api.marshal_with(uploaded_image_fields)
     def post(self, reuse):
         '''Upload a new reuse image'''

--- a/udata/core/spatial/api.py
+++ b/udata/core/spatial/api.py
@@ -90,7 +90,7 @@ class ZonesAPI(API):
 
 @ns.route('/zone/<path:id>/children', endpoint='zone_children')
 class ZoneChildrenAPI(API):
-    @api.doc('spatial_zone', params={'id': 'A zone identifier'})
+    @api.doc('spatial_zone_children', params={'id': 'A zone identifier'})
     @api.marshal_list_with(feature_collection_fields)
     def get(self, id):
         '''Fetch children of a zone.'''
@@ -105,7 +105,7 @@ class ZoneChildrenAPI(API):
 
 @ns.route('/zone/<path:id>/datasets', endpoint='zone_datasets')
 class ZoneDatasetsAPI(API):
-    @api.doc('spatial_zone', params={'id': 'A zone identifier'})
+    @api.doc('spatial_zone_datasets', params={'id': 'A zone identifier'})
     @api.expect(dataset_parser)
     @api.marshal_with(dataset_ref_fields)
     def get(self, id):

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -55,7 +55,8 @@ parser = api.page_parser()
 @ns.route('/', endpoint='topics')
 class TopicsAPI(API):
 
-    @api.doc('list_topics', model=topic_page_fields, parser=parser)
+    @api.doc('list_topics')
+    @api.expect(parser)
     @api.marshal_with(topic_page_fields)
     def get(self):
         '''List all topics'''
@@ -63,10 +64,11 @@ class TopicsAPI(API):
         return (Topic.objects.order_by('-created')
                              .paginate(args['page'], args['page_size']))
 
-    @api.doc('create_topic', responses={400: 'Validation error'})
+    @api.doc('create_topic')
     @api.secure(admin_permission)
     @api.expect(topic_fields)
     @api.marshal_with(topic_fields)
+    @api.response(400, 'Validation error')
     def post(self):
         '''Create a topic'''
         form = api.validate(TopicForm)
@@ -74,8 +76,8 @@ class TopicsAPI(API):
 
 
 @ns.route('/<topic:topic>/', endpoint='topic')
-@api.doc(responses={404: 'Object not found'})
-@api.doc(params={'topic': 'The topic ID or slug'})
+@api.param('topic', 'The topic ID or slug')
+@api.response(404, 'Object not found')
 class TopicAPI(API):
     @api.doc('get_topic')
     @api.marshal_with(topic_fields)
@@ -83,17 +85,19 @@ class TopicAPI(API):
         '''Get a given topic'''
         return topic
 
+    @api.doc('update_topic')
     @api.secure(admin_permission)
     @api.expect(topic_fields)
     @api.marshal_with(topic_fields)
-    @api.doc('update_topic', responses={400: 'Validation error'})
+    @api.response(400, 'Validation error')
     def put(self, topic):
         '''Update a given topic'''
         form = api.validate(TopicForm, topic)
         return form.save()
 
+    @api.doc('delete_topic')
     @api.secure(admin_permission)
-    @api.doc('delete_topic', model=None, responses={204: 'Object deleted'})
+    @api.response(204, 'Object deleted')
     def delete(self, topic):
         '''Delete a given topic'''
         topic.delete()

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -77,10 +77,10 @@ class MeAPI(API):
 
 
 @me.route('/avatar', endpoint='my_avatar')
-@api.doc(parser=image_parser)
 class AvatarAPI(API):
     @api.secure
     @api.doc('my_avatar')
+    @api.expect(image_parser)
     @api.marshal_with(uploaded_image_fields)
     def post(self):
         '''Upload a new avatar'''

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -288,6 +288,9 @@ class UserAPI(API):
 
 
 @ns.route('/<id>/followers/', endpoint='user_followers')
+@ns.doc(get={'id': 'list_user_followers'},
+        post={'id': 'follow_user'},
+        delete={'id': 'unfollow_user'})
 class FollowUserAPI(FollowAPI):
     model = User
 

--- a/udata/tests/api/test_base_api.py
+++ b/udata/tests/api/test_base_api.py
@@ -8,7 +8,7 @@ from udata.forms import Form, fields
 
 from . import APITestCase
 
-ns = api.namespace('fake', 'A Fake namespace')
+ns = api.namespace('fake-ns', 'A Fake namespace')
 
 
 @ns.route('/options', endpoint='fake-options')

--- a/udata/tests/api/test_swagger.py
+++ b/udata/tests/api/test_swagger.py
@@ -3,16 +3,23 @@ from __future__ import unicode_literals
 
 import json
 
-from . import APITestCase
+from flask import url_for
+from flask_restplus import schemas
+
+from udata.tests.helpers import assert200
 
 
-class SwaggerBlueprintTest(APITestCase):
+class SwaggerBlueprintTest:
+    modules = []
 
-    def test_swagger_resource_type(self):
-
-        response = self.get('api/1/swagger.json')
-        self.assert200(response)
+    def test_swagger_resource_type(self, api):
+        response = api.get(url_for('api.specs'))
+        assert200(response)
         swagger = json.loads(response.data)
         expected = swagger['paths']['/datasets/{dataset}/resources/']
         expected = expected['put']['responses']['200']['schema']['type']
-        self.assertEquals(expected, 'array')
+        assert expected == 'array'
+
+    def test_swagger_specs_validate(self, api):
+        response = api.get(url_for('api.specs'))
+        schemas.validate(response.json)


### PR DESCRIPTION
This PR fixes a lot of `swagger.json` API specs bugs allowing it to validate and so being able to use swagger tools that weren't working (like the new version of Swagger UI).

Some fixes are on the `flask-restplus` side so it has been updated with it