### PR TITLE
Remove unused `_total_pages` property

### DIFF
--- a/udata/search/result.py
+++ b/udata/search/result.py
@@ -16,7 +16,6 @@ class SearchResult(Paginable):
         self._objects = None
         self._page = kwargs.pop('page')
         self._page_size = kwargs.pop('page_size')
-        self._total_pages = kwargs.pop('total_pages')
         self._total = kwargs.pop('total')
 
     @property


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/804

This property isn't used in udata, and is not returned by list endpoints `/api/1/<object>/`.

When removed, we can used mongo list endpoints as search service, with the following setting:
```
SEARCH_SERVICE_API_URL = 'http://dev.local:7000/api/1/'
```

Do we want to set this value by default in udata settings.py?
It would allow for users migrating to udata 4 to have working search endpoints used in the front (`/fr/datasets`, etc.).
