### PR TITLE
Pin phantomjs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Current (in progress)
 
-- Nothing yet
+### Bugfixes
+
+- Pin phantomjs to version `2.1.7` [#1975](https://github.com/opendatateam/udata/pull/1975)
 
 ## 1.6.2 (2018-11-05)
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "less-loader": "^2.2.3",
     "mocha": "^3.2.0",
     "null-loader": "^0.1.1",
-    "phantomjs-prebuilt": "^2.1.7",
+    "phantomjs-prebuilt": "2.1.7",
     "script-loader": "^0.7.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
One of its dependencies is requiring a breaking version of `punycode`
(issues with es6 and webpack).

Circeci build was stuck because of it.