### PR TITLE
Add harvest csv adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Refactor and update changelog with latest udata updates [#2717](https://github.com/opendatateam/udata/pull/2717)
+- Refactor and update docs with latest udata updates [#2717](https://github.com/opendatateam/udata/pull/2717)
+- Add harvest csv adapter for a catalog of harvesters [#2722](https://github.com/opendatateam/udata/pull/2722)
 
 ## 4.0.0 (2022-03-30)
 

--- a/udata/harvest/csv.py
+++ b/udata/harvest/csv.py
@@ -1,0 +1,17 @@
+from udata.frontend import csv
+
+from .models import HarvestSource
+
+
+@csv.adapter(HarvestSource)
+class HarvestSourceCsvAdapter(csv.Adapter):
+    fields = (
+        'id',
+        'name',
+        'url',
+        ('organization', 'organization.name'),
+        ('organization_id', 'organization.id'),
+        'backend',
+        'created_at',
+        ('validation', lambda o: o.validation.state),
+    )

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -102,6 +102,9 @@ from udata.core.tags.models import *  # noqa
 from udata.features.transfer.models import *  # noqa
 from udata.features.territories.models import *  # noqa
 
+# Load HarvestSource model as harvest for catalog
+from udata.harvest.models import HarvestSource as Harvest  # noqa
+
 import udata.linkchecker.models  # noqa
 
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -389,7 +389,7 @@ class Defaults(object):
     # Export CSVs of model objects as resources of a dataset
     ########################################################
     EXPORT_CSV_MODELS = ('dataset', 'resource', 'discussion', 'organization',
-                         'reuse', 'tag')
+                         'reuse', 'tag', 'harvest')
     EXPORT_CSV_DATASET_ID = None
 
     # Autocomplete parameters

--- a/udata/tests/dataset/test_dataset_tasks.py
+++ b/udata/tests/dataset/test_dataset_tasks.py
@@ -10,6 +10,7 @@ from udata.core.dataset.csv import DatasetCsvAdapter, ResourcesCsvAdapter  # noq
 from udata.core.organization.csv import OrganizationCsvAdapter  # noqa
 from udata.core.reuse.csv import ReuseCsvAdapter  # noqa
 from udata.core.tags.csv import TagCsvAdapter  # noqa
+from udata.harvest.csv import HarvestSourceCsvAdapter  # noqa
 
 
 pytestmark = pytest.mark.usefixtures('clean_db')


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/199

Use `harvest` as model name instead of `HarvestSource`.
Indeed, csv adapter logic doesn't work well with multi words in upper camel case.

Catalog view are added in udata-front: https://github.com/etalab/udata-front/pull/100.