### PR TITLE
Fix the Python 3 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,23 +20,22 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py3-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
-          - py3-cache-v5-{{ arch }}-{{ .Branch }}
-          - py3-cache-v5-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+          - py3-cache-v6-{{ arch }}-{{ checksum "python.deps" }}
+          - py3-cache-v6-{{ arch }}-{{ .Branch }}
+          - py3-cache-v6-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
-            python -m venv venv --without-pip
+            virtualenv venv
             source venv/bin/activate
-            pip install -U pip setuptools
             pip install -e . || pip install -e .
             pip install -r requirements/circleci.pip
       - save_cache:
-          key: py3-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
+          key: py3-cache-v6-{{ arch }}-{{ checksum "python.deps" }}
           paths:
           - venv
       - save_cache:
-          key: py3-cache-v5-{{ arch }}-{{ .Branch }}
+          key: py3-cache-v6-{{ arch }}-{{ .Branch }}
           paths:
           - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,23 +20,23 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py3-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
-          - py3-cache-v4-{{ arch }}-{{ .Branch }}
-          - py3-cache-v4-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+          - py3-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
+          - py3-cache-v5-{{ arch }}-{{ .Branch }}
+          - py3-cache-v5-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
             python -m venv venv --without-pip
             source venv/bin/activate
-            pip install -U pip
+            pip install -U pip setuptools
             pip install -e . || pip install -e .
             pip install -r requirements/circleci.pip
       - save_cache:
-          key: py3-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
+          key: py3-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
           paths:
           - venv
       - save_cache:
-          key: py3-cache-v4-{{ arch }}-{{ .Branch }}
+          key: py3-cache-v5-{{ arch }}-{{ .Branch }}
           paths:
           - venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
-            python -m venv venv
+            python -m venv venv --without-pip
             source venv/bin/activate
             pip install -U pip
             pip install -e . || pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ exclude =
     specs,
     udata/static,
     udata/templates
-max-line-length = 100
 
 [wheel]
 universal = 1


### PR DESCRIPTION
This PR is an attempt to fix CircleCI build on Python official docker images:
- Latest version of venv/pip force an `ensurepip` call on venv creation but the `ensurepip` module is stripped from official docker images resulting in venv creation failure. This adds a `--without-pip` parameter on `venv` creation to prevent `ensurepip` call.
- the flake8 `max-line-length` was declared twice in `setup.cfg`. This removes the second declaration.