### PR TITLE
refac: remove autocomplete configuration

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -190,18 +190,6 @@ The id of a dataset that should be created before running the `export-csv` job a
 
 ## Search configuration
 
-### SEARCH_AUTOCOMPLETE_ENABLED
-
-**default**: `True`
-
-Enables the search autocomplete on frontend if set to `True`, disables otherwise.
-
-### SEARCH_AUTOCOMPLETE_DEBOUNCE
-
-**default**: `200`
-
-The search autocomplete debounce delay on frontend, in milliseconds.
-
 ### SEARCH_DATASET_FIELDS
 
 **default**:

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -430,11 +430,6 @@ class Defaults(object):
         'about'
     )
 
-    # Autocomplete parameters
-    #########################
-    SEARCH_AUTOCOMPLETE_ENABLED = True
-    SEARCH_AUTOCOMPLETE_DEBOUNCE = 200  # in ms
-
     # Archive parameters
     ####################
     ARCHIVE_COMMENT_USER_ID = None
@@ -460,7 +455,7 @@ class Defaults(object):
                         'DiscussionsAPI.post',
                         'SourcesAPI.post',
                         'FollowAPI.post']
-    
+
     FIXTURE_DATASET_SLUGS = []
 
 

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -47,8 +47,6 @@
 <meta name="unchecked-types" content="{{ config.LINKCHECKING_UNCHECKED_TYPES|tojson|urlencode }}" />
 <meta name="territory-enabled" content="{{ 'true' if config.ACTIVATE_TERRITORIES else 'false' }}">
 <meta name="delete-me-enabled" content="{{ 'true' if config.DELETE_ME else 'false' }}">
-<meta name="search-autocomplete-enabled" content="{{ 'true' if config.SEARCH_AUTOCOMPLETE_ENABLED else 'false' }}">
-<meta name="search-autocomplete-debounce" content="{{ config.SEARCH_AUTOCOMPLETE_DEBOUNCE }}">
 <meta name="dataset-max-resources-uncollapsed" content="{{ config.DATASET_MAX_RESOURCES_UNCOLLAPSED }}">
 <meta name="markdown-config" content="{{ {
     'tags': config.MD_ALLOWED_TAGS,


### PR DESCRIPTION
SEARCH_AUTOCOMPLETE_ENABLED and SEARCH_AUTOCOMPLETE_DEBOUNCE configuration moved to udata-front.

See https://github.com/etalab/udata-front/pull/78

BREAKING CHANGE: SEARCH_AUTOCOMPLETE_ENABLED and SEARCH_AUTOCOMPLETE_DEBOUNCE config are moved from udata to module udata-front