### PR TITLE
Fix the `udata job schedule` erroneous help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improve ModelField errors handling [#2075](https://github.com/opendatateam/udata/pull/2075)
 - Pin werkzeug dependency to `0.14.1` until incompatibilities are fixed [#2081](https://github.com/opendatateam/udata/pull/2081)
 - Prevent client-side error while handling unparseable API response [#2076](https://github.com/opendatateam/udata/pull/2076)
+- Fix the `udata job schedule` erroneous help message [#2083](https://github.com/opendatateam/udata/pull/2083)
 
 ## 1.6.5 (2019-02-27)
 

--- a/udata/core/jobs/commands.py
+++ b/udata/core/jobs/commands.py
@@ -80,7 +80,7 @@ def schedule(cron, name, params):
     Jobs args and kwargs are given as parameters without dashes.
 
     Ex:
-        udata job schedule my-job "* * 0 * *" arg1 arg2 key1=value key2=value
+        udata job schedule "* * 0 * *" my-job arg1 arg2 key1=value key2=value
     '''
     if name not in celery.tasks:
         exit_with_error('Job %s not found', name)


### PR DESCRIPTION
This PR fixes the `udata job schedule` help message which was displaying arguments in a wrong order.
