### PR TITLE
Extend dcat properties support

### DIFF
--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -22,7 +22,7 @@ from udata.rdf import (
 from udata.utils import get_by, safe_unicode
 from udata.uris import endpoint_for
 
-from .models import Dataset, Resource, Checksum, License
+from .models import Dataset, Resource, Checksum, License, UPDATE_FREQUENCIES
 
 log = logging.getLogger(__name__)
 
@@ -299,6 +299,9 @@ def frequency_from_rdf(term):
             term = URIRef(uris.validate(term))
         except uris.ValidationError:
             pass
+    if isinstance(term, Literal):
+        if term.toPython() in UPDATE_FREQUENCIES:
+            return term.toPython()
     if isinstance(term, RdfResource):
         term = term.identifier
     if isinstance(term, URIRef):

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -421,6 +421,14 @@ def dataset_from_rdf(graph, dataset=None, node=None):
     if isinstance(d.identifier, URIRef):
         dataset.extras['uri'] = d.identifier.toPython()
 
+    landing_page = url_from_rdf(d, DCAT.landingPage)
+    if landing_page:
+        try:
+            uris.validate(landing_page)
+            dataset.extras['remote_url'] = landing_page
+        except uris.ValidationError:
+            pass
+
     dataset.temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))
 
     licenses = set()

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -403,6 +403,8 @@ def dataset_from_rdf(graph, dataset=None, node=None):
     dataset.title = rdf_value(d, DCT.title)
     dataset.description = sanitize_html(d.value(DCT.description))
     dataset.frequency = frequency_from_rdf(d.value(DCT.accrualPeriodicity))
+    dataset.created_at = rdf_value(d, DCT.issued, dataset.created_at)
+    dataset.last_modified = rdf_value(d, DCT.modified, dataset.last_modified)
 
     acronym = rdf_value(d, SKOS.altLabel)
     if acronym:

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -24,6 +24,7 @@
         <dcat:keyword>Tag 1</dcat:keyword>
         <dcat:distribution rdf:resource="http://data.test.org/datasets/3/resources/1"/>
         <dct:license>Licence Ouverte Version 2.0</dct:license>
+        <dcat:landingPage>http://data.test.org/datasets/3</dcat:landingPage>
       </dcat:Dataset>
     </dcat:dataset>
     <dcterms:title>Sample DCAT Catalog</dcterms:title>

--- a/udata/harvest/tests/dcat/geonetwork.xml
+++ b/udata/harvest/tests/dcat/geonetwork.xml
@@ -44,7 +44,7 @@
       <dct:updated xmlns:dct="http://purl.org/dc/terms/">2021-05-05</dct:updated>
       <dct:publisher xmlns:dct="http://purl.org/dc/terms/"
                      rdf:resource="https://sig.oreme.org/geonetwork/srv/resources/organizations/UMR%20HydroSciences%20Montpellier%20%28HSM%29"/>
-      <dct:accrualPeriodicity xmlns:dct="http://purl.org/dc/terms/">continual</dct:accrualPeriodicity>
+      <dct:accrualPeriodicity xmlns:dct="http://purl.org/dc/terms/">daily</dct:accrualPeriodicity>
       <dct:language xmlns:dct="http://purl.org/dc/terms/">eng</dct:language>
       <dct:license xmlns:dct="http://purl.org/dc/terms/">copyright</dct:license>
       <dct:license xmlns:dct="http://purl.org/dc/terms/">license</dct:license>

--- a/udata/harvest/tests/dcat/geonetwork.xml
+++ b/udata/harvest/tests/dcat/geonetwork.xml
@@ -41,7 +41,7 @@
           /
           2005-03-30T00:00:00+02:00</dct:temporal>
       <dct:issued xmlns:dct="http://purl.org/dc/terms/">2004-11-03</dct:issued>
-      <dct:updated xmlns:dct="http://purl.org/dc/terms/">2021-05-05</dct:updated>
+      <dct:modified xmlns:dct="http://purl.org/dc/terms/">2021-05-05</dct:modified>
       <dct:publisher xmlns:dct="http://purl.org/dc/terms/"
                      rdf:resource="https://sig.oreme.org/geonetwork/srv/resources/organizations/UMR%20HydroSciences%20Montpellier%20%28HSM%29"/>
       <dct:accrualPeriodicity xmlns:dct="http://purl.org/dc/terms/">daily</dct:accrualPeriodicity>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -122,6 +122,7 @@ class DcatBackendTest:
         assert dataset.temporal_coverage is not None
         assert dataset.temporal_coverage.start == date(2016, 1, 1)
         assert dataset.temporal_coverage.end == date(2016, 12, 5)
+        assert dataset.extras['remote_url'] == 'http://data.test.org/datasets/1'
 
         assert len(dataset.resources) == 1
 
@@ -229,6 +230,7 @@ class DcatBackendTest:
         extras = {'extras__dct:identifier': '3'}
         dataset = Dataset.objects.get(**extras)
         assert dataset.license.id == 'lov2'
+        assert dataset.extras['remote_url'] == 'http://data.test.org/datasets/3'
         assert dataset.created_at.date() == date(2016, 12, 14)
         assert dataset.last_modified.date() == date(2016, 12, 14)
 

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -5,7 +5,7 @@ import pytest
 
 from datetime import date
 
-from udata.models import Dataset, License
+from udata.models import Dataset
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.dataset.factories import LicenseFactory
 
@@ -239,6 +239,7 @@ class DcatBackendTest:
         actions.run(source.slug)
         dataset = Dataset.objects.filter(organization=org).first()
         assert dataset is not None
+        assert dataset.frequency == 'daily'
 
     def test_unsupported_mime_type(self, rmock):
         url = DCAT_URL_PATTERN.format(path='', domain=TEST_DOMAIN)

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -229,6 +229,8 @@ class DcatBackendTest:
         extras = {'extras__dct:identifier': '3'}
         dataset = Dataset.objects.get(**extras)
         assert dataset.license.id == 'lov2'
+        assert dataset.created_at.date() == date(2016, 12, 14)
+        assert dataset.last_modified.date() == date(2016, 12, 14)
 
     def test_geonetwork_xml_catalog(self, rmock):
         url = mock_dcat(rmock, 'geonetwork.xml', path='catalog.xml')
@@ -239,6 +241,8 @@ class DcatBackendTest:
         actions.run(source.slug)
         dataset = Dataset.objects.filter(organization=org).first()
         assert dataset is not None
+        assert dataset.created_at.date() == date(2004, 11, 3)
+        assert dataset.last_modified.date() == date(2021, 5, 5)
         assert dataset.frequency == 'daily'
 
     def test_unsupported_mime_type(self, rmock):


### PR DESCRIPTION
Add support for frequency label, creation and modification date and use landing page property as remote url.

Fix https://github.com/etalab/data.gouv.fr/issues/767
Fix https://github.com/etalab/data.gouv.fr/issues/766
Fix https://github.com/etalab/data.gouv.fr/issues/770