### PR TITLE
Fix api v1 breaking change

### DIFF
--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -87,8 +87,8 @@ class DatasetApiParser(ModelApiParser):
         self.parser.add_argument('schema', type=str, location='args')
         self.parser.add_argument('schema_version', type=str, location='args')
 
-    @classmethod
-    def parse_filters(cls, datasets, args):
+    @staticmethod
+    def parse_filters(datasets, args):
         if args.get('q'):
             datasets = datasets.search_text(args['q'])
         if args.get('tag'):

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -82,6 +82,11 @@ class DatasetApiParser(ModelApiParser):
     def __init__(self):
         super().__init__()
         self.parser.add_argument('reuse', type=str, location='args')
+        self.parser.add_argument('tag', type=str, location='args')
+        self.parser.add_argument('organization', type=str, location='args')
+        self.parser.add_argument('owner', type=str, location='args')
+        self.parser.add_argument('schema', type=str, location='args')
+        self.parser.add_argument('schema_version', type=str, location='args')
 
 
 log = logging.getLogger(__name__)
@@ -130,7 +135,18 @@ class DatasetListAPI(API):
         if args['q']:
             datasets = datasets.search_text(args['q'])
         if args['reuse']:
-            datasets = datasets.objects(id__in=[dat.id for dat in Reuse.get(args['reuse']).datasets])
+            datasets = datasets.filter(id__in=[dat.id for dat in Reuse.get(args['reuse']).datasets])
+        if args['tag']:
+            datasets = datasets.filter(tags=args['tag'])
+        if args['organization']:
+            datasets = datasets.filter(organization=args['organization'])
+        if args['owner']:
+            datasets = datasets.filter(owner=args['owner'])
+        if args['schema']:
+            datasets = datasets.filter(resources__schema__name=args['schema'])
+        if args['schema_version']:
+            datasets = datasets.filter(resources__schema__version=args['schema_version'])
+
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return datasets.order_by(sort).paginate(args['page'], args['page_size'])
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -147,7 +147,7 @@ class DatasetListAPI(API):
         '''List or search all datasets'''
         args = dataset_parser.parse()
         datasets = Dataset.objects(archived=None, deleted=None, private=False)
-        datasets = self.parse_filters(datasets, args)
+        datasets = dataset_parser.parse_filters(datasets, args)
 
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return datasets.order_by(sort).paginate(args['page'], args['page_size'])

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -79,6 +79,11 @@ class DatasetApiParser(ModelApiParser):
         'views': 'metrics.views',
     }
 
+    def __init__(self):
+        super().__init__()
+        self.parser.add_argument('reuse', type=str, location='args')
+
+
 log = logging.getLogger(__name__)
 
 ns = api.namespace('datasets', 'Dataset related operations')
@@ -124,6 +129,8 @@ class DatasetListAPI(API):
         datasets = Dataset.objects(archived=None, deleted=None, private=False)
         if args['q']:
             datasets = datasets.search_text(args['q'])
+        if args['reuse']:
+            datasets = datasets.objects(id__in=[dat.id for dat in Reuse.get(args['reuse']).datasets])
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return datasets.order_by(sort).paginate(args['page'], args['page_size'])
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -87,6 +87,22 @@ class DatasetApiParser(ModelApiParser):
         self.parser.add_argument('schema', type=str, location='args')
         self.parser.add_argument('schema_version', type=str, location='args')
 
+    @classmethod
+    def parse_filters(cls, datasets, args):
+        if args.get('q'):
+            datasets = datasets.search_text(args['q'])
+        if args.get('tag'):
+            datasets = datasets.filter(tags=args['tag'])
+        if args.get('organization'):
+            datasets = datasets.filter(organization=args['organization'])
+        if args.get('owner'):
+            datasets = datasets.filter(owner=args['owner'])
+        if args.get('schema'):
+            datasets = datasets.filter(resources__schema__name=args['schema'])
+        if args.get('schema_version'):
+            datasets = datasets.filter(resources__schema__version=args['schema_version'])
+        return datasets
+
 
 log = logging.getLogger(__name__)
 
@@ -131,18 +147,7 @@ class DatasetListAPI(API):
         '''List or search all datasets'''
         args = dataset_parser.parse()
         datasets = Dataset.objects(archived=None, deleted=None, private=False)
