### PR TITLE
Take title into account when guessing license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use title to improve License guess [#2697](https://github.com/opendatateam/udata/pull/2697)
 
 ## 3.3.1 (2022-01-11)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -202,6 +202,15 @@ class License(db.Document):
                 license = candidates[0]
 
         if license is None:
+            # Try to match `title` with a low Damerau-Levenshtein distance
+            computed = ((l, rdlevenshtein(l.title, text)) for l in cls.objects)
+            candidates = [l for l, d in computed if d <= MAX_DISTANCE]
+            # If there is more that one match, we cannot determinate
+            # which one is closer to safely choose between candidates
+            if len(candidates) == 1:
+                license = candidates[0]
+
+        if license is None:
             # Try to single match `alternate_titles` with a low Damerau-Levenshtein distance
             computed = (
                 (l, rdlevenshtein(cls.slug.slugify(t), slug))

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -382,6 +382,12 @@ class LicenseModelTest:
         assert isinstance(found, License)
         assert license.id == found.id
 
+    def test_exact_match_by_title_with_mismatch_slug(self):
+        license = LicenseFactory(title="Licence Ouverte v2", slug="licence-2")
+        found = License.guess(license.title)
+        assert isinstance(found, License)
+        assert license.id == found.id
+
     def test_exact_match_by_title_with_spaces(self):
         license = LicenseFactory()
         found = License.guess(' {0} '.format(license.title))


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/653.

License title wasn't compared directly when guessing license, only the slug that could differ from the title.