### PR TITLE
Pin werkzeug==0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixes some memory leaks on reindexing [#2070](https://github.com/opendatateam/udata/pull/2070)
 - Prevent ExtrasField failure on null value [#2074](https://github.com/opendatateam/udata/pull/2074)
 - Improve ModelField errors handling [#2075](https://github.com/opendatateam/udata/pull/2075)
+- Pin werkzeug dependency to `0.14.1` until incompatibilities are fixed [#2081](https://github.com/opendatateam/udata/pull/2081)
 
 ## 1.6.5 (2019-02-27)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -46,6 +46,7 @@ tlds
 unicodecsv==0.14.1
 ujson==1.35
 voluptuous==0.10.5
+werkzeug==0.14.1
 wtforms-json==0.3.3
 wtforms==2.2.1
 xmltodict==0.12.0


### PR DESCRIPTION
This PR pin Werkzeug to version `0.14.1` until incompatibilities with the new `0.15+` are fixed (See [Werkzeug changelog](https://werkzeug.palletsprojects.com/en/0.15.x/changes/)).

First investigations and tests show that:
- static URL resolution is broken
- test are taking twice the time (localy, they are killed on CircleCI).
- some used modules have moved or have been refactored

Update to `0.15+` might happen in `udata 2+` in a PR
