### PR TITLE
OEmbed card for organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Handle dates before 1900 during indexing [#2256](https://github.com/opendatateam/udata/pull/2256)
 - `spatial load` command is more resilient: make use of a temporary collection when `--drop` option is provided (avoid downtime during the load), in case of exception or keybord interrupt, temporary files and collections are cleaned up [#2261](https://github.com/opendatateam/udata/pull/2261)
 - Configurable Elasticsearch timeouts. Introduce `ELASTICSEARCH_TIMEOUT` as default/read timeout and `ELASTICSEARCH_INDEX_TIMEOUT` as indexing/write timeout [#2265](https://github.com/opendatateam/udata/pull/2265)
+- OEmbed support for organizations [#2273](https://github.com/opendatateam/udata/pull/2273)
 
 ## 1.6.13 (2019-07-11)
 

--- a/udata/features/oembed/api.py
+++ b/udata/features/oembed/api.py
@@ -36,8 +36,10 @@ oembeds_parser.add_argument(
 @api.route('/oembed', endpoint='oembed')
 class OEmbedAPI(API):
     ROUTES = {
-        'datasets.show': 'dataset',
-        'reuses.show': 'reuse',
+        # endpoint: (param name, template prefix)
+        'datasets.show': ('dataset', 'dataset'),
+        'organizations.show': ('org', 'organization'),
+        'reuses.show': ('reuse', 'reuse'),
     }
 
     @api.doc('oembed')
@@ -69,7 +71,7 @@ class OEmbedAPI(API):
         if endpoint not in self.ROUTES:
             return {'message': 'The URL "{0}" does not support oembed'.format(url)}, 404
 
-        param = self.ROUTES[endpoint]
+        param, prefix = self.ROUTES[endpoint]
         item = view_args[param]
         if isinstance(item, Exception):
             if isinstance(item, HTTPException):
@@ -83,7 +85,7 @@ class OEmbedAPI(API):
             'width': width,
             'height': height,
             'item': item,
-            'type': param
+            'type': prefix
         }
         params[param] = item
         html = theme.render('oembed.html', **params)

--- a/udata/templates/organization/card.html
+++ b/udata/templates/organization/card.html
@@ -1,10 +1,10 @@
 {% cache cache_duration, 'org-card', organization.id|string, g.lang_code %}
 {% from theme('macros/certified.html') import badge_if_certified with context %}
 <a class="card organization-card" title="{{organization.name}}"
-     href="{{ url_for('organizations.show', org=organization) }}">
+     href="{{ url_for('organizations.show', org=organization, _external=True) }}">
     <div class="card-logo">
         <img alt=""
-            src="{{ organization.logo(60)|placeholder('organization') }}"
+            src="{{ organization.logo(60, external=True)|placeholder('organization', external=True) }}"
             width="60" height="60">
     </div>
     {{ badge_if_certified(organization) }}

--- a/udata/templates/organization/oembed.html
+++ b/udata/templates/organization/oembed.html
@@ -1,0 +1,3 @@
+{% with organization=org %}
+{% include theme('organization/card.html') with context %}
+{% endwith %}

--- a/udata/tests/api/test_oembed_api.py
+++ b/udata/tests/api/test_oembed_api.py
@@ -22,7 +22,7 @@ from udata.tests.helpers import assert200, assert400, assert404, assert_status, 
 
 
 class OEmbedAPITest:
-    modules = ['core.dataset', 'core.reuse']
+    modules = ['core.dataset', 'core.organization', 'core.reuse']
 
     def test_oembed_for_dataset(self, api):
         '''It should fetch a dataset in the oembed format.'''
@@ -100,6 +100,24 @@ class OEmbedAPITest:
         assert response.json['type'] == 'rich'
         assert response.json['version'] == '1.0'
         card = theme.render('reuse/card.html', reuse=reuse)
+        assert card in response.json['html']
+
+    def test_oembed_for_org(self, api):
+        '''It should fetch an organization in the oembed format.'''
+        org = OrganizationFactory()
+
+        url = url_for('api.oembed', url=org.external_url)
+        response = api.get(url)
+        assert200(response)
+        assert_cors(response)
+        assert 'html' in response.json
+        assert 'width' in response.json
+        assert 'maxwidth' in response.json
+        assert 'height' in response.json
+        assert 'maxheight' in response.json
+        assert response.json['type'] == 'rich'
+        assert response.json['version'] == '1.0'
+        card = theme.render('organization/card.html', organization=org)
         assert card in response.json['html']
 
     def test_oembed_without_url(self, api):


### PR DESCRIPTION
This PR adds OEmbed support for organizations.

As Datasets and Reuses, the oembed is simply the organization card rendered. The URLs have to be absolute in order to work embedded  outside udata (so `external=True` is given as `url_for` parameter in the org card template):

![screenshot-localhost_8080-2019 08 06-15_18_49](https://user-images.githubusercontent.com/15725/62543239-c9493c00-b85d-11e9-9107-ca60bb10776e.png)