-        if args['q']:
-            datasets = datasets.search_text(args['q'])
-        if args['tag']:
-            datasets = datasets.filter(tags=args['tag'])
-        if args['organization']:
-            datasets = datasets.filter(organization=args['organization'])
-        if args['owner']:
-            datasets = datasets.filter(owner=args['owner'])
-        if args['schema']:
-            datasets = datasets.filter(resources__schema__name=args['schema'])
-        if args['schema_version']:
-            datasets = datasets.filter(resources__schema__version=args['schema_version'])
+        datasets = self.parse_filters(datasets, args)
 
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return datasets.order_by(sort).paginate(args['page'], args['page_size'])

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -81,7 +81,6 @@ class DatasetApiParser(ModelApiParser):
 
     def __init__(self):
         super().__init__()
-        self.parser.add_argument('reuse', type=str, location='args')
         self.parser.add_argument('tag', type=str, location='args')
         self.parser.add_argument('organization', type=str, location='args')
         self.parser.add_argument('owner', type=str, location='args')
@@ -134,8 +133,6 @@ class DatasetListAPI(API):
         datasets = Dataset.objects(archived=None, deleted=None, private=False)
         if args['q']:
             datasets = datasets.search_text(args['q'])
-        if args['reuse']:
-            datasets = datasets.filter(id__in=[dat.id for dat in Reuse.get(args['reuse']).datasets])
         if args['tag']:
             datasets = datasets.filter(tags=args['tag'])
         if args['organization']:
@@ -450,7 +447,7 @@ class ResourceAPI(ResourceMixin, API):
         ResourceEditPermission(dataset).test()
         resource = self.get_resource_or_404(dataset, rid)
         form = api.validate(ResourceForm, resource)
-         # ensure API client does not override url on self-hosted resources
+        # ensure API client does not override url on self-hosted resources
         if resource.filetype == 'file':
             form._fields.get('url').data = resource.url
         form.populate_obj(resource)
@@ -661,6 +658,7 @@ class ResourceTypesAPI(API):
         '''List all resource types'''
         return [{'id': id, 'label': label}
                 for id, label in RESOURCE_TYPES.items()]
+
 
 @ns.route('/schemas/', endpoint='schemas')
 class SchemasAPI(API):

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -83,7 +83,7 @@ class OrganizationListAPI(API):
         '''List or search all organizations'''
         args = organization_parser.parse()
         organizations = Organization.objects(deleted=None)
-        organizations = self.parse_filters(organizations, args)
+        organizations = organization_parser.parse_filters(organizations, args)
 
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return organizations.order_by(sort).paginate(args['page'], args['page_size'])

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -57,6 +57,12 @@ class OrgApiParser(ModelApiParser):
         'last_modified': 'last_modified',
     }
 
+    @classmethod
+    def parse_filters(cls, organizations, args):
+        if args.get('q'):
+            organizations = organizations.search_text(args['q'])
+        return organizations
+
 
 ns = api.namespace('organizations', 'Organization related operations')
 
@@ -77,11 +83,10 @@ class OrganizationListAPI(API):
         '''List or search all organizations'''
         args = organization_parser.parse()
         organizations = Organization.objects(deleted=None)
-        if args['q']:
-            organizations = organizations.search_text(args['q'])
+        organizations = self.parse_filters(organizations, args)
+
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return organizations.order_by(sort).paginate(args['page'], args['page_size'])
-
 
     @api.secure
     @api.doc('create_organization', responses={400: 'Validation error'})

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -57,8 +57,8 @@ class OrgApiParser(ModelApiParser):
         'last_modified': 'last_modified',
     }
 
-    @classmethod
-    def parse_filters(cls, organizations, args):
+    @staticmethod
+    def parse_filters(organizations, args):
         if args.get('q'):
             organizations = organizations.search_text(args['q'])
         return organizations

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -41,6 +41,9 @@ class ReuseApiParser(ModelApiParser):
     def __init__(self):
         super().__init__()
         self.parser.add_argument('dataset', type=str, location='args')
+        self.parser.add_argument('tag', type=str, location='args')
+        self.parser.add_argument('organization', type=str, location='args')
+        self.parser.add_argument('owner', type=str, location='args')
 
 
 ns = api.namespace('reuses', 'Reuse related operations')
