### PR TITLE
Considered CDN_DOMAIN as valid and ensure error message is localized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Be consistent on search results wording and icons (Stars vs Followers) [#2013](https://github.com/opendatateam/udata/pull/2013)
 - Switch from a "full facet reset" to a "by term reset" approach in search facets [#2014](https://github.com/opendatateam/udata/pull/2014)
 - Ensures all modals have the same buttons styles and orders, same color code... [#2012](https://github.com/opendatateam/udata/pull/2012)
+- Ensure URLs from assets stored on `CDN_DOMAINS` are considered as valid and that associated error message is properly translated [#2017](https://github.com/opendatateam/udata/pull/2017)
 
 ## 1.6.2 (2018-11-05)
 

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -42,12 +42,15 @@ def enforce_filetype_file(form, field):
     allowed_domains = current_app.config.get(
         'RESOURCES_FILE_ALLOWED_DOMAINS', [])
     allowed_domains += [current_app.config.get('SERVER_NAME')]
+    if current_app.config.get('CDN_DOMAIN'):
+        allowed_domains.append(current_app.config['CDN_DOMAIN'])
     if '*' in allowed_domains:
         return
     if domain and domain not in allowed_domains:
-        message = 'URL domain not allowed for filetype {}'.format(
-            RESOURCE_FILETYPE_FILE)
-        raise validators.ValidationError(_(message))
+        message = _('Domain "{domain}" not allowed for filetype "{filetype}"').format(
+            domain=domain, filetype=RESOURCE_FILETYPE_FILE
+        )
+        raise validators.ValidationError(message)
 
 
 class BaseResourceForm(ModelForm):

--- a/udata/translations/udata.pot
+++ b/udata/translations/udata.pot
@@ -1,15 +1,15 @@
 # English translations for udata.
-# Copyright (C) 2018 Open Data Team
+# Copyright (C) 2019 Open Data Team
 # This file is distributed under the same license as the udata project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata 1.6.1.dev0\n"
+"Project-Id-Version: udata 1.6.3.dev0\n"
 "Report-Msgid-Bugs-To: i18n@opendata.team\n"
-"POT-Creation-Date: 2018-10-04 12:24+0200\n"
-"PO-Revision-Date: 2018-10-04 12:24+0200\n"
+"POT-Creation-Date: 2019-02-01 15:24+0100\n"
+"PO-Revision-Date: 2019-02-01 15:24+0100\n"
 "Last-Translator: Open Data Team <i18n@opendata.team>\n"
 "Language: en\n"
 "Language-Team: Open Data Team <i18n@opendata.team>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.5.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #: udata/settings.py:93
 msgid "Welcome"
@@ -124,7 +124,11 @@ msgstr ""
 msgid "deleted a dataset"
 msgstr ""
 
-#: udata/core/dataset/forms.py:54 udata/core/dataset/forms.py:108
+#: udata/core/dataset/forms.py:50
+msgid "Domain \"{domain}\" not allowed for filetype \"{filetype}\""
+msgstr ""
+
+#: udata/core/dataset/forms.py:57 udata/core/dataset/forms.py:111
 #: udata/core/discussions/forms.py:15 udata/core/issues/forms.py:15
 #: udata/core/reuse/forms.py:22 udata/core/site/forms.py:15
 #: udata/templates/dataset/list.html:40
@@ -140,22 +144,22 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: udata/core/dataset/forms.py:55 udata/core/dataset/forms.py:112
+#: udata/core/dataset/forms.py:58 udata/core/dataset/forms.py:115
 #: udata/core/jobs/forms.py:31 udata/core/organization/forms.py:27
 #: udata/core/reuse/forms.py:24 udata/core/topic/forms.py:20
-#: udata/harvest/forms.py:60
+#: udata/harvest/forms.py:65
 msgid "Description"
 msgstr ""
 
-#: udata/core/dataset/forms.py:57
+#: udata/core/dataset/forms.py:60
 msgid "File type"
 msgstr ""
 
-#: udata/core/dataset/forms.py:59
+#: udata/core/dataset/forms.py:62
 msgid "Whether the resource is an uploaded file, a remote file or an API"
 msgstr ""
 
-#: udata/core/dataset/forms.py:62 udata/core/reuse/forms.py:27
+#: udata/core/dataset/forms.py:65 udata/core/reuse/forms.py:27
 #: udata/templates/reuse/card.html:27 udata/templates/reuse/display.html:189
 #: udata/templates/reuse/search-labels.html:6
 #: udata/templates/reuse/search-panel.html:6
@@ -163,82 +167,82 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: udata/core/dataset/forms.py:64
+#: udata/core/dataset/forms.py:67
 msgid "Resource type (documentation, API...)"
 msgstr ""
 
-#: udata/core/dataset/forms.py:66 udata/core/reuse/forms.py:29
-#: udata/harvest/forms.py:62
+#: udata/core/dataset/forms.py:69 udata/core/reuse/forms.py:29
+#: udata/harvest/forms.py:67
 msgid "URL"
 msgstr ""
 
-#: udata/core/dataset/forms.py:68 udata/templates/dataset/search-labels.html:24
+#: udata/core/dataset/forms.py:71 udata/templates/dataset/search-labels.html:24
 msgid "Format"
 msgstr ""
 
-#: udata/core/dataset/forms.py:73
+#: udata/core/dataset/forms.py:76
 msgid "Mime type"
 msgstr ""
 
-#: udata/core/dataset/forms.py:74
+#: udata/core/dataset/forms.py:77
 msgid "The mime type associated to the extension. (ex: text/plain)"
 msgstr ""
 
-#: udata/core/dataset/forms.py:77
+#: udata/core/dataset/forms.py:80
 msgid "Size"
 msgstr ""
 
-#: udata/core/dataset/forms.py:78
+#: udata/core/dataset/forms.py:81
 msgid "The file size in bytes"
 msgstr ""
 
-#: udata/core/dataset/forms.py:80
+#: udata/core/dataset/forms.py:83
 msgid "Publication date"
 msgstr ""
 
-#: udata/core/dataset/forms.py:81
+#: udata/core/dataset/forms.py:84
 msgid "The publication date of the resource"
 msgstr ""
 
-#: udata/core/dataset/forms.py:94
+#: udata/core/dataset/forms.py:97
 msgid "Related dataset"
 msgstr ""
 
-#: udata/core/dataset/forms.py:96 udata/core/dataset/forms.py:138
-#: udata/core/reuse/forms.py:40 udata/harvest/forms.py:67
+#: udata/core/dataset/forms.py:99 udata/core/dataset/forms.py:141
+#: udata/core/reuse/forms.py:40 udata/harvest/forms.py:72
 msgid "Publish as"
 msgstr ""
 
-#: udata/core/dataset/forms.py:109 udata/core/organization/forms.py:25
+#: udata/core/dataset/forms.py:112 udata/core/organization/forms.py:25
 msgid "Acronym"
 msgstr ""
 
-#: udata/core/dataset/forms.py:110
+#: udata/core/dataset/forms.py:113
 msgid "An optionnal acronym"
 msgstr ""
 
-#: udata/core/dataset/forms.py:113
+#: udata/core/dataset/forms.py:116
 msgid "The details about the dataset (collection process, specifics...)."
 msgstr ""
 
-#: udata/core/dataset/forms.py:116 udata/templates/dataset/display.html:228
+#: udata/core/dataset/forms.py:119 udata/templates/dataset/display.html:228
 #: udata/templates/dataset/search-labels.html:9
 msgid "License"
 msgstr ""
 
-#: udata/core/dataset/forms.py:118
+#: udata/core/dataset/forms.py:121
 msgid "Update frequency"
 msgstr ""
 
-#: udata/core/dataset/forms.py:122
+#: udata/core/dataset/forms.py:125
 msgid "The frequency at which data are updated."
 msgstr ""
 
-#: udata/core/dataset/forms.py:123
+#: udata/core/dataset/forms.py:126
 msgid "Expected frequency date"
 msgstr ""
 
-#: udata/core/dataset/forms.py:126 udata/templates/dataset/card.html:40
+#: udata/core/dataset/forms.py:129 udata/templates/dataset/card.html:40
 #: udata/templates/dataset/display.html:238
 #: udata/templates/dataset/search-labels.html:15
 #: udata/templates/dataset/search-panel.html:13
@@ -247,11 +251,11 @@ msgstr ""
 msgid "Temporal coverage"
 msgstr ""
 
-#: udata/core/dataset/forms.py:127
+#: udata/core/dataset/forms.py:130
 msgid "The period covered by the data"
 msgstr ""
 
-#: udata/core/dataset/forms.py:129 udata/core/spatial/forms.py:84
+#: udata/core/dataset/forms.py:132 udata/core/spatial/forms.py:84
 #: udata/templates/dataset/display.html:330
 #: udata/templates/dataset/search-labels.html:18
 #: udata/templates/dataset/search-panel.html:15
@@ -261,29 +265,29 @@ msgstr ""
 msgid "Spatial coverage"
 msgstr ""
 
-#: udata/core/dataset/forms.py:130
+#: udata/core/dataset/forms.py:133
 msgid "The geographical area covered by the data."
 msgstr ""
 
-#: udata/core/dataset/forms.py:131 udata/core/post/forms.py:29
+#: udata/core/dataset/forms.py:134 udata/core/post/forms.py:29
 #: udata/core/reuse/forms.py:32 udata/core/site/forms.py:16
 #: udata/core/topic/forms.py:25 udata/templates/dataset/search-panel.html:10
 #: udata/templates/reuse/search-panel.html:7
 msgid "Tags"
 msgstr ""
 
-#: udata/core/dataset/forms.py:131 udata/core/reuse/forms.py:32
+#: udata/core/dataset/forms.py:134 udata/core/reuse/forms.py:32
 msgid "Some taxonomy keywords"
 msgstr ""
 
-#: udata/core/dataset/forms.py:133 udata/core/reuse/forms.py:35
+#: udata/core/dataset/forms.py:136 udata/core/reuse/forms.py:35
 #: udata/core/topic/forms.py:26 udata/templates/dataset/display.html:73
 #: udata/templates/dataset/display.html:74 udata/templates/reuse/display.html:60
 #: udata/templates/reuse/display.html:63
 msgid "Private"
 msgstr ""
 
-#: udata/core/dataset/forms.py:134 udata/core/reuse/forms.py:36
+#: udata/core/dataset/forms.py:137 udata/core/reuse/forms.py:36
 msgid "Restrict the dataset visibility to you or your organization only."
 msgstr ""
 
@@ -502,7 +506,7 @@ msgstr ""
 #: udata/core/discussions/forms.py:16 udata/core/discussions/forms.py:22
 #: udata/core/issues/forms.py:16 udata/core/issues/forms.py:21
 #: udata/core/organization/forms.py:55 udata/core/organization/forms.py:59
-#: udata/harvest/forms.py:74
+#: udata/harvest/forms.py:79
 msgid "Comment"
 msgstr ""
 
@@ -531,10 +535,9 @@ msgid "A discussion has been closed"
 msgstr ""
 
 #: udata/core/followers/metrics.py:29 udata/core/site/metrics.py:104
-#: udata/templates/dataset/followers.html:6
+#: udata/templates/dataset/followers.html:6 udata/templates/dataset/list.html:44
 #: udata/templates/dataset/search-labels.html:31
 #: udata/templates/dataset/search-panel.html:19
-#: udata/templates/dataset/search-result.html:106
 #: udata/templates/organization/display.html:58
 #: udata/templates/organization/followers.html:7
 #: udata/templates/organization/list.html:39
@@ -578,7 +581,7 @@ msgstr ""
 
 #: udata/core/jobs/forms.py:30 udata/core/organization/forms.py:23
 #: udata/core/post/forms.py:18 udata/core/topic/forms.py:18
-#: udata/harvest/forms.py:58 udata/templates/api/admin.html:10
+#: udata/harvest/forms.py:63 udata/templates/api/admin.html:10
 #: udata/templates/organization/list.html:34 udata/templates/search.html:101
 #: udata/templates/user/list.html:35
 msgid "Name"
@@ -1054,7 +1057,7 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: udata/core/user/models.py:240 udata/tests/api/test_me_api.py:374
+#: udata/core/user/models.py:241 udata/tests/api/test_me_api.py:374
 msgid "Account deletion"
 msgstr ""
 
@@ -1155,11 +1158,11 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: udata/harvest/forms.py:61
+#: udata/harvest/forms.py:66
 msgid "Some optionnal details about this harvester"
 msgstr ""
 
-#: udata/harvest/forms.py:63
+#: udata/harvest/forms.py:68
 msgid "Backend"
 msgstr ""
 
@@ -1643,7 +1646,7 @@ msgstr ""
 msgid "Recent reuses"
 msgstr ""
 
-#: udata/templates/macros/search.html:215 udata/templates/post/subnav.html:13
+#: udata/templates/macros/search.html:224 udata/templates/post/subnav.html:13
 #: udata/templates/search.html:8
 msgid "Search"
 msgstr ""
@@ -1707,10 +1710,10 @@ msgstr ""
 msgid "Badge"
 msgstr ""
 
-#: udata/templates/dataset/card.html:32 udata/templates/dataset/list.html:44
-#: udata/templates/organization/card.html:30 udata/templates/reuse/card.html:36
-#: udata/templates/search.html:77 udata/templates/search.html:91
-#: udata/templates/topic/datasets.html:37 udata/templates/user/card.html:28
+#: udata/templates/dataset/card.html:32 udata/templates/organization/card.html:30
+#: udata/templates/reuse/card.html:36 udata/templates/search.html:77
+#: udata/templates/search.html:91 udata/templates/topic/datasets.html:37
+#: udata/templates/user/card.html:28
 msgid "Stars"
 msgstr ""
 
@@ -1951,8 +1954,9 @@ msgstr ""
 #: udata/templates/organization/display.html:158
 #: udata/templates/organization/display_base.html:76
 #: udata/templates/organization/followers.html:26
-#: udata/templates/organization/search-result.html:59
-#: udata/templates/user/base.html:67 udata/templates/user/followers.html:15
+#: udata/templates/organization/search-result.html:50
+#: udata/templates/reuse/search-result.html:34 udata/templates/user/base.html:67
+#: udata/templates/user/followers.html:15
 #, python-format
 msgid "%(num)d follower"
 msgid_plural "%(num)d followers"
@@ -2003,6 +2007,12 @@ msgstr ""
 
 #: udata/templates/dataset/search-result.html:98
 msgid "Reuse number"
+msgstr ""
+
+#: udata/templates/dataset/search-result.html:106
+#: udata/templates/organization/search-result.html:48
+#: udata/templates/reuse/search-result.html:32
+msgid "Number of followers"
 msgstr ""
 
 #: udata/templates/dataset/resource/card.html:21
@@ -2137,20 +2147,16 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: udata/templates/macros/search.html:92
-msgid "Clear filter"
-msgstr ""
-
-#: udata/templates/macros/search.html:117 udata/templates/macros/search.html:147
+#: udata/templates/macros/search.html:122 udata/templates/macros/search.html:160
 msgid "More results…"
 msgstr ""
 
-#: udata/templates/macros/search.html:192
+#: udata/templates/macros/search.html:201
 #, python-format
 msgid "Results %(start)s to %(end)s on %(total)s found"
 msgstr ""
 
-#: udata/templates/macros/search.html:207
+#: udata/templates/macros/search.html:216
 msgid "No result found"
 msgstr ""
 
@@ -2551,28 +2557,11 @@ msgstr ""
 msgid "Number of reappropriations by the community"
 msgstr ""
 
-#: udata/templates/organization/search-result.html:48
-#: udata/templates/reuse/search-result.html:32
-msgid "Number of stars"
-msgstr ""
-
-#: udata/templates/organization/search-result.html:50
-#: udata/templates/reuse/search-result.html:34
-#, python-format
-msgid "%(num)d star"
-msgid_plural "%(num)d stars"
-msgstr[0] ""
-msgstr[1] ""
-
-#: udata/templates/organization/search-result.html:57
-msgid "Number of followers"
-msgstr ""
-
-#: udata/templates/organization/search-result.html:65
+#: udata/templates/organization/search-result.html:56
 msgid "Number of members"
 msgstr ""
 
-#: udata/templates/organization/search-result.html:67
+#: udata/templates/organization/search-result.html:58
 #, python-format
 msgid "%(num)d members"
 msgid_plural "%(num)d members"
@@ -2754,7 +2743,7 @@ msgid "Send the instructions again"
 msgstr ""
 
 #: udata/templates/security/login_user.html:39
-#: udata/templates/security/register_user.html:30
+#: udata/templates/security/register_user.html:33
 msgid "Sign up"
 msgstr ""
 
@@ -2777,7 +2766,7 @@ msgid ""
 "service.</a>"
 msgstr ""
 
-#: udata/templates/security/register_user.html:23
+#: udata/templates/security/register_user.html:25
 msgid ""
 "In particular, I understand that this site\n"
 "                    values the production and enrichment of datasets over "


### PR DESCRIPTION
This PR ensures that `CDN_DOMAIN`, if enabled, is considered as a valid URL domain for `file` resource type.
It also ensures the associated error message (which is now properly displayed) is localized.

The validation has also been moved from the `filetype` field (which is not displayed) to the `url` field (because this is the URL which is wrong).