### PR TITLE
Add reindexation command and modify kafka messages structure

### DIFF
--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -159,7 +159,9 @@ $ udata job unschedule my-job arg key=value
 Sometimes, you need to reindex data (in case of model breaking changes, workers defect...).
 You can use the `udata search index` command to do so.
 
-This command supports both full reindex without arguments and partial with model names as arguments:
+**Warning**: After reindexation execution, you'll need to change the alias on the search service to use the new index.
+
+This command supports reindexation of all models without arguments or particular model with model names as arguments:
 
 ```shell
 # Reindex everything
@@ -168,27 +170,17 @@ udata search index
 udata search index reuses organizations
 ```
 
-By default the command deletes the previous index in case of success or the new unfinished index in case of error but you can ask to keep indexes with the `-k/--keep` parameter
+The target index name will be time-based, ex: dataset-2022-02-20-20-02.
 
+It's possible to index documents to existing index instead of targeting a new index.
 ```shell
-# Reindex everything but keep the old index
-udata search index -k
+time udata search index --reindex false
 ```
 
-When used from an interactive terminal the command also prompt for deletion confirmation if an index with the same name already exists. This can be bypassed with the `-f/--force` parameter.
+It's possible to index or reindex only last modified documents.
 
 ```shell
-# Reindex everything and delete old index
-udata search index -f
-```
-
-It's possible to do a partial reindex by providing models (both singular and plural are supported) as arguments:
-
-```shell
-# Only reindex datasets and reuses (plural form)
-udata search index datasets reuses
-# Only reindex datasets and reuses (singular form)
-udata search index dataset reuse
+time udata search index --reindex false -f 2022-02-20-20-02
 ```
 
 ## Workers

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -34,15 +34,10 @@ class KafkaProducerSingleton:
         return KafkaProducerSingleton.__instance
 
 
-def produce(model, id, message_type, document=None):
+def produce(model, id, message_type, document=None, index=None):
     '''Produce message with marshalled document'''
     producer = KafkaProducerSingleton.get_instance()
     key = id.encode("utf-8")
-    value = {
-        'service': 'udata',
-        'data': document,
-        'message_type': message_type.value
-    }
     if model == Dataset:
         topic = 'dataset'
     if model == Organization:
@@ -51,6 +46,17 @@ def produce(model, id, message_type, document=None):
         topic = 'reuse'
     if not topic:
         return
+
+    if not index:
+        index = topic
+    value = {
+        'service': 'udata',
+        'data': document,
+        'meta': {
+            'message_type': message_type.value,
+            'index': index
+        }
+    }
 
     producer.send(topic, value=value, key=key)
     producer.flush()

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import json
 import logging
 
@@ -14,6 +15,12 @@ log = logging.getLogger(__name__)
 adapter_catalog = {}
 
 
+class KafkaMessageType(Enum):
+    INDEX = 'index'
+    REINDEX = 'reindex'
+    UNINDEX = 'unindex'
+
+
 class KafkaProducerSingleton:
     __instance = None
 
@@ -27,55 +34,54 @@ class KafkaProducerSingleton:
         return KafkaProducerSingleton.__instance
 
 
-def produce(model, id, document=None, delete=False):
+def produce(model, id, message_type, document=None):
     '''Produce message with marshalled document'''
     producer = KafkaProducerSingleton.get_instance()
     key = id.encode("utf-8")
+    value = {
+        'service': 'udata',
+        'data': document,
+        'message_type': message_type.value
+    }
     if model == Dataset:
-        if delete:
-            producer.send('dataset', key=key)
-        else:
-            producer.send('dataset', document, key=key)
-        producer.flush()
+        topic = 'dataset'
     if model == Organization:
-        if delete:
-            producer.send('organization', key=key)
-        else:
-            producer.send('organization', document, key=key)
-        producer.flush()
+        topic = 'organization'
     if model == Reuse:
-        if delete:
-            producer.send('reuse', key=key)
-        else:
-            producer.send('reuse', document, key=key)
-        producer.flush()
+        topic = 'reuse'
+    if not topic:
+        return
+
+    producer.send(topic, value=value, key=key)
+    producer.flush()
 
 
 @task(route='high.search')
