### PR TITLE
Split harvest exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Display the owner/organization on harvester view [#1921](https://github.com/opendatateam/udata/pull/1921)
+- Improve harvest validation errors handling [#1920](https://github.com/opendatateam/udata/pull/1920)
 
 ## 1.6.1 (2018-10-11)
 

--- a/udata/harvest/exceptions.py
+++ b/udata/harvest/exceptions.py
@@ -10,3 +10,8 @@ class HarvestException(Exception):
 class HarvestSkipException(HarvestException):
     '''Raised when an item is skipped'''
     pass
+
+
+class HarvestValidationError(HarvestException):
+    '''Raised when an harvested item is invalid'''
+    pass


### PR DESCRIPTION
This PR create a new `HarvestValidationError` exception to properly handle validation errors:
- proper display in admin (no useless stacktrace, only the errors)
- less stored data (no stacktrace)
- no Sentry clutering (like [this](https://sentry.data.gouv.fr/share/issue/2e974ecb67764af19db44e9babc18449/))
