### PR TITLE
Add activity.key filter to activity.atom feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add activity.key filter to activity.atom feed [#2293](https://github.com/opendatateam/udata/pull/2293)
 
 ## 1.6.14 (2019-08-14)
 

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -43,12 +43,19 @@ def inject_site():
 
 @blueprint.route('/activity.atom')
 def activity_feed():
+    activity_keys = request.args.getlist('key')
+
     feed = AtomFeed(
         current_app.config.get('SITE_TITLE'), feed_url=request.url,
         url=request.url_root)
     activities = (Activity.objects.order_by('-created_at')
                                   .limit(current_site.feed_size))
+
     for activity in activities.select_related():
+        # filter by activity.key
+        # /!\ this won't completely honor `feed_size` (only as a max value)
+        if activity_keys and activity.key not in activity_keys:
+            continue
         try:
             owner = activity.actor or activity.organization
         except DoesNotExist:

--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -53,7 +53,7 @@ def activity_feed():
 
     for activity in activities.select_related():
         # filter by activity.key
-        # /!\ this won't completely honor `feed_size` (only as a max value)
+        # /!\ this won't completely honour `feed_size` (only as a max value)
         if activity_keys and activity.key not in activity_keys:
             continue
         try:


### PR DESCRIPTION
The `activity.atom` feed can now be filtered like this: https://www.data.gouv.fr/fr/activity.atom?key=dataset:updated&key=dataset:created.

⚠️ This is suboptimal because it won't honour the `feed_size` setting. This is because we can not use `key` as a filter in the queryset. I can not see any better solution that is not over-engineered.