### PR TITLE
Allows arguments in @connect decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Allows arguments and keyword arguments in the task `@connect` decorator [#1908](https://github.com/opendatateam/udata/pull/1908)
 
 ## 1.6.0 (2018-10-02)
 

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -88,9 +88,9 @@ def get_logger(name):
     return logger
 
 
-def connect(signal):
+def connect(signal, *args, **kwargs):
     def wrapper(func):
-        t = task(func)
+        t = task(func, *args, **kwargs)
 
         def call_task(item, **kwargs):
             t.delay(item, **kwargs)


### PR DESCRIPTION
This PR allows arguments in the task `@connect` decorator allowing by example to specify task routing and priority