### PR TITLE
fix display consistency of cards for reuses inside topic pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add user slug to dataset cache key [#2146](https://github.com/opendatateam/udata/pull/2146)
+- Change display of cards of reuses on topic pages [#2148](https://github.com/opendatateam/udata/pull/2148)
 
 ## 1.6.8 (2019-05-13)
 

--- a/udata/templates/topic/display.html
+++ b/udata/templates/topic/display.html
@@ -30,7 +30,7 @@
 
                 <ul class="card-list card-list--columned">
                     {% for reuse in topic.reuses %}
-                    {% set features = ['no-footer'] %}
+                    {% set features = ['preview'] %}
                     <li class="col-xs-12 col-sm-4">
                         {% include theme('reuse/card.html') %}
                     </li>


### PR DESCRIPTION
## before

![image](https://user-images.githubusercontent.com/27315/57915826-dcb5be00-7891-11e9-89d2-1d20942784bb.png)

## after

![image](https://user-images.githubusercontent.com/27315/57915795-cd367500-7891-11e9-9107-669208c99145.png)
