### PR TITLE
Disable autocorrect, spellcheck... on search and completion fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Centralize `selectize` handling and style in `base-completer` and apply some fixes [1992](https://github.com/opendatateam/udata/pull/1992)
 - Added the missing `number` input field widget [#1993](https://github.com/opendatateam/udata/pull/1993)
 - Fix the organization private datasets and reuses counters [#1994](https://github.com/opendatateam/udata/pull/1994)
+- Disable autocorrect, spellcheck... on search and completion fields [#1995](https://github.com/opendatateam/udata/pull/1995)
 
 ## 1.6.2 (2018-11-05)
 

--- a/js/components/form/base-completer.vue
+++ b/js/components/form/base-completer.vue
@@ -6,6 +6,7 @@
     :required="required"
     :value="value | lst2str"
     :readonly="readonly || false"
+    autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
     />
 </template>
 

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -15,7 +15,8 @@
         <div class="input-group-btn">
             <button class="btn" type="submit"><i class="fa fa-search"></i></button>
         </div>
-        <input name="q" type="search" class="form-control" autocomplete="off"
+        <input name="q" type="search" class="form-control"
+            autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
             :placeholder="placeholder || _('Search')"
             v-model="query" debounce="200"
             @keydown="show = true"


### PR DESCRIPTION
This PR disable all native autocompletion and autocorrection from search and completion fields (in particular Safari autocorrect)

Fixes #1964