### PR TITLE
Handle dates before 1900 during indexing (py2 only) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ensures that date ranges are always positive (ie. `start` < `end`) [#2253](https://github.com/opendatateam/udata/pull/2253)
 - Enable completion on the "`MIME type`" resource form field (needs reindexing) [#2238](https://github.com/opendatateam/udata/pull/2238)
 - Ensure oembed rendering errors are not hidden by default error handlers and have cors headers [#2254](https://github.com/opendatateam/udata/pull/2254)
+- Handle dates before 1900 during indexing [#2256](https://github.com/opendatateam/udata/pull/2256)
 
 ## 1.6.13 (2019-07-11)
 

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -5,23 +5,23 @@ from elasticsearch_dsl import (
     Boolean, Completion, Date, Long, Object, String, Nested
 )
 
-from udata.i18n import lazy_gettext as _
 from udata.core.site.models import current_site
+from udata.core.spatial.models import (
+    admin_levels, spatial_granularities, ADMIN_LEVEL_MAX
+)
+from udata.i18n import lazy_gettext as _
 from udata.models import (
     Dataset, Organization, License, User, GeoZone, RESOURCE_TYPES
 )
 from udata.search import (
     ModelSearchAdapter, i18n_analyzer, metrics_mapping_for, register,
 )
+from udata.search.analysis import simple
 from udata.search.fields import (
     TermsFacet, ModelTermsFacet, RangeFacet, TemporalCoverageFacet,
     BoolBooster, GaussDecay, BoolFacet, ValueFactor
 )
-from udata.search.analysis import simple
-
-from udata.core.spatial.models import (
-    admin_levels, spatial_granularities, ADMIN_LEVEL_MAX
-)
+from udata.utils import to_iso_datetime
 
 # Metrics are require for dataset search
 from . import metrics  # noqa
@@ -234,9 +234,8 @@ class DatasetSearch(ModelSearchAdapter):
                     'image_url': image_url,
                 },
             },
-            'created': dataset.created_at.strftime('%Y-%m-%dT%H:%M:%S'),
-            'last_modified': dataset.last_modified.strftime(
-                '%Y-%m-%dT%H:%M:%S'),
+            'created': to_iso_datetime(dataset.created_at),
+            'last_modified': to_iso_datetime(dataset.last_modified),
             'metrics': dataset.metrics,
             'featured': dataset.featured,
             'from_certified': certified,

--- a/udata/core/organization/search.py
+++ b/udata/core/organization/search.py
@@ -3,12 +3,13 @@ from __future__ import unicode_literals
 
 from elasticsearch_dsl import Completion, Date, String
 
-from udata.i18n import lazy_gettext as _
 from udata import search
-from udata.search.fields import TermsFacet, RangeFacet
-from udata.models import Organization
 from udata.core.site.models import current_site
+from udata.i18n import lazy_gettext as _
+from udata.models import Organization
 from udata.search.analysis import simple
+from udata.search.fields import TermsFacet, RangeFacet
+from udata.utils import to_iso_datetime
 
 from . import metrics  # noqa: Metrics are need for the mapping
 
@@ -120,7 +121,7 @@ class OrganizationSearch(search.ModelSearchAdapter):
             'url': organization.url,
             'metrics': organization.metrics,
             'badges': [badge.kind for badge in organization.badges],
-            'created': organization.created_at.strftime('%Y-%m-%dT%H:%M:%S'),
+            'created': to_iso_datetime(organization.created_at),
             'org_suggest': {
                 'input': completions,
                 'output': str(organization.id),

--- a/udata/core/reuse/search.py
+++ b/udata/core/reuse/search.py
@@ -14,6 +14,7 @@ from udata.search import (
     RangeFacet, TermsFacet, ModelTermsFacet, BoolFacet
 )
 from udata.search.analysis import simple
+from udata.utils import to_iso_datetime
 
 from . import metrics  # noqa: Metrics are require for reuse search
 
@@ -152,8 +153,8 @@ class ReuseSearch(ModelSearchAdapter):
             'tags': reuse.tags,
             'tag_suggest': reuse.tags,
             'badges': [badge.kind for badge in reuse.badges],
-            'created': reuse.created_at.strftime('%Y-%m-%dT%H:%M:%S'),
-            'last_modified': reuse.last_modified.strftime('%Y-%m-%dT%H:%M:%S'),
+            'created': to_iso_datetime(reuse.created_at),
+            'last_modified': to_iso_datetime(reuse.last_modified),
             'dataset': [{
                 'id': str(d.id),
                 'title': d.title

--- a/udata/core/user/search.py
+++ b/udata/core/user/search.py
@@ -10,6 +10,7 @@ from udata.search import i18n_analyzer, metrics_mapping_for, register
 from udata.search.fields import ModelTermsFacet, RangeFacet
 from udata.search.fields import GaussDecay
 from udata.search.analysis import simple
+from udata.utils import to_iso_datetime
 
 # Metrics are required for user search
 from . import metrics  # noqa
@@ -86,7 +87,7 @@ class UserSearch(ModelSearchAdapter):
             'about': user.about,
             'organizations': [str(o.id) for o in user.organizations],
             'metrics': user.metrics,
-            'created': user.created_at.strftime('%Y-%m-%dT%H:%M:%S'),
+            'created': to_iso_datetime(user.created_at),
             'user_suggest': {
                 'input': cls.completer_tokenize(user.fullname) + [user.id],
                 'output': str(user.id),


### PR DESCRIPTION
This PR fixes indexing with date before 1900. This should not theoretically happen because there is only `created_at` and `last_modified` but some harvested dataset can have this issue.

This is a Python 2 only fix as the "before 1900" limitation has been removed in Python 3 (and so `udata.utils.to_iso*` helpers can be safely removed from `py3` branches and rely on the builtin `datetime.isoformat(timespec='seconds')`)

(fix etalab/data.gouv.fr#140 part 2)