### PR TITLE
fluidify search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove `<br>` in badge display [#2156](https://github.com/opendatateam/udata/pull/2156)
 - Display user avatar and fix its sizing [#2157](https://github.com/opendatateam/udata/pull/2157)
 - Redirect unfiltered csv exports to dataset of datasets [#2158](https://github.com/opendatateam/udata/pull/2158)
+- Fix various issues with search result page [#2166](https://github.com/opendatateam/udata/pull/2166)
 
 ## 1.6.9 (2019-05-20)
 

--- a/udata/templates/macros/paginator.html
+++ b/udata/templates/macros/paginator.html
@@ -1,4 +1,5 @@
-{% macro paginator(p, nb=3) %}
+{% macro paginator(p, nb=3, url=None) %}
+
 {% if p.pages > 1 %}
 {% set start = 1 if p.page <= nb else p.page - nb %}
 {% set end = p.pages if p.page + nb > p.pages else p.page + nb %}
@@ -18,7 +19,7 @@
         </li>
         {% for num_page in range(start, end + 1) %}
         <li {% if num_page == p.page %}class="active"{% endif %}>
-            <a href="{{ url_rewrite(page=num_page) }}" rel="nofollow">{{ num_page }}</a>
+            <a href="{{ url_rewrite(url, page=num_page) }}" rel="nofollow">{{ num_page }}</a>
         </li>
         {% endfor %}
         <li {% if p.page == p.pages %}class="disabled"{% endif %}>

--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -146,7 +146,7 @@
             <div class="col-md-8 col-lg-9 smaller">
                 <ul class="search-results">
                     {% for reuse in reuses %}
-                    {% include theme('reuse/search-result.html') %}
+                    {% include theme('reuse/search-result.html') with context %}
                     {% endfor %}
                 </ul>
 

--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -1,4 +1,5 @@
 {% extends theme("layouts/1-column.html") %}
+{% from theme('macros/paginator.html') import paginator with context %}
 {% import theme('macros/search.html') as s %}
 
 {% set body_class = 'multisearch' %}
@@ -13,9 +14,9 @@
 
 {% set bundle = 'search' %}
 
-{% set datasets_search_url = url_for('datasets.list') %}
-{% set reuses_search_url = url_for('reuses.list') %}
-{% set organizations_search_url = url_for('organizations.list') %}
+{% set datasets_search_url = url_for('datasets.list', **request.args) %}
+{% set reuses_search_url = url_for('reuses.list', **request.args) %}
+{% set organizations_search_url = url_for('organizations.list', **request.args) %}
 {% set breadcrum_class='search-bar'%}
 
 {% block breadcrumb_bar %}
@@ -126,14 +127,8 @@
                     {% include theme('dataset/search-result.html') %}
                     {% endfor %}
                 </ul>
-                {% if datasets.has_next %}
-                <p class="text-center">
-                    <a class="btn btn-grey btn-sm" href="{{ url_for('datasets.list', **request.args) }}">
-                        <span class="fa fa-fw fa-list"></span>
-                        {{ _('See the %(total)s results', total=datasets.total) }}
-                    </a>
-                </p>
-                {% endif %}
+
+                {{ paginator(datasets, url=datasets_search_url) }}
             </div>
 
             <aside class="col-md-4 col-lg-3">
@@ -151,14 +146,8 @@
                     {% include theme('reuse/search-result.html') %}
                     {% endfor %}
                 </ul>
-                {% if reuses.has_next %}
-                <p class="text-center">
-                    <a class="btn btn-grey btn-sm" href="{{ url_for('reuses.list', **request.args) }}">
-                        <span class="fa fa-fw fa-list"></span>
-                        {{ _('See the %(total)s results', total=reuses.total) }}
-                    </a>
-                </p>
-                {% endif %}
+
+                {{ paginator(reuses, url=reuses_search_url) }}
             </div>
 
             <aside class="col-md-4 col-lg-3">
@@ -178,14 +167,8 @@
                     {% include theme('organization/search-result.html') %}
                     {% endfor %}
                 </ul>
-                {% if organizations.has_next %}
-                <p class="text-center">
-                    <a class="btn btn-grey btn-sm" href="{{ url_for('organizations.list', **request.args) }}">
-                        <span class="fa fa-fw fa-list"></span>
-                        {{ _('See the %(total)s results', total=organizations.total) }}
-                    </a>
-                </p>
-                {% endif %}
+
+                {{ paginator(organizations, url=organizations_search_url) }}
             </div>
 
             <aside class="col-md-4 col-lg-3">

--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -146,7 +146,7 @@
             <div class="col-md-8 col-lg-9 smaller">
                 <ul class="search-results">
                     {% for reuse in reuses %}
-                    {% include theme('reuse/search-result.html') with context %}
+                    {% include theme('reuse/search-result.html') %}
                     {% endfor %}
                 </ul>
 
@@ -158,7 +158,7 @@
 
             <aside class="col-md-4 col-lg-3">
                 {% set search_url = reuses_search_url %}
-                {% include theme('reuse/search-panel.html') %}
+                {% include theme('reuse/search-panel.html') with context %}
             </aside>
         {% else %}
         <p class="text-center"><strong>{{ _('No results found') }}</strong></p>

--- a/udata/templates/search.html
+++ b/udata/templates/search.html
@@ -14,9 +14,9 @@
 
 {% set bundle = 'search' %}
 
-{% set datasets_search_url = url_for('datasets.list', **request.args) %}
-{% set reuses_search_url = url_for('reuses.list', **request.args) %}
-{% set organizations_search_url = url_for('organizations.list', **request.args) %}
+{% set datasets_search_url = url_for('datasets.list') %}
+{% set reuses_search_url = url_for('reuses.list') %}
+{% set organizations_search_url = url_for('organizations.list') %}
 {% set breadcrum_class='search-bar'%}
 
 {% block breadcrumb_bar %}
@@ -128,12 +128,15 @@
                     {% endfor %}
                 </ul>
 
-                {{ paginator(datasets, url=datasets_search_url) }}
+                {{ paginator(
+                    datasets,
+                    url=url_for('datasets.list', **request.args)
+                ) }}
             </div>
 
             <aside class="col-md-4 col-lg-3">
                 {% set search_url = datasets_search_url %}
-                {% include theme('dataset/search-panel.html') %}
+                {% include theme('dataset/search-panel.html') with context %}
             </aside>
         {% endif %}
     </div>
@@ -147,7 +150,10 @@
                     {% endfor %}
                 </ul>
 
-                {{ paginator(reuses, url=reuses_search_url) }}
+                {{ paginator(
+                    reuses,
+                    url=url_for('reuses.list', **request.args)
+                ) }}
             </div>
 
             <aside class="col-md-4 col-lg-3">
@@ -168,12 +174,14 @@
                     {% endfor %}
                 </ul>
 
-                {{ paginator(organizations, url=organizations_search_url) }}
+                {{ paginator(
+                    organizations, url=url_for('organizations.list', **request.args)
+                ) }}
             </div>
 
             <aside class="col-md-4 col-lg-3">
                 {% set search_url =organizations_search_url %}
-                {% include theme('organization/search-panel.html') %}
+                {% include theme('organization/search-panel.html') with context %}
             </aside>
         {% else %}
         <p class="text-center"><strong>{{ _('No results found') }}</strong></p>


### PR DESCRIPTION
- skip the "see all results" button and display pagination directly
- fix broken facets

SOLVE: https://github.com/etalab/data.gouv.fr/issues/138