### PR TITLE
Meta read-only-enabled is back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Meta read-only-enabled is back [#2664](https://github.com/opendatateam/udata/pull/2664)
 
 ## 3.2.0 (2021-09-14)
 

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -72,6 +72,7 @@
     'MIN_LENGTH': config.TAG_MIN_LENGTH,
     'MAX_LENGTH': config.TAG_MAX_LENGTH,
 }|tojson|urlencode }}" />
+<meta name="read-only-enabled" content="{{ 'true' if config.READ_ONLY_MODE else 'false' }}">
 
 {% if json_ld %}
 <script id="json_ld" type="application/ld+json">{{ json_ld|embedded_json_ld }}</script>


### PR DESCRIPTION
read-only metadata (introduced in https://github.com/opendatateam/udata/pull/2565) had disappeared during *refonte*.