### PR TITLE
Quick fix for activity.atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Dataset of datasets: id as ref instead of slug [#2195](https://github.com/opendatateam/udata/pull/2195) :warning: this introduces some settings changes, cf [documentation for EXPORT_CSV](https://github.com/opendatateam/udata/blob/master/docs/adapting-settings.md).
 - Add meta og:type: make twitter cards work [#2196](https://github.com/opendatateam/udata/pull/2196)
 - Fix UI responsiveness [#2199](https://github.com/opendatateam/udata/pull/2199)
+- Quick fix for activity.atom [#2203](https://github.com/opendatateam/udata/pull/2203)
 
 ## 1.6.11 (2019-05-29)
 

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -43,7 +43,8 @@ def inject_site():
 @blueprint.route('/activity.atom')
 def activity_feed():
     feed = AtomFeed(
-        'Site activity', feed_url=request.url, url=request.url_root)
+        current_app.config.get('SITE_TITLE'), feed_url=request.url,
+        url=request.url_root)
     activities = (Activity.objects.order_by('-created_at')
                                   .limit(current_site.feed_size))
     for activity in activities.select_related():

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -46,14 +46,15 @@ def activity_feed():
         'Site activity', feed_url=request.url, url=request.url_root)
     activities = (Activity.objects.order_by('-created_at')
                                   .limit(current_site.feed_size))
-    for activity in activities:
+    for activity in activities.select_related():
         owner = activity.actor or activity.organization
+        related = activity.related_to
         feed.add(
             id='%s#activity=%s' % (
                 url_for('site.dashboard', _external=True), activity.id),
             title='%s by %s on %s' % (
-                activity.key, owner, activity.related_to),
-            url=activity.related_to.url_for(_external=True),
+                activity.key, owner, related),
+            url=related.url_for(_external=True),
             author={
                 'name': owner,
                 'uri': owner.url_for(_external=True)

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -47,7 +47,19 @@ def activity_feed():
     activities = (Activity.objects.order_by('-created_at')
                                   .limit(current_site.feed_size))
     for activity in activities:
-        feed.add('Activity', 'Description')
+        owner = activity.actor or activity.organization
+        feed.add(
+            id='%s#activity=%s' % (
+                url_for('site.dashboard', _external=True), activity.id),
+            title='%s by %s on %s' % (
+                activity.key, owner, activity.related_to),
+            url=activity.related_to.url_for(_external=True),
+            author={
+                'name': owner,
+                'uri': owner.url_for(_external=True)
+            },
+            updated=activity.created_at
+        )
     return feed.get_response()
 
 


### PR DESCRIPTION
This fixes the `activity.atom` feed (global site activity, as shown below dashboard) that never seem to have been implemented.

It will be mainly used for moderation purposes on data.gouv.fr and it's not prettily formatted or advertised on the site.

Accessible on https://next.data.gouv.fr/fr/activity.atom for example.