### PR TITLE
Search facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Init: prompt to loads countries [#2140](https://github.com/opendatateam/udata/pull/2140)
 - Handle UTF-8 filenames in `spatial load_logos` command [#2223](https://github.com/opendatateam/udata/pull/2223)
 - Display the datasets, reuses and harvesters deleted state on listing when possible [#2228](https://github.com/opendatateam/udata/pull/2228)
+- Fix queryless (no `q` text parameter) search results scoring (or lack of scoring) [#2231](https://github.com/opendatateam/udata/pull/2231)
 
 ## 1.6.12 (2019-06-26)
 

--- a/udata/core/topic/views.py
+++ b/udata/core/topic/views.py
@@ -25,7 +25,7 @@ class TopicSearchMixin(object):
     def search(self):
         '''Override search to match on topic tags'''
         s = super(TopicSearchMixin, self).search()
-        s = s.filter('bool', should=[
+        s = s.query('bool', should=[
             Q('term', tags=tag) for tag in self.topic.tags
         ])
         return s

--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -89,10 +89,9 @@ class SearchQuery(FacetedSearch):
         '''
         if not self._filters:
             return search
-        filters = Q('match_all')
         for f in self._filters.values():
-            filters &= f
-        return search.filter(filters)
+            search = search.query(f)  # this will make a Bool(must=filter)
+        return search
 
     def search(self):
         """


### PR DESCRIPTION
This query improve (fix in the case of empty `q` query) facets and topics filtering by using a `Bool(must)` instead of a `Bool(filter)` for facets/tags filtering (see https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-bool-query.html for reference).

The `Bool(filter)` form isn't contributing to scoring leading to an unranked list of results when `q` was omitted.
As a benefic side effect, the `Bool(must)` form should improve performance as the score functions are only applied on the matching query instead of the whole indexed data (in case of `q`-less query)

## Some examples of result changes on www.data.gouv.fr

### All data with France coverage
URL: https://www.data.gouv.fr/fr/datasets/?geozone=country%3Afr

| Before | After |
|----------|---------|
| ![screenshot-www data gouv fr-2019 07 09-10-20-57](https://user-images.githubusercontent.com/15725/60871676-80d53900-a233-11e9-99da-2cf4d927bec2.png) | ![screenshot-data xps-2019 07 09-10-21-30](https://user-images.githubusercontent.com/15725/60871680-829efc80-a233-11e9-8097-4449ce313cea.png) |

### Datasets taggued `association`
URL: https://www.data.gouv.fr/fr/datasets/?tag=association

| Before | After |
|----------|---------|
| ![screenshot-www data gouv fr-2019 07 09-10-26-33](https://user-images.githubusercontent.com/15725/60871989-2b4d5c00-a234-11e9-8234-845be895deb8.png) | ![screenshot-data xps-2019 07 09-10-27-11](https://user-images.githubusercontent.com/15725/60871993-2d171f80-a234-11e9-9de5-9cabb22b16fa.png) |

### Dataset tagged `elections`
URL: 

| Before | After |
|----------|---------|
| ![screenshot-www data gouv fr-2019 07 09-10-32-26](https://user-images.githubusercontent.com/15725/60872450-f68dd480-a234-11e9-88ef-c8ff2859cdf5.png) | ![screenshot-data xps-2019 07 09-10-33-11](https://user-images.githubusercontent.com/15725/60872462-fa215b80-a234-11e9-8c37-13ffdcf64b05.png) |


### A Topic
URL: https://www.data.gouv.fr/fr/topics/education-et-recherche/datasets

| Before | After |
|----------|---------|
| ![screenshot-www data gouv fr-2019 07 09-10-29-03](https://user-images.githubusercontent.com/15725/60872123-74051500-a234-11e9-806e-402c84823dc9.png) | ![screenshot-data xps-2019 07 09-10-29-29](https://user-images.githubusercontent.com/15725/60872130-75ced880-a234-11e9-9029-a351f3e7cb09.png) |
