### PR TITLE
Delete discussion with deleted user as only participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use title to improve License guess [#2697](https://github.com/opendatateam/udata/pull/2697)
 - Add a `q` argument to the paginated datasets resources endpoint, to search through resources titles. [#2701](https://github.com/opendatateam/udata/pull/2701)
+- Delete discussion with deleted user as only participant [#2702](https://github.com/opendatateam/udata/pull/2702)
 
 ## 3.3.1 (2022-01-11)
 

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -256,6 +256,11 @@ class User(WithMetrics, UserMixin, db.Document):
                                     if member.user != self]
             organization.save()
         for discussion in Discussion.objects(discussion__posted_by=self):
+            # Remove all discussions with current user as only participant
+            if all(message.posted_by == self for message in discussion.discussion):
+                discussion.delete()
+                continue
+
             for message in discussion.discussion:
                 if message.posted_by == self:
                     message.content = 'DELETED'


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/642.

When a user is marked as deleted, all discussions with them as only participant will be deleted.