### PR TITLE
Admin deletion consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Spatial completion: only index last version of each zone and prevent completion cluttering [#2140](https://github.com/opendatateam/udata/pull/2140)
 - Init: prompt to loads countries [#2140](https://github.com/opendatateam/udata/pull/2140)
 - Handle UTF-8 filenames in `spatial load_logos` command [#2223](https://github.com/opendatateam/udata/pull/2223)
+- Display the datasets, reuses and harvesters deleted state on listing when possible [#2228](https://github.com/opendatateam/udata/pull/2228)
 
 ## 1.6.12 (2019-06-26)
 

--- a/js/components/dataset/list.vue
+++ b/js/components/dataset/list.vue
@@ -26,7 +26,7 @@ export default {
                 },
                 sort: 'title',
                 align: 'left',
-                type: 'text'
+                type: 'deletable-text'
             }, {
                 label: this._('Creation'),
                 key: 'created_at',

--- a/js/components/datatable/cells/deletable-text.vue
+++ b/js/components/datatable/cells/deletable-text.vue
@@ -1,0 +1,12 @@
+<template>
+<del v-if="item.deleted"
+    :title="_('This item has been deleted')"
+    :datetime="item.deleted">{{value}}</del>
+<span v-else>{{value}}</span>
+</template>
+
+<script>
+export default {
+    name: 'datatable-cell-deletable-text'
+};
+</script>

--- a/js/components/datatable/cells/visibility.vue
+++ b/js/components/datatable/cells/visibility.vue
@@ -8,7 +8,7 @@ import {_} from 'i18n';
 const VISIBILITIES = {
     deleted: {
         label: _('Deleted'),
-        type: 'error'
+        type: 'danger'
     },
     private: {
         label: _('Private'),

--- a/js/components/harvest/sources.vue
+++ b/js/components/harvest/sources.vue
@@ -81,7 +81,9 @@ export default {
             }, {
                 label: this._('Status'),
                 key(item) {
-                    if (item.validation.state == 'pending') {
+                    if (item.deleted) {
+                        return 'deleted';
+                    } else if (item.validation.state == 'pending') {
                         return 'validation';
                     } else if (item.validation.state == 'refused') {
                         return 'refused';

--- a/js/components/harvest/sources.vue
+++ b/js/components/harvest/sources.vue
@@ -16,7 +16,7 @@ import {STATUS_CLASSES, STATUS_I18N} from 'models/harvest/job';
 import Datatable from 'components/datatable/widget.vue';
 import placeholders from 'helpers/placeholders';
 
-const MASK = ['id', 'name', 'owner', 'last_job{status,ended}', 'organization{name,logo_thumbnail}', 'backend', 'validation{state}'];
+const MASK = ['id', 'name', 'owner', 'last_job{status,ended}', 'organization{name,logo_thumbnail}', 'backend', 'validation{state}', 'deleted'];
 
 export default {
     MASK,
@@ -30,7 +30,7 @@ export default {
     data() {
         return {
             title: this._('Harvesters'),
-            sources: new HarvestSources({mask: MASK}),
+            sources: new HarvestSources({mask: MASK, query: {deleted: true}}),
         };
     },
     computed: {
@@ -103,6 +103,10 @@ export default {
                     else if (status == 'refused') return this._('Refused');
                     return STATUS_I18N[status];
                 }
+            }, {
+                label: '',
+                align: 'center',
+                type: 'visibility',
             }, {
                 label: this._('Last run'),
                 key: 'last_job.ended',

--- a/js/components/harvest/sources.vue
+++ b/js/components/harvest/sources.vue
@@ -54,7 +54,7 @@ export default {
                 label: this._('Name'),
                 key: 'name',
                 align: 'left',
-                type: 'text'
+                type: 'deletable-text'
             });
             // Only display owner if not filtered
             if (!(this.owner instanceof Model)) {
@@ -103,10 +103,6 @@ export default {
                     else if (status == 'refused') return this._('Refused');
                     return STATUS_I18N[status];
                 }
-            }, {
-                label: '',
-                align: 'center',
-                type: 'visibility',
             }, {
                 label: this._('Last run'),
                 key: 'last_job.ended',

--- a/js/components/reuse/list.vue
+++ b/js/components/reuse/list.vue
@@ -27,7 +27,7 @@ export default {
                 label: this._('Title'),
                 key: 'title',
                 sort: 'title',
-                type: 'text'
+                type: 'deletable-text'
             },{
                 label: this._('Creation'),
                 key: 'created_at',

--- a/js/models/harvest/job.js
+++ b/js/models/harvest/job.js
@@ -10,7 +10,8 @@ export const STATUS_CLASSES = {
     'processing': 'info',
     'done': 'success',
     'done-errors': 'warning',
-    'failed': 'danger'
+    'failed': 'danger',
+    'deleted': 'danger',
 };
 
 export const STATUS_I18N = {
@@ -20,8 +21,9 @@ export const STATUS_I18N = {
     'processing': _('Processing'),
     'done': _('Done'),
     'done-errors': _('Done with errors'),
-    'failed': _('Failed')
-}
+    'failed': _('Failed'),
+    'deleted': _('Deleted'),
+};
 
 export class HarvestJob extends Model {
     fetch() {
@@ -33,6 +35,6 @@ export class HarvestJob extends Model {
         }
         return this;
     }
-};
+}
 
 export default HarvestJob;

--- a/js/views/home.vue
+++ b/js/views/home.vue
@@ -48,7 +48,7 @@ export default {
             reuses: new PageList({
                 ns: 'me',
                 fetch: 'my_org_reuses',
-                mask: ReuseList.MASK
+                mask: ReuseList.MASK.concat(['deleted'])
             }),
             issues: new PageList({
                 ns: 'me',

--- a/js/views/me.vue
+++ b/js/views/me.vue
@@ -59,12 +59,12 @@ export default  {
             reuses: new PageList({
                 ns: 'me',
                 fetch: 'my_reuses',
-                mask: ReuseList.MASK
+                mask: ReuseList.MASK.concat(['deleted'])
             }),
             datasets: new PageList({
                 ns: 'me',
                 fetch: 'my_datasets',
-                mask: DatasetList.MASK
+                mask: DatasetList.MASK.concat(['deleted'])
             }),
             y: [{
                 id: 'datasets',

--- a/js/views/organization.vue
+++ b/js/views/organization.vue
@@ -77,14 +77,14 @@ export default {
                 ns: 'organizations',
                 fetch: 'list_organization_reuses',
                 search: 'title',
-                mask: ReuseList.MASK
+                mask: ReuseList.MASK.concat(['deleted'])
             }),
             datasets: new ModelPage({
                 query: {page_size: 10, sort: '-created'},
                 ns: 'organizations',
                 fetch: 'list_organization_datasets',
                 search: 'title',
-                mask: DatasetList.MASK
+                mask: DatasetList.MASK.concat(['deleted'])
             }),
             issues: new PageList({
                 ns: 'organizations',

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -30,21 +30,23 @@ def list_backends():
     return backends.get_all(current_app).values()
 
 
-def _sources_queryset(owner=None):
-    sources = HarvestSource.objects.visible()
+def _sources_queryset(owner=None, deleted=False):
+    sources = HarvestSource.objects
+    if not deleted:
+        sources = sources.visible()
     if owner:
         sources = sources.owned_by(owner)
     return sources
 
 
-def list_sources(owner=None):
+def list_sources(owner=None, deleted=False):
     '''List all harvest sources'''
-    return list(_sources_queryset(owner=owner))
+    return list(_sources_queryset(owner=owner, deleted=deleted))
 
 
-def paginate_sources(owner=None, page=1, page_size=DEFAULT_PAGE_SIZE):
+def paginate_sources(owner=None, page=1, page_size=DEFAULT_PAGE_SIZE, deleted=False):
     '''Paginate harvest sources'''
-    sources = _sources_queryset(owner=owner)
+    sources = _sources_queryset(owner=owner, deleted=deleted)
     page = max(page or 1, 1)
     return sources.paginate(page, page_size)
 

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -168,6 +168,8 @@ preview_job_fields = api.clone('HarvestJobPreview', job_fields, {
 source_parser = api.page_parser()
 source_parser.add_argument('owner', type=str, location='args',
                            help='The organization or user ID to filter on')
+source_parser.add_argument('deleted', type=bool, location='args', default=False,
+                           help='Include sources flaggued as deleted')
 
 
 @ns.route('/sources/', endpoint='harvest_sources')
@@ -180,7 +182,8 @@ class SourcesAPI(API):
         args = source_parser.parse_args()
         return actions.paginate_sources(args.get('owner'),
                                         page=args['page'],
-                                        page_size=args['page_size'])
+                                        page_size=args['page_size'],
+                                        deleted=args['deleted'])
 
     @api.secure
     @api.doc('create_harvest_source')

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -2,6 +2,9 @@
 from __future__ import unicode_literals
 
 import logging
+import pytest
+
+from datetime import datetime
 
 from flask import url_for
 
@@ -25,6 +28,7 @@ from .factories import HarvestSourceFactory, MockBackendsMixin
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.usefixtures('clean_db')
 class HarvestAPITest(MockBackendsMixin):
     modules = ['core.organization', 'core.user', 'core.dataset']
 
@@ -43,6 +47,22 @@ class HarvestAPITest(MockBackendsMixin):
         sources = HarvestSourceFactory.create_batch(3)
 
         response = api.get(url_for('api.harvest_sources'))
+        assert200(response)
+        assert len(response.json['data']) == len(sources)
+
+    def test_list_sources_exclude_deleted(self, api):
+        sources = HarvestSourceFactory.create_batch(3)
+        HarvestSourceFactory.create_batch(2, deleted=datetime.now())
+
+        response = api.get(url_for('api.harvest_sources'))
+        assert200(response)
+        assert len(response.json['data']) == len(sources)
+
+    def test_list_sources_include_deleted(self, api):
+        sources = HarvestSourceFactory.create_batch(3)
+        sources.extend(HarvestSourceFactory.create_batch(2, deleted=datetime.now()))
+
+        response = api.get(url_for('api.harvest_sources', deleted=True))
         assert200(response)
         assert len(response.json['data']) == len(sources)
 

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from datetime import datetime
 
 from flask import url_for
@@ -13,385 +15,382 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.models import Reuse, Follow, Member, REUSE_TYPES
 from udata.utils import faker
 
-from . import APITestCase
+from udata.tests.helpers import (
+    assert200, assert201, assert204, assert400, assert404, assert410
+)
 
 
-class ReuseAPITest(APITestCase):
+pytestmark = [
+    pytest.mark.usefixtures('clean_db'),
+]
+
+
+class ReuseAPITest:
     modules = ['core.dataset', 'core.reuse', 'core.user', 'core.organization']
 
-    def test_reuse_api_list(self):
+    def test_reuse_api_list(self, api, autoindex):
         '''It should fetch a reuse list from the API'''
-        with self.autoindex():
-            reuses = [ReuseFactory(
-                datasets=[DatasetFactory()]) for i in range(3)]
+        with autoindex:
+            reuses = ReuseFactory.create_batch(3, visible=True)
 
-        response = self.get(url_for('api.reuses'))
-        self.assert200(response)
-        self.assertEqual(len(response.json['data']), len(reuses))
+        response = api.get(url_for('api.reuses'))
+        assert200(response)
+        assert len(response.json['data']) == len(reuses)
 
-    def test_reuse_api_get(self):
+    def test_reuse_api_get(self, api):
         '''It should fetch a reuse from the API'''
         reuse = ReuseFactory()
-        response = self.get(url_for('api.reuse', reuse=reuse))
-        self.assert200(response)
+        response = api.get(url_for('api.reuse', reuse=reuse))
+        assert200(response)
 
-    def test_reuse_api_get_deleted(self):
+    def test_reuse_api_get_deleted(self, api):
         '''It should not fetch a deleted reuse from the API and raise 410'''
         reuse = ReuseFactory(deleted=datetime.now())
-        response = self.get(url_for('api.reuse', reuse=reuse))
-        self.assert410(response)
+        response = api.get(url_for('api.reuse', reuse=reuse))
+        assert410(response)
 
-    def test_reuse_api_get_deleted_but_authorized(self):
+    def test_reuse_api_get_deleted_but_authorized(self, api):
         '''It should fetch a deleted reuse from the API if authorized'''
-        self.login()
-        reuse = ReuseFactory(deleted=datetime.now(), owner=self.user)
-        response = self.get(url_for('api.reuse', reuse=reuse))
-        self.assert200(response)
+        user = api.login()
+        reuse = ReuseFactory(deleted=datetime.now(), owner=user)
+        response = api.get(url_for('api.reuse', reuse=reuse))
+        assert200(response)
 
-    def test_reuse_api_create(self):
+    def test_reuse_api_create(self, api):
         '''It should create a reuse from the API'''
         data = ReuseFactory.as_dict()
-        self.login()
-        response = self.post(url_for('api.reuses'), data)
-        self.assert201(response)
-        self.assertEqual(Reuse.objects.count(), 1)
+        user = api.login()
+        response = api.post(url_for('api.reuses'), data)
+        assert201(response)
+        assert Reuse.objects.count() == 1
 
         reuse = Reuse.objects.first()
-        self.assertEqual(reuse.owner, self.user)
-        self.assertIsNone(reuse.organization)
+        assert reuse.owner == user
+        assert reuse.organization is None
 
-    def test_reuse_api_create_as_org(self):
+    def test_reuse_api_create_as_org(self, api):
         '''It should create a reuse as organization from the API'''
-        self.login()
+        user = api.login()
         data = ReuseFactory.as_dict()
-        member = Member(user=self.user, role='editor')
+        member = Member(user=user, role='editor')
         org = OrganizationFactory(members=[member])
         data['organization'] = str(org.id)
-        response = self.post(url_for('api.reuses'), data)
-        self.assert201(response)
-        self.assertEqual(Reuse.objects.count(), 1)
+        response = api.post(url_for('api.reuses'), data)
+        assert201(response)
+        assert Reuse.objects.count() == 1
 
         reuse = Reuse.objects.first()
-        self.assertIsNone(reuse.owner)
-        self.assertEqual(reuse.organization, org)
+        assert reuse.owner is None
+        assert reuse.organization == org
 
-    def test_reuse_api_create_as_permissions(self):
+    def test_reuse_api_create_as_permissions(self, api):
         """It should create a reuse as organization from the API
 
         only if user is member.
         """
-        self.login()
+        api.login()
         data = ReuseFactory.as_dict()
         org = OrganizationFactory()
         data['organization'] = str(org.id)
-        response = self.post(url_for('api.reuses'), data)
-        self.assert400(response)
-        self.assertEqual(Reuse.objects.count(), 0)
+        response = api.post(url_for('api.reuses'), data)
+        assert400(response)
+        assert Reuse.objects.count() == 0
 
-    def test_reuse_api_update(self):
+    def test_reuse_api_update(self, api):
         '''It should update a reuse from the API'''
-        self.login()
-        reuse = ReuseFactory(owner=self.user)
+        user = api.login()
+        reuse = ReuseFactory(owner=user)
         data = reuse.to_dict()
         data['description'] = 'new description'
-        response = self.put(url_for('api.reuse', reuse=reuse), data)
-        self.assert200(response)
-        self.assertEqual(Reuse.objects.count(), 1)
-        self.assertEqual(Reuse.objects.first().description, 'new description')
+        response = api.put(url_for('api.reuse', reuse=reuse), data)
+        assert200(response)
+        assert Reuse.objects.count() == 1
+        assert Reuse.objects.first().description == 'new description'
 
-    def test_reuse_api_update_deleted(self):
+    def test_reuse_api_update_deleted(self, api):
         '''It should not update a deleted reuse from the API and raise 410'''
-        self.login()
+        api.login()
         reuse = ReuseFactory(deleted=datetime.now())
-        response = self.put(url_for('api.reuse', reuse=reuse), {})
-        self.assert410(response)
+        response = api.put(url_for('api.reuse', reuse=reuse), {})
+        assert410(response)
 
-    def test_reuse_api_delete(self):
+    def test_reuse_api_delete(self, api):
         '''It should delete a reuse from the API'''
-        self.login()
-        reuse = ReuseFactory(owner=self.user)
-        response = self.delete(url_for('api.reuse', reuse=reuse))
-        self.assertStatus(response, 204)
-        self.assertEqual(Reuse.objects.count(), 1)
-        self.assertIsNotNone(Reuse.objects[0].deleted)
+        user = api.login()
+        reuse = ReuseFactory(owner=user)
+        response = api.delete(url_for('api.reuse', reuse=reuse))
+        assert204(response)
+        assert Reuse.objects.count() == 1
+        assert Reuse.objects[0].deleted is not None
 
-    def test_reuse_api_delete_deleted(self):
+    def test_reuse_api_delete_deleted(self, api):
         '''It should not delete a deleted reuse from the API and raise 410'''
-        self.login()
+        api.login()
         reuse = ReuseFactory(deleted=datetime.now())
-        response = self.delete(url_for('api.reuse', reuse=reuse))
-        self.assert410(response)
+        response = api.delete(url_for('api.reuse', reuse=reuse))
+        assert410(response)
 
-    def test_reuse_api_add_dataset(self):
+    def test_reuse_api_add_dataset(self, api):
         '''It should add a dataset to a reuse from the API'''
-        self.login()
-        reuse = ReuseFactory(owner=self.user)
+        user = api.login()
+        reuse = ReuseFactory(owner=user)
 
         dataset = DatasetFactory()
         data = {'id': dataset.id, 'class': 'Dataset'}
         url = url_for('api.reuse_add_dataset', reuse=reuse)
-        response = self.post(url, data)
-        self.assert201(response)
+        response = api.post(url, data)
+        assert201(response)
         reuse.reload()
-        self.assertEqual(len(reuse.datasets), 1)
-        self.assertEqual(reuse.datasets[-1], dataset)
+        assert len(reuse.datasets) == 1
+        assert reuse.datasets[-1] == dataset
 
         dataset = DatasetFactory()
         data = {'id': dataset.id, 'class': 'Dataset'}
         url = url_for('api.reuse_add_dataset', reuse=reuse)
-        response = self.post(url, data)
-        self.assert201(response)
+        response = api.post(url, data)
+        assert201(response)
         reuse.reload()
-        self.assertEqual(len(reuse.datasets), 2)
-        self.assertEqual(reuse.datasets[-1], dataset)
+        assert len(reuse.datasets) == 2
+        assert reuse.datasets[-1] == dataset
 
-    def test_reuse_api_add_dataset_twice(self):
+    def test_reuse_api_add_dataset_twice(self, api):
         '''It should not add twice a dataset to a reuse from the API'''
-        self.login()
+        user = api.login()
         dataset = DatasetFactory()
-        reuse = ReuseFactory(owner=self.user, datasets=[dataset])
+        reuse = ReuseFactory(owner=user, datasets=[dataset])
 
         data = {'id': dataset.id, 'class': 'Dataset'}
         url = url_for('api.reuse_add_dataset', reuse=reuse)
-        response = self.post(url, data)
-        self.assert200(response)
+        response = api.post(url, data)
+        assert200(response)
         reuse.reload()
-        self.assertEqual(len(reuse.datasets), 1)
-        self.assertEqual(reuse.datasets[-1], dataset)
+        assert len(reuse.datasets) == 1
+        assert reuse.datasets[-1] == dataset
 
-    def test_reuse_api_add_dataset_not_found(self):
+    def test_reuse_api_add_dataset_not_found(self, api):
         '''It should return 404 when adding an unknown dataset to a reuse'''
-        self.login()
-        reuse = ReuseFactory(owner=self.user)
+        user = api.login()
+        reuse = ReuseFactory(owner=user)
 
         data = {'id': 'not-found', 'class': 'Dataset'}
         url = url_for('api.reuse_add_dataset', reuse=reuse)
-        response = self.post(url, data)
+        response = api.post(url, data)
 
-        self.assert404(response)
+        assert404(response)
         reuse.reload()
-        self.assertEqual(len(reuse.datasets), 0)
+        assert len(reuse.datasets) == 0
 
-    def test_reuse_api_feature(self):
+    def test_reuse_api_feature(self, api):
         '''It should mark the reuse featured on POST'''
         reuse = ReuseFactory(featured=False)
 
-        with self.api_user(AdminFactory()):
-            response = self.post(url_for('api.reuse_featured', reuse=reuse))
-        self.assert200(response)
+        with api.user(AdminFactory()):
+            response = api.post(url_for('api.reuse_featured', reuse=reuse))
+        assert200(response)
 
         reuse.reload()
-        self.assertTrue(reuse.featured)
+        assert reuse.featured
 
-    def test_reuse_api_feature_already(self):
+    def test_reuse_api_feature_already(self, api):
         '''It shouldn't do anything to feature an already featured reuse'''
         reuse = ReuseFactory(featured=True)
 
-        with self.api_user(AdminFactory()):
-            response = self.post(url_for('api.reuse_featured', reuse=reuse))
-        self.assert200(response)
+        with api.user(AdminFactory()):
+            response = api.post(url_for('api.reuse_featured', reuse=reuse))
+        assert200(response)
 
         reuse.reload()
-        self.assertTrue(reuse.featured)
+        assert reuse.featured
 
-    def test_reuse_api_unfeature(self):
+    def test_reuse_api_unfeature(self, api):
         '''It should mark the reuse featured on POST'''
         reuse = ReuseFactory(featured=True)
 
-        with self.api_user(AdminFactory()):
-            response = self.delete(url_for('api.reuse_featured', reuse=reuse))
-        self.assert200(response)
+        with api.user(AdminFactory()):
+            response = api.delete(url_for('api.reuse_featured', reuse=reuse))
+        assert200(response)
 
         reuse.reload()
-        self.assertFalse(reuse.featured)
+        assert not reuse.featured
 
-    def test_reuse_api_unfeature_already(self):
+    def test_reuse_api_unfeature_already(self, api):
         '''It shouldn't do anything to unfeature a not featured reuse'''
         reuse = ReuseFactory(featured=False)
 
-        with self.api_user(AdminFactory()):
-            response = self.delete(url_for('api.reuse_featured', reuse=reuse))
-        self.assert200(response)
+        with api.user(AdminFactory()):
+            response = api.delete(url_for('api.reuse_featured', reuse=reuse))
+        assert200(response)
 
         reuse.reload()
-        self.assertFalse(reuse.featured)
+        assert not reuse.featured
 
-    def test_follow_reuse(self):
+    def test_follow_reuse(self, api):
         '''It should follow a reuse on POST'''
-        user = self.login()
+        user = api.login()
         to_follow = ReuseFactory()
 
-        response = self.post(url_for('api.reuse_followers', id=to_follow.id))
-        self.assert201(response)
+        response = api.post(url_for('api.reuse_followers', id=to_follow.id))
+        assert201(response)
 
-        self.assertEqual(Follow.objects.following(to_follow).count(), 0)
-        self.assertEqual(Follow.objects.followers(to_follow).count(), 1)
+        assert Follow.objects.following(to_follow).count() == 0
+        assert Follow.objects.followers(to_follow).count() == 1
         follow = Follow.objects.followers(to_follow).first()
-        self.assertIsInstance(follow.following, Reuse)
-        self.assertEqual(Follow.objects.following(user).count(), 1)
-        self.assertEqual(Follow.objects.followers(user).count(), 0)
+        assert isinstance(follow.following, Reuse)
+        assert Follow.objects.following(user).count() == 1
+        assert Follow.objects.followers(user).count() == 0
 
-    def test_unfollow_reuse(self):
+    def test_unfollow_reuse(self, api):
         '''It should unfollow the reuse on DELETE'''
-        user = self.login()
+        user = api.login()
         to_follow = ReuseFactory()
         Follow.objects.create(follower=user, following=to_follow)
 
-        response = self.delete(url_for('api.reuse_followers', id=to_follow.id))
-        self.assert200(response)
+        response = api.delete(url_for('api.reuse_followers', id=to_follow.id))
+        assert200(response)
 
         nb_followers = Follow.objects.followers(to_follow).count()
 
-        self.assertEqual(response.json['followers'], nb_followers)
+        assert response.json['followers'] == nb_followers
 
-        self.assertEqual(Follow.objects.following(to_follow).count(), 0)
-        self.assertEqual(nb_followers, 0)
-        self.assertEqual(Follow.objects.following(user).count(), 0)
-        self.assertEqual(Follow.objects.followers(user).count(), 0)
+        assert Follow.objects.following(to_follow).count() == 0
+        assert nb_followers == 0
+        assert Follow.objects.following(user).count() == 0
+        assert Follow.objects.followers(user).count() == 0
 
-    def test_suggest_reuses_api(self):
+    def test_suggest_reuses_api(self, api, autoindex):
         '''It should suggest reuses'''
-        with self.autoindex():
+        with autoindex:
             for i in range(4):
                 ReuseFactory(
                     title='test-{0}'.format(i) if i % 2 else faker.word(),
-                    datasets=[DatasetFactory()])
+                    visible=True)
 
-        response = self.get(url_for('api.suggest_reuses'),
-                            qs={'q': 'tes', 'size': '5'})
-        self.assert200(response)
+        response = api.get(url_for('api.suggest_reuses'),
+                           qs={'q': 'tes', 'size': '5'})
+        assert200(response)
 
-        self.assertLessEqual(len(response.json), 5)
-        self.assertGreater(len(response.json), 1)
+        assert len(response.json) <= 5
+        assert len(response.json) > 1
 
         for suggestion in response.json:
-            self.assertIn('id', suggestion)
-            self.assertIn('slug', suggestion)
-            self.assertIn('title', suggestion)
-            self.assertIn('score', suggestion)
-            self.assertIn('image_url', suggestion)
-            self.assertTrue(suggestion['title'].startswith('test'))
+            assert 'id' in suggestion
+            assert 'slug' in suggestion
+            assert 'title' in suggestion
+            assert 'score' in suggestion
+            assert 'image_url' in suggestion
+            assert suggestion['title'].startswith('test')
 
-    def test_suggest_reuses_api_unicode(self):
+    def test_suggest_reuses_api_unicode(self, api, autoindex):
         '''It should suggest reuses with special characters'''
-        with self.autoindex():
+        with autoindex:
             for i in range(4):
                 ReuseFactory(
                     title='testé-{0}'.format(i) if i % 2 else faker.word(),
-                    datasets=[DatasetFactory()])
+                    visible=True)
 
-        response = self.get(url_for('api.suggest_reuses'),
-                            qs={'q': 'testé', 'size': '5'})
-        self.assert200(response)
+        response = api.get(url_for('api.suggest_reuses'),
+                           qs={'q': 'testé', 'size': '5'})
+        assert200(response)
 
-        self.assertLessEqual(len(response.json), 5)
-        self.assertGreater(len(response.json), 1)
+        assert len(response.json) <= 5
+        assert len(response.json) > 1
 
         for suggestion in response.json:
-            self.assertIn('id', suggestion)
-            self.assertIn('slug', suggestion)
-            self.assertIn('title', suggestion)
-            self.assertIn('score', suggestion)
-            self.assertIn('image_url', suggestion)
-            self.assertTrue(suggestion['title'].startswith('test'))
+            assert 'id' in suggestion
+            assert 'slug' in suggestion
+            assert 'title' in suggestion
+            assert 'score' in suggestion
+            assert 'image_url' in suggestion
+            assert suggestion['title'].startswith('test')
 
-    def test_suggest_reuses_api_no_match(self):
+    def test_suggest_reuses_api_no_match(self, api, autoindex):
         '''It should not provide reuse suggestion if no match'''
-        with self.autoindex():
-            for i in range(3):
-                ReuseFactory(datasets=[DatasetFactory()])
+        with autoindex:
+            ReuseFactory.create_batch(3, visible=True)
 
-        response = self.get(url_for('api.suggest_reuses'),
-                            qs={'q': 'xxxxxx', 'size': '5'})
-        self.assert200(response)
-        self.assertEqual(len(response.json), 0)
+        response = api.get(url_for('api.suggest_reuses'),
+                           qs={'q': 'xxxxxx', 'size': '5'})
+        assert200(response)
+        assert len(response.json) == 0
 
-    def test_suggest_reuses_api_empty(self):
+    def test_suggest_reuses_api_empty(self, api, autoindex):
         '''It should not provide reuse suggestion if no data'''
-        self.init_search()
-        response = self.get(url_for('api.suggest_reuses'),
-                            qs={'q': 'xxxxxx', 'size': '5'})
-        self.assert200(response)
-        self.assertEqual(len(response.json), 0)
+        # self.init_search()
+        response = api.get(url_for('api.suggest_reuses'),
+                           qs={'q': 'xxxxxx', 'size': '5'})
+        assert200(response)
+        assert len(response.json) == 0
 
 
-class ReuseBadgeAPITest(APITestCase):
-    @classmethod
-    def setUpClass(cls):
+class ReuseBadgeAPITest:
+    modules = ['core.dataset', 'core.reuse', 'core.user', 'core.organization']
+
+    @pytest.fixture(autouse=True)
+    def setup(self, api, clean_db):
         # Register at least two badges
         Reuse.__badges__['test-1'] = 'Test 1'
         Reuse.__badges__['test-2'] = 'Test 2'
 
-        cls.factory = badge_factory(Reuse)
-
-    def setUp(self):
-        self.login(AdminFactory())
+        self.factory = badge_factory(Reuse)
+        self.user = api.login(AdminFactory())
         self.reuse = ReuseFactory()
 
-    def test_list(self):
-        response = self.get(url_for('api.available_reuse_badges'))
-        self.assertStatus(response, 200)
-        self.assertEqual(len(response.json), len(Reuse.__badges__))
+    def test_list(self, api):
+        response = api.get(url_for('api.available_reuse_badges'))
+        assert200(response)
+        assert len(response.json) == len(Reuse.__badges__)
         for kind, label in Reuse.__badges__.items():
-            self.assertIn(kind, response.json)
-            self.assertEqual(response.json[kind], label)
+            assert kind in response.json
+            assert response.json[kind] == label
 
-    def test_create(self):
+    def test_create(self, api):
         data = self.factory.as_dict()
-        with self.api_user():
-            response = self.post(
-                url_for('api.reuse_badges', reuse=self.reuse), data)
-        self.assert201(response)
+        response = api.post(url_for('api.reuse_badges', reuse=self.reuse), data)
+        assert201(response)
         self.reuse.reload()
-        self.assertEqual(len(self.reuse.badges), 1)
+        assert len(self.reuse.badges) == 1
 
-    def test_create_same(self):
+    def test_create_same(self, api):
         data = self.factory.as_dict()
-        with self.api_user():
-            self.post(
-                url_for('api.reuse_badges', reuse=self.reuse), data)
-            response = self.post(
-                url_for('api.reuse_badges', reuse=self.reuse), data)
-        self.assertStatus(response, 200)
+        api.post(url_for('api.reuse_badges', reuse=self.reuse), data)
+        response = api.post(url_for('api.reuse_badges', reuse=self.reuse), data)
+        assert200(response)
         self.reuse.reload()
-        self.assertEqual(len(self.reuse.badges), 1)
+        assert len(self.reuse.badges) == 1
 
-    def test_create_2nd(self):
+    def test_create_2nd(self, api):
         # Explicitely setting the kind to avoid collisions given the
         # small number of choices for kinds.
         kinds_keys = Reuse.__badges__.keys()
         self.reuse.add_badge(kinds_keys[0])
         data = self.factory.as_dict()
         data['kind'] = kinds_keys[1]
-        with self.api_user():
-            response = self.post(
-                url_for('api.reuse_badges', reuse=self.reuse), data)
-        self.assert201(response)
+        response = api.post(url_for('api.reuse_badges', reuse=self.reuse), data)
+        assert201(response)
         self.reuse.reload()
-        self.assertEqual(len(self.reuse.badges), 2)
+        assert len(self.reuse.badges) == 2
 
-    def test_delete(self):
+    def test_delete(self, api):
         badge = self.factory()
         self.reuse.add_badge(badge.kind)
-        with self.api_user():
-            response = self.delete(
-                url_for('api.reuse_badge', reuse=self.reuse,
-                        badge_kind=str(badge.kind)))
-        self.assertStatus(response, 204)
+        response = api.delete(url_for('api.reuse_badge',
+                                      reuse=self.reuse,
+                                      badge_kind=str(badge.kind)))
+        assert204(response)
         self.reuse.reload()
-        self.assertEqual(len(self.reuse.badges), 0)
+        assert len(self.reuse.badges) == 0
 
-    def test_delete_404(self):
-        with self.api_user():
-            response = self.delete(
-                url_for('api.reuse_badge', reuse=self.reuse,
-                        badge_kind=str(self.factory().kind)))
-        self.assert404(response)
+    def test_delete_404(self, api):
+        response = api.delete(url_for('api.reuse_badge', reuse=self.reuse,
+                                      badge_kind=str(self.factory().kind)))
+        assert404(response)
 
 
-class ReuseReferencesAPITest(APITestCase):
-    def test_reuse_types_list(self):
+class ReuseReferencesAPITest:
+    modules = ['core.reuse']
+
+    def test_reuse_types_list(self, api):
         '''It should fetch the reuse types list from the API'''
-        response = self.get(url_for('api.reuse_types'))
-        self.assert200(response)
-        self.assertEqual(len(response.json), len(REUSE_TYPES))
+        response = api.get(url_for('api.reuse_types'))
+        assert200(response)
+        assert len(response.json) == len(REUSE_TYPES)


### PR DESCRIPTION
This PR displays deleted item in the admin interface when its possible without a big API change.

It will be visible on:
- `System > Harvesters` listing
- `Me` dashboard
- `Organization` dashboard

The deleted items are presented with a `<del>` markup (introduce a new `deletable-text` cell renderer):

![screenshot-data xps-2019 07 04-15-46-53](https://user-images.githubusercontent.com/15725/60672004-a8fc1b00-9e74-11e9-8f21-fe070ad63329.png)

![Capture d’écran de 2019-07-04 15-47-44](https://user-images.githubusercontent.com/15725/60672191-04c6a400-9e75-11e9-9afa-94a9182ef872.png)


An alternative approach is to reuse the `visibility` cell renderer (no new cell renderer but wider display):
![screenshot-data xps-2019 07 04-15-37-52](https://user-images.githubusercontent.com/15725/60672059-c335f900-9e74-11e9-9f76-7ee0e0e47530.png)


NB: reuses test have been migrated while working on the initial specs, before the indexing part was removed. It can be submitted in another PR.

Related to #2216