### PR TITLE
Improve extension detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove unused `_total_pages` search property [#2726](https://github.com/opendatateam/udata/pull/2726)
 - Use -followers as default suggest sort on datasets, reuses and orgas [#2727](https://github.com/opendatateam/udata/pull/2727)
 - Reintroduce user suggest with mongo contains [#2725](https://github.com/opendatateam/udata/pull/2725)
+- Improve extension detection [#2729](https://github.com/opendatateam/udata/pull/2729/files)
 
 ## 4.0.1 (2022-04-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Remove unused `_total_pages` search property [#2726](https://github.com/opendatateam/udata/pull/2726)
 - Use -followers as default suggest sort on datasets, reuses and orgas [#2727](https://github.com/opendatateam/udata/pull/2727)
 - Reintroduce user suggest with mongo contains [#2725](https://github.com/opendatateam/udata/pull/2725)
-- Improve extension detection [#2729](https://github.com/opendatateam/udata/pull/2729/files)
+- Improve resource extension detection [#2729](https://github.com/opendatateam/udata/pull/2729/files)
 
 ## 4.0.1 (2022-04-11)
 

--- a/udata/core/storages/utils.py
+++ b/udata/core/storages/utils.py
@@ -51,10 +51,10 @@ def extension(filename):
     If it is in ALLOWED_RESOURCES_EXTENSIONS, we add it to the extension.
 
     Some examples of extension detection:
-    - test.unknown -> unkonwn.
-    - test.2022.zip -> zip.
-    - test.2022.csv.tar.gz -> csv.tar.gz.
-    - test.geojson.csv -> csv.
+    - test.unknown -> unknown
+    - test.2022.zip -> zip
+    - test.2022.csv.tar.gz -> csv.tar.gz
+    - test.geojson.csv -> csv
     '''
     filename = os.path.basename(filename)
     extension = None

--- a/udata/core/storages/utils.py
+++ b/udata/core/storages/utils.py
@@ -44,7 +44,18 @@ def mime(url):
 
 
 def extension(filename):
-    '''Properly extract the extension from filename'''
+    '''
+    Properly extract the extension from filename.
+    We keep the last extension except for archive extensions, where we check
+    previous extensions as well.
+    If it is in ALLOWED_RESOURCES_EXTENSIONS, we add it to the extension.
+
+    Some examples of extension detection:
+    - test.unknown -> unkonwn.
+    - test.2022.zip -> zip.
+    - test.2022.csv.tar.gz -> csv.tar.gz.
+    - test.geojson.csv -> csv.
+    '''
     filename = os.path.basename(filename)
     extension = None
 
@@ -60,7 +71,7 @@ def extension(filename):
 
         extension = ext if not extension else ext + '.' + extension
 
-        if ext not in current_app.config['ALLOWED_ARCHIVED_EXTENSIONS']:
+        if ext not in current_app.config['ALLOWED_ARCHIVE_EXTENSIONS']:
             # We don't want to continue the loop if this ext is not an allowed archived extension
             break
 

--- a/udata/core/storages/utils.py
+++ b/udata/core/storages/utils.py
@@ -3,6 +3,7 @@ import mimetypes
 import os
 import zlib
 
+from flask import current_app
 from slugify import Slugify
 
 CHUNK_SIZE = 2 ** 16
@@ -51,7 +52,17 @@ def extension(filename):
         filename, ext = os.path.splitext(filename)
         if ext.startswith('.'):
             ext = ext[1:]
+
+        if extension and ext not in current_app.config['ALLOWED_RESOURCES_EXTENSIONS']:
+            # We don't want to add this extension if one has already been detected
+            # and this one is not in the allowed resources extensions list.
+            break
+
         extension = ext if not extension else ext + '.' + extension
+
+        if ext not in current_app.config['ALLOWED_ARCHIVED_EXTENSIONS']:
+            # We don't want to continue the loop if this ext is not an allowed archived extension
+            break
 
     return extension
 

--- a/udata/migrations/2022-04-21-improve-extension-detection.py
+++ b/udata/migrations/2022-04-21-improve-extension-detection.py
@@ -1,0 +1,26 @@
+'''
+Recompute resources extension with improved detection
+'''
+import logging
+
+from udata.models import Dataset
+from udata.core.storages.utils import extension
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info('Processing Datasets.')
+
+    datasets = Dataset.objects().no_cache().timeout(False)
+    count = 0
+    for dataset in datasets:
+        for resource in [res for res in dataset.resources if res.fs_filename]:
+            detected_format = extension(resource.fs_filename)
+            if detected_format != resource.format:
+                resource.format = detected_format
+                count += 1
+                resource.save()
+
+    log.info(f'Modified {count} resource objects')
+    log.info('Done')

--- a/udata/migrations/2022-04-21-improve-extension-detection.py
+++ b/udata/migrations/2022-04-21-improve-extension-detection.py
@@ -15,12 +15,15 @@ def migrate(db):
     datasets = Dataset.objects().no_cache().timeout(False)
     count = 0
     for dataset in datasets:
+        save_dataset = False
         for resource in [res for res in dataset.resources if res.fs_filename]:
             detected_format = extension(resource.fs_filename)
             if detected_format != resource.format:
+                save_dataset = True
                 resource.format = detected_format
                 count += 1
-                resource.save()
+        if save_dataset:
+            dataset.save(signal_kwargs={'ignores': ['post_save']})
 
     log.info(f'Modified {count} resource objects')
     log.info('Done')

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -256,12 +256,12 @@ class Defaults(object):
 
     # Default resources extensions whitelist
 
-    ALLOWED_ARCHIVED_EXTENSIONS = [
+    ALLOWED_ARCHIVE_EXTENSIONS = [
         # Archives
         'tar', 'gz', 'tgz', 'rar', 'zip', '7z', 'xz', 'bz2'
     ]
 
-    ALLOWED_RESOURCES_EXTENSIONS = ALLOWED_ARCHIVED_EXTENSIONS + [
+    ALLOWED_RESOURCES_EXTENSIONS = ALLOWED_ARCHIVE_EXTENSIONS + [
         # Base
         'csv', 'txt', 'json', 'pdf', 'xml', 'rtf', 'xsd',
         # OpenOffice

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -277,7 +277,8 @@ class Defaults(object):
         # RDF
         'rdf', 'ttl', 'n3',
         # Misc
-        'dbf', 'prj', 'sql', 'sqlite', 'db', 'epub', 'sbn', 'sbx', 'cpg', 'lyr', 'owl', 'dxf', 'ics', 'other'
+        'dbf', 'prj', 'sql', 'sqlite', 'db', 'epub', 'sbn', 'sbx', 'cpg', 'lyr', 'owl', 'dxf',
+        'ics', 'other'
     ]
 
     ALLOWED_RESOURCES_MIMES = [
@@ -366,7 +367,7 @@ class Defaults(object):
     # Tiles URL for SD displays
     MAP_TILES_URL = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'
     # Tiles URL for HD/HiDPI displays
-    MAP_TILES_URL_HIDPI = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png'
+    MAP_TILES_URL_HIDPI = 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png'  # noqa
     # Leaflet tiles config, see https://leafletjs.com/reference-0.7.7.html#tilelayer
     MAP_TILES_CONFIG = {
         'subdomains': 'abcd',

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -255,15 +255,19 @@ class Defaults(object):
     FS_IMAGES_OPTIMIZE = True
 
     # Default resources extensions whitelist
-    ALLOWED_RESOURCES_EXTENSIONS = [
+
+    ALLOWED_ARCHIVED_EXTENSIONS = [
+        # Archives
+        'tar', 'gz', 'tgz', 'rar', 'zip', '7z', 'xz', 'bz2'
+    ]
+
+    ALLOWED_RESOURCES_EXTENSIONS = ALLOWED_ARCHIVED_EXTENSIONS + [
         # Base
         'csv', 'txt', 'json', 'pdf', 'xml', 'rtf', 'xsd',
         # OpenOffice
         'ods', 'odt', 'odp', 'odg',
         # Microsoft Office
         'xls', 'xlsx', 'doc', 'docx', 'pps', 'ppt',
-        # Archives
-        'tar', 'gz', 'tgz', 'rar', 'zip', '7z', 'xz', 'bz2',
         # Images
         'jpeg', 'jpg', 'jpe', 'gif', 'png', 'dwg', 'svg', 'tiff', 'ecw', 'svgz', 'jp2',
         # Geo

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -57,16 +57,24 @@ class StorageUtilsTest:
         assert utils.mime('test.txt') == 'text/plain'
         assert utils.mime('test') is None
 
-    def test_extension_default(self):
+    def test_extension_default(self, app):
         assert utils.extension('test.txt') == 'txt'
         assert utils.extension('prefix/test.txt') == 'txt'
         assert utils.extension('prefix.with.dot/test.txt') == 'txt'
 
-    def test_extension_compound(self):
+    def test_extension_compound(self, app):
         assert utils.extension('test.tar.gz') == 'tar.gz'
         assert utils.extension('prefix.with.dot/test.tar.gz') == 'tar.gz'
 
-    def test_no_extension(self):
+    def test_extension_compound_with_allowed_extension(self, app):
+        assert utils.extension('test.2022.csv.tar.gz') == 'csv.tar.gz'
+        assert utils.extension('prefix.with.dot/test.2022.csv.tar.gz') == 'csv.tar.gz'
+
+    def test_extension_compound_without_allowed_extension(self, app):
+        assert utils.extension('test.2022.tar.gz') == 'tar.gz'
+        assert utils.extension('prefix.with.dot/test.2022.tar.gz') == 'tar.gz'
+
+    def test_no_extension(self, app):
         assert utils.extension('test') is None
         assert utils.extension('prefix/test') is None
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/632.

- [x] we can add a migration script to modify stock, should we?
- [x] is it a bad idea to use `current_app` in utils.py? -> I guess not
- [x] check ALLOWED_RESOURCES_EXTENSIONS actual overrides -> ALLOWED_RESOURCES_EXTENSIONS is extended but not overridden.