### PR TITLE
Redirect unfiltered csv exports to dataset of datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove `<br>` in badge display [#2156](https://github.com/opendatateam/udata/pull/2156)
 - Display user avatar and fix its sizing [#2157](https://github.com/opendatateam/udata/pull/2157)
+- Redirect unfiltered csv exports to dataset of datasets [#2158](https://github.com/opendatateam/udata/pull/2158)
 
 ## 1.6.9 (2019-05-20)
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -169,7 +169,7 @@ def export_csv(self):
     Generates a CSV export of all model objects as a resource of a dataset
     '''
     ALLOWED_MODELS = current_app.config.get('EXPORT_CSV_MODELS', [])
-    DATASET_DEFAULTS = current_app.config.get('EXPORT_CSV_DATASET_INFO')
+    DATASET_DEFAULTS = current_app.config.get('EXPORT_CSV_DATASET_INFO').copy()
 
     if ALLOWED_MODELS:
         slug = DATASET_DEFAULTS.pop('slug')

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -89,7 +89,7 @@ def get_export_url(model):
 @blueprint.route('/datasets.csv', cors=True)
 def datasets_csv():
     params = multi_to_dict(request.args)
-    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'dataset' in exported_models:
         return get_export_url('dataset')
@@ -102,7 +102,7 @@ def datasets_csv():
 @blueprint.route('/resources.csv', cors=True)
 def resources_csv():
     params = multi_to_dict(request.args)
-    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'resource' in exported_models:
         return get_export_url('resource')
@@ -114,7 +114,7 @@ def resources_csv():
 @blueprint.route('/organizations.csv', cors=True)
 def organizations_csv():
     params = multi_to_dict(request.args)
-    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'organization' in exported_models:
         return get_export_url('organization')
@@ -126,7 +126,7 @@ def organizations_csv():
 @blueprint.route('/reuses.csv', cors=True)
 def reuses_csv():
     params = multi_to_dict(request.args)
-    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'reuse' in exported_models:
         return get_export_url('reuse')

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import logging
 import requests
 
-from flask import request, json, redirect, url_for, current_app
+from flask import request, json, redirect, url_for, current_app, abort
 from werkzeug.contrib.atom import AtomFeed
 
 from udata import search, theme
@@ -73,9 +73,30 @@ def map():
     return theme.render('site/map.html')
 
 
+def get_export_url(model):
+    slug = current_app.config['EXPORT_CSV_DATASET_INFO']['slug']
+    dataset = Dataset.objects.get_or_404(slug=slug)
+    resource = None
+    for r in dataset.resources:
+        if r.extras.get('csv-export:model', '') == model:
+            resource = r
+            break
+    if not resource:
+        abort(404)
+    return resource.url
+
+
 @blueprint.route('/datasets.csv', cors=True)
 def datasets_csv():
     params = multi_to_dict(request.args)
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
+    if not params and 'dataset' in exported_models:
+        export_url = get_export_url('dataset')
+        if export_url:
+            return redirect(export_url)
+        else:
+            abort(404)
     params['facets'] = False
     datasets = search.iter(Dataset, **params)
     adapter = csv.get_adapter(Dataset)
@@ -85,6 +106,14 @@ def datasets_csv():
 @blueprint.route('/resources.csv', cors=True)
 def resources_csv():
     params = multi_to_dict(request.args)
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
+    if not params and 'resource' in exported_models:
+        export_url = get_export_url('resource')
+        if export_url:
+            return redirect(export_url)
+        else:
+            abort(404)
     params['facets'] = False
     datasets = search.iter(Dataset, **params)
     return csv.stream(ResourcesCsvAdapter(datasets), 'resources')
@@ -93,6 +122,14 @@ def resources_csv():
 @blueprint.route('/organizations.csv', cors=True)
 def organizations_csv():
     params = multi_to_dict(request.args)
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
+    if not params and 'organization' in exported_models:
+        export_url = get_export_url('organization')
+        if export_url:
+            return redirect(export_url)
+        else:
+            abort(404)
     params['facets'] = False
     organizations = search.iter(Organization, **params)
     return csv.stream(OrganizationCsvAdapter(organizations), 'organizations')
@@ -101,6 +138,14 @@ def organizations_csv():
 @blueprint.route('/reuses.csv', cors=True)
 def reuses_csv():
     params = multi_to_dict(request.args)
+    # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
+    exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
+    if not params and 'reuse' in exported_models:
+        export_url = get_export_url('reuse')
+        if export_url:
+            return redirect(export_url)
+        else:
+            abort(404)
     params['facets'] = False
     reuses = search.iter(Reuse, **params)
     return csv.stream(ReuseCsvAdapter(reuses), 'reuses')

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -92,11 +92,7 @@ def datasets_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'dataset' in exported_models:
-        export_url = get_export_url('dataset')
-        if export_url:
-            return redirect(export_url)
-        else:
-            abort(404)
+        return get_export_url('dataset')
     params['facets'] = False
     datasets = search.iter(Dataset, **params)
     adapter = csv.get_adapter(Dataset)
@@ -109,11 +105,7 @@ def resources_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'resource' in exported_models:
-        export_url = get_export_url('resource')
-        if export_url:
-            return redirect(export_url)
-        else:
-            abort(404)
+        return get_export_url('resource')
     params['facets'] = False
     datasets = search.iter(Dataset, **params)
     return csv.stream(ResourcesCsvAdapter(datasets), 'resources')
@@ -125,11 +117,7 @@ def organizations_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'organization' in exported_models:
-        export_url = get_export_url('organization')
-        if export_url:
-            return redirect(export_url)
-        else:
-            abort(404)
+        return get_export_url('organization')
     params['facets'] = False
     organizations = search.iter(Organization, **params)
     return csv.stream(OrganizationCsvAdapter(organizations), 'organizations')
@@ -141,11 +129,7 @@ def reuses_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'reuse' in exported_models:
-        export_url = get_export_url('reuse')
-        if export_url:
-            return redirect(export_url)
-        else:
-            abort(404)
+        return get_export_url('reuse')
     params['facets'] = False
     reuses = search.iter(Reuse, **params)
     return csv.stream(ReuseCsvAdapter(reuses), 'reuses')

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -92,7 +92,7 @@ def datasets_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'dataset' in exported_models:
-        return get_export_url('dataset')
+        return redirect(get_export_url('dataset'))
     params['facets'] = False
     datasets = search.iter(Dataset, **params)
     adapter = csv.get_adapter(Dataset)
@@ -105,7 +105,7 @@ def resources_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'resource' in exported_models:
-        return get_export_url('resource')
+        return redirect(get_export_url('resource'))
     params['facets'] = False
     datasets = search.iter(Dataset, **params)
     return csv.stream(ResourcesCsvAdapter(datasets), 'resources')
@@ -117,7 +117,7 @@ def organizations_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'organization' in exported_models:
-        return get_export_url('organization')
+        return redirect(get_export_url('organization'))
     params['facets'] = False
     organizations = search.iter(Organization, **params)
     return csv.stream(OrganizationCsvAdapter(organizations), 'organizations')
@@ -129,7 +129,7 @@ def reuses_csv():
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if not params and 'reuse' in exported_models:
-        return get_export_url('reuse')
+        return redirect(get_export_url('reuse'))
     params['facets'] = False
     reuses = search.iter(Reuse, **params)
     return csv.stream(ReuseCsvAdapter(reuses), 'reuses')

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import StringIO
 
+import pytest
 from datetime import datetime
 
 from flask import url_for
@@ -10,6 +11,7 @@ from flask import url_for
 from udata.frontend import csv
 from udata.models import Badge, Site, PUBLIC_SERVICE
 
+from udata.core.dataset import tasks as dataset_tasks
 from udata.core.dataset.factories import DatasetFactory, ResourceFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.site.models import current_site
@@ -63,6 +65,7 @@ class SiteViewsTest(FrontTestCase):
         self.assert200(response)
 
     def test_datasets_csv(self):
+        self.app.config['EXPORT_CSV_MODELS'] = []
         with self.autoindex():
             datasets = [DatasetFactory(resources=[ResourceFactory()])
                         for _ in range(5)]
@@ -93,6 +96,20 @@ class SiteViewsTest(FrontTestCase):
         for dataset in datasets:
             self.assertIn(str(dataset.id), ids)
         self.assertNotIn(str(hidden_dataset.id), ids)
+
+    @pytest.mark.usefixtures('instance_path')
+    def test_datasets_csv_w_export_csv_feature(self):
+        # no export generated, 404
+        response = self.get(url_for('site.datasets_csv'))
+        self.assert404(response)
+
+        # generate the export
+        o = OrganizationFactory()
+        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        dataset_tasks.export_csv()
+        response = self.get(url_for('site.datasets_csv'))
+        self.assertStatus(response, 302)
+        self.assertIn('export-dataset-', response.location)
 
     def test_datasets_csv_with_filters(self):
         '''Should handle filtering but ignore paging or facets'''
@@ -138,6 +155,7 @@ class SiteViewsTest(FrontTestCase):
         self.assertNotIn(str(hidden_dataset.id), ids)
 
     def test_resources_csv(self):
+        self.app.config['EXPORT_CSV_MODELS'] = []
         with self.autoindex():
             datasets = [
                 DatasetFactory(resources=[ResourceFactory(),
@@ -175,6 +193,20 @@ class SiteViewsTest(FrontTestCase):
         for dataset in datasets:
             for resource in dataset.resources:
                 self.assertIn((str(dataset.id), str(resource.id)), ids)
+
+    @pytest.mark.usefixtures('instance_path')
+    def test_resources_csv_w_export_csv_feature(self):
+        # no export generated, 404
+        response = self.get(url_for('site.resources_csv'))
+        self.assert404(response)
+
+        # generate the export
+        o = OrganizationFactory()
+        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        dataset_tasks.export_csv()
+        response = self.get(url_for('site.resources_csv'))
+        self.assertStatus(response, 302)
+        self.assertIn('export-resource-', response.location)
 
     def test_resources_csv_with_filters(self):
         '''Should handle filtering but ignore paging or facets'''
@@ -221,6 +253,7 @@ class SiteViewsTest(FrontTestCase):
                 self.assertIn((str(dataset.id), str(resource.id)), ids)
 
     def test_organizations_csv(self):
+        self.app.config['EXPORT_CSV_MODELS'] = []
         with self.autoindex():
             orgs = [OrganizationFactory() for _ in range(5)]
             hidden_org = OrganizationFactory(deleted=datetime.now())
@@ -249,6 +282,20 @@ class SiteViewsTest(FrontTestCase):
         for org in orgs:
             self.assertIn(str(org.id), ids)
         self.assertNotIn(str(hidden_org.id), ids)
+
+    @pytest.mark.usefixtures('instance_path')
+    def test_organizations_csv_w_export_csv_feature(self):
+        # no export generated, 404
+        response = self.get(url_for('site.organizations_csv'))
+        self.assert404(response)
+
+        # generate the export
+        o = OrganizationFactory()
+        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        dataset_tasks.export_csv()
+        response = self.get(url_for('site.organizations_csv'))
+        self.assertStatus(response, 302)
+        self.assertIn('export-organization-', response.location)
 
     def test_organizations_csv_with_filters(self):
         '''Should handle filtering but ignore paging or facets'''
@@ -296,6 +343,7 @@ class SiteViewsTest(FrontTestCase):
         self.assertNotIn(str(hidden_org.id), ids)
 
     def test_reuses_csv(self):
+        self.app.config['EXPORT_CSV_MODELS'] = []
         with self.autoindex():
             reuses = [ReuseFactory(datasets=[DatasetFactory()])
                       for _ in range(5)]
@@ -326,6 +374,20 @@ class SiteViewsTest(FrontTestCase):
         for reuse in reuses:
             self.assertIn(str(reuse.id), ids)
         self.assertNotIn(str(hidden_reuse.id), ids)
+
+    @pytest.mark.usefixtures('instance_path')
+    def test_reuses_csv_w_export_csv_feature(self):
+        # no export generated, 404
+        response = self.get(url_for('site.reuses_csv'))
+        self.assert404(response)
+
+        # generate the export
+        o = OrganizationFactory()
+        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        dataset_tasks.export_csv()
+        response = self.get(url_for('site.reuses_csv'))
+        self.assertStatus(response, 302)
+        self.assertIn('export-reuse-', response.location)
 
     def test_reuses_csv_with_filters(self):
         '''Should handle filtering but ignore paging or facets'''


### PR DESCRIPTION
This redirects `/(datasets|resources|reuses|resources).csv` to the appropriate resource URL from the dataset of datasets. If the dataset of datasets feature is disabled, the export URLs behave as they used to (ie streaming export).