### PR TITLE
deleting banner settings from udata

### DIFF
--- a/udata/settings.py
+++ b/udata/settings.py
@@ -439,9 +439,6 @@ class Defaults(object):
 
     API_DOC_EXTERNAL_LINK = 'https://doc.data.gouv.fr/api/reference/'
 
-    # Global banner parameters
-    BANNER_ACTIVATED = False
-    BANNER_HTML_FILENAME = ''
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''


### PR DESCRIPTION
Deleting banner settings from udata core settings, now banner settings are only set up from the data-gouvfr theme

- cf rrelated PR : https://github.com/etalab/udata-gouvfr/pull/483#pullrequestreview-436502029
- cf update here : https://github.com/etalab/udata-gouvfr/pull/483/files#diff-48bc215b9a4ff310bbf4679b5caea52b