### PR TITLE
Avoid weakref when testing post_save_signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Safeguard `User.delete()` [#2646](https://github.com/opendatateam/udata/pull/2646)
 - Fix user delete command [#2647](https://github.com/opendatateam/udata/pull/2647)
 - _major_ Use pip-tools for requirements management [#2642](https://github.com/opendatateam/udata/pull/2642). Please [read the doc](https://github.com/opendatateam/udata/blob/master/docs/development-environment.md#python-and-virtual-environment) if you are a udata developer.
+- Avoid weakref when testing post_save_signal [#2649](https://github.com/opendatateam/udata/pull/2649)
 
 ## 3.0.4 (2021-08-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - _major_ Use pip-tools for requirements management [#2642](https://github.com/opendatateam/udata/pull/2642). Please [read the doc](https://github.com/opendatateam/udata/blob/master/docs/development-environment.md#python-and-virtual-environment) if you are a udata developer.
 - _major_ Check db integrity and apply temporary and permanent fixes [#2644](https://github.com/opendatateam/udata/pull/2644) :warning: the associated migrations can take a long time to run.
-- _major_ Use pip-tools for requirements management [#2642](https://github.com/opendatateam/udata/pull/2642). Please [read the doc](https://github.com/opendatateam/udata/blob/master/docs/development-environment.md#python-and-virtual-environment) if you are a udata developer.
 - Safeguard `User.delete()` [#2646](https://github.com/opendatateam/udata/pull/2646)
 - Fix user delete command [#2647](https://github.com/opendatateam/udata/pull/2647)
 - Protect `test_ignore_post_save_signal` from weak ref error while testing [#2649](https://github.com/opendatateam/udata/pull/2649)

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -267,10 +267,10 @@ class ResourceModelTest:
         dataset = DatasetFactory(resources=[ResourceFactory(url=url)])
         assert dataset.resources[0].url == url.strip()
 
-    @pytest.mark.usefixtures('gc_disable')
+    # @pytest.mark.usefixtures('gc_disable')
     def test_ignore_post_save_signal(self):
         resource = ResourceFactory()
-        DatasetFactory(resources=[resource])
+        _ = DatasetFactory(resources=[resource])
         unexpected_signals = Dataset.after_save, Dataset.on_update
 
         with assert_not_emit(*unexpected_signals), assert_emit(post_save):

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -267,6 +267,7 @@ class ResourceModelTest:
         dataset = DatasetFactory(resources=[ResourceFactory(url=url)])
         assert dataset.resources[0].url == url.strip()
 
+    @pytest.mark.usefixtures('gc_disable')
     def test_ignore_post_save_signal(self):
         resource = ResourceFactory()
         DatasetFactory(resources=[resource])

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -267,9 +267,9 @@ class ResourceModelTest:
         dataset = DatasetFactory(resources=[ResourceFactory(url=url)])
         assert dataset.resources[0].url == url.strip()
 
-    # @pytest.mark.usefixtures('gc_disable')
     def test_ignore_post_save_signal(self):
         resource = ResourceFactory()
+        # assigning to a variable to avoid garbage collection issue
         _ = DatasetFactory(resources=[resource])
         unexpected_signals = Dataset.after_save, Dataset.on_update
 

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -1,5 +1,3 @@
-import gc
-
 import pytest
 import shlex
 

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 import shlex
 
@@ -386,3 +388,9 @@ class SitemapClient:
 def sitemap(client):
     sitemap_client = SitemapClient(client)
     return sitemap_client
+
+
+@pytest.fixture
+def gc_disable(request):
+    request.addfinalizer(gc.enable)
+    gc.disable()

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -388,9 +388,3 @@ class SitemapClient:
 def sitemap(client):
     sitemap_client = SitemapClient(client)
     return sitemap_client
-
-
-@pytest.fixture
-def gc_disable(request):
-    request.addfinalizer(gc.enable)
-    gc.disable()


### PR DESCRIPTION
This a workaround for random test failures on `test_ignore_post_save_signal`. It disables the garbage collector during this test.

This does not address the root cause which is that https://github.com/opendatateam/udata/blob/4a2b564ac70f5f5bdfb5e42217f93c9be31d51e9/udata/core/dataset/models.py#L373 is a weak reference. I don't know if and how it's possible to turn it into a normal reference and what the impacts would be (memory leak?).

I'm not aware of any "real life" problems caused by this, so maybe just hacking the test is ok.