### PR TITLE
Automatically loads plugin default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Automatically loads default settings from plugins (if `plugin.settings` module exists) [#2058](https://github.com/opendatateam/udata/pull/2058)
 
 ## 1.6.5 (2019-02-27)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -98,6 +98,10 @@ and can perform any manual initialization.
 
 Use this entrypoint if you want to perform something not handled by previous entrypoints.
 
+### Default settings
+
+Any registered plugin may also expose some default settings in a `settings` module (ie. `my_plugin.settings`). They will be automatically discovered and registered.
+
 ### Translations
 
 Any registered plugin may also expose translations in its root module `translations` directory.

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -194,18 +194,6 @@ class Defaults(object):
     LINKCHECKING_UNAVAILABLE_THRESHOLD = 100
     LINKCHECKING_DEFAULT_LINKCHECKER = 'no_check'
 
-    # PIWIK_ID = # Demo = 11, Prod = 1
-    # PIWIK_URL = 'stats.data.gouv.fr'
-    # PIWIK_AUTH = '<32-chars-auth-token-from-piwik>'
-    # # All keys are required.
-    # PIWIK_GOALS = {
-    #     'NEW_DATASET': # Demo = 1, Prod = 7
-    #     'NEW_REUSE': # Demo = 2, Prod = 6
-    #     'NEW_FOLLOW': # Demo = 3, Prod = 3
-    #     'SHARE': , # Demo = 4, Prod = ?
-    #     'RESOURCE_DOWNLOAD': , # Demo = 5, Prod = ?
-    #     'RESOURCE_REDIRECT': , # Demo = 6, Prod = ?
-    # }
     # TRACKING_BLACKLIST = ['api.notifications', 'api.check_dataset_resource']  # Default: []
 
     DELETE_ME = True


### PR DESCRIPTION
This PR automatically loads plugins default settings if they are stored in the `plugin_package.settings` module.
This will allows all plugins to register their default settings in the same way and enforce the practice of having explicit default settings.

Piwik commented settings are removed (they will be properly registered in a `udata-piwik` pull request.