### PR TITLE
WIP: Fix DELETE responses (no content)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Pin werkzeug dependency to `0.14.1` until incompatibilities are fixed [#2081](https://github.com/opendatateam/udata/pull/2081)
 - Prevent client-side error while handling unparseable API response [#2076](https://github.com/opendatateam/udata/pull/2076)
 - Fix the `udata job schedule` erroneous help message [#2083](https://github.com/opendatateam/udata/pull/2083)
+- Fix the `DELETE` responses (no content) [#2084](https://github.com/opendatateam/udata/pull/2084)
 
 ## 1.6.5 (2019-02-27)
 

--- a/udata/core/badges/api.py
+++ b/udata/core/badges/api.py
@@ -42,4 +42,4 @@ def remove(obj, kind):
     if not obj.get_badge(kind):
         api.abort(404, 'Badge does not exists')
     obj.remove_badge(kind)
-    return '', 204
+    return 204

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -147,7 +147,7 @@ class DatasetAPI(API):
         dataset.deleted = datetime.now()
         dataset.last_modified = datetime.now()
         dataset.save()
-        return '', 204
+        return 204
 
 
 @ns.route('/<dataset:dataset>/featured/', endpoint='dataset_featured')
@@ -362,7 +362,7 @@ class ResourceAPI(ResourceMixin, API):
         dataset.resources.remove(resource)
         dataset.last_modified = datetime.now()
         dataset.save()
-        return '', 204
+        return 204
 
 
 @ns.route('/community_resources/', endpoint='community_resources')
@@ -436,7 +436,7 @@ class CommunityResourceAPI(API):
         '''Delete a given community resource'''
         ResourceEditPermission(community).test()
         community.delete()
-        return '', 204
+        return 204
 
 
 @ns.route('/<id>/followers/', endpoint='dataset_followers')

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -130,7 +130,7 @@ class DiscussionAPI(API):
         discussion = Discussion.objects.get_or_404(id=id)
         discussion.delete()
         on_discussion_deleted.send(discussion)
-        return '', 204
+        return 204
 
 
 @ns.route('/', endpoint='discussions')

--- a/udata/core/jobs/api.py
+++ b/udata/core/jobs/api.py
@@ -133,7 +133,7 @@ class JobAPI(API):
         '''Delete a single scheduled job'''
         task = self.get_or_404(id)
         task.delete()
-        return '', 204
+        return 204
 
 
 @ns.route('/tasks/<string:id>', endpoint='task')

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -114,7 +114,7 @@ class OrganizationAPI(API):
         EditOrganizationPermission(org).test()
         org.deleted = datetime.now()
         org.save()
-        return '', 204
+        return 204
 
 
 @ns.route('/badges/', endpoint='available_organization_badges')
@@ -299,7 +299,7 @@ class MemberAPI(API):
         member = org.member(user)
         if member:
             Organization.objects(id=org.id).update_one(pull__members=member)
-            return '', 204
+            return 204
         else:
             api.abort(404)
 

--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -115,7 +115,7 @@ class PostAPI(API):
     def delete(self, post):
         '''Delete a given post'''
         post.delete()
-        return '', 204
+        return 204
 
 
 @ns.route('/<post:post>/publish', endpoint='publish_post')

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -88,7 +88,7 @@ class ReuseAPI(API):
         ReuseEditPermission(reuse).test()
         reuse.deleted = datetime.now()
         reuse.save()
-        return '', 204
+        return 204
 
 
 @ns.route('/<reuse:reuse>/datasets/', endpoint='reuse_add_dataset')

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -101,4 +101,4 @@ class TopicAPI(API):
     def delete(self, topic):
         '''Delete a given topic'''
         topic.delete()
-        return '', 204
+        return 204

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -73,7 +73,7 @@ class MeAPI(API):
         user = current_user._get_current_object()
         user.mark_as_deleted()
         logout_user()
-        return '', 204
+        return 204
 
 
 @me.route('/avatar', endpoint='my_avatar')
@@ -216,7 +216,7 @@ class ApiKeyAPI(API):
         '''Clear/destroy an apikey'''
         current_user.apikey = None
         current_user.save()
-        return '', 204
+        return 204
 
 
 @ns.route('/', endpoint='users')
@@ -284,7 +284,7 @@ class UserAPI(API):
             api.abort(403, 'You cannot delete yourself with this API. ' +
                       'Use the "me" API instead.')
         user.mark_as_deleted()
-        return '', 204
+        return 204
 
 
 @ns.route('/<id>/followers/', endpoint='user_followers')


### PR DESCRIPTION
As explained here https://github.com/pallets/werkzeug/pull/1294, until we can get Werkzeug 15.1, this forces the `DELETE` responses to have a `Content-Length` of `0`. This will prevent picky browsers (Safari) from not seeing the end of the `DELETE` request.

Fix #1773.