### PR TITLE
draft: Adding an API endpoint to edit a comment

### DIFF
--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -7,7 +7,7 @@ from udata.auth import admin_permission
 from udata.api import api, API, fields
 from udata.core.user.api_fields import user_ref_fields
 
-from .forms import DiscussionCreateForm, DiscussionCommentForm
+from .forms import DiscussionCreateForm, DiscussionCommentForm, EditDiscussionCommentForm
 from .models import Message, Discussion
 from .permissions import CloseDiscussionPermission
 from .signals import (
@@ -149,7 +149,7 @@ class DiscussionCommentAPI(API):
         if len(discussion.discussion) <= cidx:
             api.abort(404, 'Comment does not exist')
         # TODO: check if current user is author of the comment
-        form = api.validate(DiscussionCommentForm)
+        form = api.validate(EditDiscussionCommentForm)
         discussion.discussion[cidx].content = form.comment.data
         discussion.save()
         return discussion

--- a/udata/core/discussions/forms.py
+++ b/udata/core/discussions/forms.py
@@ -3,7 +3,7 @@ from udata.i18n import lazy_gettext as _
 
 from .models import Discussion
 
-__all__ = ('DiscussionCreateForm', 'DiscussionCommentForm')
+__all__ = ('DiscussionCreateForm', 'DiscussionCommentForm', 'EditDiscussionCommentForm')
 
 
 class DiscussionCreateForm(ModelForm):
@@ -18,3 +18,7 @@ class DiscussionCreateForm(ModelForm):
 class DiscussionCommentForm(Form):
     comment = fields.StringField(_('Comment'), [validators.DataRequired()])
     close = fields.BooleanField(default=False)
+
+
+class EditDiscussionCommentForm(Form):
+    comment = fields.StringField(_('Comment'), [validators.DataRequired()])


### PR DESCRIPTION
see https://github.com/etalab/data.gouv.fr/issues/188

I'm sharing a draft so I can have early comments

I'm using this command to test it, it ~doesn't pass the form validation yet~ works now:

```
curl --request PATCH -H 'Content-Type: application/json' -H 'X-Api-Key:<key>' http://localhost:7000/api/1/discussions/<discussion_id>/comments/0 --data '{"comment": "test-curl"}'
```