### PR TITLE
Feature/clean user extras on delete

### DIFF
--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -223,6 +223,7 @@ class User(WithMetrics, UserMixin, db.Document):
         self.avatar_url = None
         self.website = None
         self.about = None
+        self.extras = None
         self.deleted = datetime.now()
         self.save()
         for organization in self.organizations:


### PR DESCRIPTION
We store some user data information on user.extras field. This info must be cleaned at user deletion in accordance with EU General Data Protection Regulation (GDPR)