### PR TITLE
Export multiple models objects to CSV (dataset of datasets)

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -153,6 +153,28 @@ from udata.settings import Defaults
 URLS_ALLOWED_TLDS = Defaults.URLS_ALLOWED_TLDS + set(['custom', 'company'])
 ```
 
+### EXPORT_CSV_MODELS
+
+**default**: `('dataset', 'resource', 'discussion', 'organization', 'reuse', 'tag')`
+
+List models that will be exported to CSV by the job `export-csv`.
+You can disable the feature by setting this to an empty list.
+
+### EXPORT_CSV_DATASET_INFO
+
+**default**:
+```
+{
+    'slug': 'export-csv',
+    'title': 'Export of portal data',
+    'description': 'This dataset holds the CSV exports of this portal\'s data.',
+    # this should point to an existing organization id
+    'organization': None,
+}
+```
+
+Values that will be used to find (`slug`) or create the dataset that holds the CSV exports created by `export-csv`.
+
 ## Map widget configuration
 
 ### MAP_TILES_URL

--- a/udata/core/dataset/csv.py
+++ b/udata/core/dataset/csv.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from udata.core.discussions.models import Discussion
 from udata.frontend import csv
 
-from .models import Dataset
+from .models import Dataset, Resource
 
 
 def serialize_spatial_zones(dataset):
@@ -42,6 +43,7 @@ def dataset_field(name, getter=None):
     return ('dataset.{0}'.format(name), getter or name)
 
 
+@csv.adapter(Resource)
 class ResourcesCsvAdapter(csv.NestedAdapter):
     fields = (
         dataset_field('id'),
@@ -75,6 +77,7 @@ class ResourcesCsvAdapter(csv.NestedAdapter):
     attribute = 'resources'
 
 
+@csv.adapter(Discussion)
 class IssuesOrDiscussionCsvAdapter(csv.Adapter):
     fields = (
         'id',

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -3,18 +3,21 @@ from __future__ import unicode_literals
 from compiler.ast import flatten
 from datetime import datetime, timedelta
 from sets import Set
+from tempfile import NamedTemporaryFile
 
 from celery.utils.log import get_task_logger
 from flask import current_app
 
 from udata import mail
+from udata import models as udata_models
+from udata.core import storages
+from udata.frontend import csv
 from udata.i18n import lazy_gettext as _
-from udata.models import (
-    Organization, Activity, Metrics, Topic, Issue, Discussion, Follow
-)
+from udata.models import (Follow, Issue, Discussion, Activity, Metrics, Topic,
+                          Organization)
 from udata.tasks import job
 
-from .models import Dataset, UPDATE_FREQUENCIES
+from .models import Dataset, Resource, UPDATE_FREQUENCIES, Checksum
 
 log = get_task_logger(__name__)
 
@@ -76,3 +79,107 @@ def send_frequency_reminder(self):
         nb_emails=len(reminded_people),
         nb_emails_twice=len(reminded_people) - len(Set(reminded_people))))
     print('Done')
+
+
+def get_queryset(model_cls):
+    # special case for resources
+    if model_cls.__name__ == 'Resource':
+        model_cls = getattr(udata_models, 'Dataset')
+    params = {}
+    attrs = ('private', 'deleted')
+    for attr in attrs:
+        if getattr(model_cls, attr, None):
+            params[attr] = False
+    return model_cls.objects.filter(**params)
+
+
+def get_or_create_resource(r_info, model, dataset):
+    resource = None
+    for r in dataset.resources:
+        if r.extras.get('csv-export:model', '') == model:
+            resource = r
+            break
+    if resource:
+        for k, v in r_info.items():
+            setattr(resource, k, v)
+        resource.save()
+        return False, resource
+    else:
+        r_info['extras'] = {'csv-export:model': model}
+        return True, Resource(**r_info)
+
+
+def store_resource(csvfile, model, dataset):
+    timestr = datetime.now().strftime('%Y%m%d-%H%M%S')
+    filename = 'export-%s-%s.csv' % (model, timestr)
+    prefix = '/'.join((dataset.slug, timestr))
+    storage = storages.resources
+    stored_filename = storage.save(csvfile, prefix=prefix, filename=filename)
+    r_info = storage.metadata(stored_filename)
+    checksum = r_info.pop('checksum')
+    algo, checksum = checksum.split(':', 1)
+    r_info[algo] = checksum
+    r_info['format'] = storages.utils.extension(stored_filename)
+    r_info['checksum'] = Checksum(type='sha1', value=r_info.pop('sha1'))
+    r_info['filesize'] = r_info.pop('size')
+    del r_info['filename']
+    r_info['title'] = filename
+    return get_or_create_resource(r_info, model, dataset)
+
+
+def export_csv_for_model(model, dataset):
+    model_cls = getattr(udata_models, model.capitalize(), None)
+    if not model_cls:
+        log.error('Unknow model %s' % model)
+        return
+    queryset = get_queryset(model_cls)
+    adapter = csv.get_adapter(model_cls)
+    if not adapter:
+        log.error('No adapter found for %s' % model)
+        return
+    adapter = adapter(queryset)
+
+    log.info('Exporting CSV for %s...' % model)
+
+    csvfile = NamedTemporaryFile(delete=False)
+    try:
+        # write adapter results into a tmp file
+        writer = csv.get_writer(csvfile)
+        writer.writerow(adapter.header())
+        for row in adapter.rows():
+            writer.writerow(row)
+        csvfile.seek(0)
+        # make a resource from this tmp file
+        created, resource = store_resource(csvfile, model, dataset)
+        # add it to the dataset
+        if created:
+            dataset.add_resource(resource)
+        dataset.last_modified = datetime.now()
+        dataset.save()
+    finally:
+        os.unlink(csvfile.name)
+
+
+@job('export-csv')
+def export_csv(self):
+    '''
+    Generates a CSV export of all model objects as a resource of a dataset
+    '''
+    ALLOWED_MODELS = current_app.config.get('EXPORT_CSV_MODELS', [])
+    DATASET_DEFAULTS = current_app.config.get('EXPORT_CSV_DATASET_INFO')
+
+    if ALLOWED_MODELS:
+        slug = DATASET_DEFAULTS.pop('slug')
+        organization = DATASET_DEFAULTS.get('organization')
+        if organization:
+            try:
+                DATASET_DEFAULTS['organization'] = Organization.objects.get(id=organization)
+            except Organization.DoesNotExist:
+                log.error('Organization with id %s not found.' % organization)
+        dataset, _ = Dataset.objects.get_or_create(
+            slug=slug,
+            defaults=DATASET_DEFAULTS,
+        )
+
+    for model in ALLOWED_MODELS:
+        export_csv_for_model(model, dataset)

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+import os
+
 from compiler.ast import flatten
 from datetime import datetime, timedelta
 from sets import Set

--- a/udata/core/tags/__init__.py
+++ b/udata/core/tags/__init__.py
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
-
-
-def init_app(app):
-    from .views import bp
-    app.register_blueprint(bp)

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -99,6 +99,7 @@ from udata.core.activity.models import *  # noqa
 from udata.core.topic.models import *  # noqa
 from udata.core.post.models import *  # noqa
 from udata.core.jobs.models import *  # noqa
+from udata.core.tags.models import *  # noqa
 
 from udata.features.transfer.models import *  # noqa
 from udata.features.territories.models import *  # noqa

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -315,6 +315,19 @@ class Defaults(object):
     # Don't check timestamp on assets (and avoid error on missing assets)
     CDN_TIMESTAMP = False
 
+    # Export CSVs of model objects as resources of a dataset
+    ########################################################
+    # which models should be exported
+    EXPORT_CSV_MODELS = ('dataset', 'resource', 'discussion', 'organization',
+                         'reuse', 'tag')
+    EXPORT_CSV_DATASET_INFO = {
+        'slug': 'export-csv',
+        'title': 'Export of portal data',
+        'description': 'This dataset holds the CSV exports of this portal\'s data.',
+        # this should point to an existing organization id
+        'organization': None,
+    }
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/tests/dataset/test_dataset_tasks.py
+++ b/udata/tests/dataset/test_dataset_tasks.py
@@ -1,20 +1,42 @@
 # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
-from .. import TestCase, DBTestMixin
+import pytest
 
 from udata.models import Dataset, Topic
 from udata.core.dataset import tasks
+from udata.core.organization.factories import OrganizationFactory
+# csv.adapter for Tag won't be registered if this is not imported :thinking:
+from udata.core.tags import csv as _  # noqa
 
 
-class DatasetTasksTest(TestCase, DBTestMixin):
-    def test_purge_datasets(self):
-        datasets = [
-            Dataset.objects.create(title='delete me', deleted='2016-01-01'),
-            Dataset.objects.create(title='keep me'),
-        ]
+pytestmark = pytest.mark.usefixtures('clean_db')
 
-        topic = Topic.objects.create(name='test topic', datasets=datasets)
-        tasks.purge_datasets()
 
-        topic = Topic.objects(name='test topic').first()
-        self.assertListEqual(topic.datasets, [datasets[1]])
+def test_purge_datasets():
+    datasets = [
+        Dataset.objects.create(title='delete me', deleted='2016-01-01'),
+        Dataset.objects.create(title='keep me'),
+    ]
+
+    topic = Topic.objects.create(name='test topic', datasets=datasets)
+    tasks.purge_datasets()
+
+    topic = Topic.objects(name='test topic').first()
+    assert topic.datasets[0] == datasets[1]
+
+
+@pytest.mark.usefixtures('instance_path')
+def test_export_csv(app):
+    organization = OrganizationFactory()
+    app.config['EXPORT_CSV_DATASET_INFO']['organization'] = organization.id
+    slug = app.config['EXPORT_CSV_DATASET_INFO']['slug']
+    models = app.config['EXPORT_CSV_MODELS']
+    tasks.export_csv()
+    dataset = Dataset.objects.get(slug=slug)
+    assert dataset is not None
+    assert dataset.organization == organization
+    assert len(dataset.resources) == len(models)
+    extras = [r.extras.get('csv-export:model') for r in dataset.resources]
+    for model in models:
+        assert model in extras

--- a/udata/tests/dataset/test_dataset_tasks.py
+++ b/udata/tests/dataset/test_dataset_tasks.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
 
 import pytest
 


### PR DESCRIPTION
Superseeds #1979
Fix #1977 

This introduces a job ~~with a `model` argument~~ that generates a CSV export of the model's objects from the DB. The file is then stored as a resource of a single dataset (created if not there). We could run jobs for each model we want to export every night. This reuses the `CSVAdapter` logic already available.

Things to be considered/discussed:
- ~~Should we keep the history of exports in the dataset? ATM this is what is done and it's probably valuable to have some history. But it can cause issues: a lot of resources on the page, privacy problems (especially for discussions)...~~ no history kept (on the frontend), resources are overridden
- ~~Should we have a single job that exports every (configurable) model or keep a job per model?~~ single job
- Should we optimize this a bit? ATM a temp CSV file is written in one chunk, maybe it would be more (memory) efficient to write it in chunks. I can export 100Mo in 4 minutes on my machine (resources) so it's not that slow for a job.

Things to be done:
- [x] ~~Probably move the code in another file, this is not strictly a `datasets` matter~~ did not find a better place
- [x] Move some stuff into settings in order to be configurable (dataset slug, dataset defaults, allowed models)
- [x] Introduce a setting to choose which organization publishes the dataset
- [x] Tests
