### PR TITLE
Fix empty value admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - :warning: Removed `Issues` code and logic. The corresponding MongoDB collection should be deleted when upgrading Udata. [#2681](https://github.com/opendatateam/udata/pull/2681)
 - Fix transfer ownership from org to user [#2678](https://github.com/opendatateam/udata/pull/2678)
 - Fix discussion creation on posts [#2687](https://github.com/opendatateam/udata/pull/2687)
+- Fix fields empty value in admin form to allow for unsetting fields [#2688](https://github.com/opendatateam/udata/pull/2688)
 
 ## 3.2.2 (2021-11-23)
 

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -196,7 +196,7 @@ export default {
                     value = value.filter(option => option.selected);
                     value = value.map(option => option.value);
                 } else if (TEXT_TAGS.includes(el.tagName.toLowerCase()) || TEXT_INPUTS.includes(el.type.toLowerCase())) {
-                    value = el.value || undefined;
+                    value = el.value || null;
                 } else if (el.type === 'checkbox') {
                     value = el.checked;
                 } else {

--- a/specs/components/form/base.specs.js
+++ b/specs/components/form/base.specs.js
@@ -204,9 +204,9 @@ describe('Common Form features', function() {
             ];
 
             expect(this.vm.serialize()).to.eql({
-                input: undefined,
+                input: null,
                 checkbox: false,
-                textarea: undefined,
+                textarea: null,
                 select: 'b',
             });
         });
@@ -296,8 +296,8 @@ describe('Common Form features', function() {
 
                 expect(this.vm.serialize()).to.eql({
                     nested: {
-                        a: undefined,
-                        b: undefined
+                        a: null,
+                        b: null
                     }
                 });
             });


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/611.

Use `null` instead of `undefined` because the `undefined` values were ignored in the request.
If a value is unset, the `null` value will be passed, correctly unsetting the corresponding field.