### PR TITLE
DCAT harvester refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Refactor DCAT harvesting to store only one graph (and prevent MongoDB document size overflow) [#2096](https://github.com/opendatateam/udata/pull/2096)
 
 ## 1.6.6 (2019-03-27)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -384,13 +384,15 @@ def resource_from_rdf(graph_or_distrib, dataset=None):
     return resource
 
 
-def dataset_from_rdf(graph, dataset=None):
+def dataset_from_rdf(graph, dataset=None, node=None):
     '''
     Create or update a dataset from a RDF/DCAT graph
     '''
     dataset = dataset or Dataset()
 
-    node = graph.value(predicate=RDF.type, object=DCAT.Dataset)
+    if node is None:  # Assume first match is the only match
+        node = graph.value(predicate=RDF.type, object=DCAT.Dataset)
+
     d = graph.resource(node)
 
     dataset.title = rdf_value(d, DCT.title)

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -5,11 +5,11 @@ import logging
 
 import requests
 
-from rdflib import Graph
+from rdflib import Graph, URIRef, BNode
 from rdflib.namespace import RDF
 
 from udata.rdf import (
-    DCAT, DCT, HYDRA, SPDX, namespace_manager, guess_format, url_from_rdf
+    DCAT, DCT, HYDRA, SPDX, namespace_manager, guess_format, url_from_rdf, CONTEXT
 )
 from udata.core.dataset.rdf import dataset_from_rdf
 
@@ -63,38 +63,44 @@ class DcatBackend(BaseBackend):
             if not fmt:
                 msg = 'Unsupported mime type "{0}"'.format(mime_type)
                 raise ValueError(msg)
-        self.parse_graph(self.source.url, fmt)
+        graph = self.parse_graph(self.source.url, fmt)
+        self.job.data = {'graph': graph.serialize(format='json-ld', indent=None)}
 
     def parse_graph(self, url, fmt):
         graph = Graph(namespace_manager=namespace_manager)
         while url:
-            graph.parse(data=requests.get(url).text, format=fmt)
+            subgraph = Graph(namespace_manager=namespace_manager)
+            subgraph.parse(data=requests.get(url).text, format=fmt)
 
             url = None
             for cls, prop in KNOWN_PAGINATION:
-                if (None, RDF.type, cls) in graph:
-                    pagination = graph.value(predicate=RDF.type, object=cls)
-                    pagination = graph.resource(pagination)
+                if (None, RDF.type, cls) in subgraph:
+                    pagination = subgraph.value(predicate=RDF.type, object=cls)
+                    pagination = subgraph.resource(pagination)
                     url = url_from_rdf(pagination, prop)
                     break
 
-        for id, data in self.dcat_datasets(graph):
-            self.add_item(id, graph=data)
+            graph += subgraph
 
-    def dcat_datasets(self, graph):
-        '''
-        Extract DCAT dataset from a RDF graph.
-        '''
         for node in graph.subjects(RDF.type, DCAT.Dataset):
-            dcat_id = graph.value(node, DCT.identifier)
-            subgraph = Graph(namespace_manager=namespace_manager)
-            extract_graph(graph, subgraph, node, DCAT_NESTING)
-            yield str(dcat_id), subgraph.serialize(format='json-ld',
-                                                   indent=None)
+            id = graph.value(node, DCT.identifier)
+            kwargs = {'nid': str(node)}
+            kwargs['type'] = 'uriref' if isinstance(node, URIRef) else 'blank'
+            self.add_item(id, **kwargs)
+
+        return graph
 
     def process(self, item):
         graph = Graph(namespace_manager=namespace_manager)
-        graph.parse(data=item.kwargs['graph'], format='json-ld')
+        data = item.kwargs.get('graph', self.job.data['graph'])  # handles legacy graphs
+        node = None
+
+        graph.parse(data=data, format='json-ld')
+
+        if 'nid' in item.kwargs and 'type' in item.kwargs:
+            nid = item.kwargs['nid']
+            node = URIRef(nid) if item.kwargs['type'] == 'uriref' else BNode(nid)
+
         dataset = self.get_dataset(item.remote_id)
-        dataset = dataset_from_rdf(graph, dataset)
+        dataset = dataset_from_rdf(graph, dataset, node=node)
         return dataset

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -160,6 +160,7 @@ class HarvestJob(db.Document):
     errors = db.ListField(db.EmbeddedDocumentField(HarvestError))
     items = db.ListField(db.EmbeddedDocumentField(HarvestItem))
     source = db.ReferenceField(HarvestSource, reverse_delete_rule=db.NULLIFY)
+    data = db.DictField()
 
     meta = {
         'indexes': [

--- a/udata/harvest/tests/dcat/bnodes.jsonld
+++ b/udata/harvest/tests/dcat/bnodes.jsonld
@@ -11,26 +11,25 @@
     ],
     "http://purl.org/dc/terms/title": [{"@value": "Sample DCAT Catalog"}],
     "http://www.w3.org/ns/dcat#dataset": [
-      {"@id": "http://data.test.org/datasets/1"},
-      {"@id": "http://data.test.org/datasets/2"},
-      {"@id": "http://data.test.org/datasets/3"},
-      {"@id": "http://data.test.org/datasets/4"}
+      {"@id": "_:dataset-1"},
+      {"@id": "_:dataset-2"},
+      {"@id": "_:dataset-3"}
     ],
     "http://xmlns.com/foaf/0.1/homepage": [{"@value": "http://data.test.org"}]
   },
   {
-    "@id": "http://data.test.org/organizations/1",
+    "@id": "_:org-1",
     "@type": ["http://xmlns.com/foaf/0.1/Organization"],
     "http://xmlns.com/foaf/0.1/name": [{"@value": "An Organization"}]
   },
   {
-    "@id": "http://data.test.org/contacts/1",
+    "@id": "_:contact-1",
     "@type": ["http://www.w3.org/2006/vcard/ns#Organization"],
     "http://www.w3.org/2006/vcard/ns#fn": [{"@value": "Organization contact"}],
     "http://www.w3.org/2006/vcard/ns#hasEmail": [{"@value": "hello@its.me"}]
   },
   {
-    "@id": "http://data.test.org/datasets/1",
+    "@id": "_:dataset-1",
     "@type": ["http://www.w3.org/ns/dcat#Dataset"],
     "http://purl.org/dc/terms/description": [{"@value": "Dataset 1 description"}],
     "http://purl.org/dc/terms/identifier": [{"@value": "1"}],
@@ -46,13 +45,21 @@
         "@value": "2016-12-14T19:01:24.184120"
       }
     ],
