### PR TITLE
Better dependencies management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,9 @@ jobs:
           - venv
       - run:
           name: Check dependencies
-          command: pip check
+          command: |
+            source venv/bin/activate
+            pip check
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ jobs:
           paths:
           - venv
       - run:
+          name: Check dependencies
+          command: pip check
+      - run:
           name: Run tests
           command: |
             mkdir -p reports/python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Archive dataset feature [#2172](https://github.com/opendatateam/udata/pull/2172)
+- Better dependencies management [#2182](https://github.com/opendatateam/udata/pull/2182) and [#2172/install.pip](https://github.com/opendatateam/udata/pull/2172/files#diff-d7b45472f3465d62f857d14cf59ea8a2)
 
 ## 1.6.11 (2019-05-29)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -35,7 +35,7 @@ html2text==2018.1.9
 itsdangerous==1.1.0
 Jinja2==2.10.1
 jsonschema==3.0.1
-kombu==4.2.1
+kombu[redis]==4.2.1
 lxml==4.3.3
 mongoengine==0.16.3
 msgpack-python==0.4.8

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -52,7 +52,7 @@ rdflib==4.2.2
 redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
 requests==2.21.0
 simplejson==3.16.0
-six==1.10.0
+six==1.12.0
 StringDist==1.0.9
 tlds
 ujson==1.35

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -56,6 +56,7 @@ six==1.12.0
 StringDist==1.0.9
 tlds
 ujson==1.35
+urllib3==1.24.3
 unicodecsv==0.14.1
 voluptuous==0.10.5
 werkzeug==0.14.1

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -52,6 +52,7 @@ rdflib==4.2.2
 redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
 requests==2.21.0
 simplejson==3.16.0
+six==1.12.0
 StringDist==1.0.9
 tlds
 ujson==1.35

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -50,7 +50,7 @@ PyYAML==5.1
 rdflib-jsonld==0.4.0
 rdflib==4.2.2
 redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
-requests==2.21.0
+requests==2.22.0
 simplejson==3.16.0
 six==1.12.0
 StringDist==1.0.9

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -35,7 +35,7 @@ html2text==2018.1.9
 itsdangerous==1.1.0
 Jinja2==2.10.1
 jsonschema==3.0.1
-kombu==4.6.0
+kombu==4.2.1
 lxml==4.3.3
 mongoengine==0.16.3
 msgpack-python==0.4.8

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -50,7 +50,7 @@ PyYAML==5.1
 rdflib-jsonld==0.4.0
 rdflib==4.2.2
 redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
-requests==2.22.0
+requests==2.21.0
 simplejson==3.16.0
 six==1.12.0
 StringDist==1.0.9

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -52,7 +52,7 @@ rdflib==4.2.2
 redis==2.10.6 # this can be safely upgraded back to 3.1.0 as soon as celery 4.2.2 is released
 requests==2.21.0
 simplejson==3.16.0
-six==1.12.0
+six==1.10.0
 StringDist==1.0.9
 tlds
 ujson==1.35


### PR DESCRIPTION
1️⃣ This pins `kombu` to the "right" version, it was silently broken by #2172. It would fail anyway on a fresh install, since `4.6.0` is transitively pulled and is incompatible with our version of `redispy`. We also add the `[redis]` extra to `kombu` so that `pip check` can catch wrong dependencies.

```
VersionMismatch: Redis transport requires redis-py versions 3.2.0 or later. You have 2.10.6
```

2️⃣ Also pins `six` which would fail on old installs because `jsonschema` does not install the right transitively.

```
jsonschema 3.0.1 has requirement six>=1.11.0, but you have six 1.10.0.
```

3️⃣ Also adds `pip check` to build workflow, this might help us catch errors earlier.

4️⃣ ~~Upgrades `requests`, since `urllib3==1.25.3` installed on a new env would not be compatible ⚠️ we need to release every extension where we pinned requests for this one to work :-/~~ 
**Alternative**: pin `urllib3==1.24.3` instead, unpin `requests` in all associated extensions when `udata` is released and in the next release upgrade `requests` and `urllib3`.

Next step: generate requirements through `pipenv` https://github.com/opendatateam/udata/issues/2186?