### PR TITLE
Fix munin zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactor DCAT harvesting to store only one graph (and prevent MongoDB document size overflow) [#2096](https://github.com/opendatateam/udata/pull/2096)
 - Expose sane defaults for `TRACKING_BLACKLIST` [#2098](https://github.com/opendatateam/udata/pull/2098)
 - Bubble up uploader errors [#2102](https://github.com/opendatateam/udata/pull/2102)
+- Ensure `udata worker status --munin` always outputs zero values so munin won't see it has a "no data" response [#2103](https://github.com/opendatateam/udata/pull/2103)
 
 ## 1.6.6 (2019-03-27)
 

--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -204,7 +204,7 @@ $ udata worker status --munin -q default
 $ udata worker status --munin-config -q default
 ```
 
-[munin-plugin]: https://github.com/etalab/munin-plugins/tree/master/udata-worker-status
+[munin-plugin]: https://github.com/etalab/munin-plugins/tree/master/udata
 
 
 ## Cache

--- a/udata/commands/worker.py
+++ b/udata/commands/worker.py
@@ -32,10 +32,12 @@ def start():
 
 
 def status_print_task(count, biggest_task_name, munin=False):
-    if not munin:
-        print('* %s : %s' % (count[0].ljust(biggest_task_name), count[1]))
-    else:
+    if munin:
+        # Munin expect all values, including zeros
         print('%s.value %s' % (format_field_for_munin(count[0]), count[1]))
+    elif count[1] > 0:
+        # We only display tasks with items in queue for readability
+        print('* %s : %s' % (count[0].ljust(biggest_task_name), count[1]))
 
 
 def status_print_config(queue):
@@ -56,7 +58,7 @@ def status_print_queue(queue, munin=False):
     queue_length = r.llen(queue)
     if not munin:
         print('Queue "%s": %s task(s)' % (queue, queue_length))
-    counter = Counter()
+    counter = Counter({n: 0 for n, q in get_tasks().items() if q == queue})
     biggest_task_name = 0
     for task in r.lrange(queue, 0, -1):
         task = json.loads(task)

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -100,7 +100,7 @@ def connect(signal, *args, **kwargs):
     return wrapper
 
 
-@job('log-test')
+@job('test-log')
 def log_test(self):
     self.log.debug('This is a DEBUG message')
     self.log.info('This is an INFO message')
@@ -121,7 +121,7 @@ def queue_test(self, raises=False):
         raise Exception('Test task processing')
 
 
-@job('error-test')
+@job('test-error')
 def error_test(self):
     self.log.info('There should be an error soon')
     raise Exception('There is an error')


### PR DESCRIPTION
This PR ensures that the `udata worker status --munin` always output tasks count even if count is zero.
Otherwise Munin sees it as "no data" (ie. vertical splitter in graph) and display count as `-nan` instead of `0`. It was also making Munin diagnosis difficult when a queue is empty.

This also ensure only tasks for monitored queue are listed in `udata worker status --munin-config` reducing the number of tasks by graph (extras tasks were always displayed as `-nan`. As a side-effect, caching tasks is not required anymore as it does not hit all the Celery workers anymore to list them.

A `udata worker tasks` command has been added to display all tasks and their queue/priority.

Some test jobs have been renamed to ensure they all have the same `test-` prefix and they are filtered out of munin commands.

The documentation link to the munin plugin has been updated.