### PR TITLE
Fix reindex memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Automatically loads default settings from plugins (if `plugin.settings` module exists) [#2058](https://github.com/opendatateam/udata/pull/2058)
+- Fixes some memory leaks on reindexing [#2070](https://github.com/opendatateam/udata/pull/2070)
 
 ## 1.6.5 (2019-02-27)
 

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -43,7 +43,7 @@ def iter_adapters():
 
 def iter_qs(qs, adapter):
     '''Safely iterate over a DB QuerySet yielding ES documents'''
-    for obj in qs.no_dereference().timeout(False):
+    for obj in qs.no_cache().no_dereference().timeout(False):
         if adapter.is_indexable(obj):
             try:
                 doc = adapter.from_model(obj).to_dict(include_meta=True)


### PR DESCRIPTION
This PR fixes 2 memory leak on search indexing.

The memory profile have been sampled with the following configuration:

- **CPU:** Inter Core I7 7500U
- **RAM:** 16G
- **OS:** Archlinux
- **Datasets:** 10000

## Tooling

The profiling script is: https://gist.github.com/noirbizarre/7ea0b0526814131752e6902a4254df78

It requires:
 - [`memory-profiler`](https://pypi.org/project/memory-profiler/)
 - [`objgraph`](https://pypi.org/project/objgraph/)
 - [`matplotlib`](https://pypi.org/project/matplotlib/)
 - `graphviz`

Run it with:
```shell
mprof run -o output.dat profiling.py
```
Render graph with:
```shell
mprof plot output.dat -t "Title" -o output.png
```

### Memory profile from current master

![profiling-master](https://user-images.githubusercontent.com/15725/54599795-ab5c7580-4a3b-11e9-99dd-fea5ccf791ce.png)

**Max memory usage**: ~4G

## udata `SlugField`

The udata `SlugField` instances were keeping a reference to their parent document using `self.instance`. This reference was stored in a class instance which is instanciated once on document definition and so the garbage collector was never able to collect document instances using a slug field (as there was always a reference on it)

This has been fixed by refactoring the `SlugField` population into a signal handler and not keeping a static feference on the instance.

### Memory profile with the `SlugField` fix

![profiling-fix](https://user-images.githubusercontent.com/15725/54599817-b9aa9180-4a3b-11e9-82e6-18e9fa4cb8d8.png)

**Max memory usage**: ~3.6G

## MongoEngine querysets and `no_cache()`

MongoEngine default behavior is to cache any queryset just to avoid round trip on "count then query".
This behavior cause a massive memory leak while iterating over a queryset generator.

The fix is to add a `no_cache()` call before the loop.

This fix might be beneficial on other code parts.

### Memory profile with `no_cache()`

![profiling-fix-no-cache](https://user-images.githubusercontent.com/15725/54599893-e78fd600-4a3b-11e9-9fce-c9c04d0c64b4.png)

**Max memory usage**: ~300M

## MongoEngine 0.17.0

It doesn't fix the memory leak but the update was applied just to verify that it has no impact (See [this  PR](https://github.com/opendatateam/udata/pull/2063)).
As you can see, there is some meory drop and the hole reindexing take much more longer.
The update has been removed from the PR until the cause of these drops is found.

### Memory profile

![profiling-fix-no-cache-0 17 0](https://user-images.githubusercontent.com/15725/54599985-10b06680-4a3c-11e9-9e4e-5bb9e490850a.png)

**Max memory usage**: ~300M
