### PR TITLE
Add request_timeout to es.indices.forcemerge (udata index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixes some memory leaks on reindexing [#2070](https://github.com/opendatateam/udata/pull/2070)
 - Prevent ExtrasField failure on null value [#2074](https://github.com/opendatateam/udata/pull/2074)
 - Improve ModelField errors handling [#2075](https://github.com/opendatateam/udata/pull/2075)
+- Prevent timeout on `udata index` in some cases [#2079](https://github.com/opendatateam/udata/pull/2079)
 
 ## 1.6.5 (2019-02-27)
 

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -103,7 +103,7 @@ def enable_refresh(index_name):
     es.indices.put_settings(index=index_name, body={
         'index': {'refresh_interval': refresh_interval}
     })
-    es.indices.forcemerge(index=index_name)
+    es.indices.forcemerge(index=index_name, request_timeout=30)
 
 
 def set_alias(index_name, delete=True):


### PR DESCRIPTION
Avoid a timeout on the `forcemerge` operation of the `udata index` command in some cases (was 10 seconds by default).