### PR TITLE
WIP: Rate limit discussions POST routes

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -138,6 +138,30 @@ The id of an existing user which will post a comment when a dataset is archived.
 The title of the comment optionaly posted when a dataset is archived.
 NB: the content of the comment is located in `udata/templates/comments/dataset_archived.txt`.
 
+## Rate limiting
+
+See [Flask-Limiter documentation](https://flask-limiter.readthedocs.io/en/stable/index.html) for more options.
+
+`flask_limiter.util.get_remote_address` is used as a _key_func_.
+
+## RATELIMIT_ENABLED
+
+**default**: `False`
+
+Enables the rate limiting feature. Every other related option is ignored if `False`.
+
+## RATELIMIT_STORAGE_URL
+
+**default**: `'redis://localhost:6379/14'`
+
+Storage URL for the rate limiting counter.
+
+## RATELIMIT_DISCUSSIONS
+
+**default**:  `'5/minute'`
+
+Rate limiting rule for posting discussions and comments.
+
 ## URLs validation
 
 ### URLS_ALLOW_PRIVATE

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -52,6 +52,7 @@ rdflib==4.2.2
 redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
 requests==2.21.0
 simplejson==3.16.0
+six==1.12.0
 StringDist==1.0.9
 tlds
 ujson==1.35

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -35,7 +35,7 @@ html2text==2018.1.9
 itsdangerous==1.1.0
 Jinja2==2.10.1
 jsonschema==3.0.1
-kombu==4.6.0
+kombu==4.2.1
 lxml==4.3.3
 mongoengine==0.16.3
 msgpack-python==0.4.8

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -19,6 +19,7 @@ Flask-Caching==1.4.0
 Flask-CDN==1.5.3
 flask-fs==0.6.1
 Flask-Gravatar==0.5.0
+Flask-Limiter==1.0.1
 Flask-Login==0.4.1
 Flask-Mail==0.9.1
 flask-mongoengine==0.9.5

--- a/udata/app.py
+++ b/udata/app.py
@@ -14,8 +14,8 @@ from flask import (
     Flask, abort, g, send_from_directory, json, Blueprint as BaseBlueprint,
     make_response
 )
-from flask_caching import Cache
 
+from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 from flask_navigation import Navigation
 from speaklater import is_lazy_string
@@ -204,7 +204,7 @@ def standalone(app):
 def register_extensions(app):
     from udata import (
         models, routing, tasks, mail, i18n, auth, theme, search, sitemap,
-        sentry
+        sentry, limiter
     )
     i18n.init_app(app)
     models.init_app(app)
@@ -218,6 +218,7 @@ def register_extensions(app):
     mail.init_app(app)
     search.init_app(app)
     sitemap.init_app(app)
+    limiter.init_app(app)
     sentry.init_app(app)
     from . import patch_flask_security  # noqa
     return app

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -8,6 +8,7 @@ from flask_restplus.inputs import boolean
 
 from udata.auth import admin_permission
 from udata.api import api, API, fields
+from udata.limiter import limiter, comment_limit
 from udata.core.user.api_fields import user_ref_fields
 
 from .forms import DiscussionCreateForm, DiscussionCommentForm
@@ -89,6 +90,8 @@ class DiscussionAPI(API):
     '''
     Base class for a discussion thread.
     '''
+    decorators = [limiter.limit(comment_limit, methods=['post'])]
+
     @api.doc('get_discussion')
     @api.marshal_with(discussion_fields)
     def get(self, id):
@@ -158,6 +161,8 @@ class DiscussionsAPI(API):
     '''
     Base class for a list of discussions.
     '''
+    decorators = [limiter.limit(comment_limit, methods=['post'])]
+
     @api.doc('list_discussions')
     @api.expect(parser)
     @api.marshal_with(discussion_page_fields)

--- a/udata/limiter.py
+++ b/udata/limiter.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from flask import current_app
+
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)
+
+
+def init_app(app):
+    limiter.init_app(app)
+
+
+def comment_limit():
+    return current_app.config.get('RATELIMIT_DISCUSSIONS')

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -342,7 +342,7 @@ class Defaults(object):
     ####################
     RATELIMIT_ENABLED = False
     RATELIMIT_STORAGE_URL = 'redis://localhost:6379/14'
-    RATELIMIT_COMMENT = '5/minute'
+    RATELIMIT_DISCUSSIONS = '5/minute'
 
 
 class Testing(object):

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -338,6 +338,12 @@ class Defaults(object):
     ARCHIVE_COMMENT_USER_ID = None
     ARCHIVE_COMMENT_TITLE = _('This dataset has been archived')
 
+    # Rate limiting parameters
+    ####################
+    RATELIMIT_ENABLED = False
+    RATELIMIT_STORAGE_URL = 'redis://localhost:6379/14'
+    RATELIMIT_COMMENT = '5/minute'
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/tests/api/test_limiter.py
+++ b/udata/tests/api/test_limiter.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from flask import url_for
+
+from udata.models import Discussion, Message
+from udata.core.dataset.factories import DatasetFactory
+from udata.settings import Testing
+
+
+class LimiterSettings(Testing):
+    RATELIMIT_ENABLED = True
+    RATELIMIT_DISCUSSIONS = '0/minute'
+
+
+@pytest.mark.usefixtures('clean_db')
+class APILimiterTest:
+    modules = []
+    settings = LimiterSettings
+
+    def test_limit_dicussions(self, api):
+        '''Test rate limiting on discussions'''
+        api.login()
+        dataset = DatasetFactory()
+        response = api.post(url_for('api.discussions'), {
+            'title': 'test title',
+            'comment': 'bla bla',
+            'subject': {
+                'class': 'Dataset',
+                'id': dataset.id,
+            }
+        })
+        assert response.status_code == 429
+
+    def test_limit_comments(self, api):
+        user = api.login()
+        dataset = DatasetFactory()
+        message = Message(content='bla bla', posted_by=user)
+        discussion = Discussion.objects.create(
+            subject=dataset,
+            user=user,
+            title='test discussion',
+            discussion=[message]
+        )
+        response = api.post(url_for('api.discussion', **{'id': discussion.id}), {
+            'comment': 'new bla bla'
+        })
+        assert response.status_code == 429

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -61,6 +61,7 @@ class TestClient(FlaskClient):
 @pytest.fixture
 def app(request):
     test_settings = get_settings(request)
+    test_settings.RATELIMIT_ENABLED = True
     app = create_app(settings.Defaults, override=test_settings)
     app.test_client_class = TestClient
     return app


### PR DESCRIPTION
Rebased on #2182.

This lets us rate limit those API endpoints:
- post a discussion
- post a comment in a discussion

The rate limit is disabled by default and its counter is stored in Redis (can be in memory or memcached). The rate is configurable (defaults to 5 per minute for comments).

The rate limiting logic is easily reusable on other endpoints if needed.

## TODO

- [x] tests
- [x] assess performance on next.data.gouv.fr before/after