### PR TITLE
Pin setuptools==58.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,10 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
-            virtualenv venv
+            virtualenv --no-setuptools venv
+            # FIXME set setuptools version due to 58.0.2 release
             source venv/bin/activate
+            pip install setuptools==58.0.0
             pip install -r requirements/develop.pip
             pip install -e .
       - save_cache:


### PR DESCRIPTION
Pinning setuptools in `setup_requires` doesn't seem to work (see https://stackoverflow.com/questions/58521386/should-setuptools-be-in-the-setup-requires-entry-of-setup-cfg-files).

Pinning in CI could probably work for now but it won't prevent any other env to use a newer `setuptools` version.

Any suggestion is welcome.