### PR TITLE
(build) Pin `urllib` dep

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -54,6 +54,7 @@ StringDist==1.0.9
 tlds
 ujson==1.35
 urlextract==0.14.0
+urllib3==1.25.11
 unicodecsv==0.14.1
 vine==1.3.0
 voluptuous==0.11.7


### PR DESCRIPTION
I don't know if this is still needed on your branch, but this is what fixed build for our dev docker 

Signed-off-by: Grégoire Mougeolle <gregoire@nextmap.io>