### PR TITLE
Resource form, modal and workflow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Pin phantomjs to version `2.1.7` [#1975](https://github.com/opendatateam/udata/pull/1975)
 - Protect membership accept route against flood [#1984](https://github.com/opendatateam/udata/pull/1984)
 - Ensure compatibility with IE11 and Firefox ESR [#1990](https://github.com/opendatateam/udata/pull/1990)
+- Lots of fixes on the resource form. Be explicit about uploading a new file [#1991](https://github.com/opendatateam/udata/pull/1991)
 
 ## 1.6.2 (2018-11-05)
 

--- a/js/components/dataset/resource/add-modal.vue
+++ b/js/components/dataset/resource/add-modal.vue
@@ -4,7 +4,7 @@
     :title="_('Add a resource')" :large="editing">
 
     <div class="modal-body">
-        <resource-form v-ref:form :dataset="dataset"></resource-form>
+        <resource-form v-ref:form :dataset="dataset" is-upload></resource-form>
     </div>
 
     <footer class="modal-footer text-center">
@@ -27,9 +27,11 @@
 import Dataset from 'models/dataset';
 import Modal from 'components/modal.vue';
 import ResourceForm from 'components/dataset/resource/form.vue';
+import WatchRefs from 'mixins/watch-refs';
 
 export default {
     name: 'add-resource-modal',
+    mixins: [WatchRefs],
     props: {
         dataset: {
             type: Dataset,
@@ -38,24 +40,24 @@ export default {
     },
     components: {Modal, ResourceForm},
     data() {
-        return {ready: false};
-    },
-    computed: {
-        editing() {
-            return this.ready && this.$refs && this.$refs.form && this.$refs.form.hasData;
-        }
-    },
-    ready() {
-        this.ready = true; // Artificially force editing update because $refs is not reactive
+        return {editing: false};
     },
     methods: {
+        upload() {
+            this.$refs.form.isUpload = true;
+        },
         save() {
             if (this.$refs.form.validate()) {
                 this.dataset.save_resource(this.$refs.form.serialize());
                 this.$refs.modal.close();
                 return true;
             }
-        }
-    }
+        },
+    },
+    watchRefs: {
+        'form.hasData': function(hasData) {
+            this.editing = hasData;
+        },
+    },
 };
 </script>

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -99,10 +99,10 @@
 
 <template>
 <div>
-    <form-horizontal v-if="hasData" class="resource-form file-resource-form"
+    <form-horizontal v-if="hasData && !isUpload" class="resource-form file-resource-form"
         :fields="fields" :model="resource" v-ref:form>
     </form-horizontal>
-    <div v-show="files.length" v-for="file in files" class="info-box bg-aqua">
+    <div v-for="file in files" track-by="id" class="info-box bg-aqua">
         <span class="info-box-icon">
             <span class="fa fa-cloud-upload"></span>
         </span>
@@ -117,7 +117,7 @@
             </span>
         </div>
     </div>
-    <div class="resource-choose-upload" v-if="showUploadZone">
+    <div class="resource-choose-upload" v-if="isUpload && !files.length">
         <div class="resource-upload-dropzone">
             <div class="row">
                 <div class="text-center col-xs-12">
@@ -137,7 +137,7 @@
             </div>
         </div>
         <div v-if="!hasUploadedFile">
-            <a href="" @click.prevent.stop="hasChosenRemoteFile = true">
+            <a href @click.prevent.stop="manual">
                 {{ _("You can also link to an existing remote file or URL by clicking here.") }}
             </a>
         </div>
@@ -174,6 +174,10 @@ export default {
             )}
         },
         hideNotifications: false,
+        isUpload: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -230,12 +234,8 @@ export default {
         hasData() {
             return Boolean(this.resource.url || this.hasChosenRemoteFile);
         },
-        showUploadZone() {
-            // Upload in progress
-            if (this.files.length) return false;
-            // Upload done
-            if (this.hasData || this.hasUploadedFile) return false;
-            return true;
+        canDrop() {
+            return this.isUpload && !this.files.length;
         },
         hasUploadedFile() {
             return this.resource.filetype == 'file';
@@ -285,12 +285,17 @@ export default {
         },
     },
     methods: {
+        manual() {
+            this.hasChosenRemoteFile = true;
+            this.isUpload = false;
+        },
         postUpload() {
             this.resource.filetype = 'file';
             this.file_fields = this.file_fields.map(ff => {
                 ff.readonly = true;
                 return ff;
             });
+            this.isUpload = false;
         },
         serialize() {
             // Required because of readonly fields and filetype.

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -202,43 +202,45 @@ export default {
                     label: this._('Publication date'),
                     widget: 'date-picker'
                 }],
-            file_fields: [{
-                    id: 'url',
-                    label: this._('URL'),
-                    readonly: false,
-                    widget: 'url-field',
-                }, {
-                    id: 'filesize',
-                    label: this._('Size'),
-                    readonly: false
-                }, {
-                    id: 'format',
-                    label: this._('Format'),
-                    widget: 'format-completer',
-                    readonly: false
-                }, {
-                    id: 'mime',
-                    label: this._('Mime Type'),
-                    readonly: false
-                }, {
-                    id: 'checksum',
-                    label: this._('Checksum'),
-                    widget: 'checksum',
-                    readonly: false
-                }],
-            uploadMultiple: false,
             progress: 0,
         };
     },
     computed: {
-        hasData() {
-            return Boolean(this.resource.url || this.hasChosenRemoteFile);
-        },
         canDrop() {
             return this.isUpload && !this.files.length;
         },
+        hasData() {
+            return Boolean(this.resource.url || this.hasChosenRemoteFile);
+        },
         hasUploadedFile() {
             return this.resource.filetype == 'file';
+        },
+        file_fields() {
+            const readonly = this.resource.filetype === 'file';
+            return [{
+                id: 'url',
+                label: this._('URL'),
+                widget: 'url-field',
+                readonly,
+            }, {
+                id: 'filesize',
+                label: this._('Size'),
+                readonly,
+            }, {
+                id: 'format',
+                label: this._('Format'),
+                widget: 'format-completer',
+                readonly,
+            }, {
+                id: 'mime',
+                label: this._('Mime Type'),
+                readonly,
+            }, {
+                id: 'checksum',
+                label: this._('Checksum'),
+                widget: 'checksum',
+                readonly,
+            }]
         },
         fields() {
             return this.generic_fields.concat(this.file_fields);
@@ -291,10 +293,6 @@ export default {
         },
         postUpload() {
             this.resource.filetype = 'file';
-            this.file_fields = this.file_fields.map(ff => {
-                ff.readonly = true;
-                return ff;
-            });
             this.isUpload = false;
         },
         serialize() {

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -231,9 +231,10 @@ export default {
             return Boolean(this.resource.url || this.hasChosenRemoteFile);
         },
         showUploadZone() {
+            // Upload in progress
             if (this.files.length) return false;
-            if (this.hasChosenRemoteFile) return false;
-            if (this.resource.url && !this.hasUploadedFile) return false;
+            // Upload done
+            if (this.hasData || this.hasUploadedFile) return false;
             return true;
         },
         hasUploadedFile() {

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -70,7 +70,7 @@
         margin-bottom: 0;
     }
 
-    .drop-active > & {
+    .drop-active  & {
         border: 4px dashed @green;
     }
 

--- a/js/locales/udata.en.json
+++ b/js/locales/udata.en.json
@@ -302,6 +302,7 @@
     "Remote ID": "Remote ID",
     "Remove": "Remove",
     "Reorder": "Reorder",
+    "Replace the file": "Replace the file",
     "Resize your thumbnail": "Resize your thumbnail",
     "Resources": "Resources",
     "Resources count": "Resources count",

--- a/js/locales/udata.fr.json
+++ b/js/locales/udata.fr.json
@@ -302,6 +302,7 @@
     "Remote ID": "ID distant",
     "Remove": "Supprimer",
     "Reorder": "Trier",
+    "Replace the file": "Remplacer le fichier",
     "Resize your thumbnail": "Redimensionnez votre vignette",
     "Resources": "Ressources",
     "Resources count": "Nombre de ressources",

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -63,9 +63,14 @@ export default {
             HAS_FILE_API,
         };
     },
+    computed: {
+        canDrop() {
+            return true;
+        },
+    },
     ready() {
         this.$dnd = new qq.DragAndDrop({
-            dropZoneElements: [this.$el],
+            dropZoneElements: this.canDrop ? [this.$el] : [],
             classes: {
                 dropActive: this.$options.dropActive || 'drop-active'
             },
@@ -77,6 +82,13 @@ export default {
     },
 
     watch: {
+        canDrop(canDrop) {
+            if (canDrop) {
+                this.$dnd.setupExtraDropzone(this.$el);
+            } else {
+                this.$dnd.dispose();
+            }
+        },
         upload_endpoint() {
             this._build_uploader();
         }
@@ -210,7 +222,9 @@ export default {
          * See: http://docs.fineuploader.com/branch/master/features/drag-and-drop.html#processingDroppedFilesComplete
          */
         on_dropped_files_complete(files) {
-            this.$uploader.addFiles(files); // this submits the dropped files to Fine Uploader
+            if (this.canDrop) {
+                this.$uploader.addFiles(files); // this submits the dropped files to Fine Uploader
+            }
         },
 
         /**

--- a/js/mixins/watch-refs.js
+++ b/js/mixins/watch-refs.js
@@ -1,0 +1,24 @@
+/**
+ * A mixin to workaround the $refs lack of reactivity
+ */
+export default {
+    ready() {
+        for (const $ref of Object.keys(this.$options.watchRefs)) {
+            this.watchRef($ref, this.$options.watchRefs[$ref]);
+        }
+    },
+    methods: {
+        watchRef($ref, handler) {
+            const component = $ref.split('.')[0];
+
+            const wait = () => { // Arrow func to keep `this`
+                if (this.$refs[component] === undefined) {
+                    setTimeout(wait, 1);
+                    return;
+                }
+                this.$watch(`$refs.${$ref}`, handler.bind(this));
+            };
+            wait();
+        }
+    }
+}

--- a/js/views/community-resource-wizard.vue
+++ b/js/views/community-resource-wizard.vue
@@ -32,6 +32,7 @@ export default {
                     this.dataset.fetch(this.dataset_id);
                     component.dataset = this.dataset;
                     component.resource = this.communityResource;
+                    component.isUpload = true;
                 },
                 next: (component) => {
                     if (component.validate()) {

--- a/js/views/dataset-wizard.vue
+++ b/js/views/dataset-wizard.vue
@@ -63,6 +63,7 @@ export default {
                 component: ResourceForm,
                 init: (component) => {
                     component.dataset = this.dataset;
+                    component.isUpload = true;
                 },
                 next: (component) => {
                     if (component.validate()) {


### PR DESCRIPTION
This PR improve resource form, modal and workfow handling:
- Prevent multiple uploads when only one is expected (resource modals and workflow):
  - hide the drop zone and the file picker
  - disable drag and drop
- Fixes the nested form reactivity (ensure buttons and layout changes on form change)
- Ensure reactivity on the file fields readonly attribute
- Fixes the visual indicator on file drop

Replacing a resource is now explicit with a new "Replace the file" button:

![screenshot-data xps-2019 01 24-13-34-45](https://user-images.githubusercontent.com/15725/51678540-ee224400-1fdc-11e9-9bea-2bfd6b7bf327.png)

![screenshot-data xps-2019 01 24-13-36-13](https://user-images.githubusercontent.com/15725/51678589-0befa900-1fdd-11e9-8e33-8064b0337070.png)
