### PR TITLE
Update Basemaps URL and attributions

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -343,13 +343,13 @@ Overrides user search fields and their ponderation.
 
 ### MAP_TILES_URL
 
-**default**: `'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'`
+**default**: `'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'`
 
 Tiles URL for SD displays
 
 ### MAP_TILES_URL_HIDPI
 
-**default**: `'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png'`
+**default**: `'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'`
 
 Tiles URL for HD/HiDPI displays
 
@@ -363,7 +363,7 @@ Tiles URL for HD/HiDPI displays
         '&copy;'
         '<a href="http://openstreetmap.org/copyright">OpenStreetMap</a>'
         '/'
-        '<a href="https://cartodb.com/attributions">CartoDB</a>'
+        '<a href="https://carto.com/about-carto/">CARTO</a>'
     )
 }
 ```

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -337,9 +337,9 @@ class Defaults(object):
     # Map/Tiles configuration
     ###########################################################################
     # Tiles URL for SD displays
-    MAP_TILES_URL = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'
+    MAP_TILES_URL = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
     # Tiles URL for HD/HiDPI displays
-    MAP_TILES_URL_HIDPI = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png'
+    MAP_TILES_URL_HIDPI = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'
     # Leaflet tiles config, see https://leafletjs.com/reference-0.7.7.html#tilelayer
     MAP_TILES_CONFIG = {
         'subdomains': 'abcd',
@@ -347,7 +347,7 @@ class Defaults(object):
             '&copy;'
             '<a href="http://openstreetmap.org/copyright">OpenStreetMap</a>'
             '/'
-            '<a href="https://cartodb.com/attributions">CartoDB</a>'
+            '<a href="https://carto.com/about-carto/">CARTO</a>'
         )
     }
     # Initial map center position


### PR DESCRIPTION
# Summary
This PR updates basemaps URL to the new CDN URL and fixes the attributions to match current requirements.

## Full context
We've recently changed our CDN and we have a plan mid-long term (depends on how quick we manage to stop all the traffic there) to deprecate our `.global.ssl.fastly.net` domains.

