### PR TITLE
Fixes SlugField with no_dereference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use "udata" and fix a few other typos in documentation and UI/translation strings [#2023](https://github.com/opendatateam/udata/pull/2023)
 - Add a surrounding block declaration around community section [2039](https://github.com/opendatateam/udata/pull/2039)
 - Fix broken form validation on admin discussions and issues [#2045](https://github.com/opendatateam/udata/pull/2045)
+- Fix full reindexation by avoiding `SlugField.instance` deepcopy in `no_dereference()` querysets [#2048](https://github.com/opendatateam/udata/pull/2048)
 
 ## 1.6.4 (2019-02-02)
 

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -28,6 +28,7 @@ class SlugField(StringField):
         self.lower_case = lower_case
         self.separator = separator
         self.follow = follow
+        self.instance = None
         super(SlugField, self).__init__(**kwargs)
         if follow:
             # Can't use sender=self.owner_document which is not yet defined
@@ -42,6 +43,12 @@ class SlugField(StringField):
         if instance is not None:
             self.instance = instance
         return super(SlugField, self).__set__(instance, value)
+
+    def __deepcopy__(self, memo):
+        # Fixes no_dereference by avoiding deep copying instance attribute
+        copied = self.__class__()
+        copied.__dict__.update(self.__dict__)
+        return copied
 
     def validate(self, value):
         populate_slug(self.instance, self)


### PR DESCRIPTION
This one was tricky !!!

This PR fixes the `udata search index` command and more specificaly the `.no_dereference()` usage with `SlugField`.

## Root cause

In MongoEngine 0.16, `no_reference()` behavior change to use `copy.deepcopy` on fields (sadly Mongoengine make extensive use of `copy.deepcopy` which is bad for performances).
On the other side, the `SlugField` need to keep a reference to its owning instance to be able to properly slugify on save.
As a consequence, `copy.deepcopy` was trying to copy the `SlugField.instance` field which is a model and cannot be deepcopied easily

## Fix

`copy.deepcopy` allows to override the deepcopy behavior by implementing a `__deepcopy__(self, memo)` method. This is done in this PR by making a proper new `SlugField` instance

## Future thought

The extensive use of `copy.deepcopy` might have a bad impact on performance. In order to improve that, we might need to implement some custom `__deepcopy__(self, memo)` methods on other objects because this is not done by MongoEngine itself.
As `flask-restplus` also make use of  `copy.deepcopy`, implementing custom `__deepcopy__(self, memo)` methods on models might improve performance both on DB and API sides.