### PR TITLE
Expose license alternate titles and urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Updating community resource as admin keeps original owner [#1999](https://github.com/opendatateam/udata/pull/1999)
 - Major form fixes [#2000](https://github.com/opendatateam/udata/pull/2000)
 - Improved admin errors handling: visual feedback on all errors, `Sentry-ID` header if present, hide organization unauthorized actions [#2005](https://github.com/opendatateam/udata/pull/2005)
+- Expose and import licenses `alternate_urls` and `alternate_titles` fields [#2006](https://github.com/opendatateam/udata/pull/2006)
 
 ## 1.6.2 (2018-11-05)
 

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -26,6 +26,14 @@ license_fields = api.model('License', {
     'maintainer': fields.String(description='The license official maintainer'),
     'url': fields.String(description='The license official URL'),
     'flags': fields.List(fields.String, description='Some arbitry flags'),
+    'alternate_urls': fields.List(
+        fields.String,
+        description='Same alternative known URLs (improve rematch)'
+    ),
+    'alternate_titles': fields.List(
+        fields.String,
+        description='Same alternative known titles (improve rematch)'
+    ),
 })
 
 frequency_fields = api.model('Frequency', {

--- a/udata/core/dataset/commands.py
+++ b/udata/core/dataset/commands.py
@@ -52,6 +52,8 @@ def licenses(source=DEFAULT_LICENSE_FILE):
             maintainer=json_license['maintainer'] or None,
             flags=flags,
             active=json_license.get('active', False),
+            alternate_urls=json_license.get('alternate_urls', []),
+            alternate_titles=json_license.get('alternate_titles', []),
         )
         log.info('Added license "%s"', license.title)
     try:


### PR DESCRIPTION
This PR exposes the `alternate_titles` and `alternate_urls` in the License API.
It also imports them in the `udata license` command.

Cf. #2004