### PR TITLE
remove <br>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Remove `<br>` in badge display [#2156](https://github.com/opendatateam/udata/pull/2156)
 
 ## 1.6.9 (2019-05-20)
 

--- a/udata/templates/organization/display_base.html
+++ b/udata/templates/organization/display_base.html
@@ -36,7 +36,7 @@
                                 alt="{{ org.title }}" class="scalable" />
                         </div>
                         <br/>
-                        <div class="tab-links">
+                        <div class="badges tab-links">
                             {# Badges #}
                             {% if org.badges %}
                             <p class="text-center">
@@ -46,7 +46,7 @@
                                             title="{{ _('See all organizations with that badge.') }}">
                                             <span class="fa fa-bookmark"></span>
                                             {{ org.badge_label(badge) }}</a>
-                                    </small><br/>
+                                    </small>
                                 {% endfor %}
                             </p>
                             {% endif %}


### PR DESCRIPTION
It misses some spacing and `<br>` should be not be used as such. This might break default theme but it might also bring better alignements

## before

![image](https://user-images.githubusercontent.com/27315/58179890-5b06cb80-7ca9-11e9-9b1a-429c8b7d0304.png)

## after

![image](https://user-images.githubusercontent.com/27315/58179855-47f3fb80-7ca9-11e9-892c-8168e6d02db9.png)
