### PR TITLE
Cleanup permitted_reuses data (migration) [fix #2154]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Cleanup `permitted_reuses` data (migration) [#2244](https://github.com/opendatateam/udata/pull/2244)
 
 ## 1.6.13 (2019-07-11)
 

--- a/udata/migrations/2019-07-17-delete-permitted-reuses.js
+++ b/udata/migrations/2019-07-17-delete-permitted-reuses.js
@@ -1,0 +1,19 @@
+/*
+ * Cleanup permitted_reuses metric
+ * See: https://github.com/opendatateam/udata/pull/2244
+ */
+
+var result = db.organization.update(
+    {'metrics.permitted_reuses': {$exists: true}},
+    {$unset: {'metrics.permitted_reuses': true}},
+    {multi: true}
+);
+print(result.nModified, 'organizations cleaned (removed metrics.permitted_reuses attribute).');
+
+
+result = db.metrics.update(
+    {'values.permitted_reuses': {$exists: true}},
+    {$unset: {'values.permitted_reuses': true}},
+    {multi: true}
+);
+print(result.nModified, 'metrics cleaned (removed values.permitted_reuses attribute).');


### PR DESCRIPTION
This PR adds a migration cleaning up the remaining `permitted_reuses` data:
- `metrics.permitted_reuses` in `organization` collection
- `values.permitted_reuses` in `metrics` collection

See is a left over of #2153 (Fixes #2154)