### PR TITLE
Fixes admin missing permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add activity.key filter to activity.atom feed [#2293](https://github.com/opendatateam/udata/pull/2293)
 - Allow `Authorization` as CORS header and OAuth minor fixes [#2298](https://github.com/opendatateam/udata/pull/2298)
 - Set dataset.private to False by default (and fix stock) [#2307](https://github.com/opendatateam/udata/pull/2307)
+- Fixes some inconsistencies between admin display (buttons, actions...) and real permissions [#2308](https://github.com/opendatateam/udata/pull/2308)
 
 ## 1.6.14 (2019-08-14)
 

--- a/js/components/dataset/card-list.vue
+++ b/js/components/dataset/card-list.vue
@@ -80,7 +80,7 @@
                 <dataset-card :dataset="dataset"></dataset-card>
             </div>
         </div>
-        <footer slot="footer">
+        <footer v-if="editable" slot="footer">
             <a v-show="!editing" class="text-uppercase footer-btn pointer"
                 @click="edit">
                 {{ _('Edit') }}
@@ -124,6 +124,7 @@ export default {
             default() {return this._('Datasets')}
         },
         datasets: Array,
+        editable: Boolean,
         loading: Boolean
     },
     data() {

--- a/js/components/organization/profile.vue
+++ b/js/components/organization/profile.vue
@@ -26,7 +26,7 @@
     </h3>
     <div class="profile-body">
         <image-button :src="logoSrc" :size="100" class="logo-button"
-            :endpoint="endpoint">
+            :endpoint="endpoint" :editable="org.is_admin($root.me)">
         </image-button>
         <div v-markdown="org.description"></div>
         <div v-if="org.badges | length" class="label-list">

--- a/js/components/post/content.vue
+++ b/js/components/post/content.vue
@@ -18,7 +18,7 @@
 <box :title="post.name || ''" icon="newspaper-o"
     boxclass="box-solid post-content-widget">
     <image-button :src="post.image" :size="150"
-        :endpoint="endpoint">
+        :endpoint="endpoint" :editable="$root.me.is_admin">
     </image-button>
     <p v-if="published"><strong>
         {{ _('Published on {date}', {date: published}) }}

--- a/js/components/reuse/card-list.vue
+++ b/js/components/reuse/card-list.vue
@@ -80,7 +80,7 @@
                 <reuse-card :reuse="reuse"></reuse-card>
             </div>
         </div>
-        <footer slot="footer">
+        <footer v-if="editable" slot="footer">
             <a v-show="!editing" class="text-uppercase footer-btn pointer"
                 @click="edit">
                 {{ _('Edit') }}
@@ -124,6 +124,7 @@ export default {
             default() {return this._('Reuses')}
         },
         reuses: Array,
+        editable: Boolean,
         loading: Boolean
     },
     data() {

--- a/js/components/reuse/details.vue
+++ b/js/components/reuse/details.vue
@@ -24,7 +24,7 @@
     <h3>{{reuse.title}}</h3>
     <div class="details-body">
         <image-button :src="reuse.image_thumbnail" :size="100" class="thumbnail-button"
-            :endpoint="endpoint">
+            :endpoint="endpoint" :editable="$root.me.can_edit(reuse)">
         </image-button>
         <div v-markdown="reuse.description"></div>
         <div v-if="reuse.tags" class="label-list">

--- a/js/components/user/profile.vue
+++ b/js/components/user/profile.vue
@@ -24,7 +24,7 @@
     <h3>{{user.fullname}}</h3>
         <div class="profile-body">
             <image-button :src="user | avatar_url 100" :size="100" class="avatar-button"
-                :endpoint="endpoint">
+                :endpoint="endpoint" :editable="can_edit">
             </image-button>
         <div v-markdown="user.about"></div>
     </div>
@@ -49,12 +49,15 @@ export default {
         endpoint() {
             var operation = API.me.operations.my_avatar;
             return operation.urlify({});
+        },
+        can_edit() {
+            return this.$root.me.is_admin || this.user.id == this.$root.me;
         }
     },
     components: {Box, ImageButton},
     events: {
         'image:saved': function() {
-            this.$root.me.fetch();
+            this.user.fetch();
         }
     },
 };

--- a/js/components/widgets/image-button.vue
+++ b/js/components/widgets/image-button.vue
@@ -19,7 +19,7 @@
         background-color: @overlay-color;
     }
 
-    &:hover {
+    &.editable:hover {
         border: 1px solid @overlay-color;
         background-color: lighten(@overlay-color, 30%);
 
@@ -36,11 +36,11 @@
 </style>
 
 <template>
-<div class="image-button pointer"
+<div class="image-button" :class="{editable: editable, pointer: editable}"
     :style="{width:size+'px', height:size+'px'}"
     @click="click">
     <img :src="src" />
-    <small class="change-overlay">{{ _('change') }}</small>
+    <small v-if="editable" class="change-overlay">{{ _('change') }}</small>
 </div>
 </template>
 
@@ -58,10 +58,12 @@ export default {
             type: Array,
             default: () => [100],
         },
+        editable: Boolean,
         endpoint: null
     },
     methods: {
         click() {
+            if (!this.editable) return;
             this.$root.$modal(
                 require('components/widgets/image-picker-modal.vue'),
                 {endpoint: this.endpoint, sizes: this.sizes}

--- a/js/views/dataset.vue
+++ b/js/views/dataset.vue
@@ -139,7 +139,9 @@ export default {
     },
     computed: {
         actions() {
-            const actions = [{
+            const actions = [];
+            if (this.can_edit()) {
+                actions.push({
                     label: this._('Edit'),
                     icon: 'edit',
                     method: this.edit
@@ -147,20 +149,20 @@ export default {
                     label: this._('Transfer'),
                     icon: 'send',
                     method: this.transfer_request
-                }];
-
-            if(!this.dataset.deleted) {
-                actions.push({
-                    label: this._('Delete'),
-                    icon: 'trash',
-                    method: this.confirm_delete
                 });
-            } else {
-                actions.push({
-                    label: this._('Restore'),
-                    icon: 'undo',
-                    method: this.confirm_restore
-                });
+                if(!this.dataset.deleted) {
+                    actions.push({
+                        label: this._('Delete'),
+                        icon: 'trash',
+                        method: this.confirm_delete
+                    });
+                } else {
+                    actions.push({
+                        label: this._('Restore'),
+                        icon: 'undo',
+                        method: this.confirm_restore
+                    });
+                }
             }
 
             if (this.$root.me.is_admin) {
@@ -205,6 +207,9 @@ export default {
         },
         map_footer() {
             return (this.dataset.spatial && this.dataset.spatial.granularity || this.territories_labels) !== undefined;
+        },
+        can_edit() {
+            return this.$root.me.can_edit(this.reuse)
         }
     },
     methods: {

--- a/js/views/editorial.vue
+++ b/js/views/editorial.vue
@@ -1,12 +1,12 @@
 <template>
 <layout :title="_('Editorial')">
     <div class="row">
-        <dataset-card-list class="col-xs-12 col-md-6"
+        <dataset-card-list class="col-xs-12 col-md-6" editable
             :title="_('Featured datasets')"
             :datasets="home_datasets.items"
             :loading="home_datasets.loading">
         </dataset-card-list>
-        <reuse-card-list class="col-xs-12 col-md-6"
+        <reuse-card-list class="col-xs-12 col-md-6" editable
             :title="_('Featured reuses')"
             :reuses="home_reuses.items"
             :loading="home_reuses.loading">

--- a/js/views/post.vue
+++ b/js/views/post.vue
@@ -5,8 +5,8 @@
         <post-content :post="post" class="col-xs-12"></post-content>
     </div>
     <div class="row">
-        <dataset-card-list :datasets="post.datasets" class="col-xs-12 col-md-6"></dataset-card-list>
-        <reuse-card-list :reuses="post.reuses" class="col-xs-12 col-md-6"></reuse-card-list>
+        <dataset-card-list editable :datasets="post.datasets" class="col-xs-12 col-md-6"></dataset-card-list>
+        <reuse-card-list editable :reuses="post.reuses" class="col-xs-12 col-md-6"></reuse-card-list>
     </div>
 </layout>
 </div>

--- a/js/views/reuse.vue
+++ b/js/views/reuse.vue
@@ -92,7 +92,9 @@ export default {
     },
     computed: {
         actions() {
-            const actions = [{
+            const actions = [];
+            if (this.$root.me.can_edit(this.reuse)) {
+                actions.push({
                     label: this._('Edit'),
                     icon: 'edit',
                     method: this.edit
@@ -100,20 +102,20 @@ export default {
                     label: this._('Transfer'),
                     icon: 'send',
                     method: this.transfer_request
-                }];
-
-            if(!this.reuse.deleted) {
-                actions.push({
-                    label: this._('Delete'),
-                    icon: 'trash',
-                    method: this.confirm_delete
                 });
-            } else {
-                actions.push({
-                    label: this._('Restore'),
-                    icon: 'undo',
-                    method: this.confirm_restore
-                });
+                if(!this.reuse.deleted) {
+                    actions.push({
+                        label: this._('Delete'),
+                        icon: 'trash',
+                        method: this.confirm_delete
+                    });
+                } else {
+                    actions.push({
+                        label: this._('Restore'),
+                        icon: 'undo',
+                        method: this.confirm_restore
+                    });
+                }
             }
 
             if (this.$root.me.is_admin) {

--- a/js/views/reuse.vue
+++ b/js/views/reuse.vue
@@ -11,6 +11,7 @@
     <div class="row">
         <reuse-details :reuse="reuse" class="col-xs-12 col-md-6"></reuse-details>
         <dataset-card-list id="datasets-list" :datasets="reuse.datasets"
+            :editable="can_edit"
             class="col-xs-12 col-md-6">
         </dataset-card-list>
     </div>
@@ -93,7 +94,7 @@ export default {
     computed: {
         actions() {
             const actions = [];
-            if (this.$root.me.can_edit(this.reuse)) {
+            if (this.can_edit) {
                 actions.push({
                     label: this._('Edit'),
                     icon: 'edit',
@@ -151,6 +152,9 @@ export default {
                 color: 'purple',
                 target: '#traffic'
             }];
+        },
+        can_edit() {
+            return this.$root.me.can_edit(this.reuse)
         }
     },
     events: {

--- a/js/views/topic.vue
+++ b/js/views/topic.vue
@@ -6,8 +6,8 @@
         <topic-details :topic="topic" class="col-xs-12"></topic-details>
     </div>
     <div class="row">
-        <datasets-list :datasets="topic.datasets" class="col-xs-12 col-md-6"></datasets-list>
-        <reuses-list :reuses="topic.reuses" class="col-xs-12 col-md-6"></reuses-list>
+        <datasets-list editable :datasets="topic.datasets" class="col-xs-12 col-md-6"></datasets-list>
+        <reuses-list editable :reuses="topic.reuses" class="col-xs-12 col-md-6"></reuses-list>
     </div>
 </layout>
 </div>


### PR DESCRIPTION
This PR fixes some inconsistencies between admin display and real permissions.

## Views

### Reuse view

Actions buttons, reused datasets list and image picker need reuse edit permissions.

### Dataset view

Actions button needs dataset edit permissions

### Organization view

Changing logo needs organization admin permissions

### User view

This view is used as me view (`user==me`) and user view (`user==any user`).
Actions and image picker needs edit permissions (ie. either be the displayed user or be an admin)

### Post/Topic

Every action needs admin permissions

## Components

Some components needed an `editable` (boolean) property.
- `image-button`: change avatar or associated image only when allowed
- dataset and reuse `card-list`: the edit action needs permission

## Note

Even if actions and sidebar entries are not present when not having permissions, views can be displayed with a valid copy-pasted URL.
We might need another PR to admin permissions to routing or to properly handles permission on admin-only views as they are not really admin only.