### PR TITLE
[admin] delete a single comment in a discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ensure `udata worker status --munin` always outputs zero values so munin won't see it has a "no data" response [#2103](https://github.com/opendatateam/udata/pull/2103)
 - Metrics tuning: breaks circular dependencies, drop exec_js/eval usage, proper logging... [#2113](https://github.com/opendatateam/udata/pull/2113)
 - Change reuse icon from "retweet" to "recycle" [#2122](https://github.com/opendatateam/udata/pull/2122)
+- Admins can delete a single comment in a discussion thread [#2087](https://github.com/opendatateam/udata/pull/2087)
 
 ## 1.6.6 (2019-03-27)
 

--- a/js/components/discussions/modal.vue
+++ b/js/components/discussions/modal.vue
@@ -51,7 +51,7 @@
                 v-for="(idx, message) in discussion.discussion">
                 <div class="direct-chat-info clearfix">
                     <span class="direct-chat-name pull-left">{{message.posted_by | display}}</span>
-                    <a v-if="$root.me.is_admin && canDeleteComment"  @click.prevent="confirm_delete_comment(idx)" href="" class="direct-chat-name direct-chat-delete">{{ _('Delete comment') }}</a>
+                    <a v-if="$root.me.is_admin && idx !== 0"  @click.prevent="confirm_delete_comment(idx)" href class="direct-chat-name direct-chat-delete">{{ _('Delete comment') }}</a>
                     <span class="direct-chat-timestamp pull-right">{{message.posted_on | dt}}</span>
                 </div>
                 <img class="direct-chat-img"  :alt="_('User Image')"
@@ -125,9 +125,6 @@ export default {
         },
         formValid() {
             return this.comment && this.comment.length > 0;
-        },
-        canDeleteComment() {
-            return !!this.discussion.discussion && this.discussion.discussion.length > 1;
         }
     },
     data() {

--- a/js/components/discussions/modal.vue
+++ b/js/components/discussions/modal.vue
@@ -8,6 +8,12 @@
         height: auto;
     }
 
+    .direct-chat-delete {
+        padding-left: 10px;
+        text-decoration: underline;
+        color: white;
+    }
+
     .direct-chat-timestamp {
         color: #eee;
     }
@@ -42,9 +48,10 @@
         <h3>{{ discussion.title }}</h3>
         <div class="direct-chat-messages">
             <div class="direct-chat-msg"
-                v-for="message in discussion.discussion">
+                v-for="(idx, message) in discussion.discussion">
                 <div class="direct-chat-info clearfix">
                     <span class="direct-chat-name pull-left">{{message.posted_by | display}}</span>
+                    <a v-if="$root.me.is_admin && canDeleteComment"  @click.prevent="confirm_delete_comment(idx)" href="" class="direct-chat-name direct-chat-delete">{{ _('Delete comment') }}</a>
                     <span class="direct-chat-timestamp pull-right">{{message.posted_on | dt}}</span>
                 </div>
                 <img class="direct-chat-img"  :alt="_('User Image')"
@@ -118,6 +125,9 @@ export default {
         },
         formValid() {
             return this.comment && this.comment.length > 0;
+        },
+        canDeleteComment() {
+            return !!this.discussion.discussion && this.discussion.discussion.length > 1;
         }
     },
     data() {
@@ -156,6 +166,16 @@ export default {
         },
         cancel_delete() {
             this.deleting = false;
+        },
+        confirm_delete_comment(cidx) {
+            if(confirm(this._('Are you sure you want to delete this comment?'))) {
+                API.discussions.delete_discussion_comment({id: this.discussion.id, cidx: cidx},
+                    (response) => {
+                        this.discussion.discussion.splice(cidx, 1);
+                    },
+                    this.$root.handleApiError
+                );
+            }
         },
         delete() {
             API.discussions.delete_discussion({id: this.discussion.id},

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -133,6 +133,26 @@ class DiscussionAPI(API):
         return '', 204
 
 
+@ns.route('/<id>/comments/<int:cidx>', endpoint='discussion_comment')
+class DiscussionCommentAPI(API):
+    '''
+    Base class for a comment in a discussion thread.
+    '''
+    @api.secure(admin_permission)
+    @api.doc('delete_discussion_comment')
+    @api.response(403, 'Not allowed to delete this comment')
+    def delete(self, id, cidx):
+        '''Delete a comment given its index'''
+        discussion = Discussion.objects.get_or_404(id=id)
+        if len(discussion.discussion) <= cidx:
+            api.abort(404, 'Comment does not exist')
+        elif len(discussion.discussion) == 1:
+            api.abort(400, 'You cannot delete the last comment of a discussion')
+        discussion.discussion.pop(cidx)
+        discussion.save()
+        return '', 204
+
+
 @ns.route('/', endpoint='discussions')
 class DiscussionsAPI(API):
     '''

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -146,8 +146,8 @@ class DiscussionCommentAPI(API):
         discussion = Discussion.objects.get_or_404(id=id)
         if len(discussion.discussion) <= cidx:
             api.abort(404, 'Comment does not exist')
-        elif len(discussion.discussion) == 1:
-            api.abort(400, 'You cannot delete the last comment of a discussion')
+        elif cidx == 0:
+            api.abort(400, 'You cannot delete the first comment of a discussion')
         discussion.discussion.pop(cidx)
         discussion.save()
         return '', 204

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -378,6 +378,36 @@ class DiscussionsTest(APITestCase):
         self.assertEqual(dataset.metrics['discussions'], 0)
         self.assertEqual(Discussion.objects(subject=dataset).count(), 0)
 
+    def test_delete_discussion_comment(self):
+        owner = self.login(AdminFactory())
+        user = UserFactory()
+        dataset = Dataset.objects.create(title='Test dataset', owner=owner)
+        message = Message(content='bla bla', posted_by=user)
+        message2 = Message(content='bla bla bla', posted_by=user)
+        discussion = Discussion.objects.create(
+            subject=dataset,
+            user=user,
+            title='test discussion',
+            discussion=[message, message2]
+        )
+        self.assertEqual(len(discussion.discussion), 2)
+        response = self.delete(url_for('api.discussion_comment',
+                               id=discussion.id, cidx=1))
+        self.assertStatus(response, 204)
+        discussion.reload()
+        self.assertEqual(len(discussion.discussion), 1)
+        self.assertEqual(discussion.discussion[0].content, 'bla bla')
+
+        # delete again to test list overflow
+        response = self.delete(url_for('api.discussion_comment',
+                               id=discussion.id, cidx=3))
+        self.assertStatus(response, 404)
+
+        # delete again to test last comment deletion
+        response = self.delete(url_for('api.discussion_comment',
+                               id=discussion.id, cidx=0))
+        self.assertStatus(response, 400)
+
     def test_delete_discussion_permissions(self):
         self.app.config['USE_METRICS'] = True
         dataset = Dataset.objects.create(title='Test dataset')
@@ -398,6 +428,21 @@ class DiscussionsTest(APITestCase):
         dataset.reload()
         # Metrics unchanged after attempt to delete the discussion.
         self.assertEqual(dataset.metrics['discussions'], 1)
+
+    def test_delete_discussion_comment_permissions(self):
+        dataset = Dataset.objects.create(title='Test dataset')
+        user = UserFactory()
+        message = Message(content='bla bla', posted_by=user)
+        discussion = Discussion.objects.create(
+            subject=dataset,
+            user=user,
+            title='test discussion',
+            discussion=[message]
+        )
+        self.login()
+        response = self.delete(url_for('api.discussion_comment',
+                               id=discussion.id, cidx=0))
+        self.assert403(response)
 
 
 class DiscussionCsvTest(FrontTestCase):

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -391,6 +391,13 @@ class DiscussionsTest(APITestCase):
             discussion=[message, message2]
         )
         self.assertEqual(len(discussion.discussion), 2)
+
+        # test first comment deletion
+        response = self.delete(url_for('api.discussion_comment',
+                               id=discussion.id, cidx=0))
+        self.assertStatus(response, 400)
+
+        # test effective deletion
         response = self.delete(url_for('api.discussion_comment',
                                id=discussion.id, cidx=1))
         self.assertStatus(response, 204)


### PR DESCRIPTION
Superseed #2087 

Not pretty (there's a `confirm` in there 🙈), but hey it's an admin-only feature and it works.

~~TODO: see what happens when the last comment in the discussion is removed, we should probably disable the feature.~~ The first comment on a thread cannot be deleted: API will raise `400` and feature is disabled in UI.

Fix #1965.

<img width="900" alt="Capture d'écran 2019-03-26 18 56 20" src="https://user-images.githubusercontent.com/119625/55021510-2522cf00-4ff9-11e9-857b-43bbf85f39c8.png">
<img width="475" alt="Capture d'écran 2019-03-26 18 56 27" src="https://user-images.githubusercontent.com/119625/55021514-281dbf80-4ff9-11e9-94ae-4beebd001593.png">
