### PR TITLE
Ensure deleted user slug is pseudonymized too (fix #2016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a surrounding block declaration around community section [2039](https://github.com/opendatateam/udata/pull/2039)
 - Fix broken form validation on admin discussions and issues [#2045](https://github.com/opendatateam/udata/pull/2045)
 - Fix full reindexation by avoiding `SlugField.instance` deepcopy in `no_dereference()` querysets [#2048](https://github.com/opendatateam/udata/pull/2048)
+- Ensure deleted user slug is pseudonymized [#2049](https://github.com/opendatateam/udata/pull/2049)
 
 ## 1.6.4 (2019-02-02)
 

--- a/udata/core/organization/factories.py
+++ b/udata/core/organization/factories.py
@@ -5,7 +5,7 @@ import factory
 
 from udata.factories import ModelFactory
 
-from .models import Organization, Team
+from .models import Organization, Team, Member
 
 
 class OrganizationFactory(ModelFactory):
@@ -14,6 +14,17 @@ class OrganizationFactory(ModelFactory):
 
     name = factory.Faker('sentence')
     description = factory.Faker('text')
+    members = factory.LazyAttribute(lambda o: [
+        Member(user=user, role='admin')
+        for user in o.admins
+    ] + [
+        Member(user=user, role='editor')
+        for user in o.editors
+    ])
+
+    class Params:
+        admins = []
+        editors = []
 
 
 class TeamFactory(ModelFactory):

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -215,6 +215,7 @@ class User(WithMetrics, UserMixin, db.Document):
     def mark_as_deleted(self):
         copied_user = copy(self)
         self.email = '{}@deleted'.format(self.id)
+        self.slug = 'deleted'
         self.password = None
         self.active = False
         self.first_name = 'DELETED'

--- a/udata/core/user/tests/test_user_model.py
+++ b/udata/core/user/tests/test_user_model.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
+
+import pytest
+
+from udata.core.discussions.factories import (
+    MessageDiscussionFactory, DiscussionFactory
+)
+from udata.core.followers.models import Follow
+from udata.core.user.factories import UserFactory
+from udata.core.organization.factories import OrganizationFactory
+
+pytestmark = pytest.mark.usefixtures('clean_db')
+
+
+@pytest.mark.frontend
+class UserModelTest:
+    modules = ['core.user']  # Required for mails
+
+    def test_mark_as_deleted(self):
+        user = UserFactory()
+        other_user = UserFactory()
+        org = OrganizationFactory(editors=[user])
+        discussion = DiscussionFactory(user=user, subject=org, discussion=[
+            MessageDiscussionFactory(posted_by=user)
+        ])
+        user_follow_org = Follow.objects.create(follower=user, following=org)
+        user_followed = Follow.objects.create(follower=other_user, following=user)
+
+        user.mark_as_deleted()
+
+        org.reload()
+        assert len(org.members) == 0
+
+        discussion.reload()
+        assert discussion.discussion[0].content == 'DELETED'
+
+        assert Follow.objects(id=user_follow_org.id).first() is None
+        assert Follow.objects(id=user_followed.id).first() is None
+
+        assert user.slug == 'deleted'
+
+    def test_mark_as_deleted_slug_multiple(self):
+        user = UserFactory()
+        other_user = UserFactory()
+
+        user.mark_as_deleted()
+        other_user.mark_as_deleted()
+
+        assert user.slug == 'deleted'
+        assert other_user.slug == 'deleted-1'

--- a/udata/tests/api/test_user_api.py
+++ b/udata/tests/api/test_user_api.py
@@ -281,6 +281,7 @@ class UserAPITest(APITestCase):
         other_user = UserFactory()
         response = self.delete(url_for('api.user', user=other_user))
         self.assert204(response)
+        other_user.reload()
         response = self.delete(url_for('api.user', user=other_user))
         self.assert410(response)
         response = self.delete(url_for('api.user', user=user))


### PR DESCRIPTION
This PR fixes #2016 by pseudonymizing the slug too on deletion (will be `deleted-XXX` where `XXX` is sequential)

Possible alternatives:
- use a hash instead of `deleted`
- user the user ID instead of `deleted`
- add a hash as suffix of `deleted` (ie. `deleted-ae7f89`)
- add a timestamp as suffix (ie. `deleted-2019-02-25` but collision are still handled by `SlugField` so in case of multiple deletion it will be `deleted-2019-02-25-1`, `deleted-2019-02-25-2`....)