### PR TITLE
Configurable ES timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Ensure oembed rendering errors are not hidden by default error handlers and have cors headers [#2254](https://github.com/opendatateam/udata/pull/2254)
 - Handle dates before 1900 during indexing [#2256](https://github.com/opendatateam/udata/pull/2256)
 - `spatial load` command is more resilient: make use of a temporary collection when `--drop` option is provided (avoid downtime during the load), in case of exception or keybord interrupt, temporary files and collections are cleaned up [#2261](https://github.com/opendatateam/udata/pull/2261)
+- Configurable Elasticsearch timeouts. Introduce `ELASTICSEARCH_TIMEOUT` as default/read timeout and `ELASTICSEARCH_INDEX_TIMEOUT` as indexing/write timeout [#2265](https://github.com/opendatateam/udata/pull/2265)
 
 ## 1.6.13 (2019-07-11)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -371,6 +371,19 @@ The above example will produce:
 - a `myindex` alias on `myindex-{yyyy}-{mm}-{dd}-{HH}-{MM}` on initialization
 - a temporary `myindex-test` index during each test requiring it
 
+### ELASTICSEARCH_TIMEOUT
+
+**default**: `10`
+
+The timeout (in seconds) used by search queries and as default for any operation except indexing.
+
+
+### ELASTICSEARCH_INDEX_TIMEOUT
+
+**default**: `20`
+
+The timeout (in seconds) used by indexing/write operations (should be longer than the default timeout as indexing can be quite resources intensive and response time can be longer).
+
 
 ## Mongoengine/Flask-Mongoengine options
 

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -127,18 +127,21 @@ i18n_analyzer = LocalProxy(lambda: get_i18n_analyzer())
 def reindex(obj):
     model = obj.__class__
     adapter_class = adapter_catalog.get(model)
+    timeout = current_app.config['ELASTICSEARCH_INDEX_TIMEOUT']
     if adapter_class.is_indexable(obj):
         log.info('Indexing %s (%s)', model.__name__, obj.id)
         try:
             adapter = adapter_class.from_model(obj)
-            adapter.save(using=es.client, index=es.index_name)
+            adapter.save(using=es.client, index=es.index_name,
+                         request_timeout=timeout)
         except Exception:
             log.exception('Unable to index %s "%s"', model.__name__, str(obj.id))
     elif adapter_class.exists(obj.id, using=es.client, index=es.index_name):
         log.info('Unindexing %s (%s)', model.__name__, obj.id)
         try:
             adapter = adapter_class.from_model(obj)
-            adapter.delete(using=es.client, index=es.index_name)
+            adapter.delete(using=es.client, index=es.index_name,
+                           request_timeout=timeout)
         except Exception:
             log.exception('Unable to index %s "%s"', model.__name__, str(obj.id))
     else:
@@ -153,7 +156,11 @@ def unindex(obj):
         log.info('Unindexing %s (%s)', model.__name__, obj.id)
         try:
             adapter = adapter_class.from_model(obj)
-            adapter.delete(using=es.client, index=es.index_name)
+            adapter.delete(
+                using=es.client,
+                index=es.index_name,
+                request_timeout=current_app.config['ELASTICSEARCH_INDEX_TIMEOUT'],
+            )
         except Exception:
             log.exception('Unable to unindex %s "%s"', model.__name__, str(obj.id))
     else:

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -51,14 +51,16 @@ class ElasticSearch(object):
             self.init_app(app)
 
     def init_app(self, app):
-        # using the app factory pattern _app_ctx_stack.top is None so what
-        # do we register on? app.extensions looks a little hackish (I don't
-        # know flask well enough to be sure), but that's how it's done in
-        # flask-pymongo so let's use it for now.
+        # Use ELASTICSEARCH_URL_TEST if defined during tests
         if app.config['TESTING'] and 'ELASTICSEARCH_URL_TEST' in app.config:
-                app.config['ELASTICSEARCH_URL'] = app.config['ELASTICSEARCH_URL_TEST']
+            app.config['ELASTICSEARCH_URL'] = app.config['ELASTICSEARCH_URL_TEST']
+
+        # Initialize the elasticsearch client for the current app
         app.extensions['elasticsearch'] = Elasticsearch(
-            [app.config['ELASTICSEARCH_URL']], serializer=EsJSONSerializer())
+            [app.config['ELASTICSEARCH_URL']],
+            serializer=EsJSONSerializer(),
+            timeout=app.config['ELASTICSEARCH_TIMEOUT'],
+        )
 
     def __getattr__(self, item):
         if 'elasticsearch' not in current_app.extensions.keys():

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -61,10 +61,10 @@ def iter_for_index(docs, index_name):
         yield doc
 
 
-def index_model(index_name, adapter):
+def index_model(index_name, adapter, timeout=None):
     ''' Indel all objects given a model'''
     model = adapter.model
-    log.info('Indexing {0} objects'.format(model.__name__))
+    log.info('Indexing %s objects', model.__name__)
     qs = model.objects
     if hasattr(model.objects, 'visible'):
         qs = qs.visible()
@@ -74,13 +74,14 @@ def index_model(index_name, adapter):
     docs = iter_qs(qs, adapter)
     docs = iter_for_index(docs, index_name)
 
-    for ok, info in streaming_bulk(es.client, docs, raise_on_error=False):
+    for ok, info in streaming_bulk(es.client, docs, raise_on_error=False,
+                                   request_timeout=timeout):
         if not ok:
             log.error('Unable to index %s "%s": %s', model.__name__,
                       info['index']['_id'], info['index']['error'])
 
 
-def disable_refresh(index_name):
+def disable_refresh(index_name, timeout=None):
     '''
     Disable refresh to optimize indexing
 
@@ -90,45 +91,50 @@ def disable_refresh(index_name):
         'index': {
             'refresh_interval': '-1'
         }
-    })
+    }, request_timeout=timeout)
 
 
-def enable_refresh(index_name):
+def enable_refresh(index_name, timeout=None):
     '''
     Enable refresh and force merge. To be used after indexing.
 
     See: https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html#bulk
     '''  # noqa
+    timeout = timeout or current_app.config['ELASTICSEARCH_INDEX_TIMEOUT']
     refresh_interval = current_app.config['ELASTICSEARCH_REFRESH_INTERVAL']
     es.indices.put_settings(index=index_name, body={
         'index': {'refresh_interval': refresh_interval}
-    })
-    es.indices.forcemerge(index=index_name, request_timeout=30)
+    }, request_timeout=timeout)
+    # Double the timeout as this can take some time
+    es.indices.forcemerge(index=index_name, request_timeout=timeout * 2)
 
 
-def set_alias(index_name, delete=True):
+def set_alias(index_name, delete=True, timeout=None):
     '''
     Properly end an indexation by creating an alias.
     Previous alias is deleted if needed.
     '''
-    log.info('Creating alias "{0}" on index "{1}"'.format(
-        es.index_name, index_name))
+    timeout = timeout or current_app.config['ELASTICSEARCH_INDEX_TIMEOUT']
+    log.info('Creating alias "%s" on index "%s"', es.index_name, index_name)
     if es.indices.exists_alias(name=es.index_name):
         alias = es.indices.get_alias(name=es.index_name)
         previous_indices = alias.keys()
         if index_name not in previous_indices:
-            es.indices.put_alias(index=index_name, name=es.index_name)
+            es.indices.put_alias(index=index_name, name=es.index_name,
+                                 request_timeout=timeout)
         for index in previous_indices:
             if index != index_name:
-                es.indices.delete_alias(index=index, name=es.index_name)
+                es.indices.delete_alias(index=index, name=es.index_name,
+                                        request_timeout=timeout)
                 if delete:
-                    es.indices.delete(index=index)
+                    es.indices.delete(index=index, request_timeout=timeout)
     else:
-        es.indices.put_alias(index=index_name, name=es.index_name)
+        es.indices.put_alias(index=index_name, name=es.index_name,
+                                               request_timeout=timeout)
 
 
 @contextmanager
-def handle_error(index_name, keep=False):
+def handle_error(index_name, keep=False, timeout=None):
     '''
     Handle errors while indexing.
     In case of error, properly log it, remove the index and exit.
@@ -150,7 +156,7 @@ def handle_error(index_name, keep=False):
     if has_error:
         if not keep:
             log.info('Removing index %s', index_name)
-            es.indices.delete(index=index_name)
+            es.indices.delete(index=index_name, request_timeout=timeout)
         sys.exit(-1)
 
 
@@ -159,7 +165,9 @@ def handle_error(index_name, keep=False):
 @click.option('-n', '--name', default=None, help='Optional index name')
 @click.option('-f', '--force', is_flag=True, help='Do not prompt on deletion')
 @click.option('-k', '--keep', is_flag=True, help='Do not delete indexes')
-def index(models=None, name=None, force=False, keep=False):
+
+@click.option('-t', '--timeout', type=float, help='Elasticsearch write timeout in seconds')
+def index(models=None, name=None, force=False, keep=False, timeout=None):
     '''
     Initialize or rebuild the search index
 
@@ -167,6 +175,7 @@ def index(models=None, name=None, force=False, keep=False):
     If not, all models are reindexed.
     '''
     index_name = name or default_index_name()
+    timeout = timeout or current_app.config['ELASTICSEARCH_INDEX_TIMEOUT']
 
     doc_types_names = [m.__name__.lower() for m in adapter_catalog.keys()]
     models = [model.lower().rstrip('s') for model in (models or [])]
@@ -174,25 +183,23 @@ def index(models=None, name=None, force=False, keep=False):
         if model not in doc_types_names:
             log.error('Unknown model %s', model)
             sys.exit(-1)
-
-    log.info('Initiliazing index "{0}"'.format(index_name))
+    log.info('Initiliazing index "%s"', index_name)
     if es.indices.exists(index_name):
         if IS_TTY and not force:
             msg = 'Index {0} will be deleted, are you sure?'
             click.confirm(msg.format(index_name), abort=True)
-        es.indices.delete(index_name)
+        es.indices.delete(index_name, request_timeout=timeout)
 
     es.initialize(index_name)
 
-    with handle_error(index_name, keep):
+    with handle_error(index_name, keep, timeout):
 
-        disable_refresh(index_name)
+        disable_refresh(index_name, timeout)
         for adapter in iter_adapters():
             if not models or adapter.doc_type().lower() in models:
-                index_model(index_name, adapter)
+                index_model(index_name, adapter, timeout)
             else:
-                log.info('Copying {0} objects to the new index'.format(
-                         adapter.model.__name__))
+                log.info('Copying %s objects to the new index', adapter.model.__name__)
                 # Need upgrade to Elasticsearch-py 5.0.0 to write:
                 # es.reindex({
                 #     'source': {'index': es.index_name, 'type': adapter.doc_type()},
@@ -204,11 +211,11 @@ def index(models=None, name=None, force=False, keep=False):
                 # triggers a server-side documents copy.
                 # Instead we use this helper for meant for backward compatibility
                 # but with poor performance as copy is client-side (scan+bulk)
-                es_reindex(es.client, es.index_name, index_name, scan_kwargs={
-                    'doc_type': adapter.doc_type()
-                })
+                es_reindex(es.client, es.index_name, index_name,
+                           scan_kwargs={'doc_type': adapter.doc_type()},
+                           bulk_kwargs={'request_timeout': timeout})
 
-        enable_refresh(index_name)
+        enable_refresh(index_name, timeout)
     # At this step, we don't want error handler to delete the index
     # in case of error
-    set_alias(index_name, delete=not keep)
+    set_alias(index_name, delete=not keep, timeout=timeout)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -35,6 +35,10 @@ class Defaults(object):
     ELASTICSEARCH_URL = 'localhost:9200'
     ELASTICSEARCH_INDEX_BASENAME = 'udata'
     ELASTICSEARCH_REFRESH_INTERVAL = '1s'
+    # ES Query/default timeout.
+    ELASTICSEARCH_TIMEOUT = 10  # Same default as elasticsearch library
+    # ES index timeout (should be longer)
+    ELASTICSEARCH_INDEX_TIMEOUT = 20
 
     # BROKER_TRANSPORT = 'redis'
     CELERY_BROKER_URL = 'redis://localhost:6379'


### PR DESCRIPTION
This PR makes the Elasticsearch timeouts configurable through:
- `ELASTICSEARCH_TIMEOUT` as default/read/query timeout
- `ELASTICSEARCH_INDEX_TIMEOUT` as indexing/write timeout (longuer timeout)
- the `-t/--timeout` in `udata search index` command (overrides `ELASTICSEARCH_INDEX_TIMEOUT` if provided)

This allows to improve control over timeout and so will allows to handle indexing errors such as:
```
elasticsearch.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeoutError(HTTPConnectionPool(host=u'localhost', port=9200): Read timed out. (read timeout=10))
```

**Possible improvement**: do the same for retry policy