### PR TITLE
Add dataset and reuse id to post fields mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use title to improve License guess [#2697](https://github.com/opendatateam/udata/pull/2697)
 - Add a `q` argument to the paginated datasets resources endpoint, to search through resources titles. [#2701](https://github.com/opendatateam/udata/pull/2701)
+- Fix error on post creation when adding related reuse [#2704](https://github.com/opendatateam/udata/pull/2704)
 
 ## 3.3.1 (2022-01-11)
 

--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -53,7 +53,7 @@ post_fields = api.model('Post', {
     'page': fields.UrlFor(
         'posts.show', lambda o: {'post': o},
         description='The post page URL', readonly=True, fallback_endpoint='api.post'),
-}, mask='*,datasets{title,acronym,uri,page},reuses{title,image,image_thumbnail,uri,page}')
+}, mask='*,datasets{id,title,acronym,uri,page},reuses{id,title,image,image_thumbnail,uri,page}')
 
 post_page_fields = api.model('PostPage', fields.pager(post_fields))
 

--- a/udata/core/post/tests/test_api.py
+++ b/udata/core/post/tests/test_api.py
@@ -2,8 +2,10 @@ import pytest
 
 from flask import url_for
 
+from udata.core.dataset.factories import DatasetFactory
 from udata.core.post.factories import PostFactory
 from udata.core.post.models import Post
+from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import AdminFactory
 
 from udata.tests.helpers import assert200, assert201, assert204
@@ -54,6 +56,27 @@ class PostsAPITest:
         assert200(response)
         assert Post.objects.count() == 1
         assert Post.objects.first().content == 'new content'
+
+    def test_post_api_update_with_related_dataset_and_reuse(self, api):
+        '''It should update a post from the API with related dataset and reuse'''
+        api.login(AdminFactory())
+        post = PostFactory()
+        data = post.to_dict()
+        data['content'] = 'new content'
+
+        # Add datasets
+        data['datasets'] = [DatasetFactory().to_dict()]
+        response = api.put(url_for('api.post', post=post), data)
+        assert200(response)
+
+        # Add reuses to the post value returned by the previous api call
+        data = response.json
+        data['reuses'] = [ReuseFactory().to_dict()]
+        response = api.put(url_for('api.post', post=post), data)
+        assert200(response)
+
+        assert len(response.json['datasets']) == 1
+        assert len(response.json['reuses']) == 1
 
     def test_post_api_delete(self, api):
         '''It should delete a post from the API'''


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/548.

On Post creation form, `datasets` value was set on api callback `on_fetched`. However, the `id` field was missing. When updating the post for a new reuse, it could not identify the datasets in the payload and returned an error.
The dataset and reuse `id` field was added to the `post_fields` mask to fix this issue.