### PR TITLE
Harvest sources list API fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 - Change reuse icon from "retweet" to "recycle" [#2122](https://github.com/opendatateam/udata/pull/2122)
 - Admins can delete a single comment in a discussion thread [#2087](https://github.com/opendatateam/udata/pull/2087)
 - Add cache directives to dataset display blocks [#2129](https://github.com/opendatateam/udata/pull/2129)
-- Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload)
-- Ensure HarvestItems are cleaned up on dataset deletion
+- Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload) [#2131](https://github.com/opendatateam/udata/pull/2131)
+- Ensure HarvestItems are cleaned up on dataset deletion [#2131](https://github.com/opendatateam/udata/pull/2131)
 
 ## 1.6.6 (2019-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Admins can delete a single comment in a discussion thread [#2087](https://github.com/opendatateam/udata/pull/2087)
 - Add cache directives to dataset display blocks [#2129](https://github.com/opendatateam/udata/pull/2129)
 - Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload)
+- Ensure HarvestItems are cleaned up on dataset deletion
 
 ## 1.6.6 (2019-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Change reuse icon from "retweet" to "recycle" [#2122](https://github.com/opendatateam/udata/pull/2122)
 - Admins can delete a single comment in a discussion thread [#2087](https://github.com/opendatateam/udata/pull/2087)
 - Add cache directives to dataset display blocks [#2129](https://github.com/opendatateam/udata/pull/2129)
+- Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload)
 
 ## 1.6.6 (2019-03-27)
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -15,6 +15,7 @@ from udata import mail
 from udata import models as udata_models
 from udata.core import storages
 from udata.frontend import csv
+from udata.harvest.models import HarvestJob
 from udata.i18n import lazy_gettext as _
 from udata.models import (Follow, Issue, Discussion, Activity, Metrics, Topic,
                           Organization)
@@ -44,6 +45,8 @@ def purge_datasets(self):
             datasets = topic.datasets
             datasets.remove(dataset)
             topic.update(datasets=datasets)
+        # Remove HarvestItem references
+        HarvestJob.objects(items__dataset=dataset).update(set__items__S__dataset=None)
         # Remove
         dataset.delete()
 

--- a/udata/core/metrics/tasks.py
+++ b/udata/core/metrics/tasks.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 
 @metric_need_update.connect
 def update_on_demand(metric):
-    print('update on demand', metric, metric.target)
     update_metric.delay(metric)
 
 

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -124,7 +124,9 @@ class HarvestSource(db.Owned, db.Document):
         return cls.objects(slug=ident).first() or cls.objects.get(pk=ident)
 
     def get_last_job(self):
-        return HarvestJob.objects(source=self).order_by('-created').first()
+        qs = HarvestJob.objects(source=self)
+        qs = qs.exclude('source', 'items', 'errors', 'data')
+        return qs.no_dereference().order_by('-created').first()
 
     @cached_property
     def last_job(self):

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -123,14 +123,16 @@ class HarvestSource(db.Owned, db.Document):
     def get(cls, ident):
         return cls.objects(slug=ident).first() or cls.objects.get(pk=ident)
 
-    def get_last_job(self):
+    def get_last_job(self, reduced=False):
         qs = HarvestJob.objects(source=self)
-        qs = qs.exclude('source', 'items', 'errors', 'data')
-        return qs.no_dereference().order_by('-created').first()
+        if reduced:
+            qs = qs.exclude('source', 'items', 'errors', 'data')
+            qs = qs.no_dereference()
+        return qs.order_by('-created').first()
 
     @cached_property
     def last_job(self):
-        return self.get_last_job()
+        return self.get_last_job(reduced=True)
 
     @property
     def schedule(self):

--- a/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
+++ b/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
@@ -11,7 +11,7 @@ const pipeline = [
     {$unwind: '$datasetId'}, // One row by ID
     {$lookup: {from: 'dataset', localField: 'datasetId', foreignField: '_id', as: 'dataset'}}, // Join
     {$match: {'dataset': [] }} // Only keep IDs without match
-]
+];
 
 const index = {'items.dataset': 1};
 

--- a/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
+++ b/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
@@ -1,0 +1,29 @@
+/**
+ * Delete references to deleted datasets
+ */
+
+var updated = 0;
+
+// Match all HarvestJob.items.dataset not found in dataset collection
+const pipeline = [
+    {$unwind: '$items'},  // One row by item
+    {$group: {_id: null, datasetId: {$addToSet: '$items.dataset'}}}, // Distinct Dataset IDs
+    {$unwind: '$datasetId'}, // One row by ID
+    {$lookup: {from: 'dataset', localField: 'datasetId', foreignField: '_id', as: 'dataset'}}, // Join
+    {$match: {'dataset': [] }} // Only keep IDs without match
+]
+
+const index = {'items.dataset': 1};
+
+db.harvest_job.createIndex(index);
+db.harvest_job.aggregate(pipeline).forEach(row => {
+    const result = db.harvest_job.update(
+        {'items.dataset': row.datasetId},
+        {'$set': {'items.$.dataset': null}},
+        {multi: true}
+    );
+    updated += result.nModified;
+});
+db.harvest_job.dropIndex(index);
+
+print(`Updated ${updated} HarvestJob.items.dataset broken references.`);


### PR DESCRIPTION
This PR fixes the HarvestSources list API in case of a deleted harvested dataset.
It includes:
- reduced DB/API payload on listing (limit the data pulled by `last_job` attribute) and faster response
- `HarvestJob.items.dataset` cleanup on dataset purge
- a cleanup migration for existing HarvestJobs

The migration duration depends on the `harvest_jobs` collection size and can take some time on big instances.