### PR TITLE
Prevent hosted resource's url from being set by client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
   - Remove the RESOURCES_FILE_ALLOWED_DOMAINS setting and mechanism.
   - The community resource's/resource's url could be set from the client side, even in the case of a hosted one, which is illogical.
     A hosted community resource's/resource's url should only be the sole responsibility of the backend.
-  - Consequently, the POST endpoint of the community resources/resources API is only meant for the remote ones.
-  - The PUT endpoint of the community resources/resources API will take the existing resource's url to override the one sent by the client.
+  - Consequently, the POST endpoint of the community resources/resources API is only meant for the remote ones and the PUT endpoint of the community resources/resources API will take the existing resource's url to override the one sent by the client.
 
 ## 2.3.0 (2020-09-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - :warning: Resources and community resources creation API change [#2545](https://github.com/opendatateam/udata/pull/2545):
   - Remove the RESOURCES_FILE_ALLOWED_DOMAINS setting and mechanism.
-  - The resource's url could be set from the client side, event in the case of a hosted one, which is illogical.
-    A hosted resource's url should only be the matter of the backend.
+  - The community resource's/resource's url could be set from the client side, event in the case of a hosted one, which is illogical.
+    A hosted community resource's/resource's url should only be the matter of the backend.
   - Consequently, the POST endpoint of the community resources/resources API is only meant for the remote ones.
-  - The PUT endpoint of the resources API will take the existing resource's url to override the one sent by the client.
+  - The PUT endpoint of the community resources/resources API will take the existing resource's url to override the one sent by the client.
 
 ## 2.3.0 (2020-09-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Current (in progress)
 
