### PR TITLE
Fix error when retrieving GeoZones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Escaping XML's forbidden characters [#2562](https://github.com/opendatateam/udata/pull/2562)
 - Ignore pattern feature for linkchecker [#2564](https://github.com/opendatateam/udata/pull/2564)
 - Fix TypeError when creating a superuser with an incorrect password [#2567](https://github.com/opendatateam/udata/pull/2567)
+- Fix error when retrieving GeoZones [#2570](https://github.com/opendatateam/udata/pull/2570)
 
 ## 2.4.0 (2020-10-16)
 

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -141,6 +141,7 @@ def load(filename=DEFAULT_GEOZONES_FILE, drop=False):
     prefix = 'geozones-{0}'.format(ts)
     if filename.startswith('http'):
         log.info('Downloading GeoZones bundle: %s', filename)
+        tmp.backend.ensure_path(GEOZONE_FILENAME)
         filename, _ = urlretrieve(filename, tmp.path(GEOZONE_FILENAME))
 
     log.info('Extracting GeoZones bundle')

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -11,7 +11,7 @@ from collections import Counter
 from contextlib import contextmanager
 from datetime import datetime
 from textwrap import dedent
-from urllib.request import urlretrieve
+from urllib.request import urlretrieve, urlopen
 
 import click
 import msgpack
@@ -141,8 +141,9 @@ def load(filename=DEFAULT_GEOZONES_FILE, drop=False):
     prefix = 'geozones-{0}'.format(ts)
     if filename.startswith('http'):
         log.info('Downloading GeoZones bundle: %s', filename)
-        tmp.backend.ensure_path(GEOZONE_FILENAME)
-        filename, _ = urlretrieve(filename, tmp.path(GEOZONE_FILENAME))
+        with tmp.open(GEOZONE_FILENAME, 'wb') as f:
+            f.write(urlopen(filename).read())
+            filename = tmp.path(GEOZONE_FILENAME)
 
     log.info('Extracting GeoZones bundle')
     with handle_error(prefix):


### PR DESCRIPTION
The issue is that the script try to write to `/udata/fs/tmp/` but the `tmp` directory does not exist

Related issue: https://github.com/opendatateam/docker-udata/issues/197

I'm not sure it's the best place to ensure the `/tmp/` directory is there, maybe directly at the initialization phase in `udata/core/storages/__init__.py`