### PR TITLE
Add a schema facet to the dataset search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add a schema facet to the dataset search [#2523](https://github.com/opendatateam/udata/pull/2523)
 
 ## 2.2.0 (2020-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Add a schema facet to the dataset search [#2523](https://github.com/opendatateam/udata/pull/2523)
+- Add a schema facet to the dataset search 🚧 requires datasets reindexation [#2523](https://github.com/opendatateam/udata/pull/2523)
 
 ## 2.2.0 (2020-08-05)
 

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -83,7 +83,8 @@ class DatasetSearch(ModelSearchAdapter):
     resources = Object(properties={
         'title': String(),
         'description': String(),
-        'format': String(index='not_analyzed')
+        'format': String(index='not_analyzed'),
+        'schema': String(index='not_analyzed'),
     })
     format_suggest = Completion(analyzer=simple,
                                 search_analyzer=simple,
@@ -133,6 +134,7 @@ class DatasetSearch(ModelSearchAdapter):
         'granularity': TermsFacet(field='granularity',
                                   labelizer=granularity_labelizer),
         'format': TermsFacet(field='resources.format'),
+        'schema': TermsFacet(field='resources.schema'),
         'resource_type': TermsFacet(field='resources.type',
                                     labelizer=resource_type_labelizer),
         'reuses': RangeFacet(field='metrics.reuses',
@@ -201,6 +203,7 @@ class DatasetSearch(ModelSearchAdapter):
                     'description': r.description,
                     'format': r.format,
                     'type': r.type,
+                    'schema': r.schema,
                 }
                 for r in dataset.resources],
             'format_suggest': [r.format.lower()


### PR DESCRIPTION
This PR adds a new facet to the dataset search. This will be used to identify resources that satisfy a schema, declared through the `schema` attribute of resources.

This new facet enables us to identify datasets with resources satisfying a schema. The API endpoint `/api/1/datasets/?schema=etalab/schema-irve` will list datasets embedding at least a resource satisfying the `etalab/schema-irve` schema.

We will be able to monitor how many datasets contain resources with `schema` attribute set with the endpoint `/api/1/datasets/?facets=schema`

:warning: This PR requires a reindexation of datasets. This can be done with `udata search index datasets`