### PR TITLE
Remove lots of deprecation warnings

### DIFF
--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -139,7 +139,7 @@ class UDataApi(Api):
             errors = {'Content-Type': 'expecting application/json'}
             self.abort(400, errors=errors)
         form = form_cls.from_json(request.json, obj=obj, instance=obj,
-                                  csrf_enabled=False)
+                                  meta={'csrf': False})
         if not form.validate():
             self.abort(400, errors=form.errors)
         return form

--- a/udata/core/activity/api.py
+++ b/udata/core/activity/api.py
@@ -49,7 +49,8 @@ activity_parser.add_argument(
 
 @api.route('/activity', endpoint='activity')
 class SiteActivityAPI(API):
-    @api.doc('activity', parser=activity_parser)
+    @api.doc('activity')
+    @api.expect(activity_parser)
     @api.marshal_list_with(activity_page_fields)
     def get(self):
         '''Fetch site activity, optionally filtered by user of org.'''

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -90,7 +90,8 @@ common_doc = {
 @ns.route('/', endpoint='datasets')
 class DatasetListAPI(API):
     '''Datasets collection endpoint'''
-    @api.doc('list_datasets', parser=search_parser)
+    @api.doc('list_datasets')
+    @api.expect(search_parser)
     @api.marshal_with(dataset_page_fields)
     def get(self):
         '''List or search all datasets'''
@@ -202,7 +203,8 @@ class DatasetBadgeAPI(API):
 @ns.route('/<dataset:dataset>/resources/', endpoint='resources')
 class ResourcesAPI(API):
     @api.secure
-    @api.doc('create_resource', body=resource_fields, **common_doc)
+    @api.doc('create_resource', **common_doc)
+    @api.expect(resource_fields)
     @api.marshal_with(resource_fields)
     def post(self, dataset):
         '''Create a new resource for a given dataset'''
@@ -291,7 +293,7 @@ class ResourceMixin(object):
 
 @ns.route('/<dataset:dataset>/resources/<uuid:rid>/upload/',
           endpoint='upload_dataset_resource', doc=common_doc)
-@api.doc(params={'rid': 'The resource unique identifier'})
+@api.param('rid', 'The resource unique identifier')
 class UploadDatasetResource(ResourceMixin, UploadMixin, API):
     @api.secure
     @api.doc('upload_dataset_resource')
@@ -311,7 +313,7 @@ class UploadDatasetResource(ResourceMixin, UploadMixin, API):
 
 @ns.route('/community_resources/<crid:community>/upload/',
           endpoint='upload_community_resource', doc=common_doc)
-@api.doc(params={'community': 'The community resource unique identifier'})
+@api.param('community', 'The community resource unique identifier')
 class ReuploadCommunityResource(ResourceMixin, UploadMixin, API):
     @api.secure
     @api.doc('upload_community_resource')
@@ -327,7 +329,7 @@ class ReuploadCommunityResource(ResourceMixin, UploadMixin, API):
 
 @ns.route('/<dataset:dataset>/resources/<uuid:rid>/', endpoint='resource',
           doc=common_doc)
-@api.doc(params={'rid': 'The resource unique identifier'})
+@api.param('rid', 'The resource unique identifier')
 class ResourceAPI(ResourceMixin, API):
     @api.doc('get_resource')
     @api.marshal_with(resource_fields)
@@ -339,7 +341,8 @@ class ResourceAPI(ResourceMixin, API):
         return resource
 
     @api.secure
-    @api.doc('update_resource', body=resource_fields)
+    @api.doc('update_resource')
+    @api.expect(resource_fields)
     @api.marshal_with(resource_fields)
     def put(self, dataset, rid):
         '''Update a given resource on a given dataset'''
@@ -367,8 +370,8 @@ class ResourceAPI(ResourceMixin, API):
 @ns.route('/community_resources/', endpoint='community_resources')
 class CommunityResourcesAPI(API):
     @api.doc('list_community_resources')
+    @api.expect(community_parser)
     @api.marshal_with(community_resource_page_fields)
-    @api.doc(parser=community_parser)
     def get(self):
         '''List all community resources'''
         args = community_parser.parse_args()
@@ -405,7 +408,7 @@ class CommunityResourcesAPI(API):
 
 @ns.route('/community_resources/<crid:community>/',
           endpoint='community_resource', doc=common_doc)
-@api.doc(params={'community': 'The community resource unique identifier'})
+@api.param('community', 'The community resource unique identifier')
 class CommunityResourceAPI(API):
     @api.doc('retrieve_community_resource')
     @api.marshal_with(community_resource_fields)
@@ -414,8 +417,8 @@ class CommunityResourceAPI(API):
         return community
 
     @api.secure
-    @api.doc('update_community_resource',
-             body=community_resource_fields)
+    @api.doc('update_community_resource')
+    @api.expect(community_resource_fields)
     @api.marshal_with(community_resource_fields)
     def put(self, community):
         '''Update a given community resource'''
@@ -457,8 +460,9 @@ suggest_parser.add_argument(
 
 @ns.route('/suggest/', endpoint='suggest_datasets')
 class SuggestDatasetsAPI(API):
+    @api.doc('suggest_datasets')
+    @api.expect(suggest_parser)
     @api.marshal_list_with(dataset_suggestion_fields)
-    @api.doc('suggest_datasets', parser=suggest_parser)
     def get(self):
         '''Suggest datasets'''
         args = suggest_parser.parse_args()
@@ -478,7 +482,8 @@ class SuggestDatasetsAPI(API):
 
 @ns.route('/suggest/formats/', endpoint='suggest_formats')
 class SuggestFormatsAPI(API):
-    @api.doc('suggest_formats', parser=suggest_parser)
+    @api.doc('suggest_formats')
+    @api.expect(suggest_parser)
     def get(self):
         '''Suggest file formats'''
         args = suggest_parser.parse_args()
@@ -516,7 +521,7 @@ class AllowedExtensionsAPI(API):
 
 @ns.route('/<dataset:dataset>/resources/<uuid:rid>/check/',
           endpoint='check_dataset_resource', doc=common_doc)
-@api.doc(params={'rid': 'The resource unique identifier'})
+@api.param('rid', 'The resource unique identifier')
 class CheckDatasetResource(API, ResourceMixin):
 
     @api.doc('check_dataset_resource')

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -226,7 +226,7 @@ class ResourcesAPI(API):
         ResourceEditPermission(dataset).test()
         data = {'resources': request.json}
         form = ResourcesListForm.from_json(data, obj=dataset, instance=dataset,
-                                           csrf_enabled=False)
+                                           meta={'csrf': False})
         if not form.validate():
             api.abort(400, errors=form.errors['resources'])
 

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -49,19 +49,19 @@ def enforce_filetype_file(form, field):
 
 
 class BaseResourceForm(ModelForm):
-    title = fields.StringField(_('Title'), [validators.required()])
+    title = fields.StringField(_('Title'), [validators.DataRequired()])
     description = fields.MarkdownField(_('Description'))
     filetype = fields.RadioField(
-        _('File type'), [validators.required()],
+        _('File type'), [validators.DataRequired()],
         choices=list(RESOURCE_FILETYPES.items()), default='file',
         description=_('Whether the resource is an uploaded file, '
                       'a remote file or an API'))
     type = fields.RadioField(
-        _('Type'), [validators.required()],
+        _('Type'), [validators.DataRequired()],
         choices=list(RESOURCE_TYPES.items()), default='other',
         description=_('Resource type (documentation, API...)'))
     url = fields.UploadableURLField(
-        _('URL'), [validators.required(), enforce_filetype_file],
+        _('URL'), [validators.DataRequired(), enforce_filetype_file],
         storage=resources)
     format = fields.StringField(
         _('Format'),
@@ -104,11 +104,11 @@ def map_legacy_frequencies(form, field):
 class DatasetForm(ModelForm):
     model_class = Dataset
 
-    title = fields.StringField(_('Title'), [validators.required()])
+    title = fields.StringField(_('Title'), [validators.DataRequired()])
     acronym = fields.StringField(_('Acronym'),
                                  description=_('An optional acronym'))
     description = fields.MarkdownField(
-        _('Description'), [validators.required()],
+        _('Description'), [validators.DataRequired()],
         description=_('The details about the dataset '
                       '(collection process, specifics...).'))
     license = fields.ModelSelectField(

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -135,7 +135,8 @@ class DiscussionsAPI(API):
     '''
     Base class for a list of discussions.
     '''
-    @api.doc('list_discussions', parser=parser)
+    @api.doc('list_discussions')
+    @api.expect(parser)
     @api.marshal_with(discussion_page_fields)
     def get(self):
         '''List all Discussions'''

--- a/udata/core/discussions/forms.py
+++ b/udata/core/discussions/forms.py
@@ -9,12 +9,12 @@ __all__ = ('DiscussionCreateForm', 'DiscussionCommentForm')
 class DiscussionCreateForm(ModelForm):
     model_class = Discussion
 
-    title = fields.StringField(_('Title'), [validators.required()])
-    comment = fields.StringField(_('Comment'), [validators.required()])
-    subject = fields.ModelField(_('Subject'), [validators.required()])
+    title = fields.StringField(_('Title'), [validators.DataRequired()])
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])
+    subject = fields.ModelField(_('Subject'), [validators.DataRequired()])
     extras = fields.ExtrasField()
 
 
 class DiscussionCommentForm(Form):
-    comment = fields.StringField(_('Comment'), [validators.required()])
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])
     close = fields.BooleanField(default=False)