-def reindex(classname, id=None):
+def reindex(classname, id):
     model = db.resolve_model(classname)
     obj = model.objects.get(pk=id)
     adapter_class = adapter_catalog.get(model)
+    document = adapter_class.serialize(obj)
     if adapter_class.is_indexable(obj):
         log.info('Indexing %s (%s)', model.__name__, obj.id)
         try:
-            produce(model, str(obj.id), adapter_class.serialize(obj))
+            produce(model, str(obj.id), KafkaMessageType.INDEX, document)
         except Exception:
             log.exception('Unable to index %s "%s"', model.__name__, str(obj.id))
     else:
         log.info('Unindexing %s (%s)', model.__name__, obj.id)
         try:
-            produce(model, str(obj.id), delete=True)
+            produce(model, str(obj.id), KafkaMessageType.UNINDEX, document)
         except Exception:
             log.exception('Unable to desindex %s "%s"', model.__name__, str(obj.id))
 
 
 @task(route='high.search')
-def unindex(classname, id=None):
+def unindex(classname, id):
     model = db.resolve_model(classname)
     log.info('Unindexing %s (%s)', model.__name__, id)
     try:
-        produce(model, id, delete=True)
+        produce(model, id, message=KafkaMessageType.UNINDEX)
     except Exception:
         log.exception('Unable to unindex %s "%s"', model.__name__, id)
 

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from udata.commands import cli
-from udata.search import adapter_catalog, produce
+from udata.search import adapter_catalog, produce, KafkaMessageType
 
 
 log = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ def index_model(adapter):
 
     for doc in docs:
         try:
-            produce(model, doc['id'], doc)
+            produce(model, doc['id'], KafkaMessageType.REINDEX, doc)
         except Exception as e:
             log.error('Unable to index %s "%s": %s', model, str(doc['id']),
                       str(e), exc_info=True)

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -32,7 +32,7 @@ def iter_adapters():
 
 
 def iter_qs(qs, adapter):
-    '''Safely iterate over a DB QuerySet yielding ES documents'''
+    '''Safely iterate over a DB QuerySet yielding a tuple (indexability, serialized documents)'''
     for obj in qs.no_cache().timeout(False):
         indexable = adapter.is_indexable(obj)
         try:
@@ -41,11 +41,11 @@ def iter_qs(qs, adapter):
         except Exception as e:
             model = adapter.model.__name__
             log.error('Unable to index %s "%s": %s', model, str(obj.id),
-                        str(e), exc_info=True)
+                      str(e), exc_info=True)
 
 
 def index_model(adapter, index_suffix_name=None, reindex=False, from_datetime=None):
-    ''' Indel all objects given a model'''
+    '''Index or unindex all objects given a model'''
     model = adapter.model
     log.info('Indexing %s objects', model.__name__)
     qs = model.objects
@@ -99,7 +99,7 @@ def index(models=None, reindex=True, from_datetime=None):
     Models to reindex can optionally be specified as arguments.
     If not, all models are reindexed.
 
