### PR TITLE
Ensure organization page react to URL hash changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix the organization private datasets and reuses counters [#1994](https://github.com/opendatateam/udata/pull/1994)
 - Disable autocorrect, spellcheck... on search and completion fields [#1995](https://github.com/opendatateam/udata/pull/1995)
 - Fix harvest preview in edit form not taking configuration (features and filters) [#1996](https://github.com/opendatateam/udata/pull/1996)
+- Ensure organization page react to URL hash changes (including those from right sidebar) [#1997](https://github.com/opendatateam/udata/pull/1997)
 
 ## 1.6.2 (2018-11-05)
 

--- a/js/front/organization/index.js
+++ b/js/front/organization/index.js
@@ -30,6 +30,8 @@ new Vue({
             followersVisible: false,
             // Current tab index
             currentTab: 0,
+            // URL hash value
+            hash: undefined,
         };
     },
     methods: {
@@ -49,13 +51,12 @@ new Vue({
 
         // Restore tab from hash
         if (location.hash !== '') {
-            this.$refs.tabs.$children.some((tab, index) => {
-                if (`#${tab.id}` === location.hash) {
-                    this.currentTab = index;
-                    return true;
-                }
-            });
+            this.hash = location.hash;
         }
+        // Keep tab in sync with URL hash
+        window.addEventListener('hashchange', () => {
+            this.hash = location.hash;
+        });
     },
     watch: {
         /**
@@ -64,6 +65,14 @@ new Vue({
         */
         currentTab(index) {
             location.hash = this.$refs.tabs.$children[index].id;
+        },
+        hash(hash) {
+            this.$refs.tabs.$children.some((tab, index) => {
+                if (`#${tab.id}` === hash) {
+                    this.currentTab = index;
+                    return true;
+                }
+            });
         }
     }
 });


### PR DESCRIPTION
Ensure organization page react to URL hash changes (including those from right sidebar)

Fix #1374 
Fix etalab/data.gouv.fr#38