--- a/udata/core/followers/api.py
+++ b/udata/core/followers/api.py
@@ -39,7 +39,7 @@ class FollowAPI(API):
     '''
     model = None
 
-    @api.doc(parser=parser)
+    @api.expect(parser)
     @api.marshal_with(follow_page_fields)
     def get(self, id):
         '''List all followers for a given object'''

--- a/udata/core/issues/api.py
+++ b/udata/core/issues/api.py
@@ -114,7 +114,8 @@ class IssuesAPI(API):
     '''
     List all issues.
     '''
-    @api.doc('list_issues', parser=parser)
+    @api.doc('list_issues')
+    @api.expect(parser)
     @api.marshal_with(issue_page_fields)
     def get(self):
         '''List all Issues'''

--- a/udata/core/issues/forms.py
+++ b/udata/core/issues/forms.py
@@ -9,11 +9,11 @@ __all__ = ('IssueCreateForm', 'IssueCommentForm')
 class IssueCreateForm(ModelForm):
     model_class = Issue
 
-    title = fields.StringField(_('Title'), [validators.required()])
-    comment = fields.StringField(_('Comment'), [validators.required()])
-    subject = fields.ModelField(_('Subject'), [validators.required()])
+    title = fields.StringField(_('Title'), [validators.DataRequired()])
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])
+    subject = fields.ModelField(_('Subject'), [validators.DataRequired()])
 
 
 class IssueCommentForm(Form):
-    comment = fields.StringField(_('Comment'), [validators.required()])
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])
     close = fields.BooleanField(default=False)

--- a/udata/core/jobs/api.py
+++ b/udata/core/jobs/api.py
@@ -96,7 +96,7 @@ class JobsAPI(API):
 
 
 @ns.route('/jobs/<string:id>', endpoint='job')
-@api.doc(params={'id': 'A job ID'})
+@api.param('id', 'A job ID')
 class JobAPI(API):
     def get_or_404(self, id):
         task = PeriodicTask.objects(id=id).first()
@@ -125,7 +125,7 @@ class JobAPI(API):
         return form.save()
 
     @api.secure(admin_permission)
-    @api.doc(responses={204: 'Successfuly deleted'})
+    @api.response(204, 'Successfuly deleted')
     def delete(self, id):
         '''Delete a single scheduled job'''
         task = self.get_or_404(id)

--- a/udata/core/jobs/forms.py
+++ b/udata/core/jobs/forms.py
@@ -24,7 +24,7 @@ class IntervalForm(ModelForm):
 class PeriodicTaskForm(ModelForm):
     model_class = PeriodicTask
 
-    name = fields.StringField(_('Name'), [validators.required()])
+    name = fields.StringField(_('Name'), [validators.DataRequired()])
     description = fields.StringField(_('Description'))
     task = fields.StringField(_('Tasks'))
     enabled = fields.BooleanField(_('Enabled'))

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -52,7 +52,8 @@ common_doc = {
 @ns.route('/', endpoint='organizations')
 class OrganizationListAPI(API):
     '''Organizations collection endpoint'''
-    @api.doc('list_organizations', parser=search_parser)
+    @api.doc('list_organizations')
+    @api.expect(search_parser)
     @api.marshal_with(org_page_fields)
     def get(self):
         '''List or search all organizations'''
@@ -155,9 +156,10 @@ requests_parser.add_argument(
           doc=common_doc)
 class MembershipRequestAPI(API):
     @api.secure
+    @api.doc('list_membership_requests')
+    @api.expect(requests_parser)
+    @api.response(403, 'Not Authorized')
     @api.marshal_list_with(request_fields)
-    @api.doc('list_membership_requests', parser=requests_parser)
-    @api.doc(responses={403: 'Not Authorized'})
     def get(self, org):
         '''List membership requests for a given organization'''
         OrganizationPrivatePermission(org).test()
@@ -224,18 +226,12 @@ class MembershipAcceptAPI(MembershipAPI):
         return member
 
 
-refuse_parser = api.parser()
-refuse_parser.add_argument(
-    'comment', type=str, help='The refusal reason', location='json'
-)
-
-
 @ns.route('/<org:org>/membership/<uuid:id>/refuse/',
           endpoint='refuse_membership')
 class MembershipRefuseAPI(MembershipAPI):
     @api.secure
     @api.expect(refuse_membership_fields)
-    @api.doc('refuse_membership', parser=refuse_parser, **common_doc)
+    @api.doc('refuse_membership', **common_doc)
     def post(self, org, id):
         '''Refuse user membership to a given organization.'''
         EditOrganizationPermission(org).test()
@@ -320,8 +316,9 @@ suggest_parser.add_argument(
 
 @ns.route('/suggest/', endpoint='suggest_organizations')
 class SuggestOrganizationsAPI(API):
+    @api.doc('suggest_organizations')
+    @api.expect(suggest_parser)
     @api.marshal_list_with(org_suggestion_fields)
-    @api.doc('suggest_organizations', parser=suggest_parser)
     def get(self):
         '''Suggest organizations'''
         args = suggest_parser.parse_args()

--- a/udata/core/organization/forms.py
+++ b/udata/core/organization/forms.py
@@ -17,11 +17,11 @@ __all__ = (
 class OrganizationForm(ModelForm):
     model_class = Organization
 
-    name = fields.StringField(_('Name'), [validators.required()])
+    name = fields.StringField(_('Name'), [validators.DataRequired()])
     acronym = fields.StringField(
         _('Acronym'), description=_('Shorter organization name'))
     description = fields.MarkdownField(
-        _('Description'), [validators.required()],
+        _('Description'), [validators.DataRequired()],
         description=_('The details about your organization'))
     url = fields.URLField(
         _('Website'), description=_('The organization website URL'))
@@ -49,11 +49,11 @@ class MembershipRequestForm(ModelForm):
     model_class = MembershipRequest
 
     user = fields.CurrentUserField()
-    comment = fields.StringField(_('Comment'), [validators.required()])
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])
 
 
 class MembershipRefuseForm(Form):
-    comment = fields.StringField(_('Comment'), [validators.required()])
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])
 
 
 class MemberForm(ModelForm):
@@ -61,4 +61,4 @@ class MemberForm(ModelForm):
 
     role = fields.SelectField(
         _('Role'), default='editor', choices=list(ORG_ROLES.items()),
-        validators=[validators.required()])
+        validators=[validators.DataRequired()])

--- a/udata/core/post/forms.py
+++ b/udata/core/post/forms.py
@@ -12,9 +12,9 @@ class PostForm(ModelForm):
 
     owner = fields.CurrentUserField()
 
-    name = fields.StringField(_('Name'), [validators.required()])
+    name = fields.StringField(_('Name'), [validators.DataRequired()])
     headline = fields.StringField(_('Headline'), widget=widgets.TextArea())
-    content = fields.MarkdownField(_('Content'), [validators.required()])
+    content = fields.MarkdownField(_('Content'), [validators.DataRequired()])
 
     datasets = fields.DatasetListField(_('Associated datasets'))
     reuses = fields.ReuseListField(_('Associated reuses'))

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -34,15 +34,17 @@ search_parser = ReuseSearch.as_request_parser()
 
 @ns.route('/', endpoint='reuses')
 class ReuseListAPI(API):
-    @api.doc('list_reuses', parser=search_parser)
+    @api.doc('list_reuses')
+    @api.expect(search_parser)
     @api.marshal_with(reuse_page_fields)
     def get(self):
         search_parser.parse_args()
         return search.query(ReuseSearch, **multi_to_dict(request.args))
 
     @api.secure
-    @api.doc('create_reuse', responses={400: 'Validation error'})
+    @api.doc('create_reuse')
     @api.expect(reuse_fields)
+    @api.response(400, 'Validation error')
     @api.marshal_with(reuse_fields)
     def post(self):
         '''Create a new object'''
@@ -181,8 +183,9 @@ suggest_parser.add_argument(
 
 @ns.route('/suggest/', endpoint='suggest_reuses')
 class SuggestReusesAPI(API):
+    @api.doc('suggest_reuses')
+    @api.expect(suggest_parser)
     @api.marshal_list_with(reuse_suggestion_fields)
-    @api.doc(id='suggest_reuses', parser=suggest_parser)
     def get(self):
         '''Suggest reuses'''
         args = suggest_parser.parse_args()

--- a/udata/core/reuse/forms.py
+++ b/udata/core/reuse/forms.py
@@ -16,14 +16,14 @@ def check_url_does_not_exists(form, field):
 class ReuseForm(ModelForm):
     model_class = Reuse
 
-    title = fields.StringField(_('Title'), [validators.required()])
+    title = fields.StringField(_('Title'), [validators.DataRequired()])
     description = fields.MarkdownField(
-        _('Description'), [validators.required()],
+        _('Description'), [validators.DataRequired()],
         description=_('The details about the reuse (build process, specifics, '
                       'self-critics...).'))
     type = fields.SelectField(_('Type'), choices=list(REUSE_TYPES.items()))
     url = fields.URLField(
-        _('URL'), [validators.required(), check_url_does_not_exists])
+        _('URL'), [validators.DataRequired(), check_url_does_not_exists])
     image = fields.ImageField(
         _('Image'), sizes=IMAGE_SIZES, placeholder='reuse')
     tags = fields.TagField(_('Tags'), description=_('Some taxonomy keywords'))

--- a/udata/core/site/forms.py
+++ b/udata/core/site/forms.py
@@ -9,7 +9,7 @@ __all__ = ('SiteConfigForm', )
 class SiteConfigForm(ModelForm):
     model_class = Site
 
-    title = fields.StringField(_('Title'), [validators.required()])
+    title = fields.StringField(_('Title'), [validators.DataRequired()])
     keywords = fields.TagField(_('Tags'), description=_('Some SEO keywords'))
     feed_size = fields.IntegerField(
         _('Feed size'), description=_('Number of elements in feeds'))

--- a/udata/core/tags/api.py
+++ b/udata/core/tags/api.py
@@ -18,7 +18,8 @@ parser.add_argument(
 
 @ns.route('/suggest/', endpoint='suggest_tags')
 class SuggestTagsAPI(API):
-    @api.doc(id='suggest_tags', parser=parser)
+    @api.doc('suggest_tags')
+    @api.expect(parser)
     def get(self):
         '''Suggest tags'''
         args = parser.parse_args()

--- a/udata/core/topic/forms.py
+++ b/udata/core/topic/forms.py
@@ -12,13 +12,13 @@ class TopicForm(ModelForm):
 
     owner = fields.CurrentUserField()
 
-    name = fields.StringField(_('Name'), [validators.required()])
+    name = fields.StringField(_('Name'), [validators.DataRequired()])
     description = fields.MarkdownField(
-        _('Description'), [validators.required()])
+        _('Description'), [validators.DataRequired()])
 
     datasets = fields.DatasetListField(_('Associated datasets'))
     reuses = fields.ReuseListField(_('Associated reuses'))
 
-    tags = fields.TagField(_('Tags'), [validators.required()])
+    tags = fields.TagField(_('Tags'), [validators.DataRequired()])
     private = fields.BooleanField(_('Private'))
     featured = fields.BooleanField(_('Featured'))

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -119,7 +119,8 @@ class MyMetricsAPI(API):
 @me.route('/org_datasets/', endpoint='my_org_datasets')
 class MyOrgDatasetsAPI(API):
     @api.secure
-    @api.doc('my_org_datasets', parser=filter_parser)
+    @api.doc('my_org_datasets')
+    @api.expect(filter_parser)
     @api.marshal_list_with(dataset_fields)
     def get(self):
         '''List all datasets related to me and my organizations.'''
@@ -134,7 +135,8 @@ class MyOrgDatasetsAPI(API):
 @me.route('/org_community_resources/', endpoint='my_org_community_resources')
 class MyOrgCommunityResourcesAPI(API):
     @api.secure
-    @api.doc('my_org_community_resources', parser=filter_parser)
+    @api.doc('my_org_community_resources')
+    @api.expect(filter_parser)
     @api.marshal_list_with(community_resource_fields)
     def get(self):
         '''List all community resources related to me and my organizations.'''
@@ -151,7 +153,8 @@ class MyOrgCommunityResourcesAPI(API):
 @me.route('/org_reuses/', endpoint='my_org_reuses')
 class MyOrgReusesAPI(API):
     @api.secure
-    @api.doc('my_org_reuses', parser=filter_parser)
+    @api.doc('my_org_reuses')
+    @api.expect(filter_parser)
     @api.marshal_list_with(reuse_fields)
     def get(self):
         '''List all reuses related to me and my organizations.'''
@@ -166,7 +169,8 @@ class MyOrgReusesAPI(API):
 @me.route('/org_issues/', endpoint='my_org_issues')
 class MyOrgIssuesAPI(API):
     @api.secure
-    @api.doc('my_org_issues', parser=filter_parser)
+    @api.doc('my_org_issues')
+    @api.expect(filter_parser)
     @api.marshal_list_with(issue_fields)
     def get(self):
         '''List all issues related to my organizations.'''
@@ -181,7 +185,8 @@ class MyOrgIssuesAPI(API):
 @me.route('/org_discussions/', endpoint='my_org_discussions')
 class MyOrgDiscussionsAPI(API):
     @api.secure
-    @api.doc('my_org_discussions', parser=filter_parser)
+    @api.doc('my_org_discussions')
+    @api.expect(filter_parser)
     @api.marshal_list_with(discussion_fields)
     def get(self):
         '''List all discussions related to my organizations.'''
@@ -312,8 +317,9 @@ suggest_parser.add_argument(
 
 @ns.route('/suggest/', endpoint='suggest_users')
 class SuggestUsersAPI(API):
+    @api.doc('suggest_users')
+    @api.expect(suggest_parser)
     @api.marshal_list_with(user_suggestion_fields)
-    @api.doc('suggest_users', parser=suggest_parser)
     def get(self):
         '''Suggest users'''
         args = suggest_parser.parse_args()
@@ -332,8 +338,8 @@ class SuggestUsersAPI(API):
 
 @ns.route('/roles/', endpoint='user_roles')
 class UserRolesAPI(API):
-    @api.marshal_list_with(user_role_fields)
     @api.doc('user_roles')
+    @api.marshal_list_with(user_role_fields)
     def get(self):
         '''List all possible user roles'''
         return [{'name': role.name} for role in Role.objects()]

--- a/udata/core/user/forms.py
+++ b/udata/core/user/forms.py
@@ -11,8 +11,8 @@ __all__ = ('UserProfileForm', 'UserProfileAdminForm')
 class UserProfileForm(ModelForm):
     model_class = User
 
-    first_name = fields.StringField(_('First name'), [validators.required()])
-    last_name = fields.StringField(_('Last name'), [validators.required()])
+    first_name = fields.StringField(_('First name'), [validators.DataRequired()])
+    last_name = fields.StringField(_('Last name'), [validators.DataRequired()])
     avatar = fields.ImageField(_('Avatar'), sizes=AVATAR_SIZES)
     website = fields.URLField(_('Website'))
     about = fields.MarkdownField(_('About'))

--- a/udata/features/oembed/api.py
+++ b/udata/features/oembed/api.py
@@ -36,7 +36,8 @@ class OEmbedAPI(API):
         'reuses.show': 'reuse',
     }
 
-    @api.doc('oembed', parser=oembed_parser)
+    @api.doc('oembed')
+    @api.expect(oembed_parser)
     def get(self):
         """
         An OEmbed compliant API endpoint
@@ -92,7 +93,8 @@ class OEmbedAPI(API):
 @api.route('/oembeds/', endpoint='oembeds')
 class OEmbedsAPI(API):
 
-    @api.doc('oembeds', parser=oembeds_parser)
+    @api.doc('oembeds')
+    @api.expect(oembeds_parser)
     def get(self):
         """ The returned payload is a list of OEmbed formatted responses.
 

--- a/udata/features/territories/api.py
+++ b/udata/features/territories/api.py
@@ -12,7 +12,8 @@ suggest_parser.add_argument(
 
 @api.route('/territory/suggest/', endpoint='suggest_territory')
 class SuggestTerritoriesAPI(API):
-    @api.doc(id='suggest_territory', parser=suggest_parser)
+    @api.doc('suggest_territory')
+    @api.expect(suggest_parser)
     def get(self):
         args = suggest_parser.parse_args()
         territories = check_for_territories(args['q'])

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -168,7 +168,8 @@ class FormWrapper(object):
         self.cls = cls
 
     def __call__(self, *args, **kwargs):
-        kwargs['csrf_enabled'] = False
+        meta = kwargs['meta'] = kwargs.get('meta', {})
+        meta['csrf'] = False
         return self.cls(*args, **kwargs)
 
     def __getattr__(self, name):

--- a/udata/frontend/helpers.py
+++ b/udata/frontend/helpers.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from time import time
 from urllib.parse import urlsplit, urlunsplit
 
-from babel.numbers import format_number as format_number_babel
+from babel.numbers import format_decimal
 from flask import g, url_for, request, current_app, json
 from jinja2 import Markup, contextfilter
 from werkzeug import url_decode, url_encode
@@ -389,7 +389,7 @@ def to_json(data):
 @front.app_template_global()
 def format_number(number):
     '''A locale aware formatter.'''
-    return format_number_babel(number, locale=g.lang_code)
+    return format_decimal(number, locale=g.lang_code)
 
 
 @front.app_template_filter()

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -169,7 +169,8 @@ source_parser.add_argument('owner', type=str, location='args',
 
 @ns.route('/sources/', endpoint='harvest_sources')
 class SourcesAPI(API):
-    @api.doc('list_harvest_sources', parser=source_parser)
+    @api.doc('list_harvest_sources')
+    @api.expect(source_parser)
     @api.marshal_list_with(source_page_fields)
     def get(self):
         '''List all harvest sources'''
@@ -178,8 +179,8 @@ class SourcesAPI(API):
                                         page=args['page'],
                                         page_size=args['page_size'])
 
-    @api.doc('create_harvest_source')
     @api.secure
+    @api.doc('create_harvest_source')
     @api.expect(source_fields)
     @api.marshal_with(source_fields)
     def post(self):
@@ -192,7 +193,7 @@ class SourcesAPI(API):
 
 
 @ns.route('/source/<string:ident>', endpoint='harvest_source')
-@api.doc(params={'ident': 'A source ID or slug'})
+@api.param('ident', 'A source ID or slug')
 class SourceAPI(API):
     @api.doc('get_harvest_source')
     @api.marshal_with(source_fields)
@@ -220,7 +221,7 @@ class SourceAPI(API):
 
 @ns.route('/source/<string:ident>/validate',
           endpoint='validate_harvest_source')
-@api.doc(params={'ident': 'A source ID or slug'})
+@api.param('ident', 'A source ID or slug')
 class ValidateSourceAPI(API):
     @api.doc('validate_harvest_source')
     @api.secure(admin_permission)
@@ -237,7 +238,7 @@ class ValidateSourceAPI(API):
 
 @ns.route('/source/<string:ident>/schedule',
           endpoint='schedule_harvest_source')
-@api.doc(params={'ident': 'A source ID or slug'})
+@api.param('ident', 'A source ID or slug')
 class ScheduleSourceAPI(API):
     @api.doc('schedule_harvest_source')
     @api.secure(admin_permission)
@@ -275,7 +276,7 @@ class PreviewSourceConfigAPI(API):
 
 
 @ns.route('/source/<string:ident>/preview', endpoint='preview_harvest_source')
-@api.doc(params={'ident': 'A source ID or slug'})
+@api.param('ident', 'A source ID or slug')
 class PreviewSourceAPI(API):
     @api.secure
     @api.doc('preview_harvest_source')
@@ -294,7 +295,8 @@ parser.add_argument('page_size', type=int, default=20, location='args',
 
 @ns.route('/source/<string:ident>/jobs/', endpoint='harvest_jobs')
 class JobsAPI(API):
-    @api.doc('list_harvest_jobs', parser=parser)
+    @api.doc('list_harvest_jobs')
+    @api.expect(parser)
     @api.marshal_with(job_page_fields)
     def get(self, ident):
         '''List all jobs for a given source'''
@@ -306,7 +308,8 @@ class JobsAPI(API):
 
 @ns.route('/job/<string:ident>/', endpoint='harvest_job')
 class JobAPI(API):
-    @api.doc('get_harvest_job', parser=parser)
+    @api.doc('get_harvest_job')
+    @api.expect(parser)
     @api.marshal_with(job_fields)
     def get(self, ident):
         '''List all jobs for a given source'''

--- a/udata/harvest/forms.py
+++ b/udata/harvest/forms.py
@@ -57,11 +57,11 @@ class HarvestConfigField(fields.DictField):
 
 
 class HarvestSourceForm(Form):
-    name = fields.StringField(_('Name'), [validators.required()])
+    name = fields.StringField(_('Name'), [validators.DataRequired()])
     description = fields.MarkdownField(
         _('Description'),
         description=_('Some optional details about this harvester'))
-    url = fields.URLField(_('URL'), [validators.required()])
+    url = fields.URLField(_('URL'), [validators.DataRequired()])
     backend = fields.SelectField(_('Backend'), choices=lambda: [
         (b.name, b.display_name) for b in list_backends()
     ])

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -18,7 +18,7 @@ ns = api.namespace('fake', 'A Fake namespace')
 
 
 class FakeForm(Form):
-    required = fields.StringField(validators=[validators.required()])
+    required = fields.StringField(validators=[validators.DataRequired()])
     choices = fields.SelectField(choices=(('first', ''), ('second', '')))
     email = fields.StringField(validators=[validators.Email()])
 

--- a/udata/tests/api/test_base_api.py
+++ b/udata/tests/api/test_base_api.py
@@ -43,7 +43,7 @@ class JSONFormRequestTest(APITestCase):
             'Content-Type': 'multipart/form-data'
         })
         self.assert400(response)
-        self.assertEquals(
+        self.assertEqual(
             response.json,
             {'errors': {'Content-Type': 'expecting application/json'}}
         )

--- a/udata/tests/api/test_swagger.py
+++ b/udata/tests/api/test_swagger.py
@@ -19,4 +19,8 @@ class SwaggerBlueprintTest:
 
     def test_swagger_specs_validate(self, api):
         response = api.get(url_for('api.specs'))
-        schemas.validate(response.json)
+        try:
+            schemas.validate(response.json)
+        except schemas.SchemaValidationError as e:
+            print(e.errors)
+            raise

--- a/udata/tests/api/test_user_api.py
+++ b/udata/tests/api/test_user_api.py
@@ -182,13 +182,13 @@ class UserAPITest(APITestCase):
         response = self.get(url_for('api.users'))
         self.assert200(response)
         [json] = response.json['data']
-        self.assertEquals(json['id'], str(user.id))
-        self.assertEquals(json['slug'], user.slug)
-        self.assertEquals(json['first_name'], user.first_name)
-        self.assertEquals(json['last_name'], user.last_name)
-        self.assertEquals(json['website'], user.website)
-        self.assertEquals(json['about'], user.about)
-        self.assertEquals(json['metrics'], user.metrics)
+        self.assertEqual(json['id'], str(user.id))
+        self.assertEqual(json['slug'], user.slug)
+        self.assertEqual(json['first_name'], user.first_name)
+        self.assertEqual(json['last_name'], user.last_name)
+        self.assertEqual(json['website'], user.website)
+        self.assertEqual(json['about'], user.about)
+        self.assertEqual(json['metrics'], user.metrics)
 
     def test_get_user(self):
         '''It should get a user'''

--- a/udata/tests/forms/test_form_field.py
+++ b/udata/tests/forms/test_form_field.py
@@ -18,7 +18,7 @@ class Fake(db.Document):
 
 class NestedForm(ModelForm):
     model_class = Nested
-    name = fields.StringField(validators=[fields.validators.required()])
+    name = fields.StringField(validators=[fields.validators.DataRequired()])
 
 
 class NestedFormWithId(NestedForm):

--- a/udata/tests/forms/test_nested_model_list_field.py
+++ b/udata/tests/forms/test_nested_model_list_field.py
@@ -24,12 +24,12 @@ class Fake(db.Document):
 
 class SubNestedForm(ModelForm):
     model_class = SubNested
-    name = fields.StringField(validators=[fields.validators.required()])
+    name = fields.StringField(validators=[fields.validators.DataRequired()])
 
 
 class NestedForm(ModelForm):
     model_class = Nested
-    name = fields.StringField(validators=[fields.validators.required()])
+    name = fields.StringField(validators=[fields.validators.DataRequired()])
 
 
 class NestedFormWithId(NestedForm):

--- a/udata/tests/frontend/test_dataset_frontend.py
+++ b/udata/tests/frontend/test_dataset_frontend.py
@@ -97,39 +97,39 @@ class DatasetBlueprintTest(FrontTestCase):
         response = self.get(url)
         self.assert200(response)
         json_ld = self.get_json_ld(response)
-        self.assertEquals(json_ld['@context'], 'http://schema.org')
-        self.assertEquals(json_ld['@type'], 'Dataset')
-        self.assertEquals(json_ld['@id'], str(dataset.id))
-        self.assertEquals(json_ld['description'], 'a&amp;éèëù$£')
-        self.assertEquals(json_ld['alternateName'], dataset.slug)
-        self.assertEquals(json_ld['dateCreated'][:16],
+        self.assertEqual(json_ld['@context'], 'http://schema.org')
+        self.assertEqual(json_ld['@type'], 'Dataset')
+        self.assertEqual(json_ld['@id'], str(dataset.id))
+        self.assertEqual(json_ld['description'], 'a&amp;éèëù$£')
+        self.assertEqual(json_ld['alternateName'], dataset.slug)
+        self.assertEqual(json_ld['dateCreated'][:16],
                           dataset.created_at.isoformat()[:16])
-        self.assertEquals(json_ld['dateModified'][:16],
+        self.assertEqual(json_ld['dateModified'][:16],
                           dataset.last_modified.isoformat()[:16])
-        self.assertEquals(json_ld['url'], 'http://local.test{}'.format(url))
-        self.assertEquals(json_ld['name'], dataset.title)
-        self.assertEquals(json_ld['keywords'], 'bar,foo')
-        self.assertEquals(len(json_ld['distribution']), 1)
+        self.assertEqual(json_ld['url'], 'http://local.test{}'.format(url))
+        self.assertEqual(json_ld['name'], dataset.title)
+        self.assertEqual(json_ld['keywords'], 'bar,foo')
+        self.assertEqual(len(json_ld['distribution']), 1)
 
         json_ld_resource = json_ld['distribution'][0]
-        self.assertEquals(json_ld_resource['@type'], 'DataDownload')
-        self.assertEquals(json_ld_resource['@id'], str(resource.id))
-        self.assertEquals(json_ld_resource['url'], resource.latest)
-        self.assertEquals(json_ld_resource['name'], resource.title)
-        self.assertEquals(json_ld_resource['contentUrl'], resource.url)
-        self.assertEquals(json_ld_resource['dateCreated'][:16],
+        self.assertEqual(json_ld_resource['@type'], 'DataDownload')
+        self.assertEqual(json_ld_resource['@id'], str(resource.id))
+        self.assertEqual(json_ld_resource['url'], resource.latest)
+        self.assertEqual(json_ld_resource['name'], resource.title)
+        self.assertEqual(json_ld_resource['contentUrl'], resource.url)
+        self.assertEqual(json_ld_resource['dateCreated'][:16],
                           resource.created_at.isoformat()[:16])
-        self.assertEquals(json_ld_resource['dateModified'][:16],
+        self.assertEqual(json_ld_resource['dateModified'][:16],
                           resource.modified.isoformat()[:16])
-        self.assertEquals(json_ld_resource['datePublished'][:16],
+        self.assertEqual(json_ld_resource['datePublished'][:16],
                           resource.published.isoformat()[:16])
-        self.assertEquals(json_ld_resource['encodingFormat'], 'png')
-        self.assertEquals(json_ld_resource['contentSize'],
+        self.assertEqual(json_ld_resource['encodingFormat'], 'png')
+        self.assertEqual(json_ld_resource['contentSize'],
                           resource.filesize)
-        self.assertEquals(json_ld_resource['fileFormat'], resource.mime)
-        self.assertEquals(json_ld_resource['description'],
+        self.assertEqual(json_ld_resource['fileFormat'], resource.mime)
+        self.assertEqual(json_ld_resource['description'],
                           'Title 1 Title 2')
-        self.assertEquals(json_ld_resource['interactionStatistic'],
+        self.assertEqual(json_ld_resource['interactionStatistic'],
                           {
                               '@type': 'InteractionCounter',
                               'interactionType': {
@@ -138,28 +138,28 @@ class DatasetBlueprintTest(FrontTestCase):
                               'userInteractionCount': 10,
                           })
 
-        self.assertEquals(len(json_ld['contributedDistribution']), 1)
+        self.assertEqual(len(json_ld['contributedDistribution']), 1)
         json_ld_resource = json_ld['contributedDistribution'][0]
-        self.assertEquals(json_ld_resource['@type'], 'DataDownload')
-        self.assertEquals(json_ld_resource['@id'], str(community_resource.id))
-        self.assertEquals(json_ld_resource['url'], community_resource.latest)
-        self.assertEquals(json_ld_resource['name'], community_resource.title)
-        self.assertEquals(json_ld_resource['contentUrl'],
+        self.assertEqual(json_ld_resource['@type'], 'DataDownload')
+        self.assertEqual(json_ld_resource['@id'], str(community_resource.id))
+        self.assertEqual(json_ld_resource['url'], community_resource.latest)
+        self.assertEqual(json_ld_resource['name'], community_resource.title)
+        self.assertEqual(json_ld_resource['contentUrl'],
                           community_resource.url)
-        self.assertEquals(json_ld_resource['dateCreated'][:16],
+        self.assertEqual(json_ld_resource['dateCreated'][:16],
                           community_resource.created_at.isoformat()[:16])
-        self.assertEquals(json_ld_resource['dateModified'][:16],
+        self.assertEqual(json_ld_resource['dateModified'][:16],
                           community_resource.modified.isoformat()[:16])
-        self.assertEquals(json_ld_resource['datePublished'][:16],
+        self.assertEqual(json_ld_resource['datePublished'][:16],
                           community_resource.published.isoformat()[:16])
-        self.assertEquals(json_ld_resource['encodingFormat'],
+        self.assertEqual(json_ld_resource['encodingFormat'],
                           community_resource.format)
-        self.assertEquals(json_ld_resource['contentSize'],
+        self.assertEqual(json_ld_resource['contentSize'],
                           community_resource.filesize)
-        self.assertEquals(json_ld_resource['fileFormat'],
+        self.assertEqual(json_ld_resource['fileFormat'],
                           community_resource.mime)
-        self.assertEquals(json_ld_resource['description'], 'Title 1 Title 2')
-        self.assertEquals(json_ld_resource['interactionStatistic'], {
+        self.assertEqual(json_ld_resource['description'], 'Title 1 Title 2')
+        self.assertEqual(json_ld_resource['interactionStatistic'], {
             '@type': 'InteractionCounter',
             'interactionType': {
                 '@type': 'DownloadAction',
@@ -167,14 +167,14 @@ class DatasetBlueprintTest(FrontTestCase):
             'userInteractionCount': 42,
         })
 
-        self.assertEquals(json_ld['extras'],
+        self.assertEqual(json_ld['extras'],
                           [{
                               '@type': 'http://schema.org/PropertyValue',
                               'name': 'foo',
                               'value': 'bar',
                           }])
-        self.assertEquals(json_ld['license'], 'http://www.datagouv.fr/licence')
-        self.assertEquals(json_ld['author']['@type'], 'Person')
+        self.assertEqual(json_ld['license'], 'http://www.datagouv.fr/licence')
+        self.assertEqual(json_ld['author']['@type'], 'Person')
 
     def test_json_ld_sanitize(self):
         '''Json-ld should be sanitized'''
@@ -182,7 +182,7 @@ class DatasetBlueprintTest(FrontTestCase):
         url = url_for('datasets.show', dataset=dataset)
         response = self.get(url)
         json_ld = self.get_json_ld(response)
-        self.assertEquals(json_ld['description'],
+        self.assertEqual(json_ld['description'],
                           'an &lt;script&gt;evil()&lt;/script&gt;')
 
     def test_raise_404_if_private(self):

--- a/udata/tests/frontend/test_organization_frontend.py
+++ b/udata/tests/frontend/test_organization_frontend.py
@@ -46,12 +46,12 @@ class OrganizationBlueprintTest(FrontTestCase):
         self.assertNotIn(b'<meta name="robots" content="noindex, nofollow">',
                          response.data)
         json_ld = self.get_json_ld(response)
-        self.assertEquals(json_ld['@context'], 'http://schema.org')
-        self.assertEquals(json_ld['@type'], 'Organization')
-        self.assertEquals(json_ld['alternateName'], organization.slug)
-        self.assertEquals(json_ld['url'], 'http://local.test{}'.format(url))
-        self.assertEquals(json_ld['name'], organization.name)
-        self.assertEquals(json_ld['description'], 'Title 1 Title 2')
+        self.assertEqual(json_ld['@context'], 'http://schema.org')
+        self.assertEqual(json_ld['@type'], 'Organization')
+        self.assertEqual(json_ld['alternateName'], organization.slug)
+        self.assertEqual(json_ld['url'], 'http://local.test{}'.format(url))
+        self.assertEqual(json_ld['name'], organization.name)
+        self.assertEqual(json_ld['description'], 'Title 1 Title 2')
 
     def test_render_display_if_deleted(self):
         '''It should not render the organization page if deleted'''

--- a/udata/tests/frontend/test_reuse_frontend.py
+++ b/udata/tests/frontend/test_reuse_frontend.py
@@ -57,18 +57,18 @@ class ReuseBlueprintTest(FrontTestCase):
         self.assertNotIn(b'<meta name="robots" content="noindex, nofollow">',
                          response.data)
         json_ld = self.get_json_ld(response)
-        self.assertEquals(json_ld['@context'], 'http://schema.org')
-        self.assertEquals(json_ld['@type'], 'CreativeWork')
-        self.assertEquals(json_ld['alternateName'], reuse.slug)
-        self.assertEquals(json_ld['dateCreated'][:16],
+        self.assertEqual(json_ld['@context'], 'http://schema.org')
+        self.assertEqual(json_ld['@type'], 'CreativeWork')
+        self.assertEqual(json_ld['alternateName'], reuse.slug)
+        self.assertEqual(json_ld['dateCreated'][:16],
                           reuse.created_at.isoformat()[:16])
-        self.assertEquals(json_ld['dateModified'][:16],
+        self.assertEqual(json_ld['dateModified'][:16],
                           reuse.last_modified.isoformat()[:16])
-        self.assertEquals(json_ld['url'], 'http://local.test{}'.format(url))
-        self.assertEquals(json_ld['name'], reuse.title)
-        self.assertEquals(json_ld['description'], 'Title 1 Title 2')
-        self.assertEquals(json_ld['isBasedOnUrl'], reuse.url)
-        self.assertEquals(json_ld['author']['@type'], 'Person')
+        self.assertEqual(json_ld['url'], 'http://local.test{}'.format(url))
+        self.assertEqual(json_ld['name'], reuse.title)
+        self.assertEqual(json_ld['description'], 'Title 1 Title 2')
+        self.assertEqual(json_ld['isBasedOnUrl'], reuse.url)
+        self.assertEqual(json_ld['author']['@type'], 'Person')
 
     def test_raise_404_if_private(self):
         '''It should raise a 404 if the reuse is private'''

--- a/udata/tests/frontend/test_user_frontend.py
+++ b/udata/tests/frontend/test_user_frontend.py
@@ -21,12 +21,12 @@ class UserBlueprintTest(FrontTestCase):
         response = self.get(url_for('users.show', user=user))
         self.assert200(response)
         json_ld = self.get_json_ld(response)
-        self.assertEquals(json_ld['@context'], 'http://schema.org')
-        self.assertEquals(json_ld['@type'], 'Person')
-        self.assertEquals(json_ld['name'], user.fullname)
-        self.assertEquals(json_ld['description'], 'Title 1 Title 2')
-        self.assertEquals(json_ld['url'], 'http://www.datagouv.fr/user')
-        self.assertEquals(json_ld['image'], 'http://www.datagouv.fr/avatar')
+        self.assertEqual(json_ld['@context'], 'http://schema.org')
+        self.assertEqual(json_ld['@type'], 'Person')
+        self.assertEqual(json_ld['name'], user.fullname)
+        self.assertEqual(json_ld['description'], 'Title 1 Title 2')
+        self.assertEqual(json_ld['url'], 'http://www.datagouv.fr/user')
+        self.assertEqual(json_ld['image'], 'http://www.datagouv.fr/avatar')
 
     def test_cannot_render_profile_of_an_inactive_user(self):
         '''It should raise a 410 when the user is inactive'''

--- a/udata/tests/test_linkchecker.py
+++ b/udata/tests/test_linkchecker.py
@@ -57,7 +57,7 @@ class LinkcheckerTest(TestCase):
     def test_check_resource_no_linkchecker(self, mock_fn):
         mock_fn.return_value = None
         res = check_resource(self.resource)
-        self.assertEquals(res, ({'error': 'No linkchecker configured.'}, 503))
+        self.assertEqual(res, ({'error': 'No linkchecker configured.'}, 503))
 
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_check_resource_linkchecker_ok(self, mock_fn):
@@ -70,9 +70,9 @@ class LinkcheckerTest(TestCase):
         mock_fn.return_value = DummyLinkchecker
 
         res = check_resource(self.resource)
-        self.assertEquals(res, check_res)
+        self.assertEqual(res, check_res)
         check_res.update({'check:count-availability': 1})
-        self.assertEquals(self.resource.extras, check_res)
+        self.assertEqual(self.resource.extras, check_res)
 
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_check_resource_filter_result(self, mock_fn):
@@ -84,7 +84,7 @@ class LinkcheckerTest(TestCase):
         mock_fn.return_value = DummyLinkchecker
 
         res = check_resource(self.resource)
-        self.assertEquals(res, check_res)
+        self.assertEqual(res, check_res)
         self.assertNotIn('dummy', self.resource.extras)
 
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
@@ -94,7 +94,7 @@ class LinkcheckerTest(TestCase):
                 return {'check:available': True}
         mock_fn.return_value = DummyLinkchecker
         res = check_resource(self.resource)
-        self.assertEquals(res,
+        self.assertEqual(res,
                           ({'error': 'No status in response from linkchecker'},
                            503))
 
@@ -105,7 +105,7 @@ class LinkcheckerTest(TestCase):
                 return {'check:error': 'ERROR'}
         mock_fn.return_value = DummyLinkchecker
         res = check_resource(self.resource)
-        self.assertEquals(res, ({'error': 'ERROR'}, 500))
+        self.assertEqual(res, ({'error': 'ERROR'}, 500))
 
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_check_resource_linkchecker_in_resource(self, mock_fn):
@@ -113,22 +113,22 @@ class LinkcheckerTest(TestCase):
         self.resource.save()
         check_resource(self.resource)
         args, kwargs = mock_fn.call_args
-        self.assertEquals(args, ('another_linkchecker', ))
+        self.assertEqual(args, ('another_linkchecker', ))
 
     def test_check_resource_linkchecker_no_check(self):
         self.resource.extras['check:checker'] = 'no_check'
         self.resource.save()
         res = check_resource(self.resource)
-        self.assertEquals(res.get('check:status'), 204)
-        self.assertEquals(res.get('check:available'), True)
+        self.assertEqual(res.get('check:status'), 204)
+        self.assertEqual(res.get('check:available'), True)
 
     def test_check_resource_ignored_domain(self):
         self.resource.extras = {}
         self.resource.url = 'http://example-ignore.com/url'
         self.resource.save()
         res = check_resource(self.resource)
-        self.assertEquals(res.get('check:status'), 204)
-        self.assertEquals(res.get('check:available'), True)
+        self.assertEqual(res.get('check:status'), 204)
+        self.assertEqual(res.get('check:available'), True)
 
     def test_is_need_check(self):
         self.resource.extras = {'check:available': True,
@@ -217,10 +217,10 @@ class LinkcheckerTest(TestCase):
         mock_fn.return_value = DummyLinkchecker
 
         check_resource(self.resource)
-        self.assertEquals(self.resource.extras['check:count-availability'], 1)
+        self.assertEqual(self.resource.extras['check:count-availability'], 1)
 
         check_resource(self.resource)
-        self.assertEquals(self.resource.extras['check:count-availability'], 2)
+        self.assertEqual(self.resource.extras['check:count-availability'], 2)
 
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_count_availability_reset(self, mock_fn):
@@ -236,7 +236,7 @@ class LinkcheckerTest(TestCase):
         mock_fn.return_value = DummyLinkchecker
 
         check_resource(self.resource)
-        self.assertEquals(self.resource.extras['check:count-availability'], 1)
+        self.assertEqual(self.resource.extras['check:count-availability'], 1)
 
     def test_count_availability_threshold(self):
         self.resource.extras = {


### PR DESCRIPTION
This pull request removes a lots of deprecation warnings (hundreds when running test which was making difficult to investigate test errors).

The last remainings are contributed upstream: https://github.com/rtfd/CommonMark-py/pull/141
