### PR TITLE
Ensures all modals have the same buttons styles and orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Expose and import licenses `alternate_urls` and `alternate_titles` fields [#2006](https://github.com/opendatateam/udata/pull/2006)
 - Be consistent on search results wording and icons (Stars vs Followers) [#2013](https://github.com/opendatateam/udata/pull/2013)
 - Switch from a "full facet reset" to a "by term reset" approach in search facets [#2014](https://github.com/opendatateam/udata/pull/2014)
+- Ensures all modals have the same buttons styles and orders, same color code... [#2012](https://github.com/opendatateam/udata/pull/2012)
 
 ## 1.6.2 (2018-11-05)
 

--- a/js/components/badges/modal.vue
+++ b/js/components/badges/modal.vue
@@ -26,7 +26,7 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button v-if="confirm" type="button" class="btn btn-sm btn-info btn-flat pull-left"
+        <button v-if="confirm" type="button" class="btn btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
         </button>

--- a/js/components/badges/modal.vue
+++ b/js/components/badges/modal.vue
@@ -12,7 +12,7 @@
         <div class="text-center row">
             <div class="badges col-xs-6 col-xs-offset-3">
                 <button class="btn btn-primary btn-flat btn-block"
-                    v-for="(key, label) in badges"
+                    v-for="(key, label) in badges" track-by="$index"
                     @click="toggle(key)"
                     :class="{ 'active': selected.indexOf(key) >= 0 }">
                     <span class="fa pull-left" :class="{
@@ -26,14 +26,14 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button :disabled="!hasModifications" type="button"
-            class="btn btn-success btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button v-if="confirm" type="button" class="btn btn-danger btn-flat"
+        <button v-if="confirm" type="button" class="btn btn-sm btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button :disabled="!hasModifications" type="button"
+            class="btn btn-outline btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>
@@ -117,3 +117,13 @@ export default {
     }
 };
 </script>
+
+<style lang="less">
+.badges-modal {
+    .badges {
+        .fa {
+            line-height: inherit;
+        }
+    }
+}
+</style>

--- a/js/components/dataset/delete-modal.vue
+++ b/js/components/dataset/delete-modal.vue
@@ -14,13 +14,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/dataset/resource/add-modal.vue
+++ b/js/components/dataset/resource/add-modal.vue
@@ -8,7 +8,7 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-sm btn-primary btn-flat pull-left"
+        <button type="button" class="btn btn-primary btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
         </button>

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -80,12 +80,13 @@
         </button>
         <!-- Same cancel button for every action-->
         <button type="button" v-show="edit || confirm || isUpload"
-                class="btn btn-warning btn-sm btn-flat pull-left"
+                class="btn btn-sm btn-flat pull-left"
+                :class="{'btn-danger': confirm, 'btn-primary': !confirm}"
                 @click="cancel">
             {{ _('Cancel') }}
         </button>
         <button type="button" v-show="!edit && !confirm && can_edit"
-                class="btn btn-danger btn-xs btn-flat"
+                class="btn btn-danger btn-sm btn-flat"
                 @click="confirm = true">
             {{ _('Delete') }}
         </button>
@@ -95,7 +96,7 @@
             {{ _('Edit') }}
         </button>
         <button type="button" v-show="confirm"
-                class="btn btn-danger btn-outline btn-flat"
+                class="btn btn-warning btn-flat"
                 @click="delete_confirmed">
             {{ _('Confirm') }}
         </button>

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -74,19 +74,19 @@
     <footer class="modal-footer text-center">
         <!-- Main close button (visible on read-only display) -->
         <button type="button" v-show="!edit && !confirm && !isUpload"
-                class="btn btn-primary btn-sm btn-flat pull-left"
+                class="btn btn-primary btn-flat pull-left"
                 @click="$refs.modal.close">
             {{ _('Close') }}
         </button>
         <!-- Same cancel button for every action-->
         <button type="button" v-show="edit || confirm || isUpload"
-                class="btn btn-sm btn-flat pull-left"
+                class="btn btn-flat pull-left"
                 :class="{'btn-danger': confirm, 'btn-primary': !confirm}"
                 @click="cancel">
             {{ _('Cancel') }}
         </button>
         <button type="button" v-show="!edit && !confirm && can_edit"
-                class="btn btn-danger btn-sm btn-flat"
+                class="btn btn-danger btn-flat"
                 @click="confirm = true">
             {{ _('Delete') }}
         </button>

--- a/js/components/discussions/modal.vue
+++ b/js/components/discussions/modal.vue
@@ -70,11 +70,11 @@
                 </textarea>
             </div>
         </form>
-        <button type="button" class="btn btn-sm btn-info btn-flat pull-left"
+        <button type="button" class="btn btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Close') }}
         </button>
-        <button type="button" class="btn btn-sm btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat"
             v-if="$root.me.is_admin" @click="confirm_delete">
             {{ _('Delete') }}
         </button>

--- a/js/components/discussions/modal.vue
+++ b/js/components/discussions/modal.vue
@@ -8,6 +8,19 @@
         height: auto;
     }
 
+    .direct-chat-timestamp {
+        color: #eee;
+    }
+
+    .direct-chat-text {
+        background: #fff;
+        border: 1px solid #fff;
+
+        &:before, &:after {
+            border-right-color: #fff;
+        }
+    }
+
     .card-container {
         margin-bottom: 1em;
     }
@@ -15,8 +28,8 @@
 </style>
 
 <template>
-<modal v-ref:modal :title="title" class="discussion-modal" large
-    :class="{'modal-danger': deleting}">
+<modal v-ref:modal :title="title" class="discussion-modal" :large="!deleting"
+    :class="{'modal-danger': deleting, 'modal-info': !deleting}">
     <div class="modal-body" v-show="!deleting">
         <div class="row card-container">
             <dataset-card class="col-xs-12 col-md-offset-3 col-md-6"
@@ -57,31 +70,31 @@
                 </textarea>
             </div>
         </form>
-        <button type="button" class="btn btn-danger btn-flat pull-left"
-            v-if="$root.me.is_admin" @click="confirm_delete">
-            {{ _('Delete') }}
-        </button>
-        <button type="button" class="btn btn-success btn-flat pull-left"
-            @click="comment_discussion" v-if="!discussion.closed">
-            {{ _('Comment the discussion') }}
-        </button>
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="close_discussion" v-if="!discussion.closed">
-            {{ _('Comment and close discussion') }}
-        </button>
-        <button type="button" class="btn btn-primary btn-flat"
+        <button type="button" class="btn btn-sm btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Close') }}
         </button>
+        <button type="button" class="btn btn-sm btn-danger btn-flat"
+            v-if="$root.me.is_admin" @click="confirm_delete">
+            {{ _('Delete') }}
+        </button>
+        <button type="button" class="btn btn-outline btn-flat"
+            @click="comment_discussion" v-if="!discussion.closed">
+            {{ _('Comment the discussion') }}
+        </button>
+        <button type="button" class="btn btn-outline btn-flat"
+            @click="close_discussion" v-if="!discussion.closed">
+            {{ _('Comment and close discussion') }}
+        </button>
     </footer>
     <footer class="modal-footer text-center" v-show="deleting">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="delete">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="cancel_delete">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="delete">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/harvest/delete-modal.vue
+++ b/js/components/harvest/delete-modal.vue
@@ -13,13 +13,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/harvest/schedule-modal.vue
+++ b/js/components/harvest/schedule-modal.vue
@@ -15,11 +15,11 @@
             </p>
         </div>
         <footer class="modal-footer text-center">
-            <button type="button" class="btn btn-sm btn-flat pull-left" :class="cancelClass" @click="cancel">
+            <button type="button" class="btn btn-flat pull-left" :class="cancelClass" @click="cancel">
                 {{ _('Cancel') }}
             </button>
             <button type="button"  v-if="!unscheduling && source.schedule"
-                class="btn btn-sm btn-danger btn-flat" @click="unscheduling = true">
+                class="btn btn-danger btn-flat" @click="unscheduling = true">
                 {{ _('Unschedule') }}
             </button>
             <button type="button" v-if="!unscheduling" class="btn btn-outline btn-flat" @click="schedule">

--- a/js/components/harvest/schedule-modal.vue
+++ b/js/components/harvest/schedule-modal.vue
@@ -15,18 +15,18 @@
             </p>
         </div>
         <footer class="modal-footer text-center">
-            <button type="button" v-if="!unscheduling" class="btn btn-outline btn-flat pull-left" @click="schedule">
-                {{ _('Schedule') }}
-            </button>
-            <button type="button" v-if="unscheduling" class="btn btn-warning btn-flat pull-left" @click="unschedule">
-                {{ _('Confirm') }}
+            <button type="button" class="btn btn-sm btn-flat pull-left" :class="cancelClass" @click="cancel">
+                {{ _('Cancel') }}
             </button>
             <button type="button"  v-if="!unscheduling && source.schedule"
-                class="btn btn-warning btn-flat pull-left" @click="unscheduling = true">
+                class="btn btn-sm btn-danger btn-flat" @click="unscheduling = true">
                 {{ _('Unschedule') }}
             </button>
-            <button type="button" class="btn btn-sm btn-flat" :class="cancelClass" @click="cancel">
-                {{ _('Cancel') }}
+            <button type="button" v-if="!unscheduling" class="btn btn-outline btn-flat" @click="schedule">
+                {{ _('Schedule') }}
+            </button>
+            <button type="button" v-if="unscheduling" class="btn btn-warning btn-flat" @click="unschedule">
+                {{ _('Confirm') }}
             </button>
         </footer>
     </modal>
@@ -53,7 +53,7 @@ export default {
             return [this.unscheduling ? 'modal-danger' : 'modal-primary'];
         },
         cancelClass() {
-            return [this.unscheduling ? 'btn-warning' : 'btn-primary'];
+            return [this.unscheduling ? 'btn-danger' : 'btn-primary'];
         }
     },
     data() {

--- a/js/components/issues/modal.vue
+++ b/js/components/issues/modal.vue
@@ -7,13 +7,30 @@
     .direct-chat-messages {
         height: auto;
     }
+
+    .direct-chat-timestamp {
+        color: #eee;
+    }
+
+    .direct-chat-text {
+        background: #fff;
+        border: 1px solid #fff;
+
+        &:before, &:after {
+            border-right-color: #fff;
+        }
+    }
+
+    .card-container {
+        margin-bottom: 1em;
+    }
 }
 </style>
 
 <template>
-<modal v-ref:modal :title="_('Issue')" class="issue-modal" large>
+<modal v-ref:modal :title="_('Issue')" class="modal-info issue-modal" large>
     <div class="modal-body">
-        <div class="row">
+        <div class="row card-container">
             <dataset-card class="col-xs-12 col-md-offset-3 col-md-6"
                 v-if="issue.subject | is 'dataset'"
                 :datasetid="issue.subject.id"></dataset-card>
@@ -44,17 +61,17 @@
                 </textarea>
             </div>
         </form>
-        <button type="button" class="btn btn-success btn-flat pull-left"
+        <button type="button" class="btn btn-sm btn-info btn-flat pull-left"
+            @click="$refs.modal.close">
+            {{ _('Close') }}
+        </button>
+        <button type="button" class="btn btn-outline btn-flat"
             @click="comment_issue" v-if="can_comment">
             {{ _('Comment the issue') }}
         </button>
-        <button type="button" class="btn btn-warning btn-flat pull-left"
+        <button type="button" class="btn btn-outline btn-flat"
             @click="close_issue" v-if="can_close">
             {{ _('Comment and close issue') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
-            @click="$refs.modal.close">
-            {{ _('Close') }}
         </button>
     </footer>
 </modal>

--- a/js/components/issues/modal.vue
+++ b/js/components/issues/modal.vue
@@ -61,7 +61,7 @@
                 </textarea>
             </div>
         </form>
-        <button type="button" class="btn btn-sm btn-info btn-flat pull-left"
+        <button type="button" class="btn btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Close') }}
         </button>

--- a/js/components/organization/delete-modal.vue
+++ b/js/components/organization/delete-modal.vue
@@ -13,13 +13,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/post/delete-modal.vue
+++ b/js/components/post/delete-modal.vue
@@ -14,13 +14,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/reuse/delete-modal.vue
+++ b/js/components/reuse/delete-modal.vue
@@ -13,13 +13,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/topic/delete-modal.vue
+++ b/js/components/topic/delete-modal.vue
@@ -14,13 +14,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/transfer/request-modal.vue
+++ b/js/components/transfer/request-modal.vue
@@ -51,13 +51,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button v-if="recipient" type="button" class="btn btn-success btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button v-if="confirm" type="button" class="btn btn-danger btn-flat"
+        <button v-if="confirm" type="button" class="btn btn-sm btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button v-if="recipient" type="button" class="btn btn-outline btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/transfer/request-modal.vue
+++ b/js/components/transfer/request-modal.vue
@@ -51,7 +51,7 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button v-if="confirm" type="button" class="btn btn-sm btn-info btn-flat pull-left"
+        <button v-if="confirm" type="button" class="btn btn-info btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
         </button>

--- a/js/components/transfer/response-modal.vue
+++ b/js/components/transfer/response-modal.vue
@@ -58,13 +58,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-success btn-flat pull-left"
-            @click="respond('accept')">
-            {{ _('Accept') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="respond('refuse')">
             {{ _('Refuse') }}
+        </button>
+        <button type="button" class="btn btn-success btn-flat"
+            @click="respond('accept')">
+            {{ _('Accept') }}
         </button>
     </footer>
 </modal>

--- a/js/components/user/delete-me-modal.vue
+++ b/js/components/user/delete-me-modal.vue
@@ -16,13 +16,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>

--- a/js/components/user/delete-user-modal.vue
+++ b/js/components/user/delete-user-modal.vue
@@ -17,13 +17,13 @@
     </div>
 
     <footer class="modal-footer text-center">
-        <button type="button" class="btn btn-warning btn-flat pull-left"
-            @click="confirm">
-            {{ _('Confirm') }}
-        </button>
-        <button type="button" class="btn btn-danger btn-flat"
+        <button type="button" class="btn btn-danger btn-flat pull-left"
             @click="$refs.modal.close">
             {{ _('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-warning btn-flat"
+            @click="confirm">
+            {{ _('Confirm') }}
         </button>
     </footer>
 </modal>


### PR DESCRIPTION
This PR ensures all modals have the same buttons styles and orders, same color code...

## Delete modals
![screenshot-data xps-2019 01 31-15-15-28](https://user-images.githubusercontent.com/15725/52064505-0c57e900-2575-11e9-8e1f-738bd62b5c10.png)
![screenshot-data xps-2019 01 31-15-14-31](https://user-images.githubusercontent.com/15725/52064506-0cf07f80-2575-11e9-804e-d76f44fc6e71.png)

## Edit modals
Cancel/Close button on the left, smaller, same color as the modal
Action buttons on the right, outlined, red and smaller if dangerous

![screenshot-data xps-2019 01 31-15-39-36](https://user-images.githubusercontent.com/15725/52064566-2db8d500-2575-11e9-9e8f-6270116846d2.png)
![screenshot-data xps-2019 01 31-15-15-57](https://user-images.githubusercontent.com/15725/52064567-2e516b80-2575-11e9-9438-7fbffb5aa2be.png)

## Badges
### Before
![screenshot-www data gouv fr-2019 01 31-16-41-34](https://user-images.githubusercontent.com/15725/52065642-3e6a4a80-2577-11e9-8429-ce9e24c76b3c.png)

### After
![screenshot-data xps-2019 01 31-16-42-14](https://user-images.githubusercontent.com/15725/52065651-43c79500-2577-11e9-90c7-120e2b6a2429.png)


## Issues
### Before
![screenshot-data xps-2019 01 31-16-04-59](https://user-images.githubusercontent.com/15725/52064695-6b1d6280-2575-11e9-8b31-1339fd661402.png)

### After
![screenshot-data xps-2019 01 31-16-10-22](https://user-images.githubusercontent.com/15725/52064783-97d17a00-2575-11e9-8031-56243df5aaba.png)

## Discussions
### Before
![screenshot-data xps-2019 01 31-15-48-13](https://user-images.githubusercontent.com/15725/52064696-6b1d6280-2575-11e9-922e-97e30a292257.png)

### After
![screenshot-data xps-2019 01 31-16-03-13](https://user-images.githubusercontent.com/15725/52064784-97d17a00-2575-11e9-9ef8-ab4304069f07.png)

## Yes/No modals
- `No/Refuse` in red, on the left side
- `Yes/Accept` in green, on the right side

![screenshot-data xps-2019 01 31-16-39-21](https://user-images.githubusercontent.com/15725/52065483-e6334880-2576-11e9-8665-28280aa45423.png)
