### PR TITLE
Use -followers as default suggest sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Refactor and update docs with latest udata updates [#2717](https://github.com/opendatateam/udata/pull/2717)
 - Add harvest csv adapter for a catalog of harvesters [#2722](https://github.com/opendatateam/udata/pull/2722)
+- Use -followers as default suggest sort on datasets, reuses and orgas [#2727](https://github.com/opendatateam/udata/pull/2727)
 
 ## 4.0.0 (2022-03-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## Current (in progress)
 
 - Remove unused `_total_pages` search property [#2726](https://github.com/opendatateam/udata/pull/2726)
+- Use -followers as default suggest sort on datasets, reuses and orgas [#2727](https://github.com/opendatateam/udata/pull/2727)
 
 ## 4.0.1 (2022-04-11)
 
 - Removed `post_save` signal within `add_resource` and `update_resource` methods. [#2720](https://github.com/opendatateam/udata/pull/2720)
-- Refactor and update changelog with latest udata updates [#2717](https://github.com/opendatateam/udata/pull/2717)
+- Refactor and update documentation with latest udata updates [#2717](https://github.com/opendatateam/udata/pull/2717)
 - Add harvest csv adapter for a catalog of harvesters [#2722](https://github.com/opendatateam/udata/pull/2722)
-- Use -followers as default suggest sort on datasets, reuses and orgas [#2727](https://github.com/opendatateam/udata/pull/2727)
 
 ## 4.0.0 (2022-03-30)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -67,6 +67,7 @@ from .rdf import dataset_to_rdf
 
 
 DEFAULT_SORTING = '-created_at'
+SUGGEST_SORTING = '-metrics.followers'
 
 
 class DatasetApiParser(ModelApiParser):
@@ -589,7 +590,7 @@ class DatasetSuggestAPI(API):
                 'slug': dataset.slug,
                 'image_url': dataset.image_url,
             }
-            for dataset in datasets.order_by(DEFAULT_SORTING).limit(args['size'])
+            for dataset in datasets.order_by(SUGGEST_SORTING).limit(args['size'])
         ]
 
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -44,6 +44,7 @@ from udata.core.storages.api import (
 
 
 DEFAULT_SORTING = '-created_at'
+SUGGEST_SORTING = '-metrics.followers'
 
 
 class OrgApiParser(ModelApiParser):
@@ -391,7 +392,7 @@ class OrganizationSuggestAPI(API):
                 'slug': org.slug,
                 'image_url': org.image_url,
             }
-            for org in orgs.order_by(DEFAULT_SORTING).limit(args['size'])
+            for org in orgs.order_by(SUGGEST_SORTING).limit(args['size'])
         ]
 
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -26,6 +26,7 @@ from .permissions import ReuseEditPermission
 
 
 DEFAULT_SORTING = '-created_at'
+SUGGEST_SORTING = '-metrics.followers'
 
 
 class ReuseApiParser(ModelApiParser):
@@ -238,7 +239,7 @@ class ReusesSuggestAPI(API):
                 'slug': reuse.slug,
                 'image_url': reuse.image_url,
             }
-            for reuse in reuses.order_by(DEFAULT_SORTING).limit(args['size'])
+            for reuse in reuses.order_by(SUGGEST_SORTING).limit(args['size'])
         ]
 
 

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -1070,10 +1070,16 @@ class DatasetResourceAPITest(APITestCase):
 
     def test_suggest_datasets_api(self):
         '''It should suggest datasets'''
-        for i in range(4):
+        for i in range(3):
             DatasetFactory(
                 title='test-{0}'.format(i) if i % 2 else faker.word(),
-                visible=True)
+                visible=True,
+                metrics={"followers": i})
+        max_follower_dataset = DatasetFactory(
+            title='test-4',
+            visible=True,
+            metrics={"followers": 10}
+        )
 
         response = self.get(url_for('api.suggest_datasets'),
                             qs={'q': 'tes', 'size': '5'})
@@ -1087,6 +1093,7 @@ class DatasetResourceAPITest(APITestCase):
             self.assertIn('slug', suggestion)
             self.assertIn('image_url', suggestion)
             self.assertTrue(suggestion['title'].startswith('test'))
+        self.assertEqual(response.json[0]['id'], str(max_follower_dataset.id))
 
     def test_suggest_datasets_acronym_api(self):
         '''It should suggest datasets from their acronyms'''

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -486,10 +486,14 @@ class MembershipAPITest:
 
     def test_suggest_organizations_api(self, api):
         '''It should suggest organizations'''
-        for i in range(4):
+        for i in range(3):
             OrganizationFactory(
-                name='test-{0}'.format(i) if i % 2 else faker.word())
-
+                name='test-{0}'.format(i) if i % 2 else faker.word(),
+                metrics={"followers": i})
+        max_follower_organization = OrganizationFactory(
+            name='test-4',
+            metrics={"followers": 10}
+        )
         response = api.get(url_for('api.suggest_organizations'),
                            qs={'q': 'tes', 'size': '5'})
         assert200(response)
@@ -504,6 +508,7 @@ class MembershipAPITest:
             assert 'image_url' in suggestion
             assert 'acronym' in suggestion
             assert suggestion['name'].startswith('test')
+            assert response.json[0]['id'] == str(max_follower_organization.id)
 
     def test_suggest_organizations_with_special_chars(self, api):
         '''It should suggest organizations with special caracters'''

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -288,10 +288,16 @@ class ReuseAPITest:
 
     def test_suggest_reuses_api(self, api):
         '''It should suggest reuses'''
-        for i in range(4):
+        for i in range(3):
             ReuseFactory(
                 title='test-{0}'.format(i) if i % 2 else faker.word(),
-                visible=True)
+                visible=True,
+                metrics={"followers": i})
+        max_follower_reuse = ReuseFactory(
+            title='test-4',
+            visible=True,
+            metrics={"followers": 10}
+        )
 
         response = api.get(url_for('api.suggest_reuses'),
                            qs={'q': 'tes', 'size': '5'})
@@ -306,6 +312,7 @@ class ReuseAPITest:
             assert 'title' in suggestion
             assert 'image_url' in suggestion
             assert suggestion['title'].startswith('test')
+        self.assertEqual(response.json[0]['id'], str(max_follower_reuse.id))
 
     def test_suggest_reuses_api_unicode(self, api):
         '''It should suggest reuses with special characters'''

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -312,7 +312,7 @@ class ReuseAPITest:
             assert 'title' in suggestion
             assert 'image_url' in suggestion
             assert suggestion['title'].startswith('test')
-        self.assertEqual(response.json[0]['id'], str(max_follower_reuse.id))
+        assert response.json[0]['id'] == str(max_follower_reuse.id)
 
     def test_suggest_reuses_api_unicode(self, api):
         '''It should suggest reuses with special characters'''


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/802.

Use followers as default suggest sorting for datasets, reuses and orgas.

Example in video:
https://user-images.githubusercontent.com/28541902/162416214-c712941c-089f-46b3-a33a-b515f0192be7.mp4

