### PR TITLE
Fix XSS in markdown w/ length JS filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- :warning: Security fix: fix XSS in markdown w/ length JS filter [#2471](https://github.com/opendatateam/udata/pull/2471)
 
 ## 2.0.2 (2020-04-07)
 

--- a/js/plugins/markdown.js
+++ b/js/plugins/markdown.js
@@ -25,7 +25,7 @@ export function install(Vue, options) {
         }
         let parsed = markdown(text);
         if (max_length) {
-            // strip tags (not for sanitization, done by markdown())
+            // strip tags (not for sanitisation, done by markdown())
             parsed = parsed.replace(/(<([^>]+)>)/ig, '');
             return txt.truncate(parsed || '', max_length);
         } else {

--- a/js/plugins/markdown.js
+++ b/js/plugins/markdown.js
@@ -23,13 +23,13 @@ export function install(Vue, options) {
         if (!text) {
             return '';
         }
+        let parsed = markdown(text);
         if (max_length) {
-            const div = document.createElement('div');
-            div.classList.add('markdown');
-            div.innerHTML = markdown(text);
-            return txt.truncate(div.textContent || div.innerText || '', max_length);
+            // strip tags (not for sanitization, done by markdown())
+            parsed = parsed.replace(/(<([^>]+)>)/ig, '');
+            return txt.truncate(parsed || '', max_length);
         } else {
-            return markdown(text);
+            return parsed;
         }
     });
 }


### PR DESCRIPTION
Putting the sanitised version from `markdown-it` back into an HTML node to truncate the text would remove the benefits of sanitisation. Adding a quick strip tags regex on the sanitised still seems functional and becomes secure.

<img width="750" alt="Capture d'écran 2020-04-30 10 24 14" src="https://user-images.githubusercontent.com/119625/80689250-5491ee00-8acd-11ea-939b-d8afea4eb078.png">
<img width="663" alt="Capture d'écran 2020-04-30 10 24 21" src="https://user-images.githubusercontent.com/119625/80689256-578cde80-8acd-11ea-9101-d2759bf22d60.png">

Big up to @vinyll 🙌 