### PR TITLE
Search wording and icons consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Major form fixes [#2000](https://github.com/opendatateam/udata/pull/2000)
 - Improved admin errors handling: visual feedback on all errors, `Sentry-ID` header if present, hide organization unauthorized actions [#2005](https://github.com/opendatateam/udata/pull/2005)
 - Expose and import licenses `alternate_urls` and `alternate_titles` fields [#2006](https://github.com/opendatateam/udata/pull/2006)
+- Be consistent on search results wording and picto (Stars vs Followers)
 
 ## 1.6.2 (2018-11-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Major form fixes [#2000](https://github.com/opendatateam/udata/pull/2000)
 - Improved admin errors handling: visual feedback on all errors, `Sentry-ID` header if present, hide organization unauthorized actions [#2005](https://github.com/opendatateam/udata/pull/2005)
 - Expose and import licenses `alternate_urls` and `alternate_titles` fields [#2006](https://github.com/opendatateam/udata/pull/2006)
-- Be consistent on search results wording and picto (Stars vs Followers)
+- Be consistent on search results wording and icons (Stars vs Followers) [#2013](https://github.com/opendatateam/udata/pull/2013)
 
 ## 1.6.2 (2018-11-05)
 

--- a/udata/templates/dataset/list.html
+++ b/udata/templates/dataset/list.html
@@ -15,7 +15,7 @@
 
 {% block breadcrumb %}
     <li class="active">
-    
+
         {{ _('Datasets') }}
 
         {% if datasets.total > 0 %}
@@ -24,7 +24,7 @@
                 end=datasets.page_end,
                 total=datasets.total) }}</small>
 		{% endif %}
-        
+
         {% include "dataset/search-labels.html" %}
     </li>
 {% endblock %}
@@ -41,7 +41,7 @@
     created=(_('Creation date'), 'desc'),
     last_modified=(_('Last modification date'), 'desc'),
     reuses=(_('Reuses'), 'desc'),
-    followers=(_('Stars'), 'desc')
+    followers=(_('Followers'), 'desc')
 ) }}
 </div>
 {% endblock %}
@@ -49,7 +49,7 @@
 {% block main_content %}
 <div class="row">
 
-    {% if datasets %} 
+    {% if datasets %}
         <div class="col-md-8 col-lg-9 smaller">
 
             <ul class="search-results">
@@ -67,7 +67,7 @@
     <aside class="col-md-4 col-lg-3">
     {% include theme('dataset/search-panel.html') %}
     </aside>
-    {% else %} 
+    {% else %}
         <p class="text-center">
             <strong>
                 {{ _('No results found, try to be less specific.') }}

--- a/udata/templates/dataset/search-result.html
+++ b/udata/templates/dataset/search-result.html
@@ -103,7 +103,7 @@
 
             <li>
                 <a class="btn btn-xs" v-tooltip tooltip-placement="top"
-                    title="{{ _('Followers') }}">
+                    title="{{ _('Number of followers') }}">
                     <span class="{{ ficon('fa-star') }} fa-fw"></span>
                     {{ dataset.metrics.followers or 0 }}
                 </a>

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -26,7 +26,7 @@
                 ---
             </a>
         </li>
-        {% for field, (label, order) in kwargs.items() %}
+        {% for field, (label, order) in kwargs|dictsort(by='value') %}
             {% set sort = field if order == 'asc' else '-'+field %}
             <li>
                 <a href="{{ to_url(url=url, replace=True, sort=sort) }}">

--- a/udata/templates/organization/search-result.html
+++ b/udata/templates/organization/search-result.html
@@ -46,7 +46,7 @@
             <li>
                 <a class="btn btn-xs" v-tooltip tooltip-placement="top"
                     title="{{ _('Number of followers') }}">
-                    <span class="{{ ficon('fa-followers') }} fa-fw"></span>
+                    <span class="{{ ficon('fa-star') }} fa-fw"></span>
                     {{ ngettext('%(num)d follower', '%(num)d followers', organization.metrics.followers or 0) }}
                 </a>
             </li>

--- a/udata/templates/organization/search-result.html
+++ b/udata/templates/organization/search-result.html
@@ -42,20 +42,11 @@
                 </a>
             </li>
             {% endif %}
-            {% if organization.metrics.stars %}
-            <li>
-                <a class="btn btn-xs" v-tooltip tooltip-placement="top"
-                    title="{{ _('Number of stars') }}">
-                    <span class="{{ ficon('fa-star') }} fa-fw"></span>
-                    {{ ngettext('%(num)d star', '%(num)d stars', organization.metrics.stars or 0) }}
-                </a>
-            </li>
-            {% endif %}
             {% if organization.metrics.followers %}
             <li>
                 <a class="btn btn-xs" v-tooltip tooltip-placement="top"
                     title="{{ _('Number of followers') }}">
-                    <span class="{{ ficon('fa-eye') }} fa-fw"></span>
+                    <span class="{{ ficon('fa-followers') }} fa-fw"></span>
                     {{ ngettext('%(num)d follower', '%(num)d followers', organization.metrics.followers or 0) }}
                 </a>
             </li>

--- a/udata/templates/reuse/search-result.html
+++ b/udata/templates/reuse/search-result.html
@@ -29,9 +29,9 @@
             </li>
             <li>
                 <a class="btn btn-xs" v-tooltip tooltip-placement="top"
-                    title="{{ _('Number of stars') }}">
+                    title="{{ _('Number of followers') }}">
                     <span class="fa fa-star fa-fw"></span>
-                    {{ ngettext('%(num)d star', '%(num)d stars', reuse.metrics.followers or 0) }}
+                    {{ ngettext('%(num)d follower', '%(num)d followers', reuse.metrics.followers or 0) }}
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
This PR ensures all searches (datasets, reuses and organizations have the same wording):

Use `Followers` everywhere instead of `Stars` sometimes.
Use the same icon everywhere

Bonus: order options are now sorted alphabetically

## Datasets

![screenshot-data xps-2019 01 31-17-36-20](https://user-images.githubusercontent.com/15725/52069467-0f57d700-257f-11e9-98e8-449ceb6ebc00.png)

## Organizations

![screenshot-data xps-2019 01 31-17-35-35](https://user-images.githubusercontent.com/15725/52069476-14b52180-257f-11e9-8de0-4f95dc07628a.png)

## Reuses
![screenshot-data xps-2019 01 31-17-34-31](https://user-images.githubusercontent.com/15725/52069491-1b439900-257f-11e9-9f36-6a28bb344a36.png)
