### PR TITLE
Fix sort with right sort column name

### DIFF
--- a/js/views/editorial.vue
+++ b/js/views/editorial.vue
@@ -40,7 +40,7 @@ export default {
     name: 'editorial-view',
     data() {
         return {
-            posts: new Posts({query: {sort: '-created', page_size: 10}, mask: PostList.MASK}),
+            posts: new Posts({query: {sort: '-created_at', page_size: 10}, mask: PostList.MASK}),
             topics: new Topics({query: {sort: '-created', page_size: 10}, mask: TopicList.MASK}),
             home_datasets: new List({ns: 'site', fetch: 'get_home_datasets',
                                      mask: DatasetCardList.MASK, model: Dataset}),


### PR DESCRIPTION
While looking in posts back-office, I've found out they were not sorted by more recent by default.

In the Browser Devtools Network panel, http calls are like https://www.data.gouv.fr/api/1/posts/?page_size=10&sort=-created&lang=fr&_=12345

The option sort=-created has not effect, as you can check by using `sort=+created` (https://www.data.gouv.fr/api/1/posts/?page_size=10&sort=+created&lang=fr&_=12345). On the API side, the `order_by` method inherits from Mongo Python library http://docs.mongoengine.org/apireference.html#mongoengine.queryset.QuerySet.order_by
So, it should have an effect but in fact, it doesn't.

While inspecting API signature for posts, we see sort is by default set to `-created_at` for the posts e.g https://github.com/opendatateam/udata/blob/master/udata/core/post/api.py#L75

Trying to use `sort=-created_at` instead of `sort=-created` "works" e.g https://www.data.gouv.fr/api/1/posts/?page_size=10&sort=-created_at&lang=fr&_=12345 or https://www.data.gouv.fr/api/1/posts/?page_size=10&sort=+created_at&lang=fr&_=12345

So, the issue is from API calls from the client. The call is done from code at line https://github.com/opendatateam/udata/blob/master/js/views/editorial.vue#L43

This commit fix this issue by changing `-created` with `-created_at`