-- :warning: Resources creation API change [#2545](https://github.com/opendatateam/udata/pull/2545):
+- :warning: Resources and community resources creation API change [#2545](https://github.com/opendatateam/udata/pull/2545):
   - Remove the RESOURCES_FILE_ALLOWED_DOMAINS setting and mechanism.
   - The resource's url could be set from the client side, event in the case of a hosted one, which is illogical.
     A hosted resource's url should only be the matter of the backend.
-  - Consequently, the POST endpoint of the resources API is only meant for the remote ones.
+  - Consequently, the POST endpoint of the community resources/resources API is only meant for the remote ones.
   - The PUT endpoint of the resources API will take the existing resource's url to override the one sent by the client.
 
 ## 2.3.0 (2020-09-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - :warning: Resources and community resources creation API change [#2545](https://github.com/opendatateam/udata/pull/2545):
   - Remove the RESOURCES_FILE_ALLOWED_DOMAINS setting and mechanism.
   - The community resource's/resource's url could be set from the client side, even in the case of a hosted one, which is illogical.
-    A hosted community resource's/resource's url should only be the matter of the backend.
+    A hosted community resource's/resource's url should only be the sole responsibility of the backend.
   - Consequently, the POST endpoint of the community resources/resources API is only meant for the remote ones.
   - The PUT endpoint of the community resources/resources API will take the existing resource's url to override the one sent by the client.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - :warning: Resources and community resources creation API change [#2545](https://github.com/opendatateam/udata/pull/2545):
   - Remove the RESOURCES_FILE_ALLOWED_DOMAINS setting and mechanism.
-  - The community resource's/resource's url could be set from the client side, event in the case of a hosted one, which is illogical.
+  - The community resource's/resource's url could be set from the client side, even in the case of a hosted one, which is illogical.
     A hosted community resource's/resource's url should only be the matter of the backend.
   - Consequently, the POST endpoint of the community resources/resources API is only meant for the remote ones.
   - The PUT endpoint of the community resources/resources API will take the existing resource's url to override the one sent by the client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- :warning: Resources creation API change [#2545](https://github.com/opendatateam/udata/pull/2545):
+  - Remove the RESOURCES_FILE_ALLOWED_DOMAINS setting and mechanism.
+  - The resource's url could be set from the client side, event in the case of a hosted one, which is illogical.
+    A hosted resource's url should only be the matter of the backend.
+  - Consequently, the POST endpoint of the resources API is only meant for the remote ones.
+  - The PUT endpoint of the resources API will take the existing resource's url to override the one sent by the client.
 
 ## 2.3.0 (2020-09-29)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -216,7 +216,7 @@ class ResourcesAPI(API):
         form = api.validate(ResourceForm)
         resource = Resource()
         if form._fields.get('filetype').data != 'remote':
-            return 'This endpoint is only made for remote resources', 400
+            return 'This endpoint only supports remote resources', 400
         form.populate_obj(resource)
         dataset.add_resource(resource)
         dataset.last_modified = datetime.now()
@@ -355,6 +355,7 @@ class ResourceAPI(ResourceMixin, API):
         ResourceEditPermission(dataset).test()
         resource = self.get_resource_or_404(dataset, rid)
         form = api.validate(ResourceForm, resource)
+         # ensure API client does not override url on self-hosted resources
         if resource.filetype == 'file':
             form._fields.get('url').data = resource.url
         form.populate_obj(resource)
@@ -401,6 +402,8 @@ class CommunityResourcesAPI(API):
     def post(self):
         '''Create a new community resource'''
         form = api.validate(CommunityResourceForm)
+        if form._fields.get('filetype').data != 'remote':
+            return 'This endpoint only supports remote community resources', 400
         resource = CommunityResource()
         form.populate_obj(resource)
         if not resource.dataset:
@@ -432,6 +435,8 @@ class CommunityResourceAPI(API):
         '''Update a given community resource'''
         ResourceEditPermission(community).test()
         form = api.validate(CommunityResourceForm, community)
+        if community.filetype == 'file':
+            form._fields.get('url').data = community.url
         form.populate_obj(community)
         if not community.organization and not community.owner:
             community.owner = current_user._get_current_object()

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -215,6 +215,8 @@ class ResourcesAPI(API):
         ResourceEditPermission(dataset).test()
         form = api.validate(ResourceForm)
         resource = Resource()
+        if form._fields.get('filetype').data != 'remote':
+            return 'This endpoint is only made for remote resources', 400
         form.populate_obj(resource)
         dataset.add_resource(resource)
         dataset.last_modified = datetime.now()
@@ -353,6 +355,8 @@ class ResourceAPI(ResourceMixin, API):
         ResourceEditPermission(dataset).test()
         resource = self.get_resource_or_404(dataset, rid)
         form = api.validate(ResourceForm, resource)
+        if resource.filetype == 'file':
+            form._fields.get('url').data = resource.url
         form.populate_obj(resource)
         resource.modified = datetime.now()
         dataset.last_modified = datetime.now()

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -11,7 +11,7 @@ from udata.core.spatial.forms import SpatialCoverageField
 from .models import (
     Dataset, Resource, License, Checksum, CommunityResource,
     UPDATE_FREQUENCIES, DEFAULT_FREQUENCY, RESOURCE_FILETYPES, CHECKSUM_TYPES,
-    LEGACY_FREQUENCIES, RESOURCE_TYPES, RESOURCE_FILETYPE_FILE,
+    LEGACY_FREQUENCIES, RESOURCE_TYPES,
     ResourceSchema,
 )
 
@@ -29,24 +29,6 @@ def normalize_format(data):
     '''Normalize format field: strip and lowercase'''
     if data:
         return data.strip().lower()
-
-
-def enforce_filetype_file(form, field):
-    '''Only allowed domains in resource.url when filetype is file'''
-    if form._fields.get('filetype').data != RESOURCE_FILETYPE_FILE:
-        return
-    domain = urlparse(field.data).netloc
-    allowed_domains = current_app.config['RESOURCES_FILE_ALLOWED_DOMAINS']
-    allowed_domains += [current_app.config.get('SERVER_NAME')]
-    if current_app.config.get('CDN_DOMAIN'):
-        allowed_domains.append(current_app.config['CDN_DOMAIN'])
-    if '*' in allowed_domains:
-        return
-    if domain and domain not in allowed_domains:
-        message = _('Domain "{domain}" not allowed for filetype "{filetype}"')
-        raise validators.ValidationError(message.format(
-            domain=domain, filetype=RESOURCE_FILETYPE_FILE
-        ))
 
 
 def enforce_allowed_schemas(form, field):
@@ -73,7 +55,7 @@ class BaseResourceForm(ModelForm):
         choices=list(RESOURCE_TYPES.items()), default='other',
         description=_('Resource type (documentation, API...)'))
     url = fields.UploadableURLField(
-        _('URL'), [validators.DataRequired(), enforce_filetype_file],
+        _('URL'), [validators.DataRequired()],
         storage=resources)
     format = fields.StringField(
         _('Format'),

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -55,8 +55,7 @@ class BaseResourceForm(ModelForm):
         choices=list(RESOURCE_TYPES.items()), default='other',
         description=_('Resource type (documentation, API...)'))
     url = fields.UploadableURLField(
-        _('URL'), [validators.DataRequired()],
-        storage=resources)
+        _('URL'), [validators.DataRequired()], storage=resources)
     format = fields.StringField(
         _('Format'),
         filters=[normalize_format],

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -281,9 +281,6 @@ class Defaults(object):
         # RDF
         'rdf', 'ttl', 'n3',
     ]
-    # Whitelist of urls domains for resource with filetype `file`
-    # SERVER_NAME is always included, `*` is a supported value (wildcard)
-    RESOURCES_FILE_ALLOWED_DOMAINS = []
 
     # How much time upload chunks are kept before cleanup
     UPLOAD_MAX_RETENTION = 24 * HOUR
@@ -471,7 +468,6 @@ class Testing(object):
     ACTIVATE_TERRITORIES = False
     LOGGER_HANDLER_POLICY = 'never'
     CELERYD_HIJACK_ROOT_LOGGER = False
-    RESOURCES_FILE_ALLOWED_DOMAINS = ['*']
     URLS_ALLOW_LOCAL = True  # Test server URL is local.test
     URLS_ALLOWED_TLDS = tld_set | set(['test'])
     URLS_ALLOW_PRIVATE = False


### PR DESCRIPTION
fix https://github.com/opendatateam/udata/issues/2544