### PR TITLE
Pin werkzeug to 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Init: prompt to loads countries [#2140](https://github.com/opendatateam/udata/pull/2140)
 - Handle UTF-8 filenames in `spatial load_logos` command [#2223](https://github.com/opendatateam/udata/pull/2223)
 - Display the datasets, reuses and harvesters deleted state on listing when possible [#2228](https://github.com/opendatateam/udata/pull/2228)
+- Pin werkzeug to 0.15.2 [#2232](https://github.com/opendatateam/udata/pull/2232)
 
 ## 1.6.12 (2019-06-26)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -59,7 +59,7 @@ ujson==1.35
 urllib3==1.24.3
 unicodecsv==0.14.1
 voluptuous==0.10.5
-werkzeug==0.15.2
+werkzeug==0.15.1
 wtforms-json==0.3.3
 wtforms==2.2.1
 xmltodict==0.12.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -59,7 +59,7 @@ ujson==1.35
 urllib3==1.24.3
 unicodecsv==0.14.1
 voluptuous==0.10.5
-werkzeug==0.15.4
+werkzeug==0.15.2
 wtforms-json==0.3.3
 wtforms==2.2.1
 xmltodict==0.12.0


### PR DESCRIPTION
Werkzeug >0.15.3 doubles our CI test/build time. 

We should test new releases after 0.15.4 to see if they fix this problem. In the meantime we can use 0.15.2.