### PR TITLE
Dataset of datasets: id as ref instead of slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Archive dataset feature [#2172](https://github.com/opendatateam/udata/pull/2172)
 - Better dependencies management [#2182](https://github.com/opendatateam/udata/pull/2182) and [#2172/install.pip](https://github.com/opendatateam/udata/pull/2172/files#diff-d7b45472f3465d62f857d14cf59ea8a2)
 - Add cache for organization and topic display pages [#2194](https://github.com/opendatateam/udata/pull/2194)
+- Dataset of datasets: id as ref instead of slug [#2195](https://github.com/opendatateam/udata/pull/2195) :warning: this introduces some settings changes, cf [documentation for EXPORT_CSV](https://github.com/opendatateam/udata/blob/master/docs/adapting-settings.md).
 
 ## 1.6.11 (2019-05-29)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -185,20 +185,11 @@ URLS_ALLOWED_TLDS = Defaults.URLS_ALLOWED_TLDS + set(['custom', 'company'])
 List models that will be exported to CSV by the job `export-csv`.
 You can disable the feature by setting this to an empty list.
 
-### EXPORT_CSV_DATASET_INFO
+### EXPORT_CSV_DATASET_ID
 
-**default**:
-```
-{
-    'slug': 'export-csv',
-    'title': 'Export of portal data',
-    'description': 'This dataset holds the CSV exports of this portal\'s data.',
-    # this should point to an existing organization id
-    'organization': None,
-}
-```
+**default**: `None`
 
-Values that will be used to find (`slug`) or create the dataset that holds the CSV exports created by `export-csv`.
+The id of a dataset that should be created before running the `export-csv` job and will hold the CSV exports.
 
 ## Map widget configuration
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -361,6 +361,8 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
                                   default=datetime.now, required=True)
     title = db.StringField(required=True)
     acronym = db.StringField(max_length=128)
+    # /!\ do not set directly the slug when creating or updating a dataset
+    # this will break the search indexation
     slug = db.SlugField(max_length=255, required=True, populate_from='title',
                         update=True, follow=True)
     description = db.StringField(required=True, default='')

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -169,20 +169,17 @@ def export_csv(self):
     Generates a CSV export of all model objects as a resource of a dataset
     '''
     ALLOWED_MODELS = current_app.config.get('EXPORT_CSV_MODELS', [])
-    DATASET_DEFAULTS = current_app.config.get('EXPORT_CSV_DATASET_INFO').copy()
+    DATASET_ID = current_app.config.get('EXPORT_CSV_DATASET_ID')
 
-    if ALLOWED_MODELS:
-        slug = DATASET_DEFAULTS.pop('slug')
-        organization = DATASET_DEFAULTS.get('organization')
-        if organization:
-            try:
-                DATASET_DEFAULTS['organization'] = Organization.objects.get(id=organization)
-            except Organization.DoesNotExist:
-                log.error('Organization with id %s not found.' % organization)
-        dataset, _ = Dataset.objects.get_or_create(
-            slug=slug,
-            defaults=DATASET_DEFAULTS,
-        )
+    if not DATASET_ID:
+        log.error('EXPORT_CSV_DATASET_ID setting value not set')
+        return
+
+    try:
+        dataset = Dataset.objects.get(id=DATASET_ID)
+    except Dataset.DoesNotExist:
+        log.error('EXPORT_CSV_DATASET_ID points to a non existent dataset')
+        return
 
     for model in ALLOWED_MODELS:
         export_csv_for_model(model, dataset)

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -74,8 +74,8 @@ def map():
 
 
 def get_export_url(model):
-    slug = current_app.config['EXPORT_CSV_DATASET_INFO']['slug']
-    dataset = Dataset.objects.get_or_404(slug=slug)
+    did = current_app.config['EXPORT_CSV_DATASET_ID']
+    dataset = Dataset.objects.get_or_404(id=did)
     resource = None
     for r in dataset.resources:
         if r.extras.get('csv-export:model', '') == model:

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -317,16 +317,9 @@ class Defaults(object):
 
     # Export CSVs of model objects as resources of a dataset
     ########################################################
-    # which models should be exported
     EXPORT_CSV_MODELS = ('dataset', 'resource', 'discussion', 'organization',
                          'reuse', 'tag')
-    EXPORT_CSV_DATASET_INFO = {
-        'slug': 'export-csv',
-        'title': 'Export of portal data',
-        'description': 'This dataset holds the CSV exports of this portal\'s data.',
-        # this should point to an existing organization id
-        'organization': None,
-    }
+    EXPORT_CSV_DATASET_ID = None
 
     # Autocomplete parameters
     #########################

--- a/udata/tests/dataset/test_dataset_tasks.py
+++ b/udata/tests/dataset/test_dataset_tasks.py
@@ -4,7 +4,7 @@ import pytest
 
 from udata.models import Dataset, Topic
 from udata.core.dataset import tasks
-from udata.core.organization.factories import OrganizationFactory
+from udata.core.dataset.factories import DatasetFactory
 # csv.adapter for Tag won't be registered if this is not imported :thinking:
 from udata.core.tags import csv as _  # noqa
 
@@ -27,14 +27,11 @@ def test_purge_datasets():
 
 @pytest.mark.usefixtures('instance_path')
 def test_export_csv(app):
-    organization = OrganizationFactory()
-    app.config['EXPORT_CSV_DATASET_INFO']['organization'] = organization.id
-    slug = app.config['EXPORT_CSV_DATASET_INFO']['slug']
+    dataset = DatasetFactory()
+    app.config['EXPORT_CSV_DATASET_ID'] = dataset.id
     models = app.config['EXPORT_CSV_MODELS']
     tasks.export_csv()
-    dataset = Dataset.objects.get(slug=slug)
-    assert dataset is not None
-    assert dataset.organization == organization
+    dataset = Dataset.objects.get(id=dataset.id)
     assert len(dataset.resources) == len(models)
     extras = [r.extras.get('csv-export:model') for r in dataset.resources]
     for model in models:

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -104,8 +104,8 @@ class SiteViewsTest(FrontTestCase):
         self.assert404(response)
 
         # generate the export
-        o = OrganizationFactory()
-        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        d = DatasetFactory()
+        self.app.config['EXPORT_CSV_DATASET_ID'] = d.id
         dataset_tasks.export_csv()
         response = self.get(url_for('site.datasets_csv'))
         self.assertStatus(response, 302)
@@ -201,8 +201,8 @@ class SiteViewsTest(FrontTestCase):
         self.assert404(response)
 
         # generate the export
-        o = OrganizationFactory()
-        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        d = DatasetFactory()
+        self.app.config['EXPORT_CSV_DATASET_ID'] = d.id
         dataset_tasks.export_csv()
         response = self.get(url_for('site.resources_csv'))
         self.assertStatus(response, 302)
@@ -290,8 +290,8 @@ class SiteViewsTest(FrontTestCase):
         self.assert404(response)
 
         # generate the export
-        o = OrganizationFactory()
-        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        d = DatasetFactory()
+        self.app.config['EXPORT_CSV_DATASET_ID'] = d.id
         dataset_tasks.export_csv()
         response = self.get(url_for('site.organizations_csv'))
         self.assertStatus(response, 302)
@@ -382,8 +382,8 @@ class SiteViewsTest(FrontTestCase):
         self.assert404(response)
 
         # generate the export
-        o = OrganizationFactory()
-        self.app.config['EXPORT_CSV_DATASET_INFO']['organization'] = o.id
+        d = DatasetFactory()
+        self.app.config['EXPORT_CSV_DATASET_ID'] = d.id
         dataset_tasks.export_csv()
         response = self.get(url_for('site.reuses_csv'))
         self.assertStatus(response, 302)


### PR DESCRIPTION
Creating a dataset (or editing for that matter) with a specific slug breaks search indexation. That's why this PR switches from `slug` to `id` when referencing the dataset of datasets. It's a bit more pain at feature setup but it works ™️.