### PR TITLE
Drop no_dereference (fix #2221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Improve harvest sources listing (limit `last_job` fetched and serialized fields, reduce payload) [#2214](https://github.com/opendatateam/udata/pull/2214)
 - Ensure HarvestItems are cleaned up on dataset deletion [#2214](https://github.com/opendatateam/udata/pull/2214)
 - Added `config.HARVEST_JOBS_RETENTION_DAYS` and a `harvest-purge-jobs` job to apply it [#2214](https://github.com/opendatateam/udata/pull/2214) (migration). **Warning, the migration will enforce `config.HARVEST_JOBS_RETENTION_DAYS` and can take some time on a big `HarvestJob` collection**
+- Drop `no_dereference` on indexing to avoid the "`dictionary changed size during iteration`" error until another solution is found. **Warning: this might result in more resources consumption while indexing** [#2237](https://github.com/opendatateam/udata/pull/2237)
 
 ## 1.6.12 (2019-06-26)
 

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -43,7 +43,7 @@ def iter_adapters():
 
 def iter_qs(qs, adapter):
     '''Safely iterate over a DB QuerySet yielding ES documents'''
-    for obj in qs.no_cache().no_dereference().timeout(False):
+    for obj in qs.no_cache().timeout(False):
         if adapter.is_indexable(obj):
             try:
                 doc = adapter.from_model(obj).to_dict(include_meta=True)


### PR DESCRIPTION
This PR drops `no_dereference` usage while indexing and so fixes #2221 

:warning: This might results in more resources consumption while indexing big databases