### PR TITLE
Fix territory routing for @latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - New Crowdin translations [#2360](https://github.com/opendatateam/udata/pull/2360)
+- Fix territory routing for @latest [#2447](https://github.com/opendatateam/udata/pull/2447)
 
 ## 1.6.19 (2020-01-06)
 

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -56,7 +56,12 @@ class GeoZoneQuerySet(db.BaseQuerySet):
         Ensuring the QuerySet unicity for (level, code)
         is you responsibility.
         '''
-        return self.order_by('-validity__end').first()
+        # first try to find a zone without `validity__end`
+        latest = self.filter(validity__end=None).first()
+        # only then try to find the zone with the latest `validity__end`
+        if not latest:
+            latest = self.order_by('-validity__end').first()
+        return latest
 
     def resolve(self, geoid, id_only=False):
         '''


### PR DESCRIPTION
When a URL like https://www.data.gouv.fr/fr/territories/commune/33063@latest/Bordeaux/ is requested, we now check if we have a GeoZone without `validity.end` before fetching the one with the latest `validity.end`. This seems to be necessary since the latest release of Geozone (?).

Fix https://github.com/etalab/data.gouv.fr/issues/159