### PR TITLE
Fix empty value in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - :warning: Removed `Issues` code and logic. The corresponding MongoDB collection should be deleted when upgrading Udata. [#2681](https://github.com/opendatateam/udata/pull/2681)
 - Fix transfer ownership from org to user [#2678](https://github.com/opendatateam/udata/pull/2678)
 - Fix discussion creation on posts [#2687](https://github.com/opendatateam/udata/pull/2687)
+- Fix fields empty value in admin form to allow for unsetting fields [#2688](https://github.com/opendatateam/udata/pull/2688)
 
 ## 3.2.2 (2021-11-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix fields empty value in admin form to allow for unsetting fields [#2691](https://github.com/opendatateam/udata/pull/2691)
 
 ## 3.3.0 (2021-12-10)
 
 - :warning: Removed `Issues` code and logic. The corresponding MongoDB collection should be deleted when upgrading Udata. [#2681](https://github.com/opendatateam/udata/pull/2681)
 - Fix transfer ownership from org to user [#2678](https://github.com/opendatateam/udata/pull/2678)
 - Fix discussion creation on posts [#2687](https://github.com/opendatateam/udata/pull/2687)
-- Fix fields empty value in admin form to allow for unsetting fields [#2688](https://github.com/opendatateam/udata/pull/2688)
 
 ## 3.2.2 (2021-11-23)
 

--- a/js/components/form/base-form.js
+++ b/js/components/form/base-form.js
@@ -196,7 +196,7 @@ export default {
                     value = value.filter(option => option.selected);
                     value = value.map(option => option.value);
                 } else if (TEXT_TAGS.includes(el.tagName.toLowerCase()) || TEXT_INPUTS.includes(el.type.toLowerCase())) {
-                    value = el.value || undefined;
+                    value = el.value || null;
                 } else if (el.type === 'checkbox') {
                     value = el.checked;
                 } else {

--- a/js/components/form/checksum.vue
+++ b/js/components/form/checksum.vue
@@ -22,7 +22,7 @@
         :name="typeFieldName"
         :placeholder="placeholder"
         :required="required"
-        :value="algo"
+        :value="finalType"
         :readonly="field.readonly || false"></input>
     <input type="text" class="form-control"
         :id="field.id"
@@ -30,7 +30,8 @@
         :placeholder="placeholder"
         :required="required"
         :value="value ? value.value : ''"
-        :readonly="field.readonly || false"></input>
+        :readonly="field.readonly || false"
+        v-model="checksumValue"></input>
 </div>
 </template>
 
@@ -44,6 +45,7 @@ export default {
     data() {
         return {
             specs: API.definitions.Checksum.properties,
+            checksumValue: '',
         };
     },
     computed: {
@@ -53,6 +55,10 @@ export default {
             } else {
                 return this.specs.type.default;
             }
+        },
+        finalType() {
+            // we don't want to set a type if no value is set
+            return this.checksumValue ? this.currentType : '';
         },
         typeFieldName() {
             return `${this.field.id}.type`;

--- a/specs/components/form/base.specs.js
+++ b/specs/components/form/base.specs.js
@@ -204,9 +204,9 @@ describe('Common Form features', function() {
             ];
 
             expect(this.vm.serialize()).to.eql({
-                input: undefined,
+                input: null,
                 checkbox: false,
-                textarea: undefined,
+                textarea: null,
                 select: 'b',
             });
         });
@@ -296,8 +296,8 @@ describe('Common Form features', function() {
 
                 expect(this.vm.serialize()).to.eql({
                     nested: {
-                        a: undefined,
-                        b: undefined
+                        a: null,
+                        b: null
                     }
                 });
             });

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -22,7 +22,7 @@ class ChecksumForm(ModelForm):
     model_class = Checksum
     choices = list(zip(CHECKSUM_TYPES, CHECKSUM_TYPES))
     type = fields.SelectField(choices=choices, default='sha1')
-    value = fields.StringField()
+    value = fields.StringField(_('Checksum value'), [validators.DataRequired()])
 
 
 def normalize_format(data):


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/611.

Following #2688, we re-apply the fix with a patch for checksum type.
Additionally, we added a data required validator on the checksum value form to get a proper validation error.