### PR TITLE
Prevent DoesNotExist failure on activity API (fix #2227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Configurable Elasticsearch timeouts. Introduce `ELASTICSEARCH_TIMEOUT` as default/read timeout and `ELASTICSEARCH_INDEX_TIMEOUT` as indexing/write timeout [#2265](https://github.com/opendatateam/udata/pull/2265)
 - OEmbed support for organizations [#2273](https://github.com/opendatateam/udata/pull/2273)
 - Extract search parameters as settings allowing fine tuning search without repackaging udata (see [the **Search configuration** documentation](https://udata.readthedocs.io/en/stable/adapting-settings/#search-configuration)) [#2275](https://github.com/opendatateam/udata/pull/2275)
+- Prevent `DoesNotExist` error in activity API: silence the error for the consumer but log it (ie. visible in Sentry) [#2268](https://github.com/opendatateam/udata/pull/2268)
 
 ## 1.6.13 (2019-07-11)
 


### PR DESCRIPTION
This PR prevent the `DoesNotExist` exception from breaking the Activity API.

Under the hood, the problem occurs when some data is manually deleted without a proper purge. It would need a data migration to cleanup the existing data.

*NB:* tested but not included in this PR: to reduce the size of the activity collection it's possible to use TTL index and let mongo do its job in the background (possibly configurable with a `ACTIVITY_RETENTION_DAYS` settings). See for details;
- http://docs.mongoengine.org/guide/defining-documents.html#time-to-live-indexes
- https://docs.mongodb.com/manual/core/index-ttl/
- https://docs.mongodb.com/manual/tutorial/expire-data/