### PR TITLE
Fix schema name display in resource modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix schema name display in resource modal [#2617](https://github.com/opendatateam/udata/pull/2617)
 
 ## 2.7.1 (2021-05-27)
 

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -38,7 +38,7 @@
                 <dt v-if="resource.format">{{ _('Format') }}</dt>
                 <dd v-if="resource.format">{{ resource.format }}</dd>
                 <dt v-if="resource.schema?.name">{{ _('Schema') }}</dt>
-                <dd v-if="resource.schema && resource.schema.name">{{ resource.schema.name }}</dd>
+                <dd v-if="resource.schema?.name">{{ resource.schema.name }}</dd>
                 <dt v-if="resource.mime">{{ _('Mime Type') }}</dt>
                 <dd v-if="resource.mime">{{ resource.mime }}</dd>
                 <dt v-if="resource.filesize">{{ _('Size') }}</dt>

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -37,7 +37,7 @@
                 <dd><a :href="resource.url">{{resource.url}}</a></dd>
                 <dt v-if="resource.format">{{ _('Format') }}</dt>
                 <dd v-if="resource.format">{{ resource.format }}</dd>
-                <dt v-if="resource.schema && resource.schema.name">{{ _('Schema') }}</dt>
+                <dt v-if="resource.schema?.name">{{ _('Schema') }}</dt>
                 <dd v-if="resource.schema && resource.schema.name">{{ resource.schema.name }}</dd>
                 <dt v-if="resource.mime">{{ _('Mime Type') }}</dt>
                 <dd v-if="resource.mime">{{ resource.mime }}</dd>

--- a/js/components/dataset/resource/modal.vue
+++ b/js/components/dataset/resource/modal.vue
@@ -37,8 +37,8 @@
                 <dd><a :href="resource.url">{{resource.url}}</a></dd>
                 <dt v-if="resource.format">{{ _('Format') }}</dt>
                 <dd v-if="resource.format">{{ resource.format }}</dd>
-                <dt v-if="resource.schema">{{ _('Schema') }}</dt>
-                <dd v-if="resource.schema">{{ resource.schema }}</dd>
+                <dt v-if="resource.schema && resource.schema.name">{{ _('Schema') }}</dt>
+                <dd v-if="resource.schema && resource.schema.name">{{ resource.schema.name }}</dd>
                 <dt v-if="resource.mime">{{ _('Mime Type') }}</dt>
                 <dd v-if="resource.mime">{{ resource.mime }}</dd>
                 <dt v-if="resource.filesize">{{ _('Size') }}</dt>


### PR DESCRIPTION
Fixing https://github.com/opendatateam/udata/issues/2616.

Following https://github.com/opendatateam/udata/pull/2600, we display the `name` attribute of the `schema` object.

The code seemed confusing at first, due to the usage of two different schema objects:
- those that refer to the schemas from the catalogue and that contains the fields `id`, `label` and `versions` ;
- those associated to a resource that contains a `name` attribute.

It may be worth making some small changes to clarify this point.