### PR TITLE
Prevent deleted harvesters from running until purged (fix #2185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Remove diff from js dependencies to fix CVE [#2204](https://github.com/opendatateam/udata/pull/2204)
 - Replace default sort label for better readability [#2206](https://github.com/opendatateam/udata/pull/2206)
 - Add a condition to up-to-dateness of a dataset [#2208](https://github.com/opendatateam/udata/pull/2208)
-- Prevent deleted harvester from runnning until purged
+- Prevent deleted harvesters from running until purged. Harvest jobs history is deleted too on purge. [#2209](https://github.com/opendatateam/udata/pull/2209)
 
 ## 1.6.11 (2019-05-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Remove diff from js dependencies to fix CVE [#2204](https://github.com/opendatateam/udata/pull/2204)
 - Replace default sort label for better readability [#2206](https://github.com/opendatateam/udata/pull/2206)
 - Add a condition to up-to-dateness of a dataset [#2208](https://github.com/opendatateam/udata/pull/2208)
+- Prevent deleted harvester from runnning until purged
 
 ## 1.6.11 (2019-05-29)
 

--- a/js/views/harvester.vue
+++ b/js/views/harvester.vue
@@ -45,7 +45,7 @@ import SourceWidget from 'components/harvest/source.vue';
 import JobWidget from 'components/harvest/job.vue';
 import Layout from 'components/layout.vue';
 
-const MASK = ['id', 'name', 'url', 'owner', 'organization', 'backend', 'validation{state}', 'schedule'];
+const MASK = ['id', 'name', 'url', 'owner', 'organization', 'backend', 'validation{state}', 'schedule', 'deleted'];
 
 export default {
     name: 'HarvestSourceView',

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -159,7 +159,7 @@ class HarvestJob(db.Document):
                             default=DEFAULT_HARVEST_JOB_STATUS, required=True)
     errors = db.ListField(db.EmbeddedDocumentField(HarvestError))
     items = db.ListField(db.EmbeddedDocumentField(HarvestItem))
-    source = db.ReferenceField(HarvestSource, reverse_delete_rule=db.NULLIFY)
+    source = db.ReferenceField(HarvestSource, reverse_delete_rule=db.CASCADE)
     data = db.DictField()
 
     meta = {

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -19,6 +19,8 @@ def harvest(self, ident):
     log.info('Launching harvest job for source "%s"', ident)
 
     source = HarvestSource.get(ident)
+    if source.deleted:
+        return  # Ignore deleted sources
     Backend = backends.get(current_app, source.backend)
     backend = Backend(source)
     items = backend.perform_initialization()
@@ -75,8 +77,8 @@ def harvest_finalize(results, source_id):
     harvest_job_finalize(results, job.id)
 
 
-@task(route='low.harvest')
-def purge_harvest_sources():
+@job('purge-harvesters', route='low.harvest')
+def purge_harvest_sources(self):
     log.info('Purging HarvestSources flagged as deleted')
     from .actions import purge_sources
     purge_sources()


### PR DESCRIPTION
This PR prevent deleted harvester from running until they are purged.

The purge have been named `purge-harvesters` to follow the convention.