### PR TITLE
Fix ProxyFix w/ Werkzeug 0.15.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Init: prompt to loads countries [#2140](https://github.com/opendatateam/udata/pull/2140)
 - Handle UTF-8 filenames in `spatial load_logos` command [#2223](https://github.com/opendatateam/udata/pull/2223)
 - Display the datasets, reuses and harvesters deleted state on listing when possible [#2228](https://github.com/opendatateam/udata/pull/2228)
+- :warning: Potentially breaking change: add `PROXYFIX_KWARGS` setting to correctly parse the `x-forwarded-for` headers when running behind a reverse proxy [#2230](https://github.com/opendatateam/udata/pull/2230)
 
 ## 1.6.12 (2019-06-26)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -138,6 +138,12 @@ The id of an existing user which will post a comment when a dataset is archived.
 The title of the comment optionaly posted when a dataset is archived.
 NB: the content of the comment is located in `udata/templates/comments/dataset_archived.txt`.
 
+### PROXYFIX_KWARGS
+
+**default**: `{'x_for': 1, 'x_proto': 1, 'x_host': 1}`
+
+Keyword arguments passed to the `ProxyFix` constructor, cf https://werkzeug.palletsprojects.com/en/0.15.x/middleware/proxy_fix/#werkzeug.middleware.proxy_fix.ProxyFix for configuration options.
+
 ## URLs validation
 
 ### URLS_ALLOW_PRIVATE

--- a/udata/app.py
+++ b/udata/app.py
@@ -180,7 +180,7 @@ def create_app(config='udata.settings.Defaults', override=None,
 
     app.debug = app.config['DEBUG'] and not app.config['TESTING']
 
-    app.wsgi_app = ProxyFix(app.wsgi_app)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
     init_logging(app)
     register_extensions(app)

--- a/udata/app.py
+++ b/udata/app.py
@@ -180,7 +180,8 @@ def create_app(config='udata.settings.Defaults', override=None,
 
     app.debug = app.config['DEBUG'] and not app.config['TESTING']
 
-    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
+    proxy_kwargs = app.config.get('PROXYFIX_KWARGS', {})
+    app.wsgi_app = ProxyFix(app.wsgi_app, **proxy_kwargs)
 
     init_logging(app)
     register_extensions(app)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -331,6 +331,12 @@ class Defaults(object):
     ARCHIVE_COMMENT_USER_ID = None
     ARCHIVE_COMMENT_TITLE = _('This dataset has been archived')
 
+    # ProxyFix parameters
+    ####################
+    PROXYFIX_KWARGS = {
+        'x_for': 1, 'x_proto': 1, 'x_host': 1
+    }
+
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''


### PR DESCRIPTION
We now need to specify which `x-forwarded-for` headers will be parsed by `ProxyFix`.

The default value matches our installation instructions: https://github.com/opendatateam/udata/blob/master/docs/installation.md#sample-nginx--uwsgi-configuration

https://werkzeug.palletsprojects.com/en/0.15.x/middleware/proxy_fix/#werkzeug.middleware.proxy_fix.ProxyFix