### PR TITLE
Add a modal for schemas on ressources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Adding a migration file to populate resources fs_filename new field. Scripts to delete the orphaned files are available [here](https://gist.github.com/quaxsze/dc089e4ecd2e00f82acea573d8d2cfb9).
 - Show traceback for migration errors [#2513](https://github.com/opendatateam/udata/pull/2513)
 - Add `schema` field to ressources. This field can be filled based on an external schema catalog [#2512](https://github.com/opendatateam/udata/pull/2512)
+- Add 2 new template hooks: `base.modals` (base template) and `dataset.resource.card.extra-buttons` (dataset resource card) [#2514](https://github.com/opendatateam/udata/pull/2514)
 
 ## 2.1.3 (2020-06-29)
 

--- a/udata/templates/base.html
+++ b/udata/templates/base.html
@@ -19,5 +19,6 @@
     {% block content %}{% endblock %}
     {% include theme('footer.html') %}
     {% include theme('publish-action-modal.html') %}
+    {{ hook('base.modals') }}
     {% block modals %}{% endblock %}
 {% endblock %}

--- a/udata/templates/dataset/resource/card.html
+++ b/udata/templates/dataset/resource/card.html
@@ -41,6 +41,7 @@
             </ul>
         </div>
         <div class="resource-card-actions btn-toolbar">
+            {{ hook('dataset.resource.card.extra-buttons') }}
             {% if config.PREVIEW_MODE and resource.preview_url %}
             <a class="btn btn-sm btn-primary"
                 {% if config.PREVIEW_MODE == 'iframe' %}


### PR DESCRIPTION
This PR adds a schema modal to resources that have specified a schema.

![image](https://user-images.githubusercontent.com/295709/88084787-e94b3b80-cb52-11ea-9646-26da0dc33bd2.png)

## Content of the PR
- the addition of 2 hooks on udata
- the release of a new plugin, [udata-schema-gouvfr](https://github.com/etalab/udata-schema-gouvfr)

**Please review also [the PR](https://github.com/etalab/udata-schema-gouvfr/pull/2) for the plugin**. 

Regarding hooks, I tried to stick to the naming convention in place
https://github.com/opendatateam/udata/blob/a9b15a0f5ebab39bebd9c2d9a02683e0caaef822/udata/templates/dataset/display.html#L196

I noticed the hooks mechanism [is documented](https://github.com/opendatateam/udata/blob/master/docs/extending.md#hooks), but there is no documentation regarding where they are in templates or how to find them (do a search for `{{ hook(` in templates). I could add a note in the documentation if you'd like.

## Before merging
- [x] Transfer udata-schema to etalab
- [x] Rename udata-schema to udata-schema-gouvfr
- [ ] Revert https://github.com/AntoineAugusti/udata-schema/commit/83bbe9b2bb50e390e22bdc7322538b965f490cfb (may need to bust cache on CircleCI)
- [ ] Tag 0.1.0 for udata-schema-gouvfr
