### PR TITLE
Geozones 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename og:image target :warning: this will break your custom theme, please rename your logo image file to `logo-social.png` instead of `logo-600x600.png` [#2217](https://github.com/opendatateam/udata/pull/2217)
 - Don't automatically overwrite `last_update` field if manually set [#2020](https://github.com/opendatateam/udata/pull/2220)
 - Spatial completion: only index last version of each zone and prevent completion cluttering [#2140](https://github.com/opendatateam/udata/pull/2140)
+- Init: prompt to loads countries [#2140](https://github.com/opendatateam/udata/pull/2140)
 
 ## 1.6.12 (2019-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Rename og:image target :warning: this will break your custom theme, please rename your logo image file to `logo-social.png` instead of `logo-600x600.png` [#2217](https://github.com/opendatateam/udata/pull/2217)
 - Don't automatically overwrite `last_update` field if manually set [#2020](https://github.com/opendatateam/udata/pull/2220)
+- Spatial completion: only index last version of each zone and prevent completion cluttering [#2140](https://github.com/opendatateam/udata/pull/2140)
 
 ## 1.6.12 (2019-06-26)
 
@@ -65,6 +66,7 @@
 - Admins can delete a single comment in a discussion thread [#2087](https://github.com/opendatateam/udata/pull/2087)
 - Add cache directives to dataset display blocks [#2129](https://github.com/opendatateam/udata/pull/2129)
 - Export multiple models objects to CSV (dataset of datasets) [#2124](https://github.com/opendatateam/udata/pull/2124)
+
 
 ## 1.6.6 (2019-03-27)
 

--- a/udata/commands/init.py
+++ b/udata/commands/init.py
@@ -7,6 +7,7 @@ import click
 
 from udata.commands import cli, success, IS_TTY
 from udata.core.dataset.commands import licenses
+from udata.core.spatial.commands import load as spatial_load
 from udata.core.user import commands as user_commands
 from udata.i18n import gettext as _
 from udata.search.commands import index
@@ -36,6 +37,10 @@ def init(ctx):
         text = _('Do you want to import some data-related license?')
         if click.confirm(text, default=True):
             ctx.invoke(licenses)
+
+        text = _('Do you want to import some spatial zones (countries)?')
+        if click.confirm(text, default=True):
+            ctx.invoke(spatial_load)
 
         text = _('Do you want to create some sample data?')
         if click.confirm(text, default=True):

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -28,6 +28,9 @@ from udata.core.storages import logos, tmp
 log = logging.getLogger(__name__)
 
 
+DEFAULT_GEOZONES_FILE = 'https://github.com/etalab/geozones/releases/download/2019.0/geozones-countries-2019-0-msgpack.tar.xz'
+
+
 def level_ref(level):
     return DBRef(GeoLevel._get_collection_name(), level)
 
@@ -39,9 +42,9 @@ def grp():
 
 
 @grp.command()
-@click.argument('filename', metavar='<filename>')
+@click.argument('filename', metavar='<filename>', default=DEFAULT_GEOZONES_FILE)
 @click.option('-d', '--drop', is_flag=True, help='Drop existing data')
-def load(filename, drop=False):
+def load(filename=DEFAULT_GEOZONES_FILE, drop=False):
     '''
     Load a geozones archive from <filename>
 

--- a/udata/core/spatial/factories.py
+++ b/udata/core/spatial/factories.py
@@ -114,6 +114,11 @@ class GeoZoneFactory(ModelFactory):
     geom = factory.Faker('multipolygon')
     validity = factory.SubFactory(DateRangeFactory)
 
+    class Params:
+        is_current = factory.Trait(
+            validity=factory.SubFactory(DateRangeFactory, end=None)
+        )
+
 
 class SpatialCoverageFactory(ModelFactory):
     class Meta:

--- a/udata/core/spatial/geoids.py
+++ b/udata/core/spatial/geoids.py
@@ -28,6 +28,7 @@ def parse(text):
     else:
         spatial = text
         validity = 'latest'
+    spatial = spatial.lower().replace('/', ':')  # Backward compatibility
     if ':' not in spatial:
         raise GeoIDError('Bad GeoID format: {0}'.format(text))
     # country-subset is a special case:

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -41,12 +41,13 @@ class GeoLevel(db.Document):
 
 
 class GeoZoneQuerySet(db.BaseQuerySet):
-    def valid_at(self, valid_date):
+    def valid_at(self, at):
         '''Limit current QuerySet to zone valid at a given date'''
-        is_valid = db.Q(validity__end__gt=valid_date,
-                        validity__start__lte=valid_date)
-        no_validity = db.Q(validity=None)
-        return self(is_valid | no_validity)
+        only_start = db.Q(validity__start__lte=at, validity__end=None)
+        only_end = db.Q(validity__start=None, validity__end__gt=at)
+        both = db.Q(validity__end__gt=at, validity__start__lte=at)
+        no_validity = db.Q(validity=None) | db.Q(validity__start=None, validity__end=None)
+        return self(no_validity | both | only_start | only_end)
 
     def latest(self):
         '''
@@ -248,9 +249,18 @@ class GeoZone(db.Document):
         return self.level in current_app.config.get('HANDLED_LEVELS')
 
     def valid_at(self, valid_date):
-        if not self.validity:
+        if not self.validity or not (self.validity.start or self.validity.end):
             return True
-        return self.validity.start <= valid_date <= self.validity.end
+        if self.validity.start and self.validity.end:
+            return self.validity.start <= valid_date < self.validity.end
+        elif self.validity.start:
+            return self.validity.start <= valid_date
+        else:
+            return self.validity.end > valid_date
+
+    @property
+    def is_current(self):
+        return self.valid_at(date.today())
 
     def toGeoJSON(self):
         return {

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -99,6 +99,7 @@ class GeoZone(db.Document):
     population = db.IntField()
     area = db.FloatField()
     wikipedia = db.StringField()
+    wikidata = db.StringField()
     dbpedia = db.StringField()
     flag = db.ImageField(fs=logos)
     blazon = db.ImageField(fs=logos)

--- a/udata/core/spatial/tests/test_geoid.py
+++ b/udata/core/spatial/tests/test_geoid.py
@@ -18,6 +18,15 @@ class GeoIDTest:
         assert code == 'code'
         assert validity == '1984-06-07'
 
+    def test_parse_legacy_geoid(self):
+        geoid = 'level/code@1984-06-07'
+
+        level, code, validity = geoids.parse(geoid)
+
+        assert level == 'level'
+        assert code == 'code'
+        assert validity == '1984-06-07'
+
     def test_parse_implicit_latest(self):
         geoid = 'level:code'
 

--- a/udata/models/datetime_fields.py
+++ b/udata/models/datetime_fields.py
@@ -25,7 +25,7 @@ class DateField(BaseField):
             return value
         try:
             value = parse(value, yearfirst=True).date()
-        except:
+        except Exception:
             pass
         return value
 
@@ -47,8 +47,8 @@ class DateField(BaseField):
 
 
 class DateRange(EmbeddedDocument):
-    start = DateField(required=True)
-    end = DateField(required=True)
+    start = DateField()
+    end = DateField()
 
     def to_dict(self):
         return {'start': self.start, 'end': self.end}

--- a/udata/search/adapter.py
+++ b/udata/search/adapter.py
@@ -54,7 +54,7 @@ class ModelSearchAdapter(DocType):
     def completer_tokenize(cls, value, min_length=3):
         '''Quick and dirty tokenizer for completion suggester'''
         tokens = list(itertools.chain(*[
-            [m for m in n.split("'") if len(m) > min_length]
+            [m for m in n.split("'") if len(m) >= min_length]
             for n in value.split(' ')
         ]))
         return list(set([value] + tokens + [' '.join(tokens)]))


### PR DESCRIPTION
This PR:
- ensures that only the latest version of a spatial zone is indexed
- ensures that the `spatial migrate` commands works with any levels/any country
- fixes the spatial completion indexing
- fixes the search completion tokenizer `min_length` parameter handling
- fixes the `geoid.parse()` method to handle legacy identifiers (initialy `/` instead of `:` as separator)
- fixes the `zone.validity` constraints
- prepare for GeoZones 2019 (`wikidata` attribute)
- prompt for countries in `init` command

To update, simply execute:
```shell
udata spatial load --drop /path/or/url/to/geozones/archive.tar.xz
udata spatial migrate 
```
A minimalistic Geozones archive with only countries is  available on the [Geozones release page](https://github.com/etalab/geozones/releases): https://github.com/etalab/geozones/releases/download/2019.0/geozones-countries-2019-0-msgpack.tar.xz