+    "http://purl.org/dc/terms/spatial": [
+      {
+        "@id": "http://wuEurope.com"
+      }
+    ],
     "http://purl.org/dc/terms/temporal": [{"@id": "_:temporal-1"}],
-    "http://www.w3.org/ns/dcat#landingPage": [{"@value": "http://data.test.org/datasets/1"}],
-    "http://purl.org/dc/terms/publisher": [{"@id": "http://data.test.org/organizations/1"}],
+    "http://www.w3.org/ns/dcat#landingPage": [{"@value": "_:dataset-1"}],
+    "http://purl.org/dc/terms/publisher": [{"@id": "_:org-1"}],
     "http://purl.org/dc/terms/title": [{"@value": "Dataset 1"}],
     "http://www.w3.org/2002/07/owl#versionInfo": [{"@value": "1.0"}],
-    "http://www.w3.org/ns/dcat#contactPoint": [{"@id": "http://data.test.org/contacts/1"}],
-    "http://www.w3.org/ns/dcat#distribution": [{"@id": "http://data.test.org/datasets/1/resources/1"}],
+    "http://www.w3.org/ns/dcat#contactPoint": [{"@id": "_:contact-1"}],
+    "http://www.w3.org/ns/dcat#distribution": [
+      {"@id": "_:dataset-1-resource-1"},
+      {"@id": "_:dataset-1-resource-2"}
+    ],
     "http://www.w3.org/ns/dcat#keyword": [
       {"@value": "Tag 1"},
       {"@value": "Tag 2"},
@@ -65,7 +72,7 @@
     ]
   },
   {
-    "@id": "http://data.test.org/datasets/2",
+    "@id": "_:dataset-2",
     "@type": ["http://www.w3.org/ns/dcat#Dataset"],
     "http://purl.org/dc/terms/description": [{"@value": "Dataset 2 description"}],
     "http://purl.org/dc/terms/identifier": [{"@value": "2"}],
@@ -81,11 +88,21 @@
         "@value": "2016-12-14T19:01:24.184120"
       }
     ],
