### PR TITLE
Ensure image picker only allows image files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixes an `UnicodeEncodeError` occuring when parsing RDF with unicode URLs [#1919](https://github.com/opendatateam/udata/pull/1919)
 - Fix some external assets handling cases [#1918](https://github.com/opendatateam/udata/pull/1918)
 - Harvest items can now match `source.id` before `source.domain` — no more duplicates when changing an harvester URL [#1923](https://github.com/opendatateam/udata/pull/1923)
+- Ensure image picker/cropper only allows images [#1925](https://github.com/opendatateam/udata/pull/1925)
 
 ## 1.6.1 (2018-10-11)
 

--- a/js/components/widgets/image-picker.vue
+++ b/js/components/widgets/image-picker.vue
@@ -74,10 +74,13 @@ import log from 'logger';
 import UploaderMixin from 'mixins/uploader';
 import Thumbnailer from 'components/widgets/thumbnailer.vue';
 
+const IMAGES_ONLY = ['png', 'jpg', 'jpeg', 'webp'];
+
 export default {
     name: 'image-picker',
     autoUpload: false,
     chunk: false,
+    allowedExtensions: IMAGES_ONLY,
     mixins: [UploaderMixin],
     components: {Thumbnailer},
     data() {

--- a/js/components/widgets/thumbnailer.vue
+++ b/js/components/widgets/thumbnailer.vue
@@ -96,11 +96,9 @@
 <script>
 import JCrop from 'jquery-jcrop';
 import $ from 'jquery';
-import UploaderMixin from 'mixins/uploader';
 
 export default {
     name: 'thumbnailer',
-    mixins: [UploaderMixin],
     props: {
         src: null,
         sizes: {type: Array, default: () => [50, 100]},

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -142,7 +142,7 @@ export default {
                     onComplete: this.on_complete,
                     onError: this.on_error,
                 },
-                validation: {allowedExtensions: allowedExtensions.items},
+                validation: {allowedExtensions: this.$options.allowedExtensions || allowedExtensions.items},
                 messages,
             });
         },

--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -15,6 +15,8 @@ from . import utils, chunks
 
 META = 'meta.json'
 
+IMAGES_MIMETYPES = ('image/jpeg', 'image/png', 'image/webp')
+
 
 uploaded_image_fields = api.model('UploadedImage', {
     'success': fields.Boolean(
@@ -158,6 +160,8 @@ def parse_uploaded_image(field):
     args = image_parser.parse_args()
 
     image = args['file']
+    if image.mimetype not in IMAGES_MIMETYPES:
+        api.abort(400, 'Unsupported image format')
     bbox = args.get('bbox', None)
     if bbox:
         bbox = [int(float(c)) for c in bbox.split(',')]


### PR DESCRIPTION
This ensure users won't be able to provide anything else than an image in the image picker, preventing both client and server-side errors.

Supported image types are restricted to: `png`, `jpeg` and `webp`