### PR TITLE
Improve ModelField errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Automatically loads default settings from plugins (if `plugin.settings` module exists) [#2058](https://github.com/opendatateam/udata/pull/2058)
 - Fixes some memory leaks on reindexing [#2070](https://github.com/opendatateam/udata/pull/2070)
 - Prevent ExtrasField failure on null value [#2074](https://github.com/opendatateam/udata/pull/2074)
-
+- Improve ModelField errors handling [#2075](https://github.com/opendatateam/udata/pull/2075)
 
 ## 1.6.5 (2019-02-27)
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -21,7 +21,7 @@ from udata.core.storages import tmp
 from udata.core.organization.permissions import OrganizationPrivatePermission
 from udata.i18n import lazy_gettext as _
 from udata import tags, uris
-from udata.forms import ModelForm, Form
+from udata.forms import ModelForm
 from udata.utils import to_iso_date, get_by
 
 
@@ -353,8 +353,8 @@ def clean_oid(oid, model):
             # and returns the original value on exception
             model.id.validate(oid)
             return model.id.to_python(oid)
-        except:  # Catch all exceptions as model.type is not predefined
-            raise ValueError('Unsupported identifier: ' + oid)
+        except Exception:  # Catch all exceptions as model.type is not predefined
+            raise ValueError('Unsupported identifier: {0}'.format(oid))
 
 
 class ModelFieldMixin(object):
@@ -381,30 +381,64 @@ class ModelFieldMixin(object):
 
 
 class ModelField(Field):
+    def process(self, formdata, data=unset_value):
+        if not formdata:
+            return
+        # Process prefixed values as in FormField
+        newdata = {}
+        prefix = self.short_name + '-'
+        for key in formdata.keys():
+            if key.startswith(prefix):
+                value = formdata.pop(key)
+                newdata[key.replace(prefix, '')] = value
+        if newdata:
+            formdata.add(self.short_name, newdata)
+        super(ModelField, self).process(formdata, data)
+
     def process_formdata(self, valuelist):
         if valuelist and len(valuelist) == 1 and valuelist[0]:
             specs = valuelist[0]
             model_field = getattr(self._form.model_class, self.name)
             if isinstance(specs, basestring):
-                if isinstance(model_field, db.ReferenceField):
-                    specs = {'class': str(model_field.document_type.__name__), 'id': specs}
-                elif isinstance(model_field, db.GenericReferenceField):
-                    message = _('Expect both class and identifier')
-                    raise validators.ValidationError(message)
+                specs = {'id': specs}
+            elif not specs.get('id', None):
+                raise validators.ValidationError('Missing "id" field')
+
+            if isinstance(model_field, db.ReferenceField):
+                expected_model = str(model_field.document_type.__name__)
+                if 'class' not in specs:
+                    specs['class'] = expected_model
+                elif specs['class'] != expected_model:
+                    msg = 'Expect a "{0}" class but "{1}" was found'.format(
+                        expected_model, specs['class']
+                    )
+                    raise validators.ValidationError(msg)
+            elif isinstance(model_field, db.GenericReferenceField):
+                if 'class' not in specs:
+                    msg = _('Expect both class and identifier')
+                    raise validators.ValidationError(msg)
 
             # No try/except required
             # In case of error, ValueError is raised
             # and is properly handled as form validation error
             model = db.resolve_model(specs['class'])
+            oid = clean_oid(specs, model)
 
             try:
-                self.data = model.objects.only('id').get(id=clean_oid(specs, model))
+                self.data = model.objects.only('id').get(id=oid)
             except db.DoesNotExist:
-                message = _('{0} does not exists').format(model.__name__)
-                raise validators.ValidationError(message)
-            except db.ValidationError:
-                message = _('{0} is not a valid identifier').format(specs['id'])
-                raise validators.ValidationError(message)
+                label = '{0}({1})'.format(model.__name__, oid)
+                msg = _('{0} does not exists').format(label)
+                raise validators.ValidationError(msg)
+
+    def pre_validate(self, form):
+        # If any error happen during process, we raise StopValidation here
+        # to prevent "DataRequired" validator from clearing errors
+        if self.errors:
+            raise validators.StopValidation()
+
+    def populate_obj(self, obj, name):
+        setattr(obj, name, getattr(self, 'data', None))
 
 
 class ModelChoiceField(StringField):

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -75,7 +75,7 @@ class UDataMongoEngine(MongoEngine):
         try:
             return get_document(classname)
         except self.NotRegistered:
-            message = '{0} does not exists'.format(classname)
+            message = 'Model "{0}" does not exists'.format(classname)
             raise ValueError(message)
 
 

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -75,7 +75,7 @@ class UDataMongoEngine(MongoEngine):
         try:
             return get_document(classname)
         except self.NotRegistered:
-            message = 'Model "{0}" does not exists'.format(classname)
+            message = 'Model "{0}" does not exist'.format(classname)
             raise ValueError(message)
 
 

--- a/udata/tests/forms/test_model_field.py
+++ b/udata/tests/forms/test_model_field.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from werkzeug.datastructures import MultiDict
+
+from udata.forms import ModelForm, fields
+from udata.models import db
+
+
+pytestmark = [
+    pytest.mark.usefixtures('clean_db')
+]
+
+
+class Target(db.Document):
+    name = db.StringField()
+
+
+class Model(db.Document):
+    name = db.StringField()
+    target = db.GenericReferenceField()
+
+
+class ModelExplicit(db.Document):
+    name = db.StringField()
+    target = db.ReferenceField(Target)
+
+
+class Generic:
+    model = Model
+
+    def test_error_with_inline_identifier(self):
+        expected_target = Target.objects.create()
+        form = self.form.from_json({
+            'name': 'test',
+            'target': str(expected_target.pk),
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert form.errors['target'][0] == 'Expect both class and identifier'
+
+    def test_error_with_identifier_only(self):
+        expected_target = Target.objects.create()
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {'id': str(expected_target.pk)},
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert form.errors['target'][0] == 'Expect both class and identifier'
+
+    def test_error_with_unknown_model(self):
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {
+                'class': 'Unknown',
+                'id': 42
+            },
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert form.errors['target'][0] == 'Model "Unknown" does not exists'
+
+
+class Explicit:
+    model = ModelExplicit
+
+    def test_with_inline_identifier_multidict(self):
+        expected_target = Target.objects.create()
+        model = self.model()
+        form = self.form(MultiDict({
+            'name': 'test',
+            'target': str(expected_target.pk),
+        }))
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_with_identifier_only_multidict(self):
+        expected_target = Target.objects.create()
+        model = self.model()
+        form = self.form(MultiDict({
+            'name': 'test',
+            'target-id': str(expected_target.pk),
+        }))
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_with_inline_identifier_json(self):
+        expected_target = Target.objects.create()
+        model = self.model()
+        form = self.form.from_json({
+            'name': 'test',
+            'target': str(expected_target.pk),
+        })
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_with_identifier_only_json(self):
+        expected_target = Target.objects.create()
+        model = self.model()
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {'id': str(expected_target.pk)},
+        })
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_error_with_class_mismatch(self):
+        expected_target = Target.objects.create()
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {
+                'class': 'Wrong',
+                'id': str(expected_target.pk)
+            },
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert form.errors['target'][0] == 'Expect a "Target" class but "Wrong" was found'
+
+
+class Required:
+    required = True
+
+    def test_not_provided(self):
+        form = self.form.from_json({'name': 'test'})
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert 'required' in form.errors['target'][0]
+
+    def test_none(self):
+        form = self.form.from_json({
+            'name': 'test',
+            'target': None,
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert 'required' in form.errors['target'][0]
+
+    def test_with_initial_object_none(self):
+        model = self.model(target=Target.objects.create())
+
+        form = self.form.from_json({
+            'name': 'test',
+            'target': None,
+        }, model)
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert 'required' in form.errors['target'][0]
+
+
+class Optionnal:
+    '''Optional ModelField specific tests'''
+    required = False
+
+    def test_with_initial_object_none(self):
+        model = self.model(target=Target.objects.create())
+
+        form = self.form.from_json({
+            'name': 'test',
+            'target': None,
+        }, model)
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert model.target is None
+
+
+class CommonMixin:
+    @property
+    def form(self):
+        validators = [fields.validators.required()] if self.required else []
+
+        class Form(ModelForm):
+            model_class = self.model
+            name = fields.StringField()
+            target = fields.ModelField(validators=validators)
+
+        return Form
+
+    def test_empty_data(self):
+        model = self.model()
+        form = self.form()
+        form.populate_obj(model)
+
+        assert model.target is None
+
+    def test_with_valid_multidict(self):
+        expected_target = Target.objects.create()
+        model = self.model()
+        form = self.form(MultiDict({
+            'name': 'test',
+            'target-class': 'Target',
+            'target-id': str(expected_target.pk)
+        }))
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_with_valid_json(self):
+        expected_target = Target.objects.create()
+        model = self.model()
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {
+                'class': 'Target',
+                'id': str(expected_target.pk)
+            }
+        })
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_with_initial_object(self):
+        initial_target = Target.objects.create()
+        expected_target = Target.objects.create()
+        model = self.model(target=initial_target)
+
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {
+                'class': 'Target',
+                'id': str(expected_target.pk)
+            }
+        }, model)
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_with_non_submitted_initial_object(self):
+        expected_target = Target.objects.create()
+        model = self.model(target=expected_target)
+
+        form = self.form.from_json({'name': 'test'}, model)
+
+        form.validate()
+        assert form.errors == {}
+
+        form.populate_obj(model)
+
+        assert isinstance(model.target, Target)
+        assert model.target == expected_target
+
+    def test_multidict_errors(self):
+        form = self.form(MultiDict({
+            'name': 'test',
+            'target-class': 'Target',
+        }))
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        # assert 'Unsupported identifier' in form.errors['target'][0]
+        assert form.errors['target'][0] == 'Missing "id" field'
+
+    def test_json_errors(self):
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {
+                'class': 'Target',
+            }
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert form.errors['target'][0] == 'Missing "id" field'
+
+    def test_bad_id(self):
+        form = self.form.from_json({
+            'name': 'test',
+            'target': {
+                'class': 'Target',
+                'id': 'wrong'
+            }
+        })
+
+        form.validate()
+
+        assert 'target' in form.errors
+        assert len(form.errors['target']) == 1
+        assert 'Unsupported identifier' in form.errors['target'][0]
+
+
+class Optionnal_GenericReference_Test(Generic, Optionnal, CommonMixin):
+    pass
+
+
+class Optionnal_ExplicitReference_Test(Explicit, Optionnal, CommonMixin):
+    pass
+
+
+class Required_GenericReference_Test(Generic, Required, CommonMixin):
+    pass
+
+
+class Required_ExplicitReference_Test(Explicit, Required, CommonMixin):
+    pass

--- a/udata/tests/forms/test_model_field.py
+++ b/udata/tests/forms/test_model_field.py
@@ -70,7 +70,7 @@ class Generic:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert form.errors['target'][0] == 'Model "Unknown" does not exists'
+        assert form.errors['target'][0] == 'Model "Unknown" does not exist'
 
 
 class Explicit:


### PR DESCRIPTION
This PR test and fixes some error cases on `ModelField` form field with `db.ReferenceField` and `db.GenericReferenceField`:
- Prevent 'required` error message to hide other ones
- Adds a lot of specific case more explicit error message
- Prevent some internal server errors

Fix https://github.com/opendatateam/udata/issues/2066