### PR TITLE
Display resources list actions only for user allowed to edit (fix #2325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Prevent Google ranking spam attacks on reuse pages (`rel=nofollow` on reuse link) [#2320](https://github.com/opendatateam/udata/pull/2320)
+- Display admin resources list actions only if user has permissions to edit [#2326](https://github.com/opendatateam/udata/pull/2326)
 
 ## 1.6.15 (2019-09-11)
 

--- a/js/components/dataset/resource/list.vue
+++ b/js/components/dataset/resource/list.vue
@@ -40,7 +40,7 @@
         boxclass="box-solid resources-widget"
         bodyclass="table-responsive no-padding"
         footerclass="text-center"
-        :footer="true" :empty="_('No resources')">
+        :footer="$root.me.can_edit(dataset)" :empty="_('No resources')">
         <table class="table table-hover">
             <thead>
                 <tr>
@@ -99,7 +99,7 @@
         <div class="overlay dropzone" v-if="dropping">
             <span class="fa fa-download fa-2x"></span>
         </div>
-        <footer slot="footer">
+        <footer slot="footer" v-if="$root.me.can_edit(dataset)">
             <button type="button"
                 class="btn btn-primary btn-sm btn-flat pointer"
                 v-show="!reordering"


### PR DESCRIPTION
This PR displays the dataset admin resources list actions (Add, Reorder...) only when user has edit permissions