### PR TITLE
Fix reversed daterange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Cleanup `permitted_reuses` data (migration) [#2244](https://github.com/opendatateam/udata/pull/2244)
 - Proper form errors handling on nested fields [#2246](https://github.com/opendatateam/udata/pull/2246)
 - JS models load/save/update consistency (`loading` always `true` on query, always handle error, no more silent errors) [#2247](https://github.com/opendatateam/udata/pull/2247)
+- Ensures that date ranges are always positive (ie. `start` < `end`) [#2253](https://github.com/opendatateam/udata/pull/2253)
 
 ## 1.6.13 (2019-07-11)
 

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -242,7 +242,7 @@ class DatasetSearch(ModelSearchAdapter):
                 dataset.temporal_coverage.end):
             start = dataset.temporal_coverage.start.toordinal()
             end = dataset.temporal_coverage.end.toordinal()
-            temporal_weight = min((end - start) / 365, MAX_TEMPORAL_WEIGHT)
+            temporal_weight = min(abs(end - start) / 365, MAX_TEMPORAL_WEIGHT)
             document.update({
                 'temporal_coverage': {'start': start, 'end': end},
                 'temporal_weight': temporal_weight,

--- a/udata/migrations/2019-07-23-reversed-date-range.js
+++ b/udata/migrations/2019-07-23-reversed-date-range.js
@@ -1,0 +1,29 @@
+/**
+ * Swap reversed DateRange values
+ */
+
+var updated = 0;
+
+// Match all Dataset having temporal_coverage.start > temporal_coverage.end
+const pipeline = [
+    {$project: {
+        cmp: {$cmp: ['$temporal_coverage.start', '$temporal_coverage.end']},
+        obj: '$$ROOT'
+    }},
+    {$match: {cmp: {$gt: 0}}},
+    {$replaceRoot: {newRoot: '$obj'}}
+];
+
+
+db.dataset.aggregate(pipeline).forEach(dataset => {
+    db.dataset.update(
+        {_id: dataset._id},
+        {'$set': {
+            'temporal_coverage.start': dataset.temporal_coverage.end,
+            'temporal_coverage.end': dataset.temporal_coverage.start,
+        }}
+    );
+    updated++;
+});
+
+print(`Updated ${updated} datasets with reversed temporal coverage.`);

--- a/udata/models/datetime_fields.py
+++ b/udata/models/datetime_fields.py
@@ -53,6 +53,10 @@ class DateRange(EmbeddedDocument):
     def to_dict(self):
         return {'start': self.start, 'end': self.end}
 
+    def clean(self):
+        if self.start and self.end and self.start > self.end:
+            self.start, self.end = self.end, self.start
+
 
 class Datetimed(object):
     created_at = DateTimeField(verbose_name=_('Creation date'),


### PR DESCRIPTION
This PR:
- ensures that `db.DateRange` is always expressed and stored as a positive range (ie. `start` < `end`)
- ensures that reversed data (stock data) still index properly (take date range absolute value for weight computing)
- migrates stock data to swap `start` and `end` on reversed date ranges.
- adds the missing `db.DateRange` tests