### PR TITLE
Optimize CSV generation

### DIFF
--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -167,12 +167,16 @@ def export_csv_for_model(model, dataset):
 
 
 @job('export-csv')
-def export_csv(self):
+def export_csv(self, model=None):
     '''
     Generates a CSV export of all model objects as a resource of a dataset
     '''
     ALLOWED_MODELS = current_app.config.get('EXPORT_CSV_MODELS', [])
     DATASET_ID = current_app.config.get('EXPORT_CSV_DATASET_ID')
+
+    if model and model not in ALLOWED_MODELS:
+        log.error('Unknown or unallowed model: %s' % model)
+        return
 
     if not DATASET_ID:
         log.error('EXPORT_CSV_DATASET_ID setting value not set')
@@ -184,5 +188,6 @@ def export_csv(self):
         log.error('EXPORT_CSV_DATASET_ID points to a non existent dataset')
         return
 
-    for model in ALLOWED_MODELS:
+    models = (model, ) if model else ALLOWED_MODELS
+    for model in models:
         export_csv_for_model(model, dataset)

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -96,7 +96,8 @@ def get_queryset(model_cls):
     for attr in attrs:
         if getattr(model_cls, attr, None):
             params[attr] = False
-    return model_cls.objects.filter(**params)
+    # no_cache to avoid eating up too much RAM
+    return model_cls.objects.filter(**params).no_cache()
 
 
 def get_or_create_resource(r_info, model, dataset):

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -158,13 +158,13 @@ def export_csv_for_model(model, dataset):
         csvfile.seek(0)
         # make a resource from this tmp file
         created, resource = store_resource(csvfile, model, dataset)
-        csvfile.close()
         # add it to the dataset
         if created:
             dataset.add_resource(resource)
         dataset.last_modified = datetime.now()
         dataset.save()
     finally:
+        csvfile.close()
         os.unlink(csvfile.name)
 
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -157,6 +157,7 @@ def export_csv_for_model(model, dataset):
         csvfile.seek(0)
         # make a resource from this tmp file
         created, resource = store_resource(csvfile, model, dataset)
+        csvfile.close()
         # add it to the dataset
         if created:
             dataset.add_resource(resource)

--- a/udata/frontend/csv.py
+++ b/udata/frontend/csv.py
@@ -83,8 +83,7 @@ class Adapter(object):
 
     def rows(self):
         '''Iterate over queryset objects'''
-        # no_cache to avoid eating up too much RAM with large querysets
-        return (self.to_row(o) for o in self.queryset.no_cache())
+        return (self.to_row(o) for o in self.queryset)
 
     def to_row(self, obj):
         '''Convert an object into a flat csv row'''

--- a/udata/frontend/csv.py
+++ b/udata/frontend/csv.py
@@ -83,7 +83,8 @@ class Adapter(object):
 
     def rows(self):
         '''Iterate over queryset objects'''
-        return (self.to_row(o) for o in self.queryset)
+        # no_cache to avoid eating up too much RAM with large querysets
+        return (self.to_row(o) for o in self.queryset.no_cache())
 
     def to_row(self, obj):
         '''Convert an object into a flat csv row'''


### PR DESCRIPTION
This introduces `no_cache` when generating CSV to lower memory footprint (https://github.com/MongoEngine/mongoengine/issues/365).

The `resources` (I think) export still eats up a lot of memory, this should be further looked into. This optimisation should at least allow the job to complete on our production machines.

It also looks like the memory is not completely released between the different models when doing a CSV export. Running them one after the other might help w/ memory pressure, thus the introduction a (optionnal) `model` argument.

NB: closing the csv file makes no difference memory wise but it's still a good idea I guess.

## before

![out](https://user-images.githubusercontent.com/119625/62550132-03203f80-b86a-11e9-8628-8be5b92f6979.png)

## after

![out_no_cache_all](https://user-images.githubusercontent.com/119625/62713779-9473eb00-b9fd-11e9-9472-b72399dcac74.png)