### PR TITLE
Upgrade mongo update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   python:
     docker:
       - image: udata/circleci:2-alpine
-      - image: circleci/mongo:3.4-ram
+      - image: circleci/mongo:3.6-stretch-ram
       - image: redis:alpine
       - image: udata/elasticsearch:2.4.5
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Breaking changes
 
 - The new migration system ([#1956](https://github.com/opendatateam/udata/pull/1956)) uses a new python based format. Pre-2.0 migrations are not compatible so you might need to upgrade to the latest `udata` version `<2.0.0`, execute migrations and then upgrade to `udata` 2+.
+- The targeted mongo version is now Mongo 3.6. Backward support is not guaranteed
 
 ## 1.6.15 (2019-09-11)
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     db_test:
-        image: mongo:3.2
+        image: mongo:3.6
         tmpfs: /data/db/
         ports:
           - "27018:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     db:
-        image: mongo:3.2
+        image: mongo:3.6
         volumes:
           - ./data/db:/data/db
         expose:

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -50,7 +50,7 @@ $ brew install automake autoconf libtool pkg-config python \
 
 ## MongoDB, ElasticSearch and Redis
 
-The project depends on [MongoDB][] 3.2+, [ElasticSearch][] 2.4 and [Redis][]
+The project depends on [MongoDB][] 3.6+, [ElasticSearch][] 2.4 and [Redis][]
 (beware of the version, it will not work well if they are not respected).
 
 Elasticsearch requires the [Analysis ICU][analysis-icu] plugin for your specific version.
@@ -72,7 +72,7 @@ On Debian Jessie (cf [mongo-install-instructions][] for other versions), as root
 
 ```
 $ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-$ echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main" > /etc/apt/sources.list.d/mongodb-org-3.2.list
+$ echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" > /etc/apt/sources.list.d/mongodb-org-3.6.list
 $ apt-get update
 $ apt-get install -y mongodb-org
 $ service mongod start
@@ -120,5 +120,5 @@ $ /usr/local/Cellar/elasticsearch/2.4.1/libexec/bin/plugin install analysis-icu
 [homebrew]: http://brew.sh/
 [python]: https://www.python.org/
 [analysis-icu]: https://github.com/elastic/elasticsearch-analysis-icu
-[mongo-install-instructions]: https://docs.mongodb.com/v3.2/tutorial/install-mongodb-on-debian/#install-mongodb-community-edition
+[mongo-install-instructions]: https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-debian/#install-mongodb-community-edition
 [elastic-install-instructions]: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup-repositories.html#_apt

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -36,12 +36,12 @@ itsdangerous==1.1.0
 Jinja2==2.10.1
 jsonschema==3.0.2
 lxml==4.4.1
-mongoengine==0.16.3
+mongoengine==0.18.2
 msgpack==0.5.6
 netaddr==0.7.19
 pillow==6.2.0
 pydenticon==0.3.1
-pymongo==3.7.2
+pymongo==3.9.0
 python-dateutil==2.8.0
 pytz==2019.2
 PyYAML==5.1.2

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -350,6 +350,11 @@ class Resource(ResourceMixin, WithMetrics, db.EmbeddedDocument):
     def dataset(self):
         return self._instance
 
+    def save(self, *args, **kwargs):
+        if not self.dataset:
+            raise RuntimeError('Impossible to save un orphan resource')
+        self.dataset.save(*args, **kwargs)
+
 
 class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
     created_at = DateTimeField(verbose_name=_('Creation date'),

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -352,7 +352,7 @@ class Resource(ResourceMixin, WithMetrics, db.EmbeddedDocument):
 
     def save(self, *args, **kwargs):
         if not self.dataset:
-            raise RuntimeError('Impossible to save un orphan resource')
+            raise RuntimeError('Impossible to save an orphan resource')
         self.dataset.save(*args, **kwargs)
 
 


### PR DESCRIPTION
This PR:
- switches to MongoDB 3.6
- upgrade to latest `pymongo` and `mongoengine` versions
- fixes the removal of `EmbeddedDocument.save()` until refactoring

Open thought about MongoDB 4: it seems to improve performances and consistency (Secondary reads, distributed transaction, multi documents transactions...) without breaking changes for us (See https://docs.mongodb.com/manual/release-notes/4.2-compatibility/ and https://docs.mongodb.com/manual/release-notes/4.0-compatibility/)
Why not give a try to Mongo 4.2 upgrade ?

In case we stay on Mongo 3.6, don't use Master-Slave replication, it's removed into MongoDB 4 (this will prevent nightmare upgrade from 3.6 to 4.x)