### PR TITLE
display remote source of harvested dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add user slug to dataset cache key [#2146](https://github.com/opendatateam/udata/pull/2146)
 - Change display of cards of reuses on topic pages [#2148](https://github.com/opendatateam/udata/pull/2148)
+- Display remote source of harvested dataset [#2150](https://github.com/opendatateam/udata/pull/2150)
 
 ## 1.6.8 (2019-05-13)
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -238,13 +238,7 @@
                             {% endif %}
 
                             {# Harvesting source #}
-                            {# ODS #}
-                            {% if dataset.extras['ods:url'] %}
-                                {% set source = dataset.extras['ods:url']  %}
-                            {# CKAN #}
-                            {% elif dataset.extras['remote_url'] %}
-                                {% set source = dataset.extras['remote_url']  %}
-                            {% endif %}
+                            {% set source = dataset.extras['ods:url'] or  dataset.extras['remote_url'] %}
 
                             {% if source %}
                             <li>

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -238,7 +238,7 @@
                             {% endif %}
 
                             {# Harvesting source #}
-                            {% set source = dataset.extras['ods:url'] or  dataset.extras['remote_url'] %}
+                            {% set source = dataset.extras['ods:url'] or dataset.extras['remote_url'] %}
 
                             {% if source %}
                             <li>

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -237,6 +237,14 @@
                             </li>
                             {% endif %}
 
+                            {# Source ODS #}
+                            {% if dataset.extras['ods:url'] %}
+                            <li>
+                                <a href v-tooltip title="{{ _('Remote source') }}"><span class="fa fa-fw fa-external-link "></span></a>
+                                <a href="{{ dataset.extras['ods:url'] }}">{{ _('Remote source') }}</a>
+                            </li>
+                            {% endif%}
+
                             {# Temporal coverage #}
                             {% if dataset.temporal_coverage %}
                             <li>

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -237,16 +237,16 @@
                             </li>
                             {% endif %}
 
-                            {# Source ODS #}
+                            {# Source #}
+                            {# ODS #}
                             {% if dataset.extras['ods:url'] %}
                             <li>
                                 <a href v-tooltip title="{{ _('Remote source') }}"><span class="fa fa-fw fa-external-link "></span></a>
                                 <a href="{{ dataset.extras['ods:url'] }}">{{ _('Remote source') }}</a>
                             </li>
-                            {% endif%}
 
-                            {# Source CKAN #}
-                            {% if dataset.extras['remote_url'] %}
+                            {# CKAN #}
+                            {% elif dataset.extras['remote_url'] %}
                             <li>
                                 <a href v-tooltip title="{{ _('Remote source') }}"><span class="fa fa-fw fa-external-link "></span></a>
                                 <a href="{{ dataset.extras['remote_url'] }}">{{ _('Remote source') }}</a>

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -238,18 +238,19 @@
                             {% endif %}
 
                             {# Source #}
+
                             {# ODS #}
                             {% if dataset.extras['ods:url'] %}
-                            <li>
-                                <a href v-tooltip title="{{ _('Remote source') }}"><span class="fa fa-fw fa-external-link "></span></a>
-                                <a href="{{ dataset.extras['ods:url'] }}">{{ _('Remote source') }}</a>
-                            </li>
-
+                                {% set source = dataset.extras['ods:url']  %}
                             {# CKAN #}
                             {% elif dataset.extras['remote_url'] %}
+                                {% set source = dataset.extras['remote_url']  %}
+                            {% endif %}
+
+                            {% if source %}
                             <li>
                                 <a href v-tooltip title="{{ _('Remote source') }}"><span class="fa fa-fw fa-external-link "></span></a>
-                                <a href="{{ dataset.extras['remote_url'] }}">{{ _('Remote source') }}</a>
+                                <a href="{{ source }}">{{ _('Remote source') }}</a>
                             </li>
                             {% endif%}
 

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -237,8 +237,7 @@
                             </li>
                             {% endif %}
 
-                            {# Source #}
-
+                            {# Harvesting source #}
                             {# ODS #}
                             {% if dataset.extras['ods:url'] %}
                                 {% set source = dataset.extras['ods:url']  %}

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -245,6 +245,14 @@
                             </li>
                             {% endif%}
 
+                            {# Source CKAN #}
+                            {% if dataset.extras['remote_url'] %}
+                            <li>
+                                <a href v-tooltip title="{{ _('Remote source') }}"><span class="fa fa-fw fa-external-link "></span></a>
+                                <a href="{{ dataset.extras['remote_url'] }}">{{ _('Remote source') }}</a>
+                            </li>
+                            {% endif%}
+
                             {# Temporal coverage #}
                             {% if dataset.temporal_coverage %}
                             <li>


### PR DESCRIPTION
work around to at least show a clickable link toward remote source of an harvested dataset. We could go deeper in information architecture later (:

![image](https://user-images.githubusercontent.com/27315/57919088-649ec680-7898-11e9-82bd-8cd225b2cddb.png)

cf https://github.com/etalab/data.gouv.fr/issues/127