### PR TITLE
JS models loading state and error handling consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Cleanup `permitted_reuses` data (migration) [#2244](https://github.com/opendatateam/udata/pull/2244)
 - Proper form errors handling on nested fields [#2246](https://github.com/opendatateam/udata/pull/2246)
+- JS models load/save/update consistency (`loading` always `true` on query, always handle error, no more silent errors) [#2247](https://github.com/opendatateam/udata/pull/2247)
 
 ## 1.6.13 (2019-07-11)
 

--- a/js/models/base.js
+++ b/js/models/base.js
@@ -125,6 +125,19 @@ export class Base {
             operation(data, opts, on_success.bind(this), on_error.bind(this));
         });
     }
+
+    /**
+     * Wrap an eventual error handler with basic model error handling
+     * @param {Function} handler An optionnal func(response) error handler
+     */
+    on_error(handler) {
+        return (response) => {
+            if (handler) {
+                handler(response);
+            }
+            this.loading = false;
+        };
+    }
 }
 
 /**

--- a/js/models/communityresource.js
+++ b/js/models/communityresource.js
@@ -27,22 +27,25 @@ export default class CommunityResource extends Model {
         if (this.id) {
             this.update(this, on_error);
         } else {
+            this.loading = true;
             this.$api('datasets.create_community_resource', {
                 payload: this
-            }, this.on_fetched, on_error);
+            }, this.on_fetched, this.on_error(on_error));
         }
     }
 
     update(data, on_error) {
+        this.loading = true;
         this.$api('datasets.update_community_resource', {
             community: this.id,
             payload: data
-        }, this.on_fetched, on_error);
+        }, this.on_fetched, this.on_error(on_error));
     }
 
     delete(on_error) {
+        this.loading = true;
         this.$api('datasets.delete_community_resource', {
             community: this.id
-        }, () => this.$emit('updated'), on_error);
+        }, () => this.$emit('updated'), this.on_error(on_error));
     }
 }

--- a/js/models/communityresource.js
+++ b/js/models/communityresource.js
@@ -11,6 +11,7 @@ export default class CommunityResource extends Model {
     fetch(ident) {
         ident = ident || this.id;
         if (ident) {
+            this.loading = true;
             this.$api('datasets.retrieve_community_resource', {
                 community: ident
             }, this.on_fetched);

--- a/js/models/dataset.js
+++ b/js/models/dataset.js
@@ -32,7 +32,7 @@ export default class Dataset extends Model {
             return this.update(this, on_error);
         }
         this.loading = true;
-        this.$api('datasets.create_dataset', {payload: this}, this.on_fetched, on_error);
+        this.$api('datasets.create_dataset', {payload: this}, this.on_fetched, this.on_error(on_error));
     }
 
     update(data, on_error) {
@@ -40,14 +40,15 @@ export default class Dataset extends Model {
         this.$api('datasets.update_dataset', {
             dataset: this.id,
             payload: data
-        }, this.on_fetched, on_error);
+        }, this.on_fetched, this.on_error(on_error));
     }
 
     delete_resource(id, on_error) {
+        this.loading = true;
         this.$api('datasets.delete_resource', {
             dataset: this.id,
             rid: id
-        }, () => this.fetch(), on_error);
+        }, () => this.fetch(), this.on_error(on_error));
     }
 
     save_resource(resource, on_error) {

--- a/js/models/harvest/source.js
+++ b/js/models/harvest/source.js
@@ -38,7 +38,7 @@ export class HarvestSource extends Model {
             return this.update(this, on_error);
         }
         this.loading = true;
-        this.$api('harvest.create_harvest_source', {payload: this}, this.on_fetched);
+        this.$api('harvest.create_harvest_source', {payload: this}, this.on_fetched, this.on_error(on_error));
     }
 
     update(data, on_error) {
@@ -46,7 +46,7 @@ export class HarvestSource extends Model {
         this.$api('harvest.update_harvest_source', {
             ident: this.id,
             payload: data
-        }, this.on_fetched, on_error);
+        }, this.on_fetched, this.on_error(on_error));
     }
 }
 

--- a/js/models/me.js
+++ b/js/models/me.js
@@ -4,6 +4,7 @@ import config from 'config';
 
 class Me extends User {
     fetch() {
+        this.loading = true;
         this.$api('me.get_me', {}, this.on_user_fetched);
         return this;
     }

--- a/js/models/me.js
+++ b/js/models/me.js
@@ -9,7 +9,8 @@ class Me extends User {
     }
 
     update(data, on_error) {
-        this.$api('me.update_me', {payload: JSON.stringify(data)}, this.on_fetched, on_error);
+        this.loading = true;
+        this.$api('me.update_me', {payload: JSON.stringify(data)}, this.on_fetched, this.on_error(on_error));
     }
 
     on_user_fetched(response) {

--- a/js/models/mymetrics.js
+++ b/js/models/mymetrics.js
@@ -4,6 +4,7 @@ import {Model} from 'models/base';
 export default class MyMetrics extends Model {
 
     fetch(id) {
+        this.loading = true;
         this.$api('me.my_metrics', {id: id}, this.on_fetched);
         return this;
     }

--- a/js/models/organization.js
+++ b/js/models/organization.js
@@ -11,6 +11,7 @@ export default class Organization extends Model {
     fetch(ident) {
         ident = ident || this.id || this.slug;
         if (ident) {
+            this.loading = true;
             this.$api('organizations.get_organization', {org: ident}, this.on_fetched);
         } else {
             log.error('Unable to fetch Organization: no identifier specified');

--- a/js/models/organization.js
+++ b/js/models/organization.js
@@ -19,10 +19,11 @@ export default class Organization extends Model {
     }
 
     update(data, on_error) {
+        this.loading = true;
         this.$api('organizations.update_organization', {
             org: this.id,
             payload: JSON.stringify(data)
-        }, this.on_fetched, on_error);
+        }, this.on_fetched, this.on_error(on_error));
     }
 
     save(on_error) {
@@ -34,7 +35,8 @@ export default class Organization extends Model {
     }
 
     create(on_error) {
-        this.$api('organizations.create_organization', {payload: this}, this.on_fetched, on_error);
+        this.loading = true;
+        this.$api('organizations.create_organization', {payload: this}, this.on_fetched, this.on_error(on_error));
     }
 
     role_for(obj) {

--- a/js/models/post.js
+++ b/js/models/post.js
@@ -12,6 +12,7 @@ export default class Post extends Model {
             options['X-Fields'] = mask;
         }
         if (ident) {
+            this.loading = true;
             this.$api('posts.get_post', options, this.on_fetched);
         } else {
             log.error('Unable to fetch Post: no identifier specified');

--- a/js/models/post.js
+++ b/js/models/post.js
@@ -27,20 +27,22 @@ export default class Post extends Model {
     }
 
     update(data, on_success, on_error) {
+        this.loading = true;
         this.$api('posts.update_post', {
             post: this.id,
             payload: data
-        }, on_success, on_error);
+        }, on_success, this.on_error(on_error));
     }
 
-    save() {
+    save(on_error) {
         const data = {payload: this};
         let endpoint = 'posts.create_post';
+        this.loading = true;
 
         if (this.id) {
             endpoint = 'posts.update_post';
             data.post = this.id;
         }
-        this.$api(endpoint, data, this.on_fetched);
+        this.$api(endpoint, data, this.on_fetched, this.on_error(on_error));
     }
 };

--- a/js/models/reuse.js
+++ b/js/models/reuse.js
@@ -11,6 +11,7 @@ export default class Reuse extends Model {
     fetch(ident) {
         ident = ident || this.id || this.slug;
         if (ident) {
+            this.loading = true;
             this.$api('reuses.get_reuse', {reuse: ident}, this.on_fetched);
         } else {
             log.error('Unable to fetch Reuse: no identifier specified');

--- a/js/models/reuse.js
+++ b/js/models/reuse.js
@@ -25,14 +25,16 @@ export default class Reuse extends Model {
         if (this.id) {
             return this.update(this, on_error);
         }
-        this.$api('reuses.create_reuse', {payload: this}, this.on_fetched, on_error);
+        this.loading = true;
+        this.$api('reuses.create_reuse', {payload: this}, this.on_fetched, this.on_error(on_error));
     }
 
     update(data, on_error) {
+        this.loading = true;
         this.$api('reuses.update_reuse', {
             reuse: this.id,
             payload: data
-        }, this.on_fetched, on_error);
+        }, this.on_fetched, this.on_error(on_error));
     }
 }
 

--- a/js/models/site.js
+++ b/js/models/site.js
@@ -4,6 +4,7 @@ import log from 'logger';
 
 export class Site extends Model {
     fetch() {
+        this.loading = true;
         this.$api('site.get_site', {}, this.on_fetched);
         return this;
     }

--- a/js/models/topic.js
+++ b/js/models/topic.js
@@ -6,6 +6,7 @@ export default class Topic extends Model {
     fetch(ident) {
         ident = ident || this.id || this.slug;
         if (ident) {
+            this.loading = true;
             this.$api('topics.get_topic', {topic: ident}, this.on_fetched);
         } else {
             log.error('Unable to fetch Topic: no identifier specified');

--- a/js/models/topic.js
+++ b/js/models/topic.js
@@ -13,25 +13,27 @@ export default class Topic extends Model {
         return this;
     }
 
-    save() {
+    save(on_error) {
+        this.loading = true;
         if (this.id) {
             this.$api('topics.update_topic', {
                 topic: this.id,
                 payload: this
             },
-            this.on_fetched);
+            this.on_fetched, this.on_error(on_error));
         } else {
             this.$api('topics.create_topic', {
                 payload: this
             },
-            this.on_fetched);
+            this.on_fetched, this.on_error(on_error));
         }
     }
 
     update(data, on_success, on_error) {
+        this.loading = true;
         this.$api('topics.update_topic', {
             topic: this.id,
             payload: data
-        }, on_success, on_error);
+        }, on_success, this.on_error(on_error));
     }
-};
+}

--- a/js/models/user.js
+++ b/js/models/user.js
@@ -30,10 +30,11 @@ export default class User extends Model {
     }
 
     update(data, on_error) {
+        this.loading = true;
         this.$api('users.update_user', {
             user: this.id,
             payload: JSON.stringify(data)
-        }, this.on_fetched, on_error);
+        }, this.on_fetched, this.on_error(on_error));
     }
 
     /**

--- a/js/models/user.js
+++ b/js/models/user.js
@@ -22,6 +22,7 @@ export default class User extends Model {
     fetch(ident) {
         ident = ident || this.id || this.slug;
         if (ident) {
+            this.loading = true;
             this.$api('users.get_user', {user: ident}, this.on_fetched);
         } else {
             log.error('Unable to fetch User: no identifier specified');


### PR DESCRIPTION
This PR ensure that every JS model:
- set the `loading` flag to `true` on `fetch`/`save`/`update` (and so widgets properly display a spinner)
- `save`/`update` methods always accept an optional error handler
- `save`/`update` methods always handle errors, even when no error handler is provided

The provided default error handler ensures:
- the `loading` state is set back to `false` (prevent infinite spinning on widgets)
- in the absence of a provided error handler that:
  - the error is submitted to Sentry if necessary (when there was no server side error handled by Sentry) and so notified to the user using the global Sentry handler
  - the error is logged as error in the JS console as fallback

To improve the console fallback, a feedback pubsub needs to be implemented allowing views to listen on model errors and then notify the user.

This implements/fixes #2245 and ensures etalab/data.gouv.fr#133 fix (#2246) does not get stuck on the spinner instead of properly display the form error