### PR TITLE
Show stringified extras in dataset modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Show stringified extras in dataset modal [#2527](https://github.com/opendatateam/udata/pull/2527)
 
 ## 2.2.1 (2020-08-25)
 

--- a/js/front/dataset/details-modal.vue
+++ b/js/front/dataset/details-modal.vue
@@ -35,7 +35,7 @@
                 <tbody>
                     <tr v-for="extra in dataset.extras">
                         <td>{{ extra.name }}</td>
-                        <td>{{ extra.value }}</td>
+                        <td>{{ stringify(extra.value) }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -57,6 +57,15 @@ export default {
     props: {
         dataset: Object
     },
-    components: {Modal}
+    components: {Modal},
+    methods: {
+        stringify(value) {
+            console.log(value, typeof value);
+            if (typeof value === 'string' || value instanceof String) {
+                return value;
+            }
+            return JSON.stringify(value);
+        }
+    }
 };
 </script>

--- a/js/front/dataset/details-modal.vue
+++ b/js/front/dataset/details-modal.vue
@@ -60,7 +60,6 @@ export default {
     components: {Modal},
     methods: {
         stringify(value) {
-            console.log(value, typeof value);
             if (typeof value === 'string' || value instanceof String) {
                 return value;
             }


### PR DESCRIPTION
Assuming `JSON.stringify` is safe enough since this can be a user provided value 🧐. 

## Before

<img width="375" alt="Capture d’écran 2020-08-25 à 23 25 47" src="https://user-images.githubusercontent.com/119625/91229935-ef70a100-e72a-11ea-9d9e-330ed01f2d7b.png">

## After

<img width="344" alt="Capture d’écran 2020-08-25 à 23 28 48" src="https://user-images.githubusercontent.com/119625/91229945-f4355500-e72a-11ea-846f-0cb8aee0e3ac.png">
