### PR TITLE
Order pre-commit pip-compile hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,10 @@ repos:
         args: [requirements/install.in, --output-file=requirements/install.pip]
         files: ^requirements/install\.(in|pip)$
       - id: pip-compile
+        name: pip-compile test.in
+        args: [requirements/test.in, --output-file=requirements/test.pip]
+        files: ^requirements/test\.(in|pip)$
+      - id: pip-compile
         name: pip-compile develop.in
         args: [requirements/develop.in, --output-file=requirements/develop.pip]
         files: ^requirements/develop\.(in|pip)$
@@ -14,10 +18,6 @@ repos:
         name: pip-compile doc.in
         args: [requirements/doc.in, --output-file=requirements/doc.pip]
         files: ^requirements/doc\.(in|pip)$
-      - id: pip-compile
-        name: pip-compile test.in
-        args: [requirements/test.in, --output-file=requirements/test.pip]
-        files: ^requirements/test\.(in|pip)$
       - id: pip-compile
         name: pip-compile report.in
         args: [requirements/report.in, --output-file=requirements/report.pip]


### PR DESCRIPTION
To avoid any problem, files should be compiled in their logical order of dependencies.