### PR TITLE
Change doc about udata-gouvfr to udata-front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update dependencies following setuptools 58.0.2 release that drop support for `use_2to3` [#2660](https://github.com/opendatateam/udata/pull/2660):
   - :warning: **breaking change** `rdfs` is not supported anymore
   - `jsonld` endpoints have a `@context` dict directly instead of an url to the context endpoint
+- Update documentation with [udata-front plugin renaming](https://github.com/etalab/data.gouv.fr/issues/393) [#2661](https://github.com/opendatateam/udata/pull/2661)
 
 ## 3.1.0 (2021-08-31)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -849,7 +849,7 @@ SECRET_KEY = 'A unique secret key'
 SERVER_NAME = 'www.data.dev'
 
 DEFAULT_LANGUAGE = 'fr'
-PLUGINS =  'gouvfr piwik youckan'.split()
+PLUGINS =  'front piwik youckan'.split()
 
 SITE_ID = 'www.data.dev'
 SITE_TITLE = 'Data.dev'

--- a/docs/creating-theme.md
+++ b/docs/creating-theme.md
@@ -245,7 +245,7 @@ def home_context(context):
 ```
 
 !!! note
-    You can see an example of advanced hooks usage in the [`gouvfr` theme][gouvfr-hooks].
+    You can see an example of advanced hooks usage in the [`front` theme][front-hooks].
 
 ## Translations
 
@@ -325,8 +325,7 @@ and setting properly the ``THEME`` parameter in your `udata.cfg`.
 
 Here a list of known themes for udata:
 
-- [`default`][default-theme]: default theme packaged with udata (does nothing)
-- [`gouvfr`][gouvfr-project] as part of the [`gouvfr` plugin][gouvfr-project].
+- [`gouvfr`][front-project] as part of the [`front` plugin][front-project].
 
 
 !!! note
@@ -344,7 +343,6 @@ Please report any difficulty you encounter with a dedicated [Github issue][githu
 [Babel]: http://babel.pocoo.org/
 [PyPI]: https://pypi.org/
 [gitter-chan]: https://gitter.im/opendatateam/udata
-[gouvfr-hooks]: https://github.com/etalab/udata-gouvfr/blob/master/udata_gouvfr/theme/__init__.py
+[front-hooks]: https://github.com/etalab/udata-front/blob/master/udata_front/theme/__init__.py
 [Poedit]: https://poedit.net/
-[gouvfr-project]: https://github.com/etalab/udata-gouvfr/
-[default-theme]: https://github.com/opendatateam/udata/tree/master/udata/theme/default/
+[front-project]: https://github.com/etalab/udata-front/

--- a/docs/creating-theme.md
+++ b/docs/creating-theme.md
@@ -245,7 +245,7 @@ def home_context(context):
 ```
 
 !!! note
-    You can see an example of advanced hooks usage in the [`front` theme][front-hooks].
+    You can see an example of advanced hooks usage in the [`front` plugin][front-hooks].
 
 ## Translations
 

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -410,7 +410,7 @@ class SpatialTerritoriesApiTest(APITestCase):
         response = self.get(
             url_for('api.zone_datasets', id=paca.id), qs={'dynamic': 1})
         self.assert200(response)
-        # No dynamic datasets given that they are added by gouvfr extension.
+        # No dynamic datasets given that they are added by udata-front extension.
         self.assertEqual(len(response.json), 3)
 
     def test_zone_datasets_with_dynamic_and_setting_and_size(self):
@@ -428,5 +428,5 @@ class SpatialTerritoriesApiTest(APITestCase):
                 'size': 2
             })
         self.assert200(response)
-        # No dynamic datasets given that they are added by gouvfr extension.
+        # No dynamic datasets given that they are added by udata-front extension.
         self.assertEqual(len(response.json), 2)


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/393.

Many things need to be changed about the theme documentation, but it's part of another issue: https://github.com/etalab/data.gouv.fr/issues/398. I focus on changing only `udata-gouvfr` to `udata-front`.