### PR TITLE
Harvest list api fix v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Ensure `filetype='remote'` is set when using the manual ressource form [#2236](https://github.com/opendatateam/udata/pull/2236)
 - Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload) [#2131](https://github.com/opendatateam/udata/pull/2131)
 - Ensure HarvestItems are cleaned up on dataset deletion [#2131](https://github.com/opendatateam/udata/pull/2131)
+- Added `config.HARVEST_JOBS_RETENTION_DAYS` and `harvest-purge-jobs` job to apply it
 
 ## 1.6.12 (2019-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 - Fix queryless (no `q` text parameter) search results scoring (or lack of scoring) [#2231](https://github.com/opendatateam/udata/pull/2231)
 - Miscellaneous fixes on completers [#2215](https://github.com/opendatateam/udata/pull/2215)
 - Ensure `filetype='remote'` is set when using the manual ressource form [#2236](https://github.com/opendatateam/udata/pull/2236)
-- Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload) [#2131](https://github.com/opendatateam/udata/pull/2131)
-- Ensure HarvestItems are cleaned up on dataset deletion [#2131](https://github.com/opendatateam/udata/pull/2131)
-- Added `config.HARVEST_JOBS_RETENTION_DAYS` and `harvest-purge-jobs` job to apply it
+- Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload) [#2214](https://github.com/opendatateam/udata/pull/2214)
+- Ensure HarvestItems are cleaned up on dataset deletion [#2214](https://github.com/opendatateam/udata/pull/2214)
+- Added `config.HARVEST_JOBS_RETENTION_DAYS` and a `harvest-purge-jobs` job to apply it [#2214](https://github.com/opendatateam/udata/pull/2214) (migration). **Warning, the migration will enforce `config.HARVEST_JOBS_RETENTION_DAYS` and can take some time on a big `HarvestJob` collection**
 
 ## 1.6.12 (2019-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fix queryless (no `q` text parameter) search results scoring (or lack of scoring) [#2231](https://github.com/opendatateam/udata/pull/2231)
 - Miscellaneous fixes on completers [#2215](https://github.com/opendatateam/udata/pull/2215)
 - Ensure `filetype='remote'` is set when using the manual ressource form [#2236](https://github.com/opendatateam/udata/pull/2236)
+- Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload) [#2131](https://github.com/opendatateam/udata/pull/2131)
+- Ensure HarvestItems are cleaned up on dataset deletion [#2131](https://github.com/opendatateam/udata/pull/2131)
 
 ## 1.6.12 (2019-06-26)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -285,6 +285,12 @@ The number of items to fetch while previewing an harvest source
 
 A cron expression used as default harvester schedule when validating harvesters.
 
+### HARVEST_JOBS_RETENTION_DAYS
+
+**default**: `365`
+
+The number of days of harvest jobs to keep (ie. number of days of history kept)
+
 ## Link checker configuration
 
 ### LINKCHECKING_ENABLED

--- a/udata/commands/db.py
+++ b/udata/commands/db.py
@@ -27,7 +27,7 @@ def grp():
 
 # A migration script wrapper recording the stdout lines
 SCRIPT_WRAPPER = '''
-function(plugin, filename, script) {{
+function(plugin, filename, script, config) {{
     var stdout = [];
     function print() {{
         var args = Array.prototype.slice.call(arguments);
@@ -50,7 +50,7 @@ function(plugin, filename, script) {{
 
 # Only record a migration script
 RECORD_WRAPPER = '''
-function(plugin, filename, script) {
+function(plugin, filename, script, config) {
     db.migrations.insert({
         plugin: plugin,
         filename: filename,
@@ -96,7 +96,7 @@ def execute_migration(plugin, filename, script, dryrun=False):
     success = True
     if not dryrun:
         try:
-            lines = db.eval(js, plugin, filename, script)
+            lines = db.eval(js, plugin, filename, script, current_app.config)
         except OperationFailure as e:
             log.error(e.details['errmsg'].replace('\n', '\\n'))
             success = False
@@ -115,7 +115,7 @@ def execute_migration(plugin, filename, script, dryrun=False):
 def record_migration(plugin, filename, script, **kwargs):
     '''Only record a migration without applying it'''
     db = get_db()
-    db.eval(RECORD_WRAPPER, plugin, filename, script)
+    db.eval(RECORD_WRAPPER, plugin, filename, script, current_app.config)
     return True
 
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -15,6 +15,7 @@ from udata import mail
 from udata import models as udata_models
 from udata.core import storages
 from udata.frontend import csv
+from udata.harvest.models import HarvestJob
 from udata.i18n import lazy_gettext as _
 from udata.models import (Follow, Issue, Discussion, Activity, Metrics, Topic,
                           Organization)
@@ -44,6 +45,8 @@ def purge_datasets(self):
             datasets = topic.datasets
             datasets.remove(dataset)
             topic.update(datasets=datasets)
+        # Remove HarvestItem references
+        HarvestJob.objects(items__dataset=dataset).update(set__items__S__dataset=None)
         # Remove
         dataset.delete()
 

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -5,7 +5,7 @@ import logging
 import unicodecsv as csv
 
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from bson import ObjectId
 from flask import current_app
@@ -135,6 +135,13 @@ def delete_source(ident):
 def purge_sources():
     '''Permanently remove sources flagged as deleted'''
     return HarvestSource.objects(deleted__exists=True).delete()
+
+
+def purge_jobs():
+    '''Delete jobs older than retention policy'''
+    retention = current_app.config['HARVEST_JOBS_RETENTION_DAYS']
+    expiration = datetime.now() - timedelta(days=retention)
+    return HarvestJob.objects(created__lt=expiration).delete()
 
 
 def run(ident):

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -123,12 +123,16 @@ class HarvestSource(db.Owned, db.Document):
     def get(cls, ident):
         return cls.objects(slug=ident).first() or cls.objects.get(pk=ident)
 
-    def get_last_job(self):
-        return HarvestJob.objects(source=self).order_by('-created').first()
+    def get_last_job(self, reduced=False):
+        qs = HarvestJob.objects(source=self)
+        if reduced:
+            qs = qs.exclude('source', 'items', 'errors', 'data')
+            qs = qs.no_dereference()
+        return qs.order_by('-created').first()
 
     @cached_property
     def last_job(self):
-        return self.get_last_job()
+        return self.get_last_job(reduced=True)
 
     @property
     def schedule(self):

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -82,3 +82,10 @@ def purge_harvest_sources(self):
     log.info('Purging HarvestSources flagged as deleted')
     from .actions import purge_sources
     purge_sources()
+
+
+@job('purge-harvest-jobs', route='low.harvest')
+def purge_harvest_jobs(self):
+    log.info('Purging HarvestJobs older than retention policy')
+    from .actions import purge_jobs
+    purge_jobs()

--- a/udata/harvest/tests/test_tasks.py
+++ b/udata/harvest/tests/test_tasks.py
@@ -4,15 +4,21 @@ from __future__ import unicode_literals
 import logging
 import pytest
 
-from ..tasks import purge_harvest_sources
+from ..tasks import purge_harvest_sources, purge_harvest_jobs
 
 log = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures('clean_db')
 class HarvestActionsTest:
-    def test_purge(self, mocker):
+    def test_purge_sources(self, mocker):
         '''It should purge from DB sources flagged as deleted'''
         mock = mocker.patch('udata.harvest.actions.purge_sources')
         purge_harvest_sources()
+        mock.assert_called_once_with()
+
+    def test_purge_jobs(self, mocker):
+        '''It should purge from DB jobs older than retention policy'''
+        mock = mocker.patch('udata.harvest.actions.purge_jobs')
+        purge_harvest_jobs()
         mock.assert_called_once_with()

--- a/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
+++ b/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
@@ -1,0 +1,29 @@
+/**
+ * Delete references to deleted datasets
+ */
+
+var updated = 0;
+
+// Match all HarvestJob.items.dataset not found in dataset collection
+const pipeline = [
+    {$unwind: '$items'},  // One row by item
+    {$group: {_id: null, datasetId: {$addToSet: '$items.dataset'}}}, // Distinct Dataset IDs
+    {$unwind: '$datasetId'}, // One row by ID
+    {$lookup: {from: 'dataset', localField: 'datasetId', foreignField: '_id', as: 'dataset'}}, // Join
+    {$match: {'dataset': [] }} // Only keep IDs without match
+];
+
+const index = {'items.dataset': 1};
+
+db.harvest_job.createIndex(index);
+db.harvest_job.aggregate(pipeline).forEach(row => {
+    const result = db.harvest_job.update(
+        {'items.dataset': row.datasetId},
+        {'$set': {'items.$.dataset': null}},
+        {multi: true}
+    );
+    updated += result.nModified;
+});
+db.harvest_job.dropIndex(index);
+
+print(`Updated ${updated} HarvestJob.items.dataset broken references.`);

--- a/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
+++ b/udata/migrations/2019-05-09-harvest-items-deleted-datasets.js
@@ -3,6 +3,12 @@
  */
 
 var updated = 0;
+var nbDays = config.HARVEST_JOBS_RETENTION_DAYS;
+var minDate = new Date(ISODate().getTime() - 1000 * 60 * 60 * 24 * nbDays);
+
+// Delete jobs older then minDate
+var result = db.harvest_job.deleteMany({'created': {'$lt': minDate}});
+print(`Deleted ${result.deletedCount} HarvestJobs according to retention policy (${config.HARVEST_JOBS_RETENTION_DAYS} days)`);
 
 // Match all HarvestJob.items.dataset not found in dataset collection
 const pipeline = [

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -178,6 +178,9 @@ class Defaults(object):
     # Harvesters are scheduled at midnight by default
     HARVEST_DEFAULT_SCHEDULE = '0 0 * * *'
 
+    # The number of days of harvest jobs to keep (ie. number of days of history kept)
+    HARVEST_JOBS_RETENTION_DAYS = 365
+
     # Lists levels that shouldn't be indexed
     SPATIAL_SEARCH_EXCLUDE_LEVELS = tuple()
 


### PR DESCRIPTION
This PR fixes the HarvestSources list API in case of a deleted harvested dataset.
It includes:
- reduced DB/API payload on listing (limit the data pulled by last_job attribute) and faster response
HarvestJob.items.dataset cleanup on dataset purge
- a cleanup migration for existing HarvestJobs

The migration duration depends on the harvest_jobs collection size and can take some time on big instances.

Replace #2131 and adds:
- a `HARVEST_JOBS_RETENTION_DAYS` parameter
- a `harvest-purge-jobs` job to cleanup harvest jobs older than retention policy
- the application configuration is now available in migrations as `config`
- the migration enforces `HARVEST_JOBS_RETENTION_DAYS` before the fix to reduce the amount of jobs to fix (makes way less iterations)
