### PR TITLE
replace default search sort label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Reduce following to staring [#2192](https://github.com/opendatateam/udata/pull/2192/files)
 - Simplify display of spatial coverage in search results [#2192](https://github.com/opendatateam/udata/pull/2192/files)
 - Add cache for organization and topic display pages [#2194](https://github.com/opendatateam/udata/pull/2194)
+- Replace default sort label for better readability [#2206](https://github.com/opendatateam/udata/pull/2206)
 
 ## 1.6.11 (2019-05-29)
 

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -18,7 +18,7 @@
 <div class="btn-group">
     <button type="button" class="btn btn-sorter btn-xs dropdown-toggle" data-toggle="dropdown">
         <span class="fa fa-fw fa-chevron-down hidden-sm"></span>
-        {{ label|truncate(12, True) or _('Science') }}
+        {{ label|truncate(12, True) or _('Relevance') }}
     </button>
     <ul class="dropdown-menu">
         <li>

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -18,7 +18,7 @@
 <div class="btn-group">
     <button type="button" class="btn btn-sorter btn-xs dropdown-toggle" data-toggle="dropdown">
         <span class="fa fa-fw fa-chevron-down hidden-sm"></span>
-        {{ label|truncate(12, True) or _('magic') }}
+        {{ label|truncate(12, True) or _('science') }}
     </button>
     <ul class="dropdown-menu">
         <li>

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -18,7 +18,7 @@
 <div class="btn-group">
     <button type="button" class="btn btn-sorter btn-xs dropdown-toggle" data-toggle="dropdown">
         <span class="fa fa-fw fa-chevron-down hidden-sm"></span>
-        {{ label|truncate(12, True) or '---' }}
+        {{ label|truncate(12, True) or _('magic') }}
     </button>
     <ul class="dropdown-menu">
         <li>

--- a/udata/templates/macros/search.html
+++ b/udata/templates/macros/search.html
@@ -18,7 +18,7 @@
 <div class="btn-group">
     <button type="button" class="btn btn-sorter btn-xs dropdown-toggle" data-toggle="dropdown">
         <span class="fa fa-fw fa-chevron-down hidden-sm"></span>
-        {{ label|truncate(12, True) or _('science') }}
+        {{ label|truncate(12, True) or _('Science') }}
     </button>
     <ul class="dropdown-menu">
         <li>


### PR DESCRIPTION
Right now the default label for search sort is "---" this is not very explicit and might induce a believe of random or non-existent algorithm. "magic" is coming from kickstarter.com. We can use a more corporate copy text.

![image](https://user-images.githubusercontent.com/27315/59849804-f488d200-9368-11e9-83c8-4c3badad4c0c.png)