-    "http://purl.org/dc/terms/publisher": [{"@id": "http://data.test.org/organizations/1"}],
+    "http://purl.org/dc/terms/spatial": [
+      {
+        "@id": "http://wuEurope.com"
+      }
+    ],
+    "http://purl.org/dc/terms/temporal": [{"@id": "_:temporal-2"}],
+    "http://www.w3.org/ns/dcat#landingPage": [{"@value": "_:dataset-2"}],
+    "http://purl.org/dc/terms/publisher": [{"@id": "_:org-1"}],
     "http://purl.org/dc/terms/title": [{"@value": "Dataset 2"}],
     "http://www.w3.org/2002/07/owl#versionInfo": [{"@value": "1.0"}],
-    "http://www.w3.org/ns/dcat#contactPoint": [{"@id": "http://data.test.org/contacts/1"}],
-    "http://www.w3.org/ns/dcat#distribution": [{"@id": "http://data.test.org/datasets/2/resources/1"}],
+    "http://www.w3.org/ns/dcat#contactPoint": [{"@id": "_:contact-1"}],
+    "http://www.w3.org/ns/dcat#distribution": [
+      {"@id": "_:dataset-2-resource-1"},
+      {"@id": "_:dataset-2-resource-2"}
+    ],
     "http://www.w3.org/ns/dcat#keyword": [
       {"@value": "Tag 1"},
       {"@value": "Tag 2"},
@@ -93,17 +110,7 @@
     ]
   },
   {
-    "@id": "_:temporal-1",
-    "@type": ["http://purl.org/dc/terms/PeriodOfTime"],
-    "http://schema.org/startDate": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-        "@value": "2016-12-05T00:00:00"
-      }
-    ]
-  },
-  {
-    "@id": "http://data.test.org/datasets/3",
+    "@id": "_:dataset-3",
     "@type": ["http://www.w3.org/ns/dcat#Dataset"],
     "http://purl.org/dc/terms/description": [{"@value": "Dataset 3 description"}],
     "http://purl.org/dc/terms/identifier": [{"@value": "3"}],
@@ -119,11 +126,16 @@
         "@value": "2016-12-14T19:01:24.184120"
       }
     ],
-    "http://purl.org/dc/terms/publisher": [{"@id": "http://data.test.org/organizations/1"}],
+    "http://purl.org/dc/terms/spatial": [
+      {
+        "@id": "http://wuEurope.com"
+      }
+    ],
+    "http://purl.org/dc/terms/publisher": [{"@id": "_:org-1"}],
     "http://purl.org/dc/terms/title": [{"@value": "Dataset 3"}],
     "http://www.w3.org/2002/07/owl#versionInfo": [{"@value": "1.0"}],
     "http://www.w3.org/ns/dcat#distribution": [
-      {"@id": "http://data.test.org/datasets/3/resources/1"}
+      {"@id": "_:dataset-3-resource-1"}
     ],
     "http://www.w3.org/ns/dcat#keyword": [
       {"@value": "Tag 1"},
@@ -131,7 +143,7 @@
     ]
   },
   {
-    "@id": "http://data.test.org/datasets/1/resources/1",
+    "@id": "_:dataset-1-resource-1",
     "@type": ["http://www.w3.org/ns/dcat#Distribution"],
     "http://purl.org/dc/terms/title": [{"@value": "Resource 1-1"}],
     "http://purl.org/dc/terms/description": [{"@value": "A JSON resource"}],
@@ -141,7 +153,17 @@
     ]
   },
   {
-    "@id": "http://data.test.org/datasets/2/resources/1",
+    "@id": "_:dataset-1-resource-2",
+    "@type": ["http://www.w3.org/ns/dcat#Distribution"],
+    "http://purl.org/dc/terms/title": [{"@value": "Resource 1-2"}],
+    "http://purl.org/dc/terms/description": [{"@value": "A JSON resource"}],
+    "http://purl.org/dc/terms/format": [{"@value": "JSON"}],
+    "http://www.w3.org/ns/dcat#accessURL": [
+      {"@value": "http://data.test.org/datasets/1/resources/2/file.json"}
+    ]
+  },
+  {
+    "@id": "_:dataset-2-resource-1",
     "@type": ["http://www.w3.org/ns/dcat#Distribution"],
     "http://purl.org/dc/terms/title": [{"@value": "Resource 2-1"}],
     "http://purl.org/dc/terms/description": [{"@value": "A JSON resource"}],
@@ -151,7 +173,17 @@
     ]
   },
   {
-    "@id": "http://data.test.org/datasets/3/resources/1",
+    "@id": "_:dataset-2-resource-2",
+    "@type": ["http://www.w3.org/ns/dcat#Distribution"],
+    "http://purl.org/dc/terms/title": [{"@value": "Resource 2-2"}],
+    "http://purl.org/dc/terms/description": [{"@value": "A JSON resource"}],
+    "http://purl.org/dc/terms/format": [{"@value": "JSON"}],
+    "http://www.w3.org/ns/dcat#accessURL": [
+      {"@value": "http://data.test.org/datasets/2/resources/2/file.json"}
+    ]
+  },
+  {
+    "@id": "_:dataset-3-resource-1",
     "@type": ["http://www.w3.org/ns/dcat#Distribution"],
     "http://purl.org/dc/terms/title": [{"@value": "Resource 3-1"}],
     "http://purl.org/dc/terms/description": [{"@value": "A JSON resource"}],
@@ -161,12 +193,35 @@
     ]
   },
   {
-    "@id": "http://data.test.org/catalog.jsonld?page=1",
-    "@type": ["http://www.w3.org/ns/hydra/core#PagedCollection"],
-    "http://www.w3.org/ns/hydra/core#firstPage": [{"@value": "http://data.test.org/catalog.jsonld?page=1"}],
-    "http://www.w3.org/ns/hydra/core#itemsPerPage": [{"@value": 3}],
-    "http://www.w3.org/ns/hydra/core#lastPage": [{"@value": "http://data.test.org/catalog.jsonld?page=2"}],
-    "http://www.w3.org/ns/hydra/core#nextPage": [{"@value": "http://data.test.org/catalog.jsonld?page=2"}],
-    "http://www.w3.org/ns/hydra/core#totalItems": [{"@value": 4}]
+    "@id": "_:temporal-1",
+    "@type": ["http://purl.org/dc/terms/PeriodOfTime"],
+    "http://schema.org/startDate": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "@value": "2016-12-05T00:00:00"
+      }
+    ]
+  },
+  {
+    "@id": "_:temporal-2",
+    "@type": ["http://purl.org/dc/terms/PeriodOfTime"],
+    "http://schema.org/startDate": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "@value": "2016-01-01T00:00:00"
+      }
+    ],
+    "http://schema.org/endDate": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "@value": "2016-12-05T00:00:00"
+      }
+    ]
+  },
+  {
+    "@id": "http://wuEurope.com",
+    "@type": [
+      "http://purl.org/dc/terms/Location"
+    ]
   }
 ]

--- a/udata/harvest/tests/dcat/flat.jsonld
+++ b/udata/harvest/tests/dcat/flat.jsonld
@@ -50,7 +50,7 @@
         "@id": "http://wuEurope.com"
       }
     ],
-    "http://purl.org/dc/terms/temporal": [{"@id": "temporal-1"}],
+    "http://purl.org/dc/terms/temporal": [{"@id": "_:temporal-1"}],
     "http://www.w3.org/ns/dcat#landingPage": [{"@value": "http://data.test.org/datasets/1"}],
     "http://purl.org/dc/terms/publisher": [{"@id": "http://data.test.org/organizations/1"}],
     "http://purl.org/dc/terms/title": [{"@value": "Dataset 1"}],
@@ -93,7 +93,7 @@
         "@id": "http://wuEurope.com"
       }
     ],
-    "http://purl.org/dc/terms/temporal": [{"@id": "temporal-2"}],
+    "http://purl.org/dc/terms/temporal": [{"@id": "_:temporal-2"}],
     "http://www.w3.org/ns/dcat#landingPage": [{"@value": "http://data.test.org/datasets/2"}],
     "http://purl.org/dc/terms/publisher": [{"@id": "http://data.test.org/organizations/1"}],
     "http://purl.org/dc/terms/title": [{"@value": "Dataset 2"}],
@@ -193,7 +193,7 @@
     ]
   },
   {
-    "@id": "temporal-1",
+    "@id": "_:temporal-1",
     "@type": ["http://purl.org/dc/terms/PeriodOfTime"],
     "http://schema.org/startDate": [
       {
@@ -203,7 +203,7 @@
     ]
   },
   {
-    "@id": "temporal-2",
+    "@id": "_:temporal-2",
     "@type": ["http://purl.org/dc/terms/PeriodOfTime"],
     "http://schema.org/startDate": [
       {

--- a/udata/harvest/tests/dcat/partial-collection-1.jsonld
+++ b/udata/harvest/tests/dcat/partial-collection-1.jsonld
@@ -55,7 +55,7 @@
         "@value": "2016-12-14T19:01:24.184120"
       }
     ],
-    "http://purl.org/dc/terms/temporal": [{"@id": "temporal-1"}],
+    "http://purl.org/dc/terms/temporal": [{"@id": "_:temporal-1"}],
     "http://www.w3.org/ns/dcat#landingPage": [{"@value": "http://data.test.org/datasets/1"}],
     "http://purl.org/dc/terms/publisher": [{"@id": "http://data.test.org/organizations/1"}],
     "http://purl.org/dc/terms/title": [{"@value": "Dataset 1"}],

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -94,6 +94,23 @@ class DcatBackendTest:
         assert dataset.tags == ['tag-1', 'tag-2']
         assert len(dataset.resources) == 1
 
+    def test_flat_with_blank_nodes(self, rmock):
+        filename = 'bnodes.jsonld'
+        url = mock_dcat(rmock, filename)
+        org = OrganizationFactory()
+        source = HarvestSourceFactory(backend='dcat',
+                                      url=url,
+                                      organization=org)
+
+        actions.run(source.slug)
+
+        datasets = {d.extras['dct:identifier']: d for d in Dataset.objects}
+
+        assert len(datasets) == 3
+        assert len(datasets['1'].resources) == 2
+        assert len(datasets['2'].resources) == 2
+        assert len(datasets['3'].resources) == 1
+
     def test_simple_nested_attributes(self, rmock):
         filename = 'nested.jsonld'
         url = mock_dcat(rmock, filename)

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -244,6 +244,47 @@ class RdfToDatasetTest:
         assert dataset.id == original.id
         assert dataset.title == new_title
 
+    def test_minimal_from_multiple(self):
+        node = BNode()
+        g = Graph()
+
+        title = faker.sentence()
+        g.add((node, RDF.type, DCAT.Dataset))
+        g.add((node, DCT.title, Literal(title)))
+
+        for i in range(3):
+            other = BNode()
+            g.add((other, RDF.type, DCAT.Dataset))
+            g.add((other, DCT.title, Literal(faker.sentence())))
+
+        dataset = dataset_from_rdf(g, node=node)
+        dataset.validate()
+
+        assert isinstance(dataset, Dataset)
+        assert dataset.title == title
+
+    def test_update_from_multiple(self):
+        original = DatasetFactory()
+
+        node = URIRef('https://test.org/dataset')
+        g = Graph()
+
+        new_title = faker.sentence()
+        g.add((node, RDF.type, DCAT.Dataset))
+        g.add((node, DCT.title, Literal(new_title)))
+
+        for i in range(3):
+            other = BNode()
+            g.add((other, RDF.type, DCAT.Dataset))
+            g.add((other, DCT.title, Literal(faker.sentence())))
+
+        dataset = dataset_from_rdf(g, dataset=original, node=node)
+        dataset.validate()
+
+        assert isinstance(dataset, Dataset)
+        assert dataset.id == original.id
+        assert dataset.title == new_title
+
     def test_all_fields(self):
         uri = 'https://test.org/dataset'
         node = URIRef(uri)


### PR DESCRIPTION
This PR refactor the DCAT harvesting to store only one graph for all datasets in a DCAT catalog.
The graph is stored in factorized way (ie. in JSON-LD with a `@context` to massively reduce the size.

These changes allows to process way more datasets in a single Job. As each harvesting job store all its items into a single MongoDB document, each job can store at most `16Mb` (See [MongoDB Limits](https://docs.mongodb.com/manual/reference/limits/))

This also prevent some data loss because properly slicing a graph is difficult in RDF when you don't known by advance all node properties. This will allow to parse more triplets for each dataset and resource.

These changes also allow processing of DCAT Dataset as Blank nodes instead of URIRef.