@@ -64,9 +67,16 @@ class ReuseListAPI(API):
             reuses = reuses.search_text(args['q'])
         if args['dataset']:
             reuses = reuses.filter(datasets=args['dataset'])
+
+        if args['tag']:
+            reuses = reuses.filter(tags=args['tag'])
+        if args['organization']:
+            reuses = reuses.filter(organization=args['organization'])
+        if args['owner']:
+            reuses = reuses.filter(owner=args['owner'])
+
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return reuses.order_by(sort).paginate(args['page'], args['page_size'])
-
 
     @api.secure
     @api.doc('create_reuse')

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -38,6 +38,10 @@ class ReuseApiParser(ModelApiParser):
         'views': 'metrics.views',
     }
 
+    def __init__(self):
+        super().__init__()
+        self.parser.add_argument('dataset', type=str, location='args')
+
 
 ns = api.namespace('reuses', 'Reuse related operations')
 
@@ -58,6 +62,8 @@ class ReuseListAPI(API):
         reuses = Reuse.objects(deleted=None, private__ne=True)
         if args['q']:
             reuses = reuses.search_text(args['q'])
+        if args['dataset']:
+            reuses = reuses.filter(datasets=args['dataset'])
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return reuses.order_by(sort).paginate(args['page'], args['page_size'])
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -78,7 +78,7 @@ class ReuseListAPI(API):
     def get(self):
         args = reuse_parser.parse()
         reuses = Reuse.objects(deleted=None, private__ne=True)
-        reuses = self.parse_filters(reuses, args)
+        reuses = reuse_parser.parse_filters(reuses, args)
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return reuses.order_by(sort).paginate(args['page'], args['page_size'])
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -45,6 +45,21 @@ class ReuseApiParser(ModelApiParser):
         self.parser.add_argument('organization', type=str, location='args')
         self.parser.add_argument('owner', type=str, location='args')
 
+    @classmethod
+    def parse_filters(cls, reuses, args):
+        if args.get('q'):
+            reuses = reuses.search_text(args['q'])
+        if args.get('dataset'):
+            reuses = reuses.filter(datasets=args['dataset'])
+
+        if args.get('tag'):
+            reuses = reuses.filter(tags=args['tag'])
+        if args.get('organization'):
+            reuses = reuses.filter(organization=args['organization'])
+        if args.get('owner'):
+            reuses = reuses.filter(owner=args['owner'])
+        return reuses
+
 
 ns = api.namespace('reuses', 'Reuse related operations')
 
@@ -63,18 +78,7 @@ class ReuseListAPI(API):
     def get(self):
         args = reuse_parser.parse()
         reuses = Reuse.objects(deleted=None, private__ne=True)
-        if args['q']:
-            reuses = reuses.search_text(args['q'])
-        if args['dataset']:
-            reuses = reuses.filter(datasets=args['dataset'])
-
-        if args['tag']:
-            reuses = reuses.filter(tags=args['tag'])
-        if args['organization']:
-            reuses = reuses.filter(organization=args['organization'])
-        if args['owner']:
-            reuses = reuses.filter(owner=args['owner'])
-
+        reuses = self.parse_filters(reuses, args)
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return reuses.order_by(sort).paginate(args['page'], args['page_size'])
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -45,8 +45,8 @@ class ReuseApiParser(ModelApiParser):
         self.parser.add_argument('organization', type=str, location='args')
         self.parser.add_argument('owner', type=str, location='args')
 
-    @classmethod
-    def parse_filters(cls, reuses, args):
+    @staticmethod
+    def parse_filters(reuses, args):
         if args.get('q'):
             reuses = reuses.search_text(args['q'])
         if args.get('dataset'):

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -90,6 +90,53 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(len(response.json['data']), 3)
         self.assertEqual(response.json['data'][0]['id'], str(to_follow.id))
 
+    def test_dataset_api_list_with_filters(self):
+        '''Should filters datasets results based on query filters'''
+        owner = UserFactory()
+        org = OrganizationFactory()
+
+        [VisibleDatasetFactory() for i in range(2)]
+
+        tag_dataset = VisibleDatasetFactory(tags=['my-tag', 'other'])
+        owner_dataset = VisibleDatasetFactory(owner=owner)
+        org_dataset = VisibleDatasetFactory(organization=org)
+        schema_dataset = VisibleDatasetFactory(resources=[
+            ResourceFactory(schema={'name': 'my-schema', 'version': '1.0.0'})
+        ])
+        schema_version2_dataset = VisibleDatasetFactory(resources=[
+            ResourceFactory(schema={'name': 'other-schema', 'version': '2.0.0'})
+        ])
+
+        # filter on tag
+        response = self.get(url_for('api.datasets', tag='my-tag'))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(tag_dataset.id))
+
+        # filter on owner
+        response = self.get(url_for('api.datasets', owner=owner.id))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(owner_dataset.id))
+
+        # filter on organization
+        response = self.get(url_for('api.datasets', organization=org.id))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(org_dataset.id))
+
+        # filter on schema
+        response = self.get(url_for('api.datasets', schema='my-schema'))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(schema_dataset.id))
+
+        # filter on schema version
+        response = self.get(url_for('api.datasets', schema_version='2.0.0'))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(schema_version2_dataset.id))
+
     def test_dataset_api_get(self):
         '''It should fetch a dataset from the API'''
         resources = [ResourceFactory() for _ in range(2)]

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -9,6 +9,7 @@ from udata.core.dataset.factories import DatasetFactory
 from udata.core.user.factories import AdminFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.organization.factories import OrganizationFactory
+from udata.core.user.factories import UserFactory
 from udata.models import Reuse, Follow, Member, REUSE_TOPICS, REUSE_TYPES
 from udata.utils import faker
 
@@ -32,6 +33,35 @@ class ReuseAPITest:
         response = api.get(url_for('api.reuses'))
         assert200(response)
         assert len(response.json['data']) == len(reuses)
+
+    def test_reuse_api_list_with_filters(self, api):
+        '''Should filters reuses results based on query filters'''
+        owner = UserFactory()
+        org = OrganizationFactory()
+
+        [ReuseFactory() for i in range(2)]
+
+        tag_reuse = ReuseFactory(tags=['my-tag', 'other'])
+        owner_reuse = ReuseFactory(owner=owner)
+        org_reuse = ReuseFactory(organization=org)
+
+        # filter on tag
+        response = api.get(url_for('api.reuses', tag='my-tag'))
+        assert200(response)
+        assert len(response.json['data']) == 1
+        assert response.json['data'][0]['id'] == str(tag_reuse.id)
+
+        # filter on owner
+        response = api.get(url_for('api.reuses', owner=owner.id))
+        assert200(response)
+        assert len(response.json['data']) == 1
+        assert response.json['data'][0]['id'] == str(owner_reuse.id)
+
+        # filter on organization
+        response = api.get(url_for('api.reuses', organization=org.id))
+        assert200(response)
+        assert len(response.json['data']) == 1
+        assert response.json['data'][0]['id'] == str(org_reuse.id)
 
     def test_reuse_api_get(self, api):
         '''It should fetch a reuse from the API'''


### PR DESCRIPTION
When moving to api v2 for search architecture, existing list routes (`/api/1/datasets`) now use mongo list instead of a complex search query (available at `/api/2/datasets/search`). Existing filters of `/api/1/datasets` (`reuses` and `organizations` as well) have been dropped and only `sort` has been kept. See the [actual reference](https://doc.data.gouv.fr/api/reference/#/datasets/list_datasets).

This breaking change now impacts the reuse list on a dataset page in admin. Indeed, the `dataset` filter on the `api/1/reuses/?dataset=dataset_id` is not available. Ex: https://dev-02.data.gouv.fr/fr/admin/dataset/6124f0769c35f96b7d71feae/.

We need to discuss our strategy regarding this breaking change. The solutions could be:

1. let the breaking change and implement missing filter for admin only -> breaking change, small work
2. move `api/2/dataset/search` to `api/1/dataset` and remove mongo list -> small breaking change (not 100% iso), small work
3. re-implement **useful** filters on `/api/1/dataset` with the mongo list -> small breaking change, small work
4. re-implement **all** existing filters on `/api/1/dataset` with the mongo list -> no breaking change, considerable work
5. ... ?

We need to take into consideration:
- the impact of a breaking change -> what are the actual api usage ?
- code duplication
- workload
- logical responsibility of the code (difference between mongo list and elastic search)

This PR proposes a fix for this issue with solution 1.