### PR TITLE
Prevent the "Add resource" modal from closing when using the frontend "Add resource" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix broken form validation on admin discussions and issues [#2045](https://github.com/opendatateam/udata/pull/2045)
 - Fix full reindexation by avoiding `SlugField.instance` deepcopy in `no_dereference()` querysets [#2048](https://github.com/opendatateam/udata/pull/2048)
 - Ensure deleted user slug is pseudonymized [#2049](https://github.com/opendatateam/udata/pull/2049)
+- Prevent the "Add resource" modal from closing when using the frontend "Add resource" button
 
 ## 1.6.4 (2019-02-02)
 


### PR DESCRIPTION
This PR prevent the "Add resource" modal from closing when using the dataset frontend "Add resource" button.

Related to the fact this modal is non-routable and so when opened from the admin (which was the testing use case) there is no initial dataset loading (on which the modal closing was binding)

Fixes etalab/data.gouv.fr#123