### PR TITLE
Fix admin form errors handling on nested fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Cleanup `permitted_reuses` data (migration) [#2244](https://github.com/opendatateam/udata/pull/2244)
+- Proper form errors handling on nested fields [#2246](https://github.com/opendatateam/udata/pull/2246)
 
 ## 1.6.13 (2019-07-11)
 

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -1,6 +1,6 @@
 import API from 'api';
 import {_} from 'i18n';
-import {setattr, isObject, isString, findComponent} from 'utils';
+import {setattr, isObject, isString, findComponent, flattenObject} from 'utils';
 import log from 'logger';
 import moment from 'moment';
 import $ from 'jquery-validation';  // Ensure jquery & jquery.validate plugin are both loaded
@@ -270,7 +270,7 @@ export default {
             });
         },
         fill_errors(errors) {
-            Object.entries(errors).forEach(([field, errs]) => {
+            Object.entries(flattenObject(errors)).forEach(([field, errs]) => {
                 const el = this.$form.querySelector(`[name="${field}"]`);
                 const $field = this.findField(el);
                 $field.errors = errs;

--- a/js/utils.js
+++ b/js/utils.js
@@ -9,7 +9,7 @@ export function isFunction(obj) {
  * Check if an object is an Object
  */
 export function isObject(obj) {
-    return obj === Object(obj);
+    return obj === Object(obj) && !Array.isArray(obj);
 }
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -93,6 +93,24 @@ export function findComponent($root, el) {
     return $match || $root;
 }
 
+/**
+ * Flatten a nested objects tree into a flat single object
+ * with dotted keys instead of nested object attributes.
+ *
+ * @param {Object} obj The source nested object to flatten
+ * @param {String} prefix Track the key preffix in recursions
+ * @return {Object} A flat object with dotted keys insted of nested ottributes
+ */
+export function flattenObject(obj, prefix='') {
+    const pre = prefix.length ? prefix + '.' : '';
+    return Object.entries(obj).reduce((out, [key, prop]) => {
+        key = pre + key;
+        if (isObject(prop)) Object.assign(out, flattenObject(prop, key));
+        else out[key] = prop;
+        return out;
+    }, {});
+}
+
 
 export default {
     isFunction,
@@ -103,4 +121,5 @@ export default {
     parseQS,
     escapeRegex,
     findComponent,
+    flattenObject,
 };

--- a/specs/utils.specs.js
+++ b/specs/utils.specs.js
@@ -25,6 +25,7 @@ describe('Utils', function() {
             expect(u.isObject(true)).to.be.false;
             expect(u.isObject(null)).to.be.false;
             expect(u.isObject(undefined)).to.be.false;
+            expect(u.isObject([42])).to.be.false;
         });
     });
 

--- a/specs/utils.specs.js
+++ b/specs/utils.specs.js
@@ -125,4 +125,26 @@ describe('Utils', function() {
             expect(u.escapeRegex('noop')).to.eql('noop');
         });
     });
+
+    describe('flattenObject', function() {
+        it('should flatten nested object keys', function() {
+            const obj = {
+                a: 1, b: {c: true, d: {e: 'foo'}}, f: false,
+                g: ['red', 'green', 'blue'], h: [{i: 2, j: 3}]
+            };
+            expect(u.flattenObject(obj)).to.eql({
+                'a': 1,
+                'b.c': true,
+                'b.d.e': 'foo',
+                'f': false,
+                'g': ['red', 'green', 'blue'],
+                'h': [{i: 2, j: 3}],
+            });
+        });
+
+        it('should not change flat objects', function() {
+            const obj = {a: 0, b: 1, c: 2};
+            expect(u.flattenObject(obj)).to.eql(obj);
+        });
+    });
 });


### PR DESCRIPTION
This PR ensure that admin form errors on nested fields like `spatial.coverage` are properly handled (ie. injected into their fields for display).

This fixes etalab/data.gouv.fr#133 but there is another bug behind: #2245 (will be fixed in another PR)