### PR TITLE
Protect membership accept route against flood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Current (in progress)
 
-### Bugfixes
-
 - Pin phantomjs to version `2.1.7` [#1975](https://github.com/opendatateam/udata/pull/1975)
+- Protect membership accept route against flood [#1984](https://github.com/opendatateam/udata/pull/1984)
 
 ## 1.6.2 (2018-11-05)
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -97,8 +97,8 @@ class OrganizationAPI(API):
 
         :raises PermissionDenied:
         '''
-        request_deleted = request.json.get('deleted', True) 
-        if org.deleted and request_deleted is not None: 
+        request_deleted = request.json.get('deleted', True)
+        if org.deleted and request_deleted is not None:
             api.abort(410, 'Organization has been deleted')
         EditOrganizationPermission(org).test()
         form = api.validate(OrganizationForm, org)
@@ -210,6 +210,9 @@ class MembershipAcceptAPI(MembershipAPI):
         '''Accept user membership to a given organization.'''
         EditOrganizationPermission(org).test()
         membership_request = self.get_or_404(org, id)
+
+        if org.is_member(membership_request.user):
+            return org.member(membership_request.user), 409
 
         membership_request.status = 'accepted'
         membership_request.handled_by = current_user._get_current_object()

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -232,6 +232,14 @@ class MembershipAPITest:
         assert request.handled_on is not None
         assert request.refusal_comment is None
 
+        # test accepting twice will raise 409
+        api_url = url_for(
+            'api.accept_membership',
+            org=organization,
+            id=membership_request.id)
+        response = api.post(api_url)
+        assert_status(response, 409)
+
     def test_only_admin_can_accept_membership(self, api):
         user = api.login()
         applicant = UserFactory()


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/117. 

This should prevent massive membership acceptances, leading to members duplication.