### PR TITLE
Add an empty count_discussions method on post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - :warning: Removed `Issues` code and logic. The corresponding MongoDB collection should be deleted when upgrading Udata. [#2681](https://github.com/opendatateam/udata/pull/2681)
 - Fix transfer ownership from org to user [#2678](https://github.com/opendatateam/udata/pull/2678)
+- Fix discussion creation on posts [#2687](https://github.com/opendatateam/udata/pull/2687)
 
 ## 3.2.2 (2021-11-23)
 

--- a/udata/core/post/models.py
+++ b/udata/core/post/models.py
@@ -62,3 +62,7 @@ class Post(db.Datetimed, db.Document):
     @property
     def external_url(self):
         return self.url_for(_external=True)
+
+    def count_discussions(self):
+        # There are no metrics on Post to store discussions count
+        pass


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/643.

On new discussion, a signal was launched to `count_discussions`. Posts didn't have this method and it raised an error.
Add this method that just pass because there are no metrics to store discussion count on posts.