### PR TITLE
Miscellaneous fixes on completers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Handle UTF-8 filenames in `spatial load_logos` command [#2223](https://github.com/opendatateam/udata/pull/2223)
 - Display the datasets, reuses and harvesters deleted state on listing when possible [#2228](https://github.com/opendatateam/udata/pull/2228)
 - Fix queryless (no `q` text parameter) search results scoring (or lack of scoring) [#2231](https://github.com/opendatateam/udata/pull/2231)
+- Miscellaneous fixes on completers [#2215](https://github.com/opendatateam/udata/pull/2215)
 
 ## 1.6.12 (2019-06-26)
 

--- a/js/components/form/base-completer.vue
+++ b/js/components/form/base-completer.vue
@@ -19,7 +19,30 @@ import CustomError from 'error';
 import utils from 'utils';
 import {FieldComponentMixin} from 'components/form/base-field';
 
-import 'selectize';
+import Selectize from 'selectize';
+
+/**
+ * A Selectize plugin to avoid field clearing on blur
+ * Based on: https://github.com/selectize/selectize.js/issues/999#issuecomment-380382572
+ */
+Selectize.define('preserve-on-blur', function (options) {
+    this.onBlur = ((e) => {
+        var original = this.onBlur;
+
+        return function (e) {
+            // Capture the current input value
+            var $input = this.$control_input;
+            var inputValue = $input.val();
+
+            // Do the default actions
+            original.apply(this, [e]);
+
+            // Set the value back                    
+            this.setTextboxValue(inputValue);
+        };
+    })();
+});
+
 
 class CompleterError extends CustomError {};
 
@@ -47,7 +70,7 @@ export default {
         selectize_options() {
             var opts = this.$options.selectize;
 
-            return $.extend({},
+            opts = $.extend({},
                 utils.isFunction(opts) ? opts.apply(this, []) : opts,
                 {
                     persist: false,
@@ -61,6 +84,8 @@ export default {
                     }
                 }
             );
+            opts.plugins.push('preserve-on-blur');
+            return opts;
         }
     },
     events: {

--- a/js/components/form/base-completer.vue
+++ b/js/components/form/base-completer.vue
@@ -159,10 +159,12 @@ export default {
     }
 
     .selectize-dropdown .selectize-option {
+        padding-left: 5px;
         .logo {
             width: 25px;
             height: 25px;
             border: 1px solid @gray-lighter;
+            margin-left: -5px;
             margin-right: 5px;
             img {
                 width: 100%;

--- a/js/components/form/base-completer.vue
+++ b/js/components/form/base-completer.vue
@@ -114,6 +114,12 @@ export default {
                 callback();
             });
         },
+        clear() {
+            if (this.selectize) {
+                this.selectize.clear(true);
+                this.selectize.setTextboxValue('');
+            }
+        },
         destroy() {
             if (this.selectize) {
                 this.selectize.destroy();

--- a/js/components/form/zone-completer.vue
+++ b/js/components/form/zone-completer.vue
@@ -92,7 +92,7 @@ export default {
             render: {
                 option: (data, escape) => {
                     const opt = [
-                            '<div class="selectize-zone">',
+                            '<div class="selectize-option selectize-zone">',
                             '<span class="title">',
                             '<span class="name">',
                             escape(data.name),

--- a/js/components/organization/members.vue
+++ b/js/components/organization/members.vue
@@ -16,7 +16,7 @@
         }
     }
 
-    .selectize-control {
+    .form-control.selectize-control {
         height: @field-height;
     }
 

--- a/js/components/organization/members.vue
+++ b/js/components/organization/members.vue
@@ -129,7 +129,7 @@
             <span class="input-group-addon">
                 <span class="fa fa-user"></span>
             </span>
-            <user-completer v-ref:completer></user-completer>
+            <user-completer v-ref:completer :placeholder="_('Search an user')"></user-completer>
             <span class="input-group-btn">
                 <button class="btn btn-warning" type="button"
                     @click="close_completer">

--- a/js/components/organization/members.vue
+++ b/js/components/organization/members.vue
@@ -132,7 +132,7 @@
             <user-completer v-ref:completer></user-completer>
             <span class="input-group-btn">
                 <button class="btn btn-warning" type="button"
-                    @click="adding = false;">
+                    @click="close_completer">
                     <span class="fa fa-close"></span>
                 </button>
             </span>
@@ -180,6 +180,10 @@ export default {
         }
     },
     methods: {
+        close_completer() {
+            this.adding = false;
+            this.$refs.completer.clear(); // Prevent state from persisting
+        },
         member_click(member) {
             this.$root.$modal(MemberModal, {member: member, org: this.org});
         },


### PR DESCRIPTION
## Logo-less completers

Add a missing left padding on logo-less completers:

| Before | After |
|----------|---------|
| ![screenshot-www data gouv fr-2019 06 27-18-43-50](https://user-images.githubusercontent.com/15725/60288625-ea407800-9914-11e9-8199-eea3736f0186.png) | ![screenshot-data xps-2019 06 27-18-44-21](https://user-images.githubusercontent.com/15725/60288629-ec0a3b80-9914-11e9-8a16-e1bb2cf28c32.png) |

## Clear on blur
Selectize have an agressive blur (right click or "open inspector" blur) and by default it clears the field on blur. This PR prevent the annoying field clearing on blur.

## Add members

This PR fixes the broken user completer layout at the bottom of the members widget when adding user.
It also prevent the state from persisting between consecutive adds.
Also adds a placeholder for cleaner intent.

| Before | After |
|----------|---------|
| ![screenshot-data xps-2019 06 27-19-43-42](https://user-images.githubusercontent.com/15725/60288934-8c606000-9915-11e9-8516-8dcbd8d0596f.png) |  ![screenshot-data xps-2019 06 27-19-59-24](https://user-images.githubusercontent.com/15725/60289170-1b6d7800-9916-11e9-8afd-1525a8bc7e60.png) |

