### PR TITLE
Fixed typo in commands in quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ You will need to install [docker]() and [docker-compose][] before getting starte
 ```
 git clone https://github.com/opendatateam/docker-udata
 cd docker-udata
-docker-compose up
+docker compose up
 ```
 
 The platform is available at [http://localhost:7000](http://localhost:7000).


### PR DESCRIPTION
The command is `docker compose` instead of `docker-compose`