### PR TITLE
No follow on external reuse links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Prevent Google ranking spam attacks on reuse pages (`rel=nofollow` on reuse link) [#2320](https://github.com/opendatateam/udata/pull/2320)
 
 ## 1.6.15 (2019-09-11)
 

--- a/udata/templates/reuse/display.html
+++ b/udata/templates/reuse/display.html
@@ -76,7 +76,7 @@
                 {{ reuse.description|markdown }}
 
                 <div class="reuse-image">
-                    <a href="{{ reuse.url }}">
+                    <a href="{{ reuse.url }}" rel="nofollow">
                         <img src="{{ reuse.image|placeholder('reuse') }}"
                             alt="{{ reuse.title }}" class="scalable" />
                         <br/>


### PR DESCRIPTION
This PR ensures that reuse external link does not provide Google ranking to spammers (ie. `rel=nofollow` on it).
