### PR TITLE
Activate plugins before creating app when testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add larger reuse thumbnail image [#2638](https://github.com/opendatateam/udata/pull/2638)
+- Apply mark.options before creating app when testing [#2643](https://github.com/opendatateam/udata/pull/2643)
 
 ## 3.0.3 (2021-07-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Add larger reuse thumbnail image [#2638](https://github.com/opendatateam/udata/pull/2638)
-- Apply mark.options before creating app when testing [#2643](https://github.com/opendatateam/udata/pull/2643)
+- Activate plugins before creating app when testing [#2643](https://github.com/opendatateam/udata/pull/2643)
 
 ## 3.0.3 (2021-07-30)
 

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -101,12 +101,16 @@ def get_settings(request):
     if marker:
         return marker.args[0]
     _settings = getattr(request.cls, 'settings', settings.Testing)
-    # apply the options marker from pytest_flask as soon as app is created
+    # apply the options(plugins) marker from pytest_flask as soon as app is created
     # https://github.com/pytest-dev/pytest-flask/blob/a62ea18cb0fe89e3f3911192ab9ea4f9b12f8a16/pytest_flask/plugin.py#L126
     # this lets us have default settings for plugins applied while testing
+    plugins = []
     for options in request.node.iter_markers('options'):
-        for key, value in options.kwargs.items():
-            setattr(_settings, key.upper(), value)
+        option = options.kwargs.get('plugins') or options.kwargs.get('PLUGINS')
+        if option:
+            plugins += option
+    if plugins:
+        setattr(_settings, 'PLUGINS', plugins)
     return _settings
 
 

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -106,9 +106,8 @@ def get_settings(request):
     # this lets us have default settings for plugins applied while testing
     plugins = []
     for options in request.node.iter_markers('options'):
-        option = options.kwargs.get('plugins') or options.kwargs.get('PLUGINS')
-        if option:
-            plugins += option
+        option = options.kwargs.get('plugins', []) or options.kwargs.get('PLUGINS', [])
+        plugins += option
     if plugins:
         setattr(_settings, 'PLUGINS', plugins)
     return _settings

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -1,6 +1,5 @@
 import pytest
 import shlex
-import sys
 
 from contextlib import contextmanager
 from urllib.parse import urlparse
@@ -101,7 +100,14 @@ def get_settings(request):
     marker = request.node.get_closest_marker('settings')
     if marker:
         return marker.args[0]
-    return getattr(request.cls, 'settings', settings.Testing)
+    _settings = getattr(request.cls, 'settings', settings.Testing)
+    # apply the options marker from pytest_flask as soon as app is created
+    # https://github.com/pytest-dev/pytest-flask/blob/a62ea18cb0fe89e3f3911192ab9ea4f9b12f8a16/pytest_flask/plugin.py#L126
+    # this lets us have default settings for plugins applied while testing
+    for options in request.node.iter_markers('options'):
+        for key, value in options.kwargs.items():
+            setattr(_settings, key.upper(), value)
+    return _settings
 
 
 def drop_db(app):

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -104,12 +104,11 @@ def get_settings(request):
     # apply the options(plugins) marker from pytest_flask as soon as app is created
     # https://github.com/pytest-dev/pytest-flask/blob/a62ea18cb0fe89e3f3911192ab9ea4f9b12f8a16/pytest_flask/plugin.py#L126
     # this lets us have default settings for plugins applied while testing
-    plugins = []
+    plugins = getattr(_settings, 'PLUGINS', [])
     for options in request.node.iter_markers('options'):
         option = options.kwargs.get('plugins', []) or options.kwargs.get('PLUGINS', [])
         plugins += option
-    if plugins:
-        setattr(_settings, 'PLUGINS', plugins)
+    setattr(_settings, 'PLUGINS', plugins)
     return _settings
 
 


### PR DESCRIPTION
Necessary for https://github.com/opendatateam/udata-recommendations/pull/183.

This duplicates what `pytest-flask` does but at a higher level (before app is created). I have mixed feelings about this but I can't think of a better idea and the logic is pretty sane.

EDIT: it's now scoped to plugins, good feelings now.