### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Update dependencies following setuptools 58.0.2 release that drop support for `use_2to3` [#2660](https://github.com/opendatateam/udata/pull/2660)
 
 ## 3.1.0 (2021-08-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Current (in progress)
 
-- Update dependencies following setuptools 58.0.2 release that drop support for `use_2to3` [#2660](https://github.com/opendatateam/udata/pull/2660)
+- Update dependencies following setuptools 58.0.2 release that drop support for `use_2to3` [#2660](https://github.com/opendatateam/udata/pull/2660):
+  - :warning: **breaking change** `rdfs` is not supported anymore
+  - `jsonld` endpoints have a `@context` dict directly instead of an url to the context endpoint
 
 ## 3.1.0 (2021-08-31)
 

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -154,10 +154,6 @@ faker==3.0.0
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   factory-boy
-feedparser==6.0.8
-    # via
-    #   -c requirements/test.pip
-    #   -r requirements/test.in
 filelock==3.0.12
     # via virtualenv
 flask==1.1.4
@@ -526,10 +522,6 @@ rfc3986==1.5.0
     # via twine
 secretstorage==3.3.1
     # via keyring
-sgmllib3k==1.0.0
-    # via
-    #   -c requirements/test.pip
-    #   feedparser
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -154,7 +154,7 @@ faker==3.0.0
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   factory-boy
-feedparser==5.2.1
+feedparser==6.0.8
     # via
     #   -c requirements/test.pip
     #   -r requirements/test.in
@@ -526,6 +526,10 @@ rfc3986==1.5.0
     # via twine
 secretstorage==3.3.1
     # via keyring
+sgmllib3k==1.0.0
+    # via
+    #   -c requirements/test.pip
+    #   feedparser
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -117,6 +117,7 @@ cryptography==2.8
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   authlib
+    #   secretstorage
 distlib==0.3.2
     # via virtualenv
 dnspython==2.1.0
@@ -293,6 +294,7 @@ importlib-metadata==4.6.3
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
+    #   backports.entry-points-selectable
     #   jsonschema
     #   keyring
     #   pep517
@@ -315,6 +317,10 @@ itsdangerous==1.1.0
     #   -r requirements/install.in
     #   flask
     #   flask-security-too
+jeepney==0.7.1
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==2.10.3
     # via
     #   -c requirements/install.pip
@@ -355,7 +361,7 @@ mock==3.0.5
     # via
     #   -c requirements/test.pip
     #   -r requirements/test.in
-mongoengine==0.18.2
+mongoengine==0.20.0
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -484,13 +490,7 @@ pytz==2019.3
     #   flask-restplus
 pyyaml==5.4.1
     # via pre-commit
-rdflib==5.0.0
-    # via
-    #   -c requirements/install.pip
-    #   -c requirements/test.pip
-    #   -r requirements/install.in
-    #   rdflib-jsonld
-rdflib-jsonld==0.5.0
+rdflib==6.0.0
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -524,6 +524,8 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==1.5.0
     # via twine
+secretstorage==3.3.1
+    # via keyring
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip
@@ -547,10 +549,8 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   mock
-    #   mongoengine
     #   pytest
     #   python-dateutil
-    #   rdflib
     #   readme-renderer
     #   requests-mock
     #   virtualenv

--- a/requirements/doc.pip
+++ b/requirements/doc.pip
@@ -266,7 +266,7 @@ mistune==0.8.4
     #   -r requirements/install.in
 mkdocs==1.0.4
     # via -r requirements/doc.in
-mongoengine==0.18.2
+mongoengine==0.20.0
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
@@ -327,12 +327,7 @@ pytz==2019.3
     #   flask-restplus
 pyyaml==5.4.1
     # via mkdocs
-rdflib==5.0.0
-    # via
-    #   -c requirements/install.pip
-    #   -r requirements/install.in
-    #   rdflib-jsonld
-rdflib-jsonld==0.5.0
+rdflib==6.0.0
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
@@ -369,9 +364,7 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   livereload
-    #   mongoengine
     #   python-dateutil
-    #   rdflib
     #   wtforms-json
 speaklater==1.3
     # via

--- a/requirements/install.in
+++ b/requirements/install.in
@@ -37,7 +37,7 @@ jsonschema==3.2.0
 kombu[redis]==4.4.0
 lxml==4.4.2
 mistune==0.8.4
-mongoengine==0.18.2
+mongoengine==0.20.0
 msgpack==0.6.2
 netaddr==0.7.19
 pillow==8.0.0
@@ -45,10 +45,10 @@ pydenticon==0.3.1
 pymongo==3.10.1
 python-dateutil==2.8.1
 pytz==2019.3
-rdflib-jsonld==0.5.0
 redis==3.3.11
-rdflib==5.0.0
+rdflib==6.0.0
 requests==2.24.0
+setuptools==58.0.0
 simplejson==3.17.0
 StringDist==1.0.9
 tlds

--- a/requirements/install.in
+++ b/requirements/install.in
@@ -48,7 +48,6 @@ pytz==2019.3
 redis==3.3.11
 rdflib==6.0.0
 requests==2.24.0
-setuptools==58.0.0
 simplejson==3.17.0
 StringDist==1.0.9
 tlds

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -170,7 +170,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via -r requirements/install.in
-mongoengine==0.18.2
+mongoengine==0.20.0
     # via
     #   -r requirements/install.in
     #   celerybeat-mongo
@@ -210,11 +210,7 @@ pytz==2019.3
     #   babel
     #   celery
     #   flask-restplus
-rdflib==5.0.0
-    # via
-    #   -r requirements/install.in
-    #   rdflib-jsonld
-rdflib-jsonld==0.5.0
+rdflib==6.0.0
     # via -r requirements/install.in
 redis==3.3.11
     # via
@@ -241,9 +237,7 @@ six==1.16.0
     #   flask-restplus
     #   isodate
     #   jsonschema
-    #   mongoengine
     #   python-dateutil
-    #   rdflib
     #   wtforms-json
 speaklater==1.3
     # via flask-babelex

--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -147,7 +147,7 @@ faker==3.0.0
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   factory-boy
-feedparser==5.2.1
+feedparser==6.0.8
     # via
     #   -c requirements/test.pip
     #   -r requirements/test.in
@@ -486,6 +486,10 @@ requests-mock==1.7.0
     # via
     #   -c requirements/test.pip
     #   -r requirements/test.in
+sgmllib3k==1.0.0
+    # via
+    #   -c requirements/test.pip
+    #   feedparser
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip

--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -147,10 +147,6 @@ faker==3.0.0
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   factory-boy
-feedparser==6.0.8
-    # via
-    #   -c requirements/test.pip
-    #   -r requirements/test.in
 flake8==3.7.8
     # via -r requirements/report.in
 flask==1.1.4
@@ -486,10 +482,6 @@ requests-mock==1.7.0
     # via
     #   -c requirements/test.pip
     #   -r requirements/test.in
-sgmllib3k==1.0.0
-    # via
-    #   -c requirements/test.pip
-    #   feedparser
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip

--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -340,7 +340,7 @@ mock==3.0.5
     # via
     #   -c requirements/test.pip
     #   -r requirements/test.in
-mongoengine==0.18.2
+mongoengine==0.20.0
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -460,13 +460,7 @@ pytz==2019.3
     #   babel
     #   celery
     #   flask-restplus
-rdflib==5.0.0
-    # via
-    #   -c requirements/install.pip
-    #   -c requirements/test.pip
-    #   -r requirements/install.in
-    #   rdflib-jsonld
-rdflib-jsonld==0.5.0
+rdflib==6.0.0
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -515,10 +509,8 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   mock
-    #   mongoengine
     #   pytest
     #   python-dateutil
-    #   rdflib
     #   requests-mock
     #   wtforms-json
 speaklater==1.3

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,7 +1,6 @@
 -r install.in
 -c install.pip
 
-feedparser==6.0.8
 httpretty==0.9.7
 mock==3.0.5
 pytest==4.6.3

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,7 +1,7 @@
 -r install.in
 -c install.pip
 
-feedparser==5.2.1
+feedparser==6.0.8
 httpretty==0.9.7
 mock==3.0.5
 pytest==4.6.3

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -115,7 +115,7 @@ faker==3.0.0
     #   -c requirements/install.pip
     #   -r requirements/install.in
     #   factory-boy
-feedparser==5.2.1
+feedparser==6.0.8
     # via -r requirements/test.in
 flask==1.1.4
     # via
@@ -374,6 +374,8 @@ requests==2.24.0
     #   requests-mock
 requests-mock==1.7.0
     # via -r requirements/test.in
+sgmllib3k==1.0.0
+    # via feedparser
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -115,8 +115,6 @@ faker==3.0.0
     #   -c requirements/install.pip
     #   -r requirements/install.in
     #   factory-boy
-feedparser==6.0.8
-    # via -r requirements/test.in
 flask==1.1.4
     # via
     #   -c requirements/install.pip
@@ -374,8 +372,6 @@ requests==2.24.0
     #   requests-mock
 requests-mock==1.7.0
     # via -r requirements/test.in
-sgmllib3k==1.0.0
-    # via feedparser
 simplejson==3.17.0
     # via
     #   -c requirements/install.pip

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -269,7 +269,7 @@ mistune==0.8.4
     #   -r requirements/install.in
 mock==3.0.5
     # via -r requirements/test.in
-mongoengine==0.18.2
+mongoengine==0.20.0
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
@@ -354,12 +354,7 @@ pytz==2019.3
     #   babel
     #   celery
     #   flask-restplus
-rdflib==5.0.0
-    # via
-    #   -c requirements/install.pip
-    #   -r requirements/install.in
-    #   rdflib-jsonld
-rdflib-jsonld==0.5.0
+rdflib==6.0.0
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
@@ -400,10 +395,8 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   mock
-    #   mongoengine
     #   pytest
     #   python-dateutil
-    #   rdflib
     #   requests-mock
     #   wtforms-json
 speaklater==1.3

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -147,7 +147,7 @@ def resource_to_rdf(resource, dataset=None, graph=None):
     if resource.mime:
         r.add(DCAT.mediaType, Literal(resource.mime))
     if resource.format:
-        r.add(DCT.term('format'), Literal(resource.format))
+        r.add(DCT.format, Literal(resource.format))
     if resource.checksum:
         checksum = graph.resource(BNode())
         checksum.set(RDF.type, SPDX.Checksum)
@@ -315,7 +315,7 @@ def title_from_rdf(rdf, url):
         last_part = url.split('/')[-1]
         if '.' in last_part and '?' not in last_part:
             return last_part
-    fmt = rdf_value(rdf, DCT.term('format'))
+    fmt = rdf_value(rdf, DCT.format)
     lang = current_app.config['DEFAULT_LANGUAGE']
     with i18n.language(lang):
         if fmt:
@@ -350,7 +350,7 @@ def resource_from_rdf(graph_or_distrib, dataset=None):
     resource.description = sanitize_html(distrib.value(DCT.description))
     resource.filesize = rdf_value(distrib, DCAT.bytesSize)
     resource.mime = rdf_value(distrib, DCAT.mediaType)
-    fmt = rdf_value(distrib, DCT.term('format'))
+    fmt = rdf_value(distrib, DCT.format)
     if fmt:
         resource.format = fmt.lower()
     checksum = distrib.value(SPDX.checksum)

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -6,7 +6,7 @@ from rdflib import Graph, URIRef, BNode
 from rdflib.namespace import RDF
 
 from udata.rdf import (
-    DCAT, DCT, HYDRA, SPDX, namespace_manager, guess_format, url_from_rdf, CONTEXT
+    DCAT, DCT, HYDRA, SPDX, namespace_manager, guess_format, url_from_rdf
 )
 from udata.core.dataset.rdf import dataset_from_rdf
 
@@ -92,7 +92,7 @@ class DcatBackend(BaseBackend):
         data = item.kwargs.get('graph', self.job.data['graph'])  # handles legacy graphs
         node = None
 
-        graph.parse(data=bytes(data), format='json-ld')
+        graph.parse(data=bytes(data, encoding='utf8'), format='json-ld')
 
         if 'nid' in item.kwargs and 'type' in item.kwargs:
             nid = item.kwargs['nid']

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -160,9 +160,7 @@ def populate_slug(instance, field):
             qs = qs(id__ne=previous.id)
 
         def exists(s):
-            return qs(
-                class_check=False, **{field.db_field: s}
-            ).limit(1).count(True) > 0
+            return qs(**{field.db_field: s}).clear_cls_query().limit(1).count(True) > 0
 
         while exists(slug):
             slug = '{0}-{1}'.format(base_slug, index)

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -11,7 +11,6 @@ from rdflib.namespace import (
     Namespace, NamespaceManager, DCTERMS, SKOS, FOAF, XSD, RDFS, RDF
 )
 from rdflib.util import SUFFIX_FORMAT_MAP, guess_format as raw_guess_format
-from rdflib_jsonld.context import Context
 
 # Extra Namespaces
 ADMS = Namespace('http://www.w3.org/ns/adms#')
@@ -204,26 +203,6 @@ CONTEXT = {
 }
 
 
-class UDataContext(Context):
-    '''
-    An hackish way to serialize context as a root relative URL.
-
-    Exploit this issue https://github.com/RDFLib/rdflib-jsonld/issues/37
-    and the fact that this method is used to render the context in the
-    resulting JSON-LD.
-
-    See:
-        https://github.com/RDFLib/rdflib-jsonld/blob/master/rdflib_jsonld/serializer.py#L101-L103
-    '''
-
-    def to_dict(self):
-        '''Hackish way to provide the site context URL'''
-        return url_for('api.site_jsonld_context', _external=True)
-
-
-context = UDataContext(CONTEXT)
-
-
 def url_from_rdf(rdf, prop):
     '''
     Try to extract An URL from a resource property.
@@ -286,7 +265,7 @@ def graph_response(graph, format):
     }
     kwargs = {}
     if fmt == 'json-ld':
-        kwargs['context'] = context
+        kwargs['context'] = CONTEXT
     if isinstance(graph, RdfResource):
         graph = graph.graph
-    return escape_xml_illegal_chars(graph.serialize(format=fmt, **kwargs).decode('utf-8')), 200, headers
+    return escape_xml_illegal_chars(graph.serialize(format=fmt, **kwargs)), 200, headers

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -11,7 +11,6 @@ from rdflib.namespace import (
     Namespace, NamespaceManager, DCTERMS, SKOS, FOAF, XSD, RDFS, RDF
 )
 from rdflib.util import SUFFIX_FORMAT_MAP, guess_format as raw_guess_format
-from rdflib.plugins.serializers.jsonld import Context
 
 # Extra Namespaces
 ADMS = Namespace('http://www.w3.org/ns/adms#')
@@ -204,26 +203,6 @@ CONTEXT = {
 }
 
 
-class UDataContext(Context):
-    '''
-    An hackish way to serialize context as a root relative URL.
-
-    Exploit this issue https://github.com/RDFLib/rdflib-jsonld/issues/37
-    and the fact that this method is used to render the context in the
-    resulting JSON-LD.
-
-    See:
-        https://github.com/RDFLib/rdflib-jsonld/blob/master/rdflib_jsonld/serializer.py#L101-L103
-    '''
-
-    def to_dict(self):
-        '''Hackish way to provide the site context URL'''
-        return url_for('api.site_jsonld_context', _external=True)
-
-
-context = UDataContext(CONTEXT)
-
-
 def url_from_rdf(rdf, prop):
     '''
     Try to extract An URL from a resource property.
@@ -286,7 +265,7 @@ def graph_response(graph, format):
     }
     kwargs = {}
     if fmt == 'json-ld':
-        kwargs['context'] = context
+        kwargs['context'] = CONTEXT
     if isinstance(graph, RdfResource):
         graph = graph.graph
     return escape_xml_illegal_chars(graph.serialize(format=fmt, **kwargs)), 200, headers

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -11,6 +11,7 @@ from rdflib.namespace import (
     Namespace, NamespaceManager, DCTERMS, SKOS, FOAF, XSD, RDFS, RDF
 )
 from rdflib.util import SUFFIX_FORMAT_MAP, guess_format as raw_guess_format
+from rdflib.plugins.serializers.jsonld import Context
 
 # Extra Namespaces
 ADMS = Namespace('http://www.w3.org/ns/adms#')
@@ -203,6 +204,26 @@ CONTEXT = {
 }
 
 
+class UDataContext(Context):
+    '''
+    An hackish way to serialize context as a root relative URL.
+
+    Exploit this issue https://github.com/RDFLib/rdflib-jsonld/issues/37
+    and the fact that this method is used to render the context in the
+    resulting JSON-LD.
+
+    See:
+        https://github.com/RDFLib/rdflib-jsonld/blob/master/rdflib_jsonld/serializer.py#L101-L103
+    '''
+
+    def to_dict(self):
+        '''Hackish way to provide the site context URL'''
+        return url_for('api.site_jsonld_context', _external=True)
+
+
+context = UDataContext(CONTEXT)
+
+
 def url_from_rdf(rdf, prop):
     '''
     Try to extract An URL from a resource property.
@@ -265,7 +286,7 @@ def graph_response(graph, format):
     }
     kwargs = {}
     if fmt == 'json-ld':
-        kwargs['context'] = CONTEXT
+        kwargs['context'] = context
     if isinstance(graph, RdfResource):
         graph = graph.graph
     return escape_xml_illegal_chars(graph.serialize(format=fmt, **kwargs)), 200, headers

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -803,7 +803,7 @@ class DatasetRdfViewsTest:
             response = client.get(url, headers={'Accept': 'application/ld+json'})
             assert200(response)
             assert response.content_type == 'application/ld+json'
-            assert response.json['@context']['@vocab'] == "http://www.w3.org/ns/dcat#"
+            assert response.json['@context']['@vocab'] == 'http://www.w3.org/ns/dcat#'
 
     @pytest.mark.parametrize('fmt,mime', [
         ('n3', 'text/n3'),

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -140,7 +140,7 @@ class DatasetToRdfTest:
         assert r.value(DCAT.accessURL).identifier == URIRef(permalink)
         assert r.value(DCAT.bytesSize) == Literal(resource.filesize)
         assert r.value(DCAT.mediaType) == Literal(resource.mime)
-        assert r.value(DCT.term('format')) == Literal(resource.format)
+        assert r.value(DCT.format) == Literal(resource.format)
 
         checksum = r.value(SPDX.checksum)
         assert r.graph.value(checksum.identifier, RDF.type) == SPDX.Checksum
@@ -395,7 +395,7 @@ class RdfToDatasetTest:
         g.add((node, DCT.modified, Literal(modified)))
         g.add((node, DCAT.bytesSize, Literal(filesize)))
         g.add((node, DCAT.mediaType, Literal(mime)))
-        g.add((node, DCT.term('format'), Literal('CSV')))
+        g.add((node, DCT.format, Literal('CSV')))
 
         checksum = BNode()
         g.add((node, SPDX.checksum, checksum))
@@ -475,7 +475,7 @@ class RdfToDatasetTest:
 
         g.set((node, RDF.type, DCAT.Distribution))
         g.set((node, DCAT.downloadURL, URIRef(url)))
-        g.set((node, DCT.term('format'), Literal('CSV')))
+        g.set((node, DCT.format, Literal('CSV')))
 
         resource = resource_from_rdf(g)
         resource.validate()
@@ -803,8 +803,7 @@ class DatasetRdfViewsTest:
             response = client.get(url, headers={'Accept': 'application/ld+json'})
             assert200(response)
             assert response.content_type == 'application/ld+json'
-            context_url = url_for('api.site_jsonld_context', _external=True)
-            assert response.json['@context'] == context_url
+            assert response.json['@context']['@vocab'] == "http://www.w3.org/ns/dcat#"
 
     @pytest.mark.parametrize('fmt,mime', [
         ('n3', 'text/n3'),
@@ -812,7 +811,6 @@ class DatasetRdfViewsTest:
         ('ttl', 'application/x-turtle'),
         ('xml', 'application/rdf+xml'),
         ('rdf', 'application/rdf+xml'),
-        ('rdfs', 'application/rdf+xml'),
         ('owl', 'application/rdf+xml'),
         ('trig', 'application/trig'),
     ])

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -803,8 +803,7 @@ class DatasetRdfViewsTest:
             response = client.get(url, headers={'Accept': 'application/ld+json'})
             assert200(response)
             assert response.content_type == 'application/ld+json'
-            context_url = url_for('api.site_jsonld_context', _external=True)
-            assert response.json['@context'] == context_url
+            assert response.json['@context']['@vocab'] == 'http://www.w3.org/ns/dcat#'
 
     @pytest.mark.parametrize('fmt,mime', [
         ('n3', 'text/n3'),

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -803,7 +803,8 @@ class DatasetRdfViewsTest:
             response = client.get(url, headers={'Accept': 'application/ld+json'})
             assert200(response)
             assert response.content_type == 'application/ld+json'
-            assert response.json['@context']['@vocab'] == 'http://www.w3.org/ns/dcat#'
+            context_url = url_for('api.site_jsonld_context', _external=True)
+            assert response.json['@context'] == context_url
 
     @pytest.mark.parametrize('fmt,mime', [
         ('n3', 'text/n3'),

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -164,7 +164,7 @@ class SiteRdfViewsTest:
         response = client.get(url, headers={'Accept': 'application/ld+json'})
         assert200(response)
         assert response.content_type == 'application/ld+json'
-        assert response.json['@context']['@vocab'] == "http://www.w3.org/ns/dcat#"
+        assert response.json['@context']['@vocab'] == 'http://www.w3.org/ns/dcat#'
 
     def test_catalog_rdf_n3(self, client):
         url = url_for('api.site_rdf_catalog_format', format='n3')

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -164,8 +164,7 @@ class SiteRdfViewsTest:
         response = client.get(url, headers={'Accept': 'application/ld+json'})
         assert200(response)
         assert response.content_type == 'application/ld+json'
-        context_url = url_for('api.site_jsonld_context', _external=True)
-        assert response.json['@context'] == context_url
+        assert response.json['@context']['@vocab'] == "http://www.w3.org/ns/dcat#"
 
     def test_catalog_rdf_n3(self, client):
         url = url_for('api.site_rdf_catalog_format', format='n3')
@@ -179,7 +178,7 @@ class SiteRdfViewsTest:
         assert200(response)
         assert response.content_type == 'application/x-turtle'
 
-    @pytest.mark.parametrize('fmt', ('xml', 'rdf', 'rdfs', 'owl'))
+    @pytest.mark.parametrize('fmt', ('xml', 'rdf', 'owl'))
     def test_catalog_rdf_rdfxml(self, fmt, client):
         url = url_for('api.site_rdf_catalog_format', format=fmt)
         response = client.get(url, headers={'Accept': 'application/rdf+xml'})

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -164,8 +164,7 @@ class SiteRdfViewsTest:
         response = client.get(url, headers={'Accept': 'application/ld+json'})
         assert200(response)
         assert response.content_type == 'application/ld+json'
-        context_url = url_for('api.site_jsonld_context', _external=True)
-        assert response.json['@context'] == context_url
+        assert response.json['@context']['@vocab'] == 'http://www.w3.org/ns/dcat#'
 
     def test_catalog_rdf_n3(self, client):
         url = url_for('api.site_rdf_catalog_format', format='n3')

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -164,7 +164,8 @@ class SiteRdfViewsTest:
         response = client.get(url, headers={'Accept': 'application/ld+json'})
         assert200(response)
         assert response.content_type == 'application/ld+json'
-        assert response.json['@context']['@vocab'] == 'http://www.w3.org/ns/dcat#'
+        context_url = url_for('api.site_jsonld_context', _external=True)
+        assert response.json['@context'] == context_url
 
     def test_catalog_rdf_n3(self, client):
         url = url_for('api.site_rdf_catalog_format', format='n3')


### PR DESCRIPTION
# Updating dependencies

In order to fix https://github.com/etalab/data.gouv.fr/issues/512.

This updated deps were also tested in https://github.com/etalab/udata-front/pull/6.

## mongoengine

Changelog: https://github.com/MongoEngine/mongoengine/blob/master/docs/changelog.rst#changes-in-0200.

Some breaking changes, but it seems that few impact us directly.

Notes:
- `class_check` no more supported.

## feedparser

Changelog: https://github.com/kurtmckee/feedparser/blob/develop/CHANGELOG.rst

feedparser doesn't seem used on udata side. Maybe we should remove it?

## rdflib-jsonld

Using rdflib that has a jsonld plugin shipped already.
Documentation: https://github.com/RDFLib/rdflib-jsonld#using-the-plug-in-jsonld-serializerparser-with-rdflib

Notes:
- We used a hack to set the context to the url. Should we continue to do that?
- Somehow rdfs doesn't look supported?
- `DCT.term('format')` was replaced by `DCT.format`
- Some encoding changes