### PR TITLE
[circle] remove branch restrictions and GitHub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,4 +169,11 @@ workflows:
       - publish:
           requires:
             - dist
+          filters:		
+            branches:		
+              only:		
+                - master		
+                - /[0-9]+(\.[0-9]+)+/		
+            tags:		
+              only: /v[0-9]+(\.[0-9]+)+/		
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,82 +156,17 @@ jobs:
             pip install twine
             twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
 
-  github:
-    docker:
-      - image: udata/circleci:2-alpine
-    environment:
-       BASH_ENV: /root/.bashrc
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Upload github release
-          command: gh_release
-
 workflows:
   version: 2
   build:
     jobs:
-      - python:
-          filters:
-            branches:
-              only:
-                - master
-                - /[0-9]+(\.[0-9]+)+/
-                - /pull/[0-9]+/
-                - /pyup-update-.+/
-                - /renovate\/.+/
-                - l10n_master
-                - /metricsBreakDown(-.*)?/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)+/
-      - assets:
-          filters:
-            branches:
-              only:
-                - master
-                - /[0-9]+(\.[0-9]+)+/
-                - /pull/[0-9]+/
-                - /pyup-update-.+/
-                - /renovate\/.+/
-                - l10n_master
-                - /metricsBreakDown(-.*)?/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)+/
+      - python
+      - assets
       - dist:
           requires:
             - python
             - assets
-          filters:
-            branches:
-              only:
-                - master
-                - /[0-9]+(\.[0-9]+)+/
-                - /pull/[0-9]+/
-                - /pyup-update-.+/
-                - /renovate\/.+/
-                - l10n_master
-                - /metricsBreakDown(-.*)?/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)+/
       - publish:
           requires:
             - dist
-          filters:
-            branches:
-              only:
-                - master
-                - /[0-9]+(\.[0-9]+)+/
-                - /metricsBreakDown(-.*)?/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)+/
-          context: org-global
-      - github:
-          requires:
-            - dist
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)+/
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,11 +169,11 @@ workflows:
       - publish:
           requires:
             - dist
-          filters:		
-            branches:		
-              only:		
-                - master		
-                - /[0-9]+(\.[0-9]+)+/		
-            tags:		
-              only: /v[0-9]+(\.[0-9]+)+/		
+          filters:
+            branches:
+              only:
+                - master
+                - /[0-9]+(\.[0-9]+)+/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)+/
           context: org-global


### PR DESCRIPTION
This will allow to build branches from this repo (not only from forks). I can't think of any valid reason to enforce this restriction (except forcing people to make a fork, but like for #2475 it can be a hassle).

This also removes the GitHub job: uploading a wheel to GitHub is overkill and error prone. Pypi is good enough. Plus, the GitHub upload has been broken for a while now.