### PR TITLE
Refresh schemas list on fetch

### DIFF
--- a/js/components/dataset/resource/form.vue
+++ b/js/components/dataset/resource/form.vue
@@ -179,8 +179,13 @@ export default {
             default: false,
         },
     },
+    created() {
+        // Refresh list of schemas once fetched from the API
+        schemas.$on('updated', () => {this.hasSchemas = schemas.has_data;});
+    },
     data() {
         return {
+            hasSchemas: schemas.has_data,
             hasChosenRemoteFile: false,
             generic_fields: [{
                     id: 'title',
@@ -247,7 +252,7 @@ export default {
             return this.generic_fields.concat(this.schema_field).concat(this.file_fields);
         },
         schema_field() {
-            if (schemas.has_data) {
+            if (this.hasSchemas) {
                 const values = [{id: '', label: ''}].concat(schemas.data);
                 return [{
                     id: 'schema',


### PR DESCRIPTION
Follow up of #2512: a bug was present where the schema list was not displayed because of a slow fetch from the API.

This PR fixes this by updating properties when schemas have been fetched.