### PR TITLE
Fix remote resource upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix remote resource upload [#2632](https://github.com/opendatateam/udata/pull/2632)
 
 ## 3.0.1 (2021-07-09)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -238,7 +238,7 @@ class DatasetBadgeAPI(API):
 
 @ns.route('/r/<uuid:id>', endpoint='resource_redirect')
 class ResourceRedirectAPI(API):
-    @api.doc('create_resource', **common_doc)
+    @api.doc('redirect_resource', **common_doc)
     def get(self, id):
         '''
         Redirect to the latest version of a resource given its identifier.


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/365.

We will need to update swagger specs file (https://github.com/etalab/data.gouv.fr/issues/373).