### PR TITLE
Fix TypeError when creating a superuser with an incorrect password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Escaping XML's forbidden characters [#2562](https://github.com/opendatateam/udata/pull/2562)
 - Ignore pattern feature for linkchecker [#2564](https://github.com/opendatateam/udata/pull/2564)
+- Fix TypeError when creating a superuser with an incorrect password [#2567](https://github.com/opendatateam/udata/pull/2567)
 
 ## 2.4.0 (2020-10-16)
 

--- a/udata/core/user/commands.py
+++ b/udata/core/user/commands.py
@@ -40,7 +40,7 @@ def create():
         user = datastore.create_user(**data)
         success('User(id={u.id} email={u.email}) created'.format(u=user))
         return user
-    errors = '\n'.join('\n'.join(e) for e in form.errors.values())
+    errors = '\n'.join('\n'.join([str(x) for x in e]) for e in form.errors.values())
     exit_with_error('Error creating user', errors)
 
 

--- a/udata/core/user/commands.py
+++ b/udata/core/user/commands.py
@@ -40,7 +40,7 @@ def create():
         user = datastore.create_user(**data)
         success('User(id={u.id} email={u.email}) created'.format(u=user))
         return user
-    errors = '\n'.join('\n'.join([str(x) for x in e]) for e in form.errors.values())
+    errors = '\n'.join('\n'.join([str(m) for m in e]) for e in form.errors.values())
     exit_with_error('Error creating user', errors)
 
 


### PR DESCRIPTION
Exact error when entering an invalid password:

```
  File "/usr/local/lib/python3.7/site-packages/udata/core/user/commands.py", line 43, in <genexpr>
    errors = '\n'.join('\n'.join(e) for e in form.errors.values())
TypeError: sequence item 0: expected str instance, _LazyString found
```