### PR TITLE
Extend debounce delay on autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Extend debounce delay on autocomplete [#2137](https://github.com/opendatateam/udata/pull/2137)
 
 ## 1.6.7 (2019-05-10)
 

--- a/js/components/site-search.vue
+++ b/js/components/site-search.vue
@@ -18,7 +18,7 @@
         <input name="q" type="search" class="form-control"
             autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
             :placeholder="placeholder || _('Search')"
-            v-model="query" debounce="200"
+            v-model="query" debounce="600"
             @keydown="show = true"
             @keydown.up.prevent="up"
             @keydown.down.prevent="down"


### PR DESCRIPTION
We see a lot of `suggest` API calls failing on the uWSGI side when we're under heavy load. This may help by sending less requests.