### PR TITLE
Improve oembed errors handling (no hidden error, CORS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - JS models load/save/update consistency (`loading` always `true` on query, always handle error, no more silent errors) [#2247](https://github.com/opendatateam/udata/pull/2247)
 - Ensures that date ranges are always positive (ie. `start` < `end`) [#2253](https://github.com/opendatateam/udata/pull/2253)
 - Enable completion on the "`MIME type`" resource form field (needs reindexing) [#2238](https://github.com/opendatateam/udata/pull/2238)
+- Ensure oembed rendering errors are not hidden by default error handlers and have cors headers [#2254](https://github.com/opendatateam/udata/pull/2254)
 
 ## 1.6.13 (2019-07-11)
 

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -18,7 +18,7 @@ from udata.features.territories.models import (
 from udata.frontend.markdown import mdstrip
 from udata.settings import Testing
 from udata.utils import faker
-from udata.tests.helpers import assert200, assert400, assert404, assert_status
+from udata.tests.helpers import assert200, assert400, assert404, assert_status, assert_cors
 
 
 class OEmbedAPITest:
@@ -31,6 +31,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url=dataset.external_url)
         response = api.get(url)
         assert200(response)
+        assert_cors(response)
         assert 'html' in response.json
         assert 'width' in response.json
         assert 'maxwidth' in response.json
@@ -49,6 +50,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url=dataset.external_url)
         response = api.get(url)
         assert200(response)
+        assert_cors(response)
 
         card = theme.render('dataset/card.html', dataset=dataset)
         assert card in response.json['html']
@@ -62,6 +64,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url=redirect_url)
         response = api.get(url)
         assert200(response)
+        assert_cors(response)
         assert 'html' in response.json
         assert 'width' in response.json
         assert 'maxwidth' in response.json
@@ -79,6 +82,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url=dataset_url)
         response = api.get(url)
         assert404(response)
+        assert_cors(response)
 
     def test_oembed_for_reuse(self, api):
         '''It should fetch a reuse in the oembed format.'''
@@ -87,6 +91,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url=reuse.external_url)
         response = api.get(url)
         assert200(response)
+        assert_cors(response)
         assert 'html' in response.json
         assert 'width' in response.json
         assert 'maxwidth' in response.json
@@ -114,6 +119,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url='http://local.test/somewhere')
         response = api.get(url)
         assert404(response)
+        assert_cors(response)
 
     def test_oembed_with_port_in_https_url(self, api):
         '''It should works on HTTPS URLs with explicit port.'''
@@ -130,6 +136,7 @@ class OEmbedAPITest:
         url = url_for('api.oembed', url=dataset.external_url, format='xml')
         response = api.get(url)
         assert_status(response, 501)
+        assert_cors(response)
         assert response.json['message'] == 'Only JSON format is supported'
 
 

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -216,3 +216,11 @@ def assert_urls_equal(url1, url2):
     q2 = parse_qs(p2.query)
     assert q1 == q2, 'Query does not match'
     assert p1.fragment == p2.fragment, 'Fragment does not match'
+
+
+def assert_cors(response):
+    '''CORS headers presence assertion'''
+    __tracebackhide__ = True
+    assert 'Access-Control-Allow-Origin' in response.headers
+    assert 'Access-Control-Allow-Methods' in response.headers
+    assert 'Access-Control-Max-Age' in response.headers


### PR DESCRIPTION
This PR improve oembed errors handling and fixes #2255.

This one has been detected while working on https://github.com/etalab/datagouv-search-indicator: one of the dataset have been removed (INSEE legacy SIRENE dataset) and this prevent from requesting oembed for this dataset (or more precisely from seing it's a 404 and the dataset does not exists anymore)

**Note**: this fixes specific error case on oembed but in order to have CORS on all errors a fix is required on flask-restplus