### PR TITLE
Fix missing checksum type in admin form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - :warning: Removed `Issues` code and logic. The corresponding MongoDB collection should be deleted when upgrading Udata. [#2681](https://github.com/opendatateam/udata/pull/2681)
 - Fix transfer ownership from org to user [#2678](https://github.com/opendatateam/udata/pull/2678)
 - Fix discussion creation on posts [#2687](https://github.com/opendatateam/udata/pull/2687)
-- Fix fields empty value in admin form to allow for unsetting fields [#2688](https://github.com/opendatateam/udata/pull/2688)
+- Fix fields empty value in admin form to allow for unsetting fields [#2688](https://github.com/opendatateam/udata/pull/2688) [#2690](https://github.com/opendatateam/udata/pull/2690)
 
 ## 3.2.2 (2021-11-23)
 

--- a/js/components/form/checksum.vue
+++ b/js/components/form/checksum.vue
@@ -22,7 +22,7 @@
         :name="typeFieldName"
         :placeholder="placeholder"
         :required="required"
-        :value="algo"
+        :value="currentType"
         :readonly="field.readonly || false"></input>
     <input type="text" class="form-control"
         :id="field.id"

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -266,6 +266,9 @@ class ResourceMixin(object):
 
     def clean(self):
         super(ResourceMixin, self).clean()
+        # Set checksum field to None if checksum.value isn't set
+        if self.checksum and not self.checksum.value:
+            self.checksum = None
         if not self.urlhash or 'url' in self._get_changed_fields():
             self.urlhash = hash_url(self.url)
 


### PR DESCRIPTION
Following #2688, it appeared that the resource checksum type was missing.

It wasn't a problem before because it wasn't send to the API as it was undefined, but with the previous PR it sends a `null` value, not allowed by the API.
Change the erroneous value `algo` by the correct `currentType`.