### PR TITLE
Fix sentry id event logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Fix sentry id event logging [#2364](https://github.com/opendatateam/udata/pull/2634)
 - Dirty hotfix on RDF api endpoints to prevent json dumping on formated response [#2631](https://github.com/opendatateam/udata/pull/2631)
 - Fix remote resource upload [#2632](https://github.com/opendatateam/udata/pull/2632)
 

--- a/udata/sentry.py
+++ b/udata/sentry.py
@@ -49,7 +49,7 @@ def init_app(app):
             log.error('sentry-sdk is required to use Sentry')
             return
 
-        sentry_public_dsn = public_dsn(app.config['SENTRY_DSN'])
+        app.config['SENTRY_PUBLIC_DSN'] = public_dsn(app.config['SENTRY_DSN'])
 
         # Do not send HTTPExceptions
         exceptions = set(app.config['SENTRY_IGNORE_EXCEPTIONS'])
@@ -57,7 +57,7 @@ def init_app(app):
             exceptions.add(exception)
 
         sentry_sdk.init(
-            dsn=sentry_public_dsn,
+            dsn=app.config['SENTRY_PUBLIC_DSN'],
             integrations=[FlaskIntegration(), CeleryIntegration()],
             ignore_errors=list(exceptions)
         )


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/358.

Cherry-picked from https://github.com/opendatateam/udata/pull/2633, so that we can merge this fix faster.