-    If reindex is true, indexation will be made on a new index.
+    If reindex is true, indexation will be made on a new index and unindexable documents ignored.
 
     If from_datetime is specified, only models modified since this datetime will be indexed.
     '''

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import sys
 
@@ -16,6 +17,14 @@ def grp():
     pass
 
 
+TIMESTAMP_FORMAT = '%Y-%m-%d-%H-%M'
+
+
+def default_index_suffix_name(now):
+    '''Build a time based index suffix name'''
+    return '-' + now.strftime(TIMESTAMP_FORMAT)
+
+
 def iter_adapters():
     '''Iter over adapter in predictable way'''
     adapters = adapter_catalog.values()
@@ -25,43 +34,81 @@ def iter_adapters():
 def iter_qs(qs, adapter):
     '''Safely iterate over a DB QuerySet yielding ES documents'''
     for obj in qs.no_cache().timeout(False):
-        if adapter.is_indexable(obj):
-            try:
-                doc = adapter.serialize(obj)
-                yield doc
-            except Exception as e:
-                model = adapter.model.__name__
-                log.error('Unable to index %s "%s": %s', model, str(obj.id),
-                          str(e), exc_info=True)
+        indexable = adapter.is_indexable(obj)
+        try:
+            doc = adapter.serialize(obj)
+            yield indexable, doc
+        except Exception as e:
+            model = adapter.model.__name__
+            log.error('Unable to index %s "%s": %s', model, str(obj.id),
+                        str(e), exc_info=True)
 
 
-def index_model(adapter):
+def index_model(adapter, index_suffix_name=None, reindex=False, from_datetime=None):
     ''' Indel all objects given a model'''
     model = adapter.model
     log.info('Indexing %s objects', model.__name__)
     qs = model.objects
-    if hasattr(model.objects, 'visible'):
-        qs = qs.visible()
+    if from_datetime:
+        qs = qs.filter(last_modified__gte=from_datetime)
+    index_name = adapter.model.__name__.lower()
+    if index_suffix_name:
+        index_name += index_suffix_name
 
     docs = iter_qs(qs, adapter)
-
-    for doc in docs:
+    for indexable, doc in docs:
         try:
-            produce(model, doc['id'], KafkaMessageType.REINDEX, doc)
+            if indexable:
+                message_type = KafkaMessageType.REINDEX if reindex else KafkaMessageType.INDEX
+                produce(model, doc['id'], message_type, doc, index=index_name)
+            if not indexable and not reindex:
+                produce(model, doc['id'], KafkaMessageType.UNINDEX, doc, index=index_name)
         except Exception as e:
             log.error('Unable to index %s "%s": %s', model, str(doc['id']),
                       str(e), exc_info=True)
 
 
+def finalize_reindex(models, index_suffix_name, start):
+    log.warning(
+        f'In order to use the newly created index, you should set the alias '
+        f'on the search service. Ex on `udata-search-service`, run:\n'
+        f'`flask set-alias {index_suffix_name.lstrip("-")}`'
+    )
+
+    modified_since_reindex = 0
+    for adapter in iter_adapters():
+        if not models or adapter.model.__name__.lower() in models:
+            modified_since_reindex += adapter.model.objects(last_modified__gte=start).count()
+
+    log.warning(
+        f'{modified_since_reindex} documents have been modified since reindexation start. '
+        f'After having set the appropriate alias, you can index last changes since the '
+        f'beginning of the indexation. Example, you can run:\n'
+        f'`time udata search index -r false -f {index_suffix_name.lstrip("-")}`'
+    )
+
+
 @grp.command()
 @click.argument('models', nargs=-1, metavar='[<model> ...]')
-def index(models=None):
+@click.option('-r', '--reindex', default=True, type=bool)
+@click.option('-f', '--from_datetime', type=str)
+def index(models=None, reindex=True, from_datetime=None):
     '''
     Initialize or rebuild the search index
 
     Models to reindex can optionally be specified as arguments.
     If not, all models are reindexed.
+
+    If reindex is true, indexation will be made on a new index.
+
+    If from_datetime is specified, only models modified since this datetime will be indexed.
     '''
+
+    start = datetime.now()
+    index_suffix_name = default_index_suffix_name(start)
+    if from_datetime:
+        from_datetime = datetime.strptime(from_datetime, TIMESTAMP_FORMAT)
+
     doc_types_names = [m.__name__.lower() for m in adapter_catalog.keys()]
     models = [model.lower().rstrip('s') for model in (models or [])]
     for model in models:
@@ -71,4 +118,7 @@ def index(models=None):
 
     for adapter in iter_adapters():
         if not models or adapter.model.__name__.lower() in models:
-            index_model(adapter)
+            index_model(adapter, index_suffix_name, reindex, from_datetime)
+
+    if reindex:
+        finalize_reindex(models, index_suffix_name, start)

--- a/udata/tests/search/test_adapter.py
+++ b/udata/tests/search/test_adapter.py
@@ -148,7 +148,7 @@ class IndexingLifecycleTest(APITestCase):
 
         producer = KafkaProducerSingleton.get_instance()
 
-        index_model(DatasetSearch, index_suffix_name=None, reindex=False, from_datetime=None)
+        index_model(DatasetSearch, start=None, reindex=False, from_datetime=None)
 
         expected_value = {
             'service': 'udata',
@@ -168,14 +168,14 @@ class IndexingLifecycleTest(APITestCase):
 
         producer = KafkaProducerSingleton.get_instance()
 
-        index_model(DatasetSearch, index_suffix_name='-2022-02-20', reindex=True, from_datetime=None)
+        index_model(DatasetSearch, start=datetime.datetime(2022, 2, 20, 20, 2), reindex=True)
 
         expected_value = {
             'service': 'udata',
             'data': DatasetSearch.serialize(fake_data),
             'meta': {
                 'message_type': 'reindex',
-                'index': 'dataset-2022-02-20'
+                'index': 'dataset-2022-02-20-20-02'
             }
         }
         producer.send.assert_called_with('dataset', value=expected_value,
@@ -189,10 +189,10 @@ class IndexingLifecycleTest(APITestCase):
 
         producer = KafkaProducerSingleton.get_instance()
 
-        index_model(DatasetSearch, from_datetime=datetime.datetime(2023, 1, 1))
+        index_model(DatasetSearch, start=None, from_datetime=datetime.datetime(2023, 1, 1))
         producer.send.assert_not_called()
 
-        index_model(DatasetSearch, from_datetime=datetime.datetime(2021, 1, 1))
+        index_model(DatasetSearch, start=None, from_datetime=datetime.datetime(2021, 1, 1))
 
         expected_value = {
             'service': 'udata',

--- a/udata/tests/search/test_adapter.py
+++ b/udata/tests/search/test_adapter.py
@@ -112,7 +112,10 @@ class IndexingLifecycleTest(APITestCase):
         expected_value = {
             'service': 'udata',
             'data': DatasetSearch.serialize(fake_data),
-            'message_type': 'unindex'
+            'meta': {
+                'message_type': 'unindex',
+                'index': 'dataset'
+            }
         }
         producer.send.assert_called_with('dataset', value=expected_value, key=b'61fd30cb29ea95c7bc0e1211')
 
@@ -127,6 +130,9 @@ class IndexingLifecycleTest(APITestCase):
         expected_value = {
             'service': 'udata',
             'data': DatasetSearch.serialize(fake_data),
-            'message_type': 'index'
+            'meta': {
+                'message_type': 'index',
+                'index': 'dataset'
+            }
         }
         producer.send.assert_called_with('dataset', value=expected_value, key=b'61fd30cb29ea95c7bc0e1211')

--- a/udata/tests/search/test_adapter.py
+++ b/udata/tests/search/test_adapter.py
@@ -109,7 +109,12 @@ class IndexingLifecycleTest(APITestCase):
         reindex.run(*as_task_param(fake_data))
         producer = KafkaProducerSingleton.get_instance()
 
-        producer.send.assert_called_with('dataset', key=b'61fd30cb29ea95c7bc0e1211')
+        expected_value = {
+            'service': 'udata',
+            'data': DatasetSearch.serialize(fake_data),
+            'message_type': 'unindex'
+        }
+        producer.send.assert_called_with('dataset', value=expected_value, key=b'61fd30cb29ea95c7bc0e1211')
 
     def test_producer_should_send_a_message_with_payload_if_indexable(self):
         kafka_mock = Mock()
@@ -119,4 +124,9 @@ class IndexingLifecycleTest(APITestCase):
         reindex.run(*as_task_param(fake_data))
         producer = KafkaProducerSingleton.get_instance()
 
-        producer.send.assert_called_with('dataset', DatasetSearch.serialize(fake_data), key=b'61fd30cb29ea95c7bc0e1211')
+        expected_value = {
+            'service': 'udata',
+            'data': DatasetSearch.serialize(fake_data),
+            'message_type': 'index'
+        }
+        producer.send.assert_called_with('dataset', value=expected_value, key=b'61fd30cb29ea95c7bc0e1211')


### PR DESCRIPTION
We add a reindexation command logic that produces messages with appropriate meta info.

We add a message type property to the message in Kafka.
For now, the three types are only `index`, `reindex` and `unindex`.