### PR TITLE
Allow `Authorization` as CORS header and OAuth minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Add activity.key filter to activity.atom feed [#2293](https://github.com/opendatateam/udata/pull/2293)
-- Allow `Authorization` as CORS header and Atom minor fixes [#2298](https://github.com/opendatateam/udata/pull/2298)
+- Allow `Authorization` as CORS header and OAuth minor fixes [#2298](https://github.com/opendatateam/udata/pull/2298)
 
 ## 1.6.14 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add activity.key filter to activity.atom feed [#2293](https://github.com/opendatateam/udata/pull/2293)
+- Allow `Authorization` as CORS header and Atom minor fixes [#2298](https://github.com/opendatateam/udata/pull/2298)
 
 ## 1.6.14 (2019-08-14)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -595,15 +595,23 @@ You can see the full configuration option list in
 
 The default identity used for outgoing mails.
 
-## Flask-OAuthlib options
+## Authlib options
 
-udata is Oauthlib to provide OAuth2 on the API.
+udata uses Authlib to provide OAuth2 on the API.
 The full option list is available in
-[the official Flask-OAuthlib documentation][flask-oauthlib-doc]
+[the official Authlib documentation][authlib-doc]
 
-### OAUTH2_PROVIDER_TOKEN_EXPIRES_IN
+### OAUTH2_TOKEN_EXPIRES_IN
 
-**default**: `30 * 24 * 60 * 60` (30 days)
+**default**:
+```python
+    {
+        'authorization_code': 10 * 24 * HOUR,
+        'implicit': 10 * 24 * HOUR,
+        'password': 10 * 24 * HOUR,
+        'client_credentials': 10 * 24 * HOUR
+    }
+```
 
 The OAuth2 token duration.
 
@@ -806,4 +814,4 @@ FS_ROOT = '/srv/http/www.data.dev/fs'
 [flask-cache-doc]: https://pythonhosted.org/Flask-Cache/
 [flask-mail-doc]: https://pythonhosted.org/flask-mail/
 [flask-mongoengine-doc]: https://flask-mongoengine.readthedocs.org/
-[flask-oauthlib-doc]: https://flask-oauthlib.readthedocs.org/en/latest/oauth2.html#configuration
+[authlib-doc]: https://docs.authlib.org/en/latest/flask/2/authorization-server.html#server

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -49,6 +49,7 @@ PREFLIGHT_HEADERS = (
     'Accept',
     'Accept-Charset',
     'Accept-Language',
+    'Authorization',
     'Cache-Control',
     'Content-Encoding',
     'Content-Length',

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -136,7 +136,12 @@ class Defaults(object):
     # OAuth 2 settings
     OAUTH2_PROVIDER_ERROR_ENDPOINT = 'oauth.oauth_error'
     OAUTH2_REFRESH_TOKEN_GENERATOR = True
-    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 30 * 24 * HOUR  # 30 days
+    OAUTH2_TOKEN_EXPIRES_IN = {
+        'authorization_code': 10 * 24 * HOUR,
+        'implicit': 10 * 24 * HOUR,
+        'password': 10 * 24 * HOUR,
+        'client_credentials': 10 * 24 * HOUR
+    }
 
     MD_ALLOWED_TAGS = [
         'a',

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -137,10 +137,10 @@ class Defaults(object):
     OAUTH2_PROVIDER_ERROR_ENDPOINT = 'oauth.oauth_error'
     OAUTH2_REFRESH_TOKEN_GENERATOR = True
     OAUTH2_TOKEN_EXPIRES_IN = {
-        'authorization_code': 10 * 24 * HOUR,
+        'authorization_code': 30 * 24 * HOUR,
         'implicit': 10 * 24 * HOUR,
-        'password': 10 * 24 * HOUR,
-        'client_credentials': 10 * 24 * HOUR
+        'password': 30 * 24 * HOUR,
+        'client_credentials': 30 * 24 * HOUR
     }
 
     MD_ALLOWED_TAGS = [

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -90,7 +90,7 @@ class APIAuthTest:
         assert response.json == {'success': True}
 
     def test_oauth_auth(self, api, oauth):
-        '''Should handle  OAuth header authentication'''
+        '''Should handle OAuth header authentication'''
         user = UserFactory()
         token = OAuth2Token.objects.create(
             client=oauth,


### PR DESCRIPTION
This PR:
- ~~Allows to use implicit grant: it was not possible because we always had a `secret` set on an `OAuth2Client`, due to the way `default` works on a MongoEngine field. Implicit grant won't work if there's a secret set on the client. A Boolean field `is_implicit` is now available to bypass the `secret` logic.~~ Actually, you can use `client.secret = ''` and it works fine 😬 
- Switches the token expiration times config from the now-unused `Flask-OAuthlib` syntax to the new `authlib` one. Set expiration time to 10 days for implicit grant tokens, vs 1 hour for the lib default. Set expiration time to 30 days for other grants, as we used to specify with `OAUTH2_PROVIDER_TOKEN_EXPIRES_IN`.
- Adds the `Authorization` header as allowed `PREFLIGHT_HEADERS`, w/o this the implicit grant workflow is useless on a web app.

To be considered:
- Maybe deprecate implicit grant in favour of https://docs.authlib.org/en/latest/specs/rfc7636.html#specs-rfc7636 (cf https://oauth.net/2/grant-types/implicit/).
- `OAUTH2_PROVIDER_ERROR_ENDPOINT` and `OAUTH2_REFRESH_TOKEN_GENERATOR` are probably unused, but I'm not sure how to migrate those to `authlib`.