### PR TITLE
Add user slug to dataset cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add user slug to dataset cache key [#2146](https://github.com/opendatateam/udata/pull/2146)
 
 ## 1.6.8 (2019-05-13)
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -33,7 +33,7 @@
 {% endblock %}
 
 {% block content %}
-{% cache cache_duration, 'dataset-content', dataset.id|string, g.lang_code %}
+{% cache cache_duration, 'dataset-content', dataset.id|string, g.lang_code, current_user.slug or 'anonymous' %}
 <!-- Placeholder for non-routable modals -->
 <div v-el:modal></div>
 <section class="content {% if not dataset.organization.public_service %}non{% endif %}certified">


### PR DESCRIPTION
This will avoid having a "Modify" button written into cache for unprivileged users, or no button appearing for admin users. The majority of the cache keys should be with `anonymous`, thus preserving the efficiency of the cache 🤞.