### PR TITLE
spatial load command improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enable completion on the "`MIME type`" resource form field (needs reindexing) [#2238](https://github.com/opendatateam/udata/pull/2238)
 - Ensure oembed rendering errors are not hidden by default error handlers and have cors headers [#2254](https://github.com/opendatateam/udata/pull/2254)
 - Handle dates before 1900 during indexing [#2256](https://github.com/opendatateam/udata/pull/2256)
+- `spatial load` command is more resilient: make use of a temporary collection when `--drop` option is provided (avoid downtime during the load), in case of exception or keybord interrupt, temporary files and collections are cleaned up [#2261](https://github.com/opendatateam/udata/pull/2261)
 
 ## 1.6.13 (2019-07-11)
 

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -117,7 +117,7 @@ def load(filename=DEFAULT_GEOZONES_FILE, drop=False):
 
     log.info('Loading levels.msgpack')
     levels_filepath = tmp.path('levels.msgpack')
-    if drop:
+    if drop and GeoLevel.objects.count():
         name = '_'.join((GeoLevel._get_collection_name(), ts))
         target = GeoLevel._get_collection_name()
         with switch_collection(GeoLevel, name):
@@ -130,7 +130,7 @@ def load(filename=DEFAULT_GEOZONES_FILE, drop=False):
 
     log.info('Loading zones.msgpack')
     zones_filepath = tmp.path('zones.msgpack')
-    if drop:
+    if drop and GeoZone.objects.count():
         name = '_'.join((GeoZone._get_collection_name(), ts))
         target = GeoZone._get_collection_name()
         with switch_collection(GeoZone, name):


### PR DESCRIPTION
This PR improves the `spatial load` command to be more resilient:
- extracts the geozones archive into its own `tmp` storage subdirectory
- makes use of a temporary collection and then overwrite the existing one when using `--drop`
- cleanup the temporary files on success
- handles exceptions and keyboard interrupts and cleanup when it occurs

These changes:
- prevent filling the `tmp` storage with undeleted files
- prevent against partial loads in case of errors or interruptions
- prevent frontend/API/admin errors on missing spatial zone during `spatial load --drop`