### PR TITLE
Pin redis version for Celery compatibility

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -39,7 +39,7 @@ pytz==2018.9
 PyYAML==3.13
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
-redis==3.1.0
+redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
 requests==2.21.0
 StringDist==1.0.9
 tlds


### PR DESCRIPTION
Pin redis version to 2.10.6 since 3.x is not compatible with Celery < 4.2.2
see https://github.com/celery/celery/pull/5176