### PR TITLE
Add [flake8] max-line-length = 100

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ exclude =
     specs,
     udata/static,
     udata/templates
+max-line-length = 100
 
 [wheel]
 universal = 1


### PR DESCRIPTION
I was pretty sure we already had this somewhere but I can't find it anymore 🤔 Neither does my new editor.

We already breached the 80 characters limit anyway: https://github.com/opendatateam/udata/blob/master/udata/core/dataset/tasks.py#L49