### PR TITLE
Don't overwrite last_update field if manually set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Rename og:image target :warning: this will break your custom theme, please rename your logo image file to `logo-social.png` instead of `logo-600x600.png` [#2217](https://github.com/opendatateam/udata/pull/2217)
+- Don't automatically overwrite `last_update` field if manually set [#2020](https://github.com/opendatateam/udata/pull/2220)
 
 ## 1.6.12 (2019-06-26)
 

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -205,7 +205,6 @@ class BaseBackend(object):
             if self.dryrun:
                 dataset.validate()
             else:
-                dataset.last_modified = datetime.now()
                 dataset.save()
             item.dataset = dataset
             item.status = 'done'

--- a/udata/harvest/tests/test_base_backend.py
+++ b/udata/harvest/tests/test_base_backend.py
@@ -6,11 +6,13 @@ import pytest
 from datetime import datetime
 from urlparse import urlparse
 
+from dateutil.parser import parse
 from voluptuous import Schema
 
 from udata.utils import faker
 from udata.core.dataset.factories import DatasetFactory
 from udata.models import Dataset
+from udata.tests.helpers import assert_equal_dates
 
 from .factories import HarvestSourceFactory
 
@@ -40,6 +42,8 @@ class FakeBackend(BaseBackend):
         dataset = self.get_dataset(item.remote_id)
         for key, value in DatasetFactory.as_dict(visible=True).items():
             setattr(dataset, key, value)
+        if self.source.config.get('last_modified'):
+            dataset.last_modified = self.source.config['last_modified']
         return dataset
 
 
@@ -66,6 +70,7 @@ class HarvestFilterTest:
 @pytest.mark.usefixtures('clean_db')
 class BaseBackendTest:
     def test_simple_harvest(self):
+        now = datetime.now()
         nb_datasets = 3
         source = HarvestSourceFactory(config={'nb_datasets': nb_datasets})
         backend = FakeBackend(source)
@@ -75,11 +80,12 @@ class BaseBackendTest:
         assert len(job.items) == nb_datasets
         assert Dataset.objects.count() == nb_datasets
         for dataset in Dataset.objects():
+            assert_equal_dates(dataset.last_modified, now)
             assert dataset.extras['harvest:source_id'] == str(source.id)
             assert dataset.extras['harvest:domain'] == source.domain
             assert dataset.extras['harvest:remote_id'].startswith('fake-')
-            datetime.strptime(dataset.extras['harvest:last_update'],
-                              '%Y-%m-%dT%H:%M:%S.%f')
+            harvest_last_update = parse(dataset.extras['harvest:last_update'])
+            assert_equal_dates(harvest_last_update, now)
 
     def test_has_feature_defaults(self):
         source = HarvestSourceFactory()
@@ -144,6 +150,33 @@ class BaseBackendTest:
             assert dataset.extras['harvest:source_id'] == str(source.id)
             parsed = urlparse(source_url).netloc.split(':')[0]
             assert parsed == dataset.extras['harvest:domain']
+
+    def test_dont_overwrite_last_modified(self, mocker):
+        last_modified = faker.date_time_between(start_date='-30y', end_date='-1y')
+        source = HarvestSourceFactory(config={'nb_datasets': 1, 'last_modified': last_modified})
+        backend = FakeBackend(source)
+
+        backend.harvest()
+
+        dataset = Dataset.objects.first()
+
+        assert dataset.last_modified == last_modified
+        harvest_last_update = parse(dataset.extras['harvest:last_update'])
+        assert_equal_dates(harvest_last_update, datetime.now())
+
+    def test_dont_overwrite_last_modified_even_if_set_to_same(self, mocker):
+        last_modified = faker.date_time_between(start_date='-30y', end_date='-1y')
+        source = HarvestSourceFactory(config={'nb_datasets': 1, 'last_modified': last_modified})
+        backend = FakeBackend(source)
+
+        backend.harvest()
+        backend.harvest()  # Harvest twice to test same last_modified
+
+        dataset = Dataset.objects.first()
+
+        assert dataset.last_modified == last_modified
+        harvest_last_update = parse(dataset.extras['harvest:last_update'])
+        assert_equal_dates(harvest_last_update, datetime.now())
 
 
 @pytest.mark.usefixtures('clean_db')

--- a/udata/models/datetime_fields.py
+++ b/udata/models/datetime_fields.py
@@ -63,5 +63,6 @@ class Datetimed(object):
 
 @pre_save.connect
 def set_modified_datetime(sender, document, **kwargs):
-    if isinstance(document, Datetimed):
+    changed = document._get_changed_fields()
+    if isinstance(document, Datetimed) and 'last_modified' not in changed:
         document.last_modified = datetime.now()

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -12,7 +12,7 @@ from mongoengine.fields import BaseField
 from udata.settings import Defaults
 from udata.models import db, Dataset, validate_config, build_test_config
 from udata.errors import ConfigError
-from udata.tests.helpers import assert_json_equal
+from udata.tests.helpers import assert_json_equal, assert_equal_dates
 
 pytestmark = [
     pytest.mark.usefixtures('clean_db')
@@ -301,9 +301,40 @@ class DatetimedTest:
             created_at=earlier, last_modified=earlier)
 
         datetimed.save()
+        datetimed.reload()
 
-        assert datetimed.created_at == earlier
-        assert now <= datetimed.last_modified <= datetime.now()
+        assert_equal_dates(datetimed.created_at, earlier)
+        assert_equal_dates(datetimed.last_modified, now)
+
+    def test_save_last_modified_instance_manually_set(self):
+        now = datetime.now()
+        manual = now - timedelta(days=1)
+        earlier = now - timedelta(days=2)
+        datetimed = DatetimedTester.objects.create(created_at=earlier, last_modified=earlier)
+
+        datetimed.last_modified = manual
+        datetimed.save()
+        datetimed.reload()
+
+        assert_equal_dates(datetimed.created_at, earlier)
+        assert_equal_dates(datetimed.last_modified, manual)
+
+    def test_save_last_modified_instance_manually_set_same_value(self):
+        now = datetime.now()
+        manual = now - timedelta(days=1)
+        earlier = now - timedelta(days=2)
+        datetimed = DatetimedTester.objects.create(created_at=earlier, last_modified=earlier)
+
+        datetimed.last_modified = manual
+        datetimed.save()
+        datetimed.reload()
+
+        datetimed.last_modified = manual
+        datetimed.save()
+        datetimed.reload()
+
+        assert_equal_dates(datetimed.created_at, earlier)
+        assert_equal_dates(datetimed.last_modified, manual)
 
 
 class ExtrasFieldTest:


### PR DESCRIPTION
This PR prevent automatic `last_update` overwrite when it has been manually set.

Harvesting now rely on the same `last_update` handling (was also overwritten in `BaseHarvester`) and so benefit from this change.

Fix #2111