### PR TITLE
Remote resource race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Display the datasets, reuses and harvesters deleted state on listing when possible [#2228](https://github.com/opendatateam/udata/pull/2228)
 - Fix queryless (no `q` text parameter) search results scoring (or lack of scoring) [#2231](https://github.com/opendatateam/udata/pull/2231)
 - Miscellaneous fixes on completers [#2215](https://github.com/opendatateam/udata/pull/2215)
+- Ensure `filetype='remote'` is set when using the manual ressource form [#2236](https://github.com/opendatateam/udata/pull/2236)
 
 ## 1.6.12 (2019-06-26)
 

--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -288,6 +288,7 @@ export default {
     methods: {
         manual() {
             this.hasChosenRemoteFile = true;
+            this.resource.filetype = 'remote';
             this.isUpload = false;
         },
         postUpload() {

--- a/js/components/form/base-completer.vue
+++ b/js/components/form/base-completer.vue
@@ -37,7 +37,7 @@ Selectize.define('preserve-on-blur', function (options) {
             // Do the default actions
             original.apply(this, [e]);
 
-            // Set the value back                    
+            // Set the value back
             this.setTextboxValue(inputValue);
         };
     })();
@@ -76,6 +76,7 @@ export default {
                     persist: false,
                     closeAfterSelect: true,
                     load: this.load_suggestions.bind(this),
+                    plugins: [],
                     onItemAdd: (value, $item) => {
                         this.$dispatch('completer:item-add', value, $item);
                         if (this.$options.selectize.onItemAdd) {


### PR DESCRIPTION
This PR fix a case where `filetype` is set to `null` when filling the manual admin resource form by forcing the `filetype` value when enabling the manual form (using the link).

Fix #1987