### PR TITLE
display user avatars at various places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Display user avatar and fix its sizing [#2157](https://github.com/opendatateam/udata/pull/2157)
 
 ## 1.6.9 (2019-05-20)
 

--- a/less/site.less
+++ b/less/site.less
@@ -221,7 +221,7 @@ hr {
 }
 
 img.scalable {
-    max-width: 100%;
+    width: 100%;
 }
 
 .clickable {

--- a/udata/templates/dataset/card.html
+++ b/udata/templates/dataset/card.html
@@ -8,9 +8,13 @@
                 width="70" height="70">
         </div>
         {{ badge_if_certified(dataset.organization) }}
+    {% elif dataset.owner %}
+    <div class="card-logo">
+        <img src="{{ dataset.owner.avatar(70, external=True) | placeholder('organization', external=True) }}" alt="">
+    </div>
     {% else %}
     <div class="card-logo">
-        <img src="{{ ''|placeholder('organization', external=True) }}" alt="">
+        <img src="{{ '' | placeholder('organization', external=True) }}" alt="">
     </div>
     {% endif %}
     <div class="card-body">

--- a/udata/templates/dataset/card.html
+++ b/udata/templates/dataset/card.html
@@ -16,7 +16,7 @@
     </div>
     {% else %}
     <div class="card-logo">
-        <img src="{{ '' | placeholder('organization', external=True) }}" alt="">
+        <img src="{{ ''|placeholder('organization', external=True) }}" alt="">
     </div>
     {% endif %}
     <div class="card-body">

--- a/udata/templates/dataset/card.html
+++ b/udata/templates/dataset/card.html
@@ -10,7 +10,9 @@
         {{ badge_if_certified(dataset.organization) }}
     {% elif dataset.owner %}
     <div class="card-logo">
-        <img src="{{ dataset.owner.avatar(70, external=True) | placeholder('organization', external=True) }}" alt="">
+        <img alt="{{ dataset.owner.fullname }}"
+            src="{{ dataset.owner.avatar(70)|placeholder('user') }}"
+            width="70" height="70">
     </div>
     {% else %}
     <div class="card-logo">

--- a/udata/templates/dataset/search-result.html
+++ b/udata/templates/dataset/search-result.html
@@ -9,6 +9,10 @@
                 width="70" height="70">
         </div>
         {{ badge_if_certified(dataset.organization) }}
+        {% elif dataset.owner %}
+        <div class="result-logo pull-left">
+            <img src="{{ dataset.owner.avatar(70)|placeholder('organization') }}" alt="">
+        </div>
         {% else %}
         <div class="result-logo pull-left">
             <img src="{{ ''|placeholder('organization') }}" alt="">

--- a/udata/templates/dataset/search-result.html
+++ b/udata/templates/dataset/search-result.html
@@ -11,7 +11,9 @@
         {{ badge_if_certified(dataset.organization) }}
         {% elif dataset.owner %}
         <div class="result-logo pull-left">
-            <img src="{{ dataset.owner.avatar(70)|placeholder('organization') }}" alt="">
+            <img alt="{{ dataset.owner.fullname }}"
+                src="{{ dataset.owner.avatar(70)|placeholder('user') }}"
+                width="70" height="70">
         </div>
         {% else %}
         <div class="result-logo pull-left">

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -147,8 +147,7 @@
                         <a href="{{ url_for('users.show', user=reuse.owner) }}"
                             title="{{ reuse.owner.fullname }}">
                             <img src="{{ reuse.owner|avatar_url(200) }}"
-                                alt="{{ reuse.owner.fullname }}" class="scalable"
-                                width="200" height="200"/>
+                                alt="{{ reuse.owner.fullname }}" class="scalable" />
                         </a>
                         <h4 class="text-center">{{ reuse.owner.fullname }}</h4>
                         <div class="caption text-left">


### PR DESCRIPTION
also use `.scalable` as full responsive images (i.e `width: 100%`)

next step might be to have a different placeholder for users and orgs