### PR TITLE
DCAT fixes and debug cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update dependencies following setuptools 58.0.2 release that drop support for `use_2to3` [#2660](https://github.com/opendatateam/udata/pull/2660):
   - :warning: **breaking change** `rdfs` is not supported anymore
   - `jsonld` endpoints have a `@context` dict directly instead of an url to the context endpoint
+- Various DCAT fixes (geonetwork compatibility) and debug command [#2662](https://github.com/opendatateam/udata/pull/2662)
 
 ## 3.1.0 (2021-08-31)
 

--- a/udata/commands/dcat.py
+++ b/udata/commands/dcat.py
@@ -2,7 +2,7 @@ import click
 
 from rdflib import URIRef, BNode
 
-from udata.commands import cli
+from udata.commands import cli, green, yellow, cyan, echo, magenta
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.dataset.rdf import dataset_from_rdf
 from udata.harvest.tests.factories import HarvestSourceFactory, HarvestJobFactory
@@ -18,24 +18,26 @@ def grp():
 @click.argument('url')
 def parse_url(url):
     '''Parse the datasets in a DCAT format located at URL (debug)'''
+    echo(cyan('Parsing url {}'.format(url)))
     source = HarvestSourceFactory()
     source.url = url
     backend = DcatBackend(source, dryrun=True)
     job = HarvestJobFactory()
     backend.job = job
     format = backend.get_format()
-    print('format:', format)
+    echo(yellow('Detected format: {}'.format(format)))
     graph = backend.parse_graph(url, format)
-    print('graph', graph)
     for item in job.items:
-        print(item.remote_id, item.kwargs)
+        echo(magenta('Processing item {}'.format(item.remote_id)))
+        echo('Item kwargs: {}'.format(yellow(item.kwargs)))
         node = backend.get_node_from_item(item)
         dataset = DatasetFactory()
         dataset = dataset_from_rdf(graph, dataset, node=node)
-        print('---')
-        print(dataset)
-        print(dataset.license)
-        print(dataset.description)
-        print(dataset.tags)
-        print([(r.title, r.format, r.url) for r in dataset.resources])
-        print('---')
+        echo('')
+        echo(green('Dataset found!'))
+        echo('Title: {}'.format(yellow(dataset)))
+        echo('License: {}'.format(yellow(dataset.license)))
+        echo('Description: {}'.format(yellow(dataset.description)))
+        echo('Tags: {}'.format(yellow(dataset.tags)))
+        echo('Resources: {}'.format(yellow([(r.title, r.format, r.url) for r in dataset.resources])))
+        echo('')

--- a/udata/commands/dcat.py
+++ b/udata/commands/dcat.py
@@ -17,7 +17,7 @@ def grp():
 @grp.command()
 @click.argument('url')
 def parse_url(url):
-    '''Parse the graph located at URL'''
+    '''Parse the datasets in a DCAT format located at URL (debug)'''
     source = HarvestSourceFactory()
     source.url = url
     backend = DcatBackend(source, dryrun=True)

--- a/udata/commands/dcat.py
+++ b/udata/commands/dcat.py
@@ -1,0 +1,41 @@
+import click
+
+from rdflib import URIRef, BNode
+
+from udata.commands import cli
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.dataset.rdf import dataset_from_rdf
+from udata.harvest.tests.factories import HarvestSourceFactory, HarvestJobFactory
+from udata.harvest.backends.dcat import DcatBackend
+
+@cli.group('dcat')
+def grp():
+    '''DCAT diagnosis operations'''
+    pass
+
+
+@grp.command()
+@click.argument('url')
+def parse_url(url):
+    '''Parse the graph located at URL'''
+    source = HarvestSourceFactory()
+    source.url = url
+    backend = DcatBackend(source, dryrun=True)
+    job = HarvestJobFactory()
+    backend.job = job
+    format = backend.get_format()
+    print('format:', format)
+    graph = backend.parse_graph(url, format)
+    print('graph', graph)
+    for item in job.items:
+        print(item.remote_id, item.kwargs)
+        node = backend.get_node_from_item(item)
+        dataset = DatasetFactory()
+        dataset = dataset_from_rdf(graph, dataset, node=node)
+        print('---')
+        print(dataset)
+        print(dataset.license)
+        print(dataset.description)
+        print(dataset.tags)
+        print([(r.title, r.format, r.url) for r in dataset.resources])
+        print('---')

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -98,7 +98,7 @@ class DcatBackend(BaseBackend):
 
     def process(self, item):
         graph = Graph(namespace_manager=namespace_manager)
-        data = item.kwargs.get('graph', self.job.data['graph'])  # handles legacy graphs
+        data = self.job.data['graph']
 
         node = self.get_node_from_item(item)
         graph.parse(data=bytes(data, encoding='utf8'), format='json-ld')

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -49,7 +49,10 @@ class DcatBackend(BaseBackend):
         '''List all datasets for a given ...'''
         fmt = self.get_format()
         graph = self.parse_graph(self.source.url, fmt)
-        self.job.data = {'graph': graph.serialize(format='json-ld', indent=None)}
+        self.job.data = {
+            'graph': graph.serialize(format=fmt, indent=None),
+            'format': fmt,
+        }
 
     def get_format(self):
         fmt = guess_format(self.source.url)
@@ -99,9 +102,10 @@ class DcatBackend(BaseBackend):
     def process(self, item):
         graph = Graph(namespace_manager=namespace_manager)
         data = self.job.data['graph']
+        format = self.job.data['format']
 
         node = self.get_node_from_item(item)
-        graph.parse(data=bytes(data, encoding='utf8'), format='json-ld')
+        graph.parse(data=bytes(data, encoding='utf8'), format=format)
 
         dataset = self.get_dataset(item.remote_id)
         dataset = dataset_from_rdf(graph, dataset, node=node)

--- a/udata/harvest/tests/dcat/geonetwork.xml
+++ b/udata/harvest/tests/dcat/geonetwork.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <dcat:CatalogRecord xmlns:dcat="http://www.w3.org/ns/dcat#"
+                       rdf:about="https://sig.oreme.org/geonetwork/records/0c456d2d-9548-4a2a-94ef-231d9d890ce2">
+      <foaf:primaryTopic xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                         rdf:resource="https://sig.oreme.org/geonetwork/srv/resources/0c456d2d-9548-4a2a-94ef-231d9d890ce2%20https%3A%2F%2Fsig.oreme.org%2Fgeonetwork%2Fsrv%2Fresources0c456d2d-9548-4a2a-94ef-231d9d890ce2"/>
+      <dct:conformsTo xmlns:dct="http://purl.org/dc/terms/"
+                      rdf:resource="https://www.iso.org/standard/32557.html"/>
+      <dct:issued xmlns:dct="http://purl.org/dc/terms/">2021-07-28</dct:issued>
+      <dct:modified xmlns:dct="http://purl.org/dc/terms/">2021-07-28</dct:modified>
+   </dcat:CatalogRecord>
+   <dcat:Dataset xmlns:dcat="http://www.w3.org/ns/dcat#"
+                 rdf:about="https://sig.oreme.org/geonetwork/srv/resources/datasets/0c456d2d-9548-4a2a-94ef-231d9d890ce2 https://sig.oreme.org/geonetwork/srv/resources0c456d2d-9548-4a2a-94ef-231d9d890ce2">
+      <dct:identifier xmlns:dct="http://purl.org/dc/terms/">0c456d2d-9548-4a2a-94ef-231d9d890ce2 https://sig.oreme.org/geonetwork/srv/resources0c456d2d-9548-4a2a-94ef-231d9d890ce2</dct:identifier>
+      <dct:title xmlns:dct="http://purl.org/dc/terms/">Data of type chemistry in Le Gardon basin, from the Observatory of the former mining site of Carnoulès (TO Carnoules)</dct:title>
+      <dct:abstract xmlns:dct="http://purl.org/dc/terms/">Data of type chemistry measured on Le Gardon basin within the framework of the Observatory of the former mining site of Carnoulès (TO Carnoules), part of the Pollution downstream of mining sites observatory (SO POLLUMINE) hosted by the Mediterranean Research Observatory of Environment (OSU OREME, http://www.oreme.org). Measurements start on 03-11-2004 and are regularly updated with new data.</dct:abstract>
+      <dcat:keyword>biodiversity dynamics</dcat:keyword>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/ef">Environmental monitoring facilities</dcat:theme>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/hb">Habitats and biotopes</dcat:theme>
+      <dcat:theme rdf:resource="http://www.eionet.europa.eu/gemet/concept/834">biogeochemistry</dcat:theme>
+      <dcat:theme rdf:resource="http://www.eionet.europa.eu/gemet/concept/3305">flora (biology)</dcat:theme>
+      <dcat:theme rdf:resource="http://www.eionet.europa.eu/gemet/concept/5218">microbiology</dcat:theme>
+      <dcat:theme rdf:resource="http://www.eionet.europa.eu/gemet/concept/5261">mine</dcat:theme>
+      <dcat:theme rdf:resource="http://www.eionet.europa.eu/gemet/concept/6445">pollution</dcat:theme>
+      <dcat:theme rdf:resource="http://www.eionet.europa.eu/gemet/concept/3138">fauna</dcat:theme>
+      <dcat:theme rdf:resource="http://aims.fao.org/aos/agrovoc/c_910">biogeochemistry</dcat:theme>
+      <dcat:theme rdf:resource="http://aims.fao.org/aos/agrovoc/c_4800">microbiology</dcat:theme>
+      <dcat:theme rdf:resource="http://aims.fao.org/aos/agrovoc/c_2821">fauna</dcat:theme>
+      <dcat:theme rdf:resource="http://aims.fao.org/aos/agrovoc/c_29036">metals</dcat:theme>
+      <foaf:thumbnail xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                      rdf:resource="https://data.oreme.org/assets/images/carnoules-medium.jpg"/>
+      <dct:spatial xmlns:dct="http://purl.org/dc/terms/">
+         <ogc:Polygon xmlns:ogc="http://www.opengis.net/rdf#">
+            <ogc:asWKT rdf:datatype="http://www.opengis.net/rdf#WKTLiteral">
+            &lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+            Polygon((3.98197778 44.05310833, 3.98197778 44.11806389, 4.00346389 44.11806389, 4.00346389 44.05310833, 3.98197778 44.05310833))
+          </ogc:asWKT>
+         </ogc:Polygon>
+      </dct:spatial>
+      <dct:temporal xmlns:dct="http://purl.org/dc/terms/">2004-11-03T00:00:00+01:00
+          /
+          2005-03-30T00:00:00+02:00</dct:temporal>
+      <dct:issued xmlns:dct="http://purl.org/dc/terms/">2004-11-03</dct:issued>
+      <dct:updated xmlns:dct="http://purl.org/dc/terms/">2021-05-05</dct:updated>
+      <dct:publisher xmlns:dct="http://purl.org/dc/terms/"
+                     rdf:resource="https://sig.oreme.org/geonetwork/srv/resources/organizations/UMR%20HydroSciences%20Montpellier%20%28HSM%29"/>
+      <dct:accrualPeriodicity xmlns:dct="http://purl.org/dc/terms/">continual</dct:accrualPeriodicity>
+      <dct:language xmlns:dct="http://purl.org/dc/terms/">eng</dct:language>
+      <dct:license xmlns:dct="http://purl.org/dc/terms/">copyright</dct:license>
+      <dct:license xmlns:dct="http://purl.org/dc/terms/">license</dct:license>
+      <dct:license xmlns:dct="http://purl.org/dc/terms/"
+                   rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">no limitations to public access</dct:license>
+      <dct:license xmlns:dct="http://purl.org/dc/terms/"
+                   rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">No conditions apply to access and use.</dct:license>
+      <dcat:distribution rdf:resource="https://sig.oreme.org/geonetwork/records/0c456d2d-9548-4a2a-94ef-231d9d890ce2#WWW%3ALINK-1.0-http--link-Data%20on%20OSU%20OREME%20data%20portal"/>
+      <dcat:distribution rdf:resource="https://sig.oreme.org/geonetwork/records/0c456d2d-9548-4a2a-94ef-231d9d890ce2#WWW%3ALINK-1.0-http--link-Information%20on%20OSU%20OREME%20website"/>
+      <dcat:distribution rdf:resource="https://sig.oreme.org/geonetwork/records/0c456d2d-9548-4a2a-94ef-231d9d890ce2#OGC%3AWMS-carnoules_station"/>
+      <dcat:distribution rdf:resource="https://sig.oreme.org/geonetwork/records/0c456d2d-9548-4a2a-94ef-231d9d890ce2#OGC%3AWFS-carnoules_station"/>
+      <dct:relation xmlns:dct="http://purl.org/dc/terms/"
+                    rdf:resource="https://sig.oreme.org/geonetwork/records/ac9a8cb5-51b7-4d54-9b8c-3e30d09ed5b4"/>
+      <dcat:dataQuality>The measured parameters are: Aluminium (Al) (ppb), Antimony (Sb) (ppb), Arsenic (As) (ppb), Barium (Ba) (ppb), Beryllium (Be) (ppb), Bicarbonate (mg/l), Boron (B) (ppb), Cadmium (Cd) (ppb), Calcium (Ca) (mg/l), Calcium (Ca) (ppb), Carbonate (mg/l), Cerium (Ce) (ppb), Cesium (Cs) (ppb), Chlorine (Cl) (mg/l), Chromium (Cr) (ppb), Cobalt (Co) (ppb), Conductivity (µS/cm (T. ref 25°C)), Copper (Cu) (ppb), Dissolved oxygen (%), Dissolved oxygen (mg/l), Dysprosium (Dy) (ppb), Erbium (Er) (ppb), Europium (Eu) (ppb), Gadolinium (Gd) (ppb), Gallium (Ga) (ppb), Germanium (Ge) (ppb), Hafnium (Hf) (ppb), Holmium (Ho) (ppb), Iron (Fe) (mg/l), Iron (Fe) (ppb), Lanthanum (La) (ppb), Lead (Pb) (ppb), Lithium (Li) (ppb), Lutetium (Lu) (ppb), Magnesium (Mg) (mg/l), Magnesium (Mg) (ppb), m-alkalinity (mg/l), Manganese (Mn) (ppb), Molybdenum (Mo) (ppb), Neodymium (Nd) (ppb), Nickel (Ni) (ppb), Nitrate (mg/l), Oxyded Arsenic As(V) (ppb), Palladium (Pd) (ppb), Phosphorus (P) (ppb), pH (unit), Platinum (Pt) (ppb), Potassium (K) (mg/l), Potassium (K) (ppb), Praseodymium (Pr) (ppb), Redox potential (mV), Reduced Arsenic As(III) (ppb), Reduced Iron Fe(II) (mg/l), Rhenium (Re) (ppb), Rubidium (Rb) (ppb), Samarium (Sm) (ppb), Selenium (Se) (ppb), Silicon (Si) (ppb), Silver (Ag) (ppb), Sodium (Na) (mg/l), Sodium (Na) (ppb), Strontium (Sr) (ppb), Sulfate (mg/l), Sulfur (S) (ppb), Suspended Particulate Matter (mg/l), Terbium (Tb) (ppb), Thallium (Tl) (ppb), Thorium (Th) (ppb), Thulium (Tm) (ppb), Tin (Sn) (ppb), Titanium (Ti) (ppb), Total Dissolved Solids (TDS) (mg/l), Total organic carbon (TOC) (mg/l), Tungsten (W) (ppb), Uranium (U) (ppb), Vanadium (V) (ppb), Water temperature (°C), Ytterbium (Yb) (ppb), Yttrium (Y) (ppb), Zinc (Zn) (ppb), Zirconium (Zr) (ppb).</dcat:dataQuality>
+   </dcat:Dataset>
+</rdf:RDF>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -230,6 +230,15 @@ class DcatBackendTest:
         dataset = Dataset.objects.get(**extras)
         assert dataset.license.id == 'lov2'
 
+    def test_geonetwork_xml_catalog(self, rmock):
+        url = mock_dcat(rmock, 'geonetwork.xml', path='catalog.xml')
+        org = OrganizationFactory()
+        source = HarvestSourceFactory(backend='dcat',
+                                      url=url,
+                                      organization=org)
+        actions.run(source.slug)
+        dataset = Dataset.objects.filter(organization=org).first()
+        assert dataset is not None
 
     def test_unsupported_mime_type(self, rmock):
         url = DCAT_URL_PATTERN.format(path='', domain=TEST_DOMAIN)

--- a/udata/utils.py
+++ b/udata/utils.py
@@ -285,4 +285,6 @@ class UnicodeLoremProvider(LoremProvider):
 
 def safe_unicode(string):
     '''Safely transform any object into utf8 decoded str'''
+    if string is None:
+        return None
     return string.decode('utf8') if isinstance(string, bytes) else str(string)


### PR DESCRIPTION
This fixes some errors encountered while parsing https://sig.oreme.org/geonetwork/srv/eng/rdf.search. They _seem_ to make sense in a general context.

List of changes described in comments.

Also, it introduces a `udata dcat parse-url <url>` command that mocks an harvesting from the given URL and outputs information for debugging.

```
$ udata dcat parse-url -q https://sig.oreme.org/geonetwork/srv/eng/rdf.search
Parsing url https://sig.oreme.org/geonetwork/srv/eng/rdf.search
Detected format: xml
Processing item 10.15148/4140d06c-fa31-4b4c-8c0f-38e6d0c62fbc https://sig.oreme.org/geonetwork/srv/resourcese685cbc4-0d10-436d-af4c-b89468b703f6
Item kwargs: {'nid': 'https://sig.oreme.org/geonetwork/srv/resources/datasets/10.15148/4140d06c-fa31-4b4c-8c0f-38e6d0c62fbc https://sig.oreme.org/geonetwork/srv/resourcese685cbc4-0d10-436d-af4c-b89468b703f6', 'type': 'uriref'}

Dataset found!
Title: Time series of type climatology-meteorology-atmosphere in Port-Miou basin - PORT-MIOU observatory - KARST observatory network -OZCAR Critical Zone network Research Infrastructure
License: License Not Specified
Description:
Tags: ['SNO KARST', 'hydrochemistry']
Resources: [('See site information on DEIMS / LTER', 'www:link-1.0-http--link', 'https://deims.org/9abe3e61-7bd8-461d-8674-c33e70f198ba'), ('Get associated data with DOI', 'www:link-1.0-http--link', 'https://doi.org/10.15148/cfd01a5b-b7fd-41aa-8884-84dbddac767e'), ('Search data on OSU OREME data portal', 'www:link-1.0-http--link', 'http://data.oreme.org/snokarst/snokarst_data_export')]
Dataset is valid ✅
```