### PR TITLE
Remove resources in dataset search serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove unused `_total_pages` search property [#2726](https://github.com/opendatateam/udata/pull/2726)
 - Use -followers as default suggest sort on datasets, reuses and orgas [#2727](https://github.com/opendatateam/udata/pull/2727)
 - Reintroduce user suggest with mongo contains [#2725](https://github.com/opendatateam/udata/pull/2725)
+- Remove resources in dataset search serialization [#2730](https://github.com/opendatateam/udata/pull/2730)
 
 ## 4.0.1 (2022-04-11)
 

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -89,29 +89,6 @@ class DatasetSearch(ModelSearchAdapter):
             extras[key] = to_iso_datetime(value) if isinstance(value, datetime.datetime) else value
         document.update({'extras': extras})
 
-        serialized_resources = []
-        for resource in dataset.resources:
-            resource_dict = {
-                'id': str(resource.id),
-                'url': resource.url,
-                'format': resource.format,
-                'title': resource.title,
-                'schema': resource.schema,
-                'latest': resource.latest,
-                'description': resource.description,
-                'filetype': resource.filetype,
-                'type': resource.type,
-                'created_at': to_iso_datetime(resource.created_at),
-                'modified': to_iso_datetime(resource.modified),
-                'published': to_iso_datetime(resource.published)
-            }
-            extras = {}
-            for key, value in resource.extras.items():
-                extras[key] = to_iso_datetime(value) if isinstance(value, datetime.datetime) else value
-            resource_dict.update({'extras': extras})
-            serialized_resources.append(resource_dict)
-        document.update({'resources': serialized_resources})
-
         if (dataset.temporal_coverage is not None and
                 dataset.temporal_coverage.start and
                 dataset.temporal_coverage.end):


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/798.

We don't need to serialize resources in dataset serialization.
udata-search-service didn't use resources serialization, only `resources_count`.
We will have resources dedicated messages instead (see https://github.com/opendatateam/udata/pull/2733).