### PR TITLE
Show traceback for migration error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Show traceback for migration errors [#2513](https://github.com/opendatateam/udata/pull/2513)
 
 ## 2.1.3 (2020-06-29)
 

--- a/udata/commands/db.py
+++ b/udata/commands/db.py
@@ -76,7 +76,7 @@ def migrate(record, dry_run=False):
                 format_output(re.output, not re.exc)
                 success = False
             except migrations.MigrationError as me:
-                format_output(me.output, False)
+                format_output(me.output, False, traceback=me.traceback)
                 success = False
             else:
                 format_output(output, True)

--- a/udata/commands/db.py
+++ b/udata/commands/db.py
@@ -34,10 +34,14 @@ def status_label(record):
         return red(record.status)
 
 
-def format_output(output, success=True):
+def format_output(output, success=True, traceback=None):
     echo('  │')
     for level, msg in output:
         echo('  │ {0}'.format(msg))
+    echo('  │')
+    if traceback:
+        for tb in traceback.split('\n'):
+            echo('  │ {0}'.format(tb))
     echo('  │')
     echo('  └──[{0}]'.format(green('OK') if success else red('KO')))
     echo('')
@@ -123,4 +127,4 @@ def display_op(op):
     timestamp = white(op['date'].strftime(DATE_FORMAT))
     label = white(op['type'].title()) + ' '
     echo('{label:.<70} [{date}]'.format(label=label, date=timestamp))
-    format_output(op['output'], op['success'])
+    format_output(op['output'], success=op['success'], traceback=op['traceback'])

--- a/udata/migrations/__init__.py
+++ b/udata/migrations/__init__.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import os
 import queue
+import traceback
 
 from datetime import datetime
 from logging.handlers import QueueHandler
@@ -83,6 +84,7 @@ class Record(dict):
           - success
           - rollback
           - rollback-error
+          - error
           - recorded
         '''
         if not self.exists():
@@ -117,14 +119,14 @@ class Record(dict):
         op = self.ops[-1]
         return op['success'] and op['type'] in ('migrate', 'record')
 
-    def add(self, type, migration, output, state, success):
+    def add(self, _type, migration, output, state, success):
         script = inspect.getsource(migration)
         return Record(self.collection.find_one_and_update(
             {'plugin': self.plugin, 'filename': self.filename},
             {
                 '$push': {'ops': {
                     'date': datetime.now(),
-                    'type': type,
+                    'type': _type,
                     'script': script,
                     'output': output,
                     'state': state,
@@ -218,7 +220,8 @@ class Migration:
                 out = _extract_output(q)
             except Exception as e:
                 out = _extract_output(q)
-                self.add_record('migrate', out, db._state, False)
+                tb = traceback.format_exc()
+                self.add_record('migrate', out, db._state, False, traceback=tb)
                 fe = MigrationError('Error while executing migration',
                                     output=out, exc=e)
                 if hasattr(self.module, 'rollback'):
@@ -246,7 +249,7 @@ class Migration:
             return False
         return bool(self.collection.delete_one(self.db_query).deleted_count)
 
-    def add_record(self, type, output, state, success):
+    def add_record(self, type, output, state, success, traceback=None):
         script = inspect.getsource(self.module)
         return Record(self.collection.find_one_and_update(
             self.db_query,
@@ -258,6 +261,7 @@ class Migration:
                     'output': output,
                     'state': state,
                     'success': success,
+                    'traceback': traceback,
                 }}
             },
             upsert=True,

--- a/udata/migrations/__init__.py
+++ b/udata/migrations/__init__.py
@@ -28,11 +28,12 @@ class MigrationError(Exception):
     :param output str: An optionnal array of logging output
     :param exc Exception: An optionnal underlying exception
     '''
-    def __init__(self, msg, output=None, exc=None):
+    def __init__(self, msg, output=None, exc=None, traceback=None):
         super().__init__(msg)
         self.msg = msg
         self.output = output
         self.exc = exc
+        self.traceback = traceback
 
 
 class RollbackError(MigrationError):
@@ -223,7 +224,7 @@ class Migration:
                 tb = traceback.format_exc()
                 self.add_record('migrate', out, db._state, False, traceback=tb)
                 fe = MigrationError('Error while executing migration',
-                                    output=out, exc=e)
+                                    output=out, exc=e, traceback=tb)
                 if hasattr(self.module, 'rollback'):
                     try:
                         self.module.rollback(db)


### PR DESCRIPTION
```
$ udata db info udata:2020-07-15-dummy
➢ udata:2020-07-15-dummy ............................................... [2020-07-15 15:08]

Migrate ................................................. [2020-07-15 15:01]
  │
  │ yup
  │
  │ Traceback (most recent call last):
  │   File "/Users/alexandre/Developer/Etalab/udata/udata/migrations/__init__.py", line 219, in execute
  │     self.module.migrate(db)
  │   File "<string>", line 8, in migrate
  │ Exception: nope nope nope
  │
  │
  └──[KO]

Migrate ................................................. [2020-07-15 15:08]
  │
  │ yup
  │
  │
  └──[OK]
```

```
$ udata db migrate
➢ udata:2020-07-15-dummy ............................................... [Apply]
  │
  │
  │ Traceback (most recent call last):
  │   File "/Users/alexandre/Developer/Etalab/udata/udata/migrations/__init__.py", line 220, in execute
  │     self.module.migrate(db)
  │   File "<string>", line 2, in migrate
  │   Exception: yup yup
  │
  │
  └──[KO]
```