### PR TITLE
Migrate from raven to sentry-sdk (#2605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Migrate from raven to sentry-sdk [#2620](https://github.com/opendatateam/udata/pull/2620)
 - Add a UdataCleaner class to use udata's markdown configuration on SafeMarkup as well [#2619](https://github.com/opendatateam/udata/pull/2619)
 - Fix schema name display in resource modal [#2617](https://github.com/opendatateam/udata/pull/2617)
 

--- a/requirements/sentry.pip
+++ b/requirements/sentry.pip
@@ -1,1 +1,1 @@
-raven[flask] >= 5.8.0
+sentry-sdk[flask] >= 1.1.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         'test': tests_require,
-        'sentry': ['raven[flask]>=6.1.0'],
+        'sentry': ['sentry-sdk[flask] >= 1.1.0'],
     },
     entry_points={
         'console_scripts': [

--- a/udata/sentry.py
+++ b/udata/sentry.py
@@ -16,6 +16,7 @@ RE_DSN = re.compile(
     r'@(?P<domain>.+)/(?P<site_id>\d+)')
 
 SECRET_DSN_DEPRECATED_MSG = 'DSN with secret is deprecated, use a public DSN instead'
+ERROR_PARSE_DSN_MSG = 'Unable to parse Sentry DSN'
 
 # Controlled exceptions that Sentry should ignore
 IGNORED_EXCEPTIONS = HTTPException, PermissionDenied, UploadProgress
@@ -24,13 +25,14 @@ def public_dsn(dsn):
     '''Check if DSN is public or raise a warning and turn it into a public one'''
     m = RE_DSN.match(dsn)
     if not m:
-        log.error('Unable to parse Sentry DSN')
+        log.error(ERROR_PARSE_DSN_MSG)
+        raise ValueError(ERROR_PARSE_DSN_MSG)
 
     if not m["secret"]:
         return dsn
 
     log.warning(SECRET_DSN_DEPRECATED_MSG)
-    warnings.warn(SECRET_DSN_DEPRECATED_MSG, category=DeprecationWarning, stacklevel=2)
+    warnings.warn(SECRET_DSN_DEPRECATED_MSG, category=DeprecationWarning)
 
     public = '{scheme}://{client_id}@{domain}/{site_id}'.format(
         **m.groupdict())

--- a/udata/sentry.py
+++ b/udata/sentry.py
@@ -13,14 +13,12 @@ log = logging.getLogger(__name__)
 
 RE_DSN = re.compile(
     r'(?P<scheme>https?)://(?P<client_id>[0-9a-f]+)(?::(?P<secret>[0-9a-f]+))?'
-    '@(?P<domain>.+)/(?P<site_id>\d+)')
+    r'@(?P<domain>.+)/(?P<site_id>\d+)')
 
 SECRET_DSN_DEPRECATED_MSG = 'DSN with secret is deprecated, use a public DSN instead'
 
 # Controlled exceptions that Sentry should ignore
 IGNORED_EXCEPTIONS = HTTPException, PermissionDenied, UploadProgress
-
-# TODO: check if public_dsn is still needed (no secret anymore) ?
 
 def public_dsn(dsn):
     '''Check if DSN is public or raise a warning and turn it into a public one'''


### PR DESCRIPTION
Fix #2605.

Update sentry python lib from `raven` to `sentry-sdk`.

Question :
- How to  make sure that we log the same exact errors (ex: check Celery integration) ?
- Can we directly use a public sentry DSN ? The DSN with secret is not used and deprecated:
  > Deprecated DSN includes a secret which is no longer required by newer SDK versions. 