### PR TITLE
Revert "Update werkzeug from 0.14.1 to 0.15.4 (#2144)"

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -59,7 +59,7 @@ ujson==1.35
 urllib3==1.24.3
 unicodecsv==0.14.1
 voluptuous==0.10.5
-werkzeug==0.15.4
+werkzeug==0.14.1
 wtforms-json==0.3.3
 wtforms==2.2.1
 xmltodict==0.12.0


### PR DESCRIPTION
This reverts commit 67a8f48b5ba9ca2b96d3660d202f6ef7297b2ca1.

Replaces #2233 (see there for details of why)