### PR TITLE
Hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Use python based migrations instead of relying on mongo internal and deprecated `js_exec`
   - Handle rollback (optionnal)
   - Detailled history
+- Template hooks generalization: allows to dynamically extend template with widgets and snippets from extensions. See [the dedicated documentation section](https://udata.readthedocs.io/en/stable/extending/#hooks) [#2323](https://github.com/opendatateam/udata/pull/2323)
 
 ### Breaking changes
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -31,6 +31,70 @@ Plugins can expose extra view features via the `udata.views` module entrypoint i
 
 - a blueprint (should be named `blueprint`)
 - some view filters
+- some hooks implementation
+
+#### Hooks
+
+Hooks are small html snippets loaded dynamicaly.
+
+In any template, you can add a placeholder for hooks using one of these syntaxes:
+
+```html+jinja
+# All snippets concatened
+{{ hook('my-custom-hook') }}
+
+# More complex layout with a for loop
+<ul>
+{% for widget in hook('my-widgets') %}
+<li>{{ widget }}</li>
+{% endofr %}
+</ul>
+
+# Optionnal parameters support
+{{ hook('my-parametric-hook', arg1, arg2, kw=value) }}
+```
+
+In a view plugin, a hook implementation is a simple decorated function with the context as first argument.
+
+```python
+from udata.frontend import template_hook
+
+@template_hook
+def my_hook(ctx):  # Will be available in {{ hook('my_hook') }}
+    return 'my hook'
+
+
+@template_hook('another-hook')  # Will be available as {{ hook('another-hook') }}
+def my_custom_hook(ctx):
+    return 'my custom hook'
+```
+
+A hook can render a template as simplfy as any basic view:
+
+```python
+@template_hook
+def my_widget(ctx):
+    return theme.render_template('my/widget.html, **ctx)
+```
+
+Hooks can be conditionnaly rendered:
+
+```python
+@template_hook('conditionnal-hook', when=lambda ctx: 'key' in ctx)
+def my_conditionnal_hook(ctx):
+    return 'key is present in context and value is {}'.format(ctx['key'])
+```
+
+Hooks can also receive parameters in addition to context:
+
+```html+jinja
+{{ hook('with-params', arg1, key=value) }}
+```
+```python
+@template_hook('with-params')
+def my_hook(ctx, arg, **kwargs):
+    # Do something with params
+```
 
 ### Metrics (`udata.metrics`)
 

--- a/udata/app.py
+++ b/udata/app.py
@@ -2,7 +2,7 @@ import bson
 import datetime
 import logging
 import os
-import pkgutil
+import importlib
 import types
 
 from os.path import abspath, join, dirname, isfile, exists
@@ -168,10 +168,14 @@ def create_app(config='udata.settings.Defaults', override=None,
         if pkg == 'udata':
             continue  # Defaults are already loaded
         module = '{}.settings'.format(pkg)
-        if pkgutil.find_loader(module):
-            settings = pkgutil.get_loader(module)
-            for key, default in settings.__dict__.items():
-                app.config.setdefault(key, default)
+        try:
+            settings = importlib.import_module(module)
+        except ImportError:
+            continue
+        for key, default in settings.__dict__.items():
+            if key.startswith('__'):
+                continue
+            app.config.setdefault(key, default)
 
     app.json_encoder = UDataJsonEncoder
 

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -59,11 +59,6 @@ def render_snippets(funcs):
 
 
 @front.app_context_processor
-def inject_template_hooks():
-    return {'hook_%s' % k: v for (k, v) in _template_hooks.items()}
-
-
-@front.app_context_processor
 def inject_hooks():
     return {
         'header_snippets': lambda: render_snippets(_header_snippets),

--- a/udata/frontend/__init__.py
+++ b/udata/frontend/__init__.py
@@ -62,14 +62,14 @@ class HookRenderer:
         self.kwargs = kwargs
 
     def __html__(self):
-        return ''.join(f(self.ctx, *self.args, *self.kwargs)
+        return ''.join(f(self.ctx, *self.args, **self.kwargs)
                        for f, w in self.funcs
                        if w is None or w(self.ctx))
 
     def __iter__(self):
         for func, when in self.funcs:
             if when is None or when(self.ctx):
-                yield func(self.ctx, *self.args, *self.kwargs)
+                yield func(self.ctx, *self.args, **self.kwargs)
 
 
 @contextfunction

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -187,8 +187,8 @@
                     </div>
                 </div></div>
                 {# end button bar #}
-                {% if hook_dataset_recommendations and dataset.extras.recommendations %}
-                    {{ hook_dataset_recommendations(dataset.extras.recommendations)|safe }}
+                {% if dataset.extras.recommendations %}
+                {{ hook('dataset_recommendations', dataset.extras.recommendations) }}
                 {% endif %}
             </div>
             {# end left column #}

--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -187,9 +187,7 @@
                     </div>
                 </div></div>
                 {# end button bar #}
-                {% if dataset.extras.recommendations %}
-                {{ hook('dataset_recommendations', dataset.extras.recommendations) }}
-                {% endif %}
+                {{ hook('dataset.display.after-description') }}
             </div>
             {# end left column #}
 

--- a/udata/templates/raw.html
+++ b/udata/templates/raw.html
@@ -25,6 +25,8 @@
 
     {% block extra_head %}{% endblock %}
 
+    {{ header_snippets() }}
+
     {% endblock raw_head %}
 
   </head>
@@ -38,9 +40,7 @@
     {% endif %}
     {% block extra_js %}{% endblock %}
 
-    {% for snippet in footer_snippets %}
-    {{ snippet()|safe }}
-    {% endfor %}
+    {{ footer_snippets() }}
 
   </body>
 </html>

--- a/udata/templates/raw.html
+++ b/udata/templates/raw.html
@@ -25,7 +25,7 @@
 
     {% block extra_head %}{% endblock %}
 
-    {{ header_snippets() }}
+    {{ hook('header.snippets') }}
 
     {% endblock raw_head %}
 
@@ -40,7 +40,7 @@
     {% endif %}
     {% block extra_js %}{% endblock %}
 
-    {{ footer_snippets() }}
+    {{ hook('footer.snippets') }}
 
   </body>
 </html>

--- a/udata/tests/frontend/test_hooks.py
+++ b/udata/tests/frontend/test_hooks.py
@@ -12,6 +12,16 @@ def single(ctx):
     return 'single'
 
 
+@template_hook
+def hello(ctx, name):
+    return 'Hello {}'.format(name)
+
+
+@template_hook
+def kwargs(ctx, **kwargs):
+    return ', '.join(sorted('{0}={1}'.format(k, v) for k, v in kwargs.items()))
+
+
 @template_hook('multiple')
 def first(ctx):
     return 'first'
@@ -34,12 +44,22 @@ def false(ctx):
 
 @bp.route('/empty/render')
 def render_empty():
-    return render_template_string('{{ hook("siemptyngle") }}')
+    return render_template_string('{{ hook("empty") }}')
 
 
 @bp.route('/empty/iter')
 def iter_empty():
     return render_template_string('{% for w in hook("empty") %}<{{ w }}>{% endfor %}')
+
+
+@bp.route('/hello')
+def render_hello():
+    return render_template_string('{{ hook("hello", "world") }}')
+
+
+@bp.route('/kwargs')
+def render_kwargs():
+    return render_template_string('{{ hook("kwargs", key="value", other=42) }}')
 
 
 @bp.route('/single/render')
@@ -119,3 +139,13 @@ class HooksTest:
         response = client.get(url_for('hooks_tests.iter_conditionnal'))
         assert200(response)
         assert b'<true>' == response.data
+
+    def test_arguments(self, client):
+        response = client.get(url_for('hooks_tests.render_hello'))
+        assert200(response)
+        assert b'Hello world' == response.data
+
+    def test_kwargs(self, client):
+        response = client.get(url_for('hooks_tests.render_kwargs'))
+        assert200(response)
+        assert b'key=value, other=42' == response.data

--- a/udata/tests/frontend/test_hooks.py
+++ b/udata/tests/frontend/test_hooks.py
@@ -22,6 +22,16 @@ def second(ctx):
     return 'second'
 
 
+@template_hook('conditionnal', when=lambda ctx: True)
+def true(ctx):
+    return 'true'
+
+
+@template_hook('conditionnal', when=lambda ctx: False)
+def false(ctx):
+    return 'false'
+
+
 @bp.route('/empty/render')
 def render_empty():
     return render_template_string('{{ hook("siemptyngle") }}')
@@ -50,6 +60,16 @@ def render_multiple():
 @bp.route('/multiple/iter')
 def iter_multiple():
     return render_template_string('{% for w in hook("multiple") %}<{{ w }}>{% endfor %}')
+
+
+@bp.route('/conditionnal/render')
+def render_conditionnal():
+    return render_template_string('{{ hook("conditionnal") }}')
+
+
+@bp.route('/conditionnal/iter')
+def iter_conditionnal():
+    return render_template_string('{% for w in hook("conditionnal") %}<{{ w }}>{% endfor %}')
 
 
 @pytest.fixture
@@ -84,8 +104,18 @@ class HooksTest:
         response = client.get(url_for('hooks_tests.render_multiple'))
         assert200(response)
         assert b'firstsecond' == response.data
-    
+
     def test_iter_multiple_template_hooks(self, client):
         response = client.get(url_for('hooks_tests.iter_multiple'))
         assert200(response)
         assert b'<first><second>' == response.data
+
+    def test_conditionnal_template_hooks(self, client):
+        response = client.get(url_for('hooks_tests.render_conditionnal'))
+        assert200(response)
+        assert b'true' == response.data
+
+    def test_iter_conditionnal_template_hooks(self, client):
+        response = client.get(url_for('hooks_tests.iter_conditionnal'))
+        assert200(response)
+        assert b'<true>' == response.data

--- a/udata/tests/frontend/test_hooks.py
+++ b/udata/tests/frontend/test_hooks.py
@@ -1,0 +1,91 @@
+import pytest
+
+from flask import Blueprint, render_template_string, url_for
+from udata.frontend import template_hook
+from udata.tests.helpers import assert200
+
+bp = Blueprint('hooks_tests', __name__, url_prefix='/hooks_tests')
+
+
+@template_hook
+def single(ctx):
+    return 'single'
+
+
+@template_hook('multiple')
+def first(ctx):
+    return 'first'
+
+
+@template_hook('multiple')
+def second(ctx):
+    return 'second'
+
+
+@bp.route('/empty/render')
+def render_empty():
+    return render_template_string('{{ hook("siemptyngle") }}')
+
+
+@bp.route('/empty/iter')
+def iter_empty():
+    return render_template_string('{% for w in hook("empty") %}<{{ w }}>{% endfor %}')
+
+
+@bp.route('/single/render')
+def render_single():
+    return render_template_string('{{ hook("single") }}')
+
+
+@bp.route('/single/iter')
+def iter_single():
+    return render_template_string('{% for w in hook("single") %}<{{ w }}>{% endfor %}')
+
+
+@bp.route('/multiple/render')
+def render_multiple():
+    return render_template_string('{{ hook("multiple") }}')
+
+
+@bp.route('/multiple/iter')
+def iter_multiple():
+    return render_template_string('{% for w in hook("multiple") %}<{{ w }}>{% endfor %}')
+
+
+@pytest.fixture
+def app(app):
+    app.register_blueprint(bp)
+    return app
+
+
+@pytest.mark.frontend
+class HooksTest:
+    def test_empty_template_hook(self, client):
+        response = client.get(url_for('hooks_tests.render_empty'))
+        assert200(response)
+        assert b'' == response.data
+
+    def test_iter_empty_template_hook(self, client):
+        response = client.get(url_for('hooks_tests.iter_empty'))
+        assert200(response)
+        assert b'' == response.data
+
+    def test_single_template_hook(self, client):
+        response = client.get(url_for('hooks_tests.render_single'))
+        assert200(response)
+        assert b'single' == response.data
+
+    def test_iter_single_template_hook(self, client):
+        response = client.get(url_for('hooks_tests.iter_single'))
+        assert200(response)
+        assert b'<single>' == response.data
+
+    def test_multiple_template_hooks(self, client):
+        response = client.get(url_for('hooks_tests.render_multiple'))
+        assert200(response)
+        assert b'firstsecond' == response.data
+    
+    def test_iter_multiple_template_hooks(self, client):
+        response = client.get(url_for('hooks_tests.iter_multiple'))
+        assert200(response)
+        assert b'<first><second>' == response.data


### PR DESCRIPTION
This PR generalize template hooks allowing extension to contribute snippets and template to dynamically load them.


Hooks are small html snippets loaded dynamicaly.

In any template, you can add a placeholder for hooks using one of these syntaxes:

```html+jinja
# All snippets concatened
{{ hook('my-custom-hook') }}

# More complex layout with a for loop
<ul>
{% for widget in hook('my-widgets') %}
<li>{{ widget }}</li>
{% endofr %}
</ul>

# Optionnal parameters support
{{ hook('my-parametric-hook', arg1, arg2, kw=value) }}
```

In a view plugin, a hook implementation is a simple decorated function with the context as first argument.

```python
from udata.frontend import template_hook

@template_hook
def my_hook(ctx):  # Will be available in {{ hook('my_hook') }}
    return 'my hook'


@template_hook('another-hook')  # Will be available as {{ hook('another-hook') }}
def my_custom_hook(ctx):
    return 'my custom another-hook'
```

Hooks can be conditionnaly rendered:

```python
@template_hook('conditionnal-hook', when=lambda ctx: 'key' in ctx)
def my_conditionnal_hook(ctx):
    return 'key is present in context and value is {}'.format(ctx['key'])
```

Hooks can also receive parameters in addition to context:

```html+jinja
{{ hook('with-params', arg1, key=value) }}
```
```python
@template_hook('with-params')
def my_hook(ctx, arg, **kwargs):
    # Do something with params
```