### PR TITLE
Style links in admin modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Style links in admin modals [#2292](https://github.com/opendatateam/udata/pull/2292)
 
 ## 1.6.14 (2019-08-14)
 

--- a/less/udata/modal.less
+++ b/less/udata/modal.less
@@ -1,7 +1,6 @@
 .modal-content {
   dd a:not(.card) {
-    color: @link-color;
-    text-decoration: none;
+    text-decoration: underline;
     text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
## Before

<img width="611" alt="Capture d'écran 2019-08-21 11 27 15" src="https://user-images.githubusercontent.com/119625/63420340-c5451e80-c406-11e9-9b3b-4895a3b3c50b.png">

## After

<img width="618" alt="Capture d'écran 2019-08-21 11 24 23" src="https://user-images.githubusercontent.com/119625/63420356-caa26900-c406-11e9-8c20-ad1aeaf52b23.png">

Not really sure about the scope of this change, but it's look like the blue background is a property of `modal-body` in the admin, so applying this to `modal-content` looks right.