### PR TITLE
Added missing number input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ensure compatibility with IE11 and Firefox ESR [#1990](https://github.com/opendatateam/udata/pull/1990)
 - Lots of fixes on the resource form. Be explicit about uploading a new file [#1991](https://github.com/opendatateam/udata/pull/1991)
 - Centralize `selectize` handling and style in `base-completer` and apply some fixes [1992](https://github.com/opendatateam/udata/pull/1992)
+- Added the missing `number` input field widget [#1993](https://github.com/opendatateam/udata/pull/1993)
 
 ## 1.6.2 (2018-11-05)
 

--- a/js/components/form/base-field.js
+++ b/js/components/form/base-field.js
@@ -39,6 +39,7 @@ export const BaseField = {
     components: {
         // Only register the common components
         'text-input': require('components/form/text-input.vue'),
+        'number-input': require('components/form/number-input.vue'),
         'hidden-input': require('components/form/hidden-input.vue'),
         'select-input': require('components/form/select-input.vue'),
         'markdown-editor': require('components/form/markdown-editor.vue'),
@@ -117,6 +118,8 @@ export const BaseField = {
                 widget = this.field.widget;
             } else if (this.property.type === 'boolean') {
                 widget = 'checkbox';
+            } else if (this.property.type === 'integer') {
+                widget = 'number-input';
             } else if (this.property.type === 'string') {
                 if (this.property.format === 'markdown') {
                     widget = 'markdown-editor';

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -55,6 +55,7 @@ const TEXT_INPUTS = [
     'email',
     'hidden',
     'month',
+    'number',
     'range',
     'search',
     'tel',

--- a/js/components/form/number-input.vue
+++ b/js/components/form/number-input.vue
@@ -1,0 +1,19 @@
+<template>
+<input type="number" class="form-control"
+    :id="field.id"
+    :name="field.id"
+    :placeholder="placeholder"
+    :required="required"
+    :readonly="readonly"
+    :value="value"
+    @input="onChange"></input>
+</template>
+
+<script>
+import {FieldComponentMixin} from 'components/form/base-field';
+
+export default {
+    name: 'number-input',
+    mixins: [FieldComponentMixin],
+};
+</script>

--- a/specs/components/form/fields.specs.js
+++ b/specs/components/form/fields.specs.js
@@ -145,7 +145,7 @@ describe('Common Fields features', function() {
             expect(vm.property).to.eql({type: 'integer', format: 'int64'});
             expect(vm.is_bool).to.be.false;
             expect(vm.placeholder).to.equal('');
-            expect(vm.widget).to.equal('text-input');
+            expect(vm.widget).to.equal('number-input');
         });
     });
 });


### PR DESCRIPTION
This PR add the missing `number` input field and so enforce number validation on Integer fields. 

Fixes etalab/data.gouv.fr#89