### PR TITLE
Handles UTF-8 filenames in geologos archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Rename og:image target :warning: this will break your custom theme, please rename your logo image file to `logo-social.png` instead of `logo-600x600.png` [#2217](https://github.com/opendatateam/udata/pull/2217)
 - Don't automatically overwrite `last_update` field if manually set [#2020](https://github.com/opendatateam/udata/pull/2220)
+- Handle UTF-8 filenames in `spatial load_logos` command [#2223](https://github.com/opendatateam/udata/pull/2223)
 
 ## 1.6.12 (2019-06-26)
 

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -121,6 +121,12 @@ def load(filename, drop=False):
     shutil.rmtree(tmp.path('translations'))  # Not in use for now.
 
 
+def safe_tarinfo(tarinfo):
+    '''make a tarinfo utf8-compatible'''
+    tarinfo.name = tarinfo.name.decode('utf8')
+    return tarinfo
+
+
 @grp.command()
 @click.argument('filename', metavar='<filename>')
 def load_logos(filename):
@@ -135,8 +141,9 @@ def load_logos(filename):
 
     log.info('Extracting GeoLogos bundle')
     with contextlib.closing(lzma.LZMAFile(filename)) as xz:
-        with tarfile.open(fileobj=xz) as f:
-            f.extractall(tmp.root)
+        with tarfile.open(fileobj=xz, encoding='utf8') as tar:
+            decoded = (safe_tarinfo(t) for t in tar.getmembers())
+            tar.extractall(tmp.root, members=decoded)
 
     log.info('Moving to the final location and cleaning up')
     if os.path.exists(logos.root):


### PR DESCRIPTION
This PR fixes geologos archive loading (`udata spatial load_logos`) with utf-8 logo filenames on systems where `sys.getdefaultencoding()` returns `ascii`.