### PR TITLE
Reintroduce user suggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Refactor and update docs with latest udata updates [#2717](https://github.com/opendatateam/udata/pull/2717)
 - Add harvest csv adapter for a catalog of harvesters [#2722](https://github.com/opendatateam/udata/pull/2722)
+- Reintroduce user suggest with mongo contains [#2725](https://github.com/opendatateam/udata/pull/2725)
 
 ## 4.0.0 (2022-03-30)
 

--- a/udata/core/user/api_fields.py
+++ b/udata/core/user/api_fields.py
@@ -91,6 +91,16 @@ apikey_fields = api.model('ApiKey', {
 
 user_page_fields = api.model('UserPage', fields.pager(user_fields))
 
+user_suggestion_fields = api.model('UserSuggestion', {
+    'id': fields.String(description='The user identifier', readonly=True),
+    'first_name': fields.String(description='The user first name',
+                                readonly=True),
+    'last_name': fields.String(description='The user last name',
+                               readonly=True),
+    'avatar_url': fields.String(description='The user avatar URL'),
+    'slug': fields.String(
+        description='The user permalink string', readonly=True),
+})
 
 notifications_fields = api.model('Notification', {
     'type': fields.String(description='The notification type', readonly=True),


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/803.

The user suggest is still used in admin and was reintroduced.

We use the mongo `contains`, similarly to other suggests, but based on the slug to search for first and last name.