### PR TITLE
Bubble up uploader errors - fix #2101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Refactor DCAT harvesting to store only one graph (and prevent MongoDB document size overflow) [#2096](https://github.com/opendatateam/udata/pull/2096)
 - Expose sane defaults for `TRACKING_BLACKLIST` [#2098](https://github.com/opendatateam/udata/pull/2098)
+- Bubble up uploader errors [#2102](https://github.com/opendatateam/udata/pull/2102)
 
 ## 1.6.6 (2019-03-27)
 

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -138,7 +138,7 @@ export default {
             edit: false,
             confirm: false,
             dataset: this.$parent.$parent.dataset,  // Because this is a nested view
-            resource: undefined,
+            resource: {},
             next_route: null,
             isUpload: false,
             hasUploadedFile: false,

--- a/js/mixins/uploader.js
+++ b/js/mixins/uploader.js
@@ -152,7 +152,7 @@ export default {
                     onSubmitted: this.on_submit,
                     onProgress: this.on_progress,
                     onComplete: this.on_complete,
-                    onError: this.on_error,
+                    onError: this.on_upload_error,
                 },
                 validation: {allowedExtensions: this.$options.allowedExtensions || allowedExtensions.items},
                 messages,
@@ -232,7 +232,7 @@ export default {
          *
          * See: http://docs.fineuploader.com/branch/master/api/events.html#error
          */
-        on_error(id, name, reason, xhr) {
+        on_upload_error(id, name, reason, xhr) {
             if (this.errors.has(id)) return;  // Already notified on first chunk error
             // If there is a JSON message display it instead of the non-explicit default one
             if (xhr) {


### PR DESCRIPTION
Renaming `on_error` in the uploader prevents the parent form from redefining the callback and wrongly handling the errors.

Setting the `resource` to `{}` by default prevents some warning on first resource modal load.

There's still a problem where the error message does not display the valid extensions. But if I fix that some other error arise (the request is actually sent, another message displayed... 😑), so I'll leave that for later.

<img width="349" alt="Capture d'écran 2019-04-10 15 52 50" src="https://user-images.githubusercontent.com/119625/55887173-58469000-5bad-11e9-8fe7-efc2cc0a141a.png">