### PR TITLE
Fix typo (computed property vs. method)

### DIFF
--- a/js/views/dataset.vue
+++ b/js/views/dataset.vue
@@ -140,7 +140,7 @@ export default {
     computed: {
         actions() {
             const actions = [];
-            if (this.can_edit()) {
+            if (this.can_edit) {
                 actions.push({
                     label: this._('Edit'),
                     icon: 'edit',


### PR DESCRIPTION
Fix a typo in #2308 making dataset actions invisibles.