### PR TITLE
Fix some external assets handling cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improve harvest validation errors handling [#1920](https://github.com/opendatateam/udata/pull/1920)
 - Make extra TOS text customizable [#1922](https://github.com/opendatateam/udata/pull/1922)
 - Fixes an `UnicodeEncodeError` occuring when parsing RDF with unicode URLs [#1919](https://github.com/opendatateam/udata/pull/1919)
+- Fix some external assets handling cases [#1918](https://github.com/opendatateam/udata/pull/1918)
 
 ## 1.6.1 (2018-10-11)
 

--- a/udata/frontend/helpers.py
+++ b/udata/frontend/helpers.py
@@ -48,8 +48,8 @@ def static_global(filename, _burst=True, **kwargs):
 
 
 @front.app_template_global()
-def manifest(app, filename):
-    return assets.from_manifest(app, filename)
+def manifest(app, filename, **kwargs):
+    return assets.from_manifest(app, filename, **kwargs)
 
 
 @front.app_template_test()

--- a/udata/theme/__init__.py
+++ b/udata/theme/__init__.py
@@ -49,11 +49,13 @@ def theme_static_with_version(ctx, filename, external=False):
     '''Override the default theme static to add cache burst'''
     if current_app.theme_manager.static_folder:
         url = assets.cdn_for('_themes.static',
-                             filename=current.identifier + '/' + filename)
+                             filename=current.identifier + '/' + filename,
+                             _external=external)
     else:
         url = assets.cdn_for('_themes.static',
                              themeid=current.identifier,
-                             filename=filename)
+                             filename=filename,
+                             _external=external)
     if url.endswith('/'):  # this is a directory, no need for cache burst
         return url
     if current_app.config['DEBUG']:


### PR DESCRIPTION
This PR fixes some external assets cases:
- sometimes `external` keyword was ignored
- sometimes it didn't exists

This mostly fixes oembed cards.