### PR TITLE
Fix created sort mapping used in mongo search

### DIFF
--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -22,7 +22,7 @@ class DatasetSearch(ModelSearchAdapter):
     search_url = 'datasets/'
 
     sorts = {
-        'created': 'created',
+        'created': 'created_at',
         'reuses': 'metrics.reuses',
         'followers': 'metrics.followers',
         'views': 'metrics.views',

--- a/udata/core/organization/search.py
+++ b/udata/core/organization/search.py
@@ -19,7 +19,7 @@ class OrganizationSearch(search.ModelSearchAdapter):
         'datasets': 'metrics.datasets',
         'followers': 'metrics.followers',
         'views': 'metrics.views',
-        'created': 'created'
+        'created': 'created_at'
     }
 
     filters = {

--- a/udata/core/reuse/search.py
+++ b/udata/core/reuse/search.py
@@ -19,7 +19,7 @@ class ReuseSearch(ModelSearchAdapter):
     search_url = 'reuses/'
 
     sorts = {
-        'created': 'created',
+        'created': 'created_at',
         'datasets': 'metrics.datasets',
         'followers': 'metrics.followers',
         'views': 'metrics.views'


### PR DESCRIPTION
Due to code duplication, I think we had an issue with `created` sort.