### PR TITLE
Harvest items can now match source.id before source.domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Make extra TOS text customizable [#1922](https://github.com/opendatateam/udata/pull/1922)
 - Fixes an `UnicodeEncodeError` occuring when parsing RDF with unicode URLs [#1919](https://github.com/opendatateam/udata/pull/1919)
 - Fix some external assets handling cases [#1918](https://github.com/opendatateam/udata/pull/1918)
+- Harvest items can now match `source.id` before `source.domain` — no more duplicates when changing an harvester URL [#1923](https://github.com/opendatateam/udata/pull/1923)
 
 ## 1.6.1 (2018-10-11)
 

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -246,10 +246,18 @@ class BaseBackend(object):
         after_harvest_job.send(self)
 
     def get_dataset(self, remote_id):
-        '''Get or create a dataset given its remote ID (and its source)'''
+        '''Get or create a dataset given its remote ID (and its source)
+        We first try to match `source_id` to be source domain independent
+        '''
+        dataset = Dataset.objects(__raw__={
+            'extras.harvest:source_id': self.source.id,
+            'extras.harvest:remote_id': remote_id,
+        }).first()
+        if dataset:
+            return dataset
         dataset = Dataset.objects(__raw__={
             'extras.harvest:remote_id': remote_id,
-            'extras.harvest:domain': self.source.domain
+            'extras.harvest:domain': self.source.domain,
         }).first()
         return dataset or Dataset()
 

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -250,14 +250,11 @@ class BaseBackend(object):
         We first try to match `source_id` to be source domain independent
         '''
         dataset = Dataset.objects(__raw__={
-            'extras.harvest:source_id': self.source.id,
             'extras.harvest:remote_id': remote_id,
-        }).first()
-        if dataset:
-            return dataset
-        dataset = Dataset.objects(__raw__={
-            'extras.harvest:remote_id': remote_id,
-            'extras.harvest:domain': self.source.domain,
+            '$or': [
+                {'extras.harvest:domain': self.source.domain},
+                {'extras.harvest:source_id': str(self.source.id)},
+            ],
         }).first()
         return dataset or Dataset()
 


### PR DESCRIPTION
This should allow us to modify a Harvester url without recreating all the datasets as duplicates.