### PR TITLE
Fix form events not bubbling (and harvester config being hidden)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Current (in progress)
 
 - Allows arguments and keyword arguments in the task `@connect` decorator [#1908](https://github.com/opendatateam/udata/pull/1908)
-- Allow to restore assets after being deleted.( Datasets, Organizations and Reuses) [#1901](https://github.com/opendatateam/udata/pull/1901)
+- Allows to restore assets after being deleted (Datasets, Organizations and Reuses) [#1901](https://github.com/opendatateam/udata/pull/1901)
+- Fixes form events not bubbling (and so fixes harvester config not displaying) [#1914](https://github.com/opendatateam/udata/pull/1914)
 
 ## 1.6.0 (2018-10-02)
 

--- a/js/components/form/base-field.js
+++ b/js/components/form/base-field.js
@@ -48,6 +48,7 @@ export const BaseField = {
     events: {
         'field:value-change': function(value) {
             this.$dispatch('field:change', this, value);
+            return true;  // Let the event continue its bubbling
         }
     },
     props: {

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -85,6 +85,7 @@ export default {
     events: {
         'field:change': function(field, value) {
             this.$dispatch('form:change', this, field, value);
+            return true;  // Let the event continue its bubbling
         }
     },
     computed: {

--- a/js/components/harvest/form.vue
+++ b/js/components/harvest/form.vue
@@ -56,11 +56,13 @@ export default {
             if (field.field.id == 'backend') {
                 this.backendValue = value;
             }
+            return true;  // Let the event continue its bubbling
         },
         'form:change': function(form) {
             if (form.validate()) {
                 this.$dispatch('harvest:source:form:changed', this.serialize());
             }
+            return true;  // Let the event continue its bubbling
         }
     },
     computed: {


### PR DESCRIPTION
This PR fix an issue with form events: some handlers were preventing the events from continuing to bubble up.
As a side-effect, the harvester config was never displayed.