### PR TITLE
Normalize score between 0 and 1

### DIFF
--- a/js/components/charts/doughnut.vue
+++ b/js/components/charts/doughnut.vue
@@ -21,7 +21,7 @@ export default {
             const data = {
                 datasets: [{
                     backgroundColor: [ "#3C8DBC", "#F5F5F5" ],
-                    data: [ this.score, config.quality_max_score - this.score ],
+                    data: [ this.score, 1 - this.score ],
                 }],
             };
 

--- a/js/config.js
+++ b/js/config.js
@@ -165,8 +165,6 @@ export const search_autocomplete_debounce = _jsonMeta('search-autocomplete-debou
  */
 export const read_only_enabled = _jsonMeta('read-only-enabled');
 
-export const quality_max_score = _jsonMeta('quality-max-score');
-
 
 export default {
     user,
@@ -192,5 +190,4 @@ export default {
     search_autocomplete_debounce,
     markdown,
     read_only_enabled,
-    quality_max_score,
 };

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -639,10 +639,24 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
         result['score'] = self.compute_quality_score(result)
         return result
 
+    @staticmethod
+    def normalize_score(score):
+        """
+        Normalize score by dividing it by the quality max score.
+        Make sure to update QUALITY_MAX_SCORE accordingly if the max score changes.
+        """
+        QUALITY_MAX_SCORE = 9
+        return score / QUALITY_MAX_SCORE
+
     def compute_quality_score(self, quality):
-        """Compute the score related to the quality of that dataset."""
+        """
+        Compute the score related to the quality of that dataset.
+        The score is normalized between 0 and 1.
+
+        Make sure to update normalize_score if the max score changes.
+        """
         score = 0
-        UNIT = current_app.config.get('QUALITY_MAX_SCORE') / current_app.config.get('QUALITY_CHECKS_NUMBER')
+        UNIT = 1
         if quality['license']:
             score += UNIT
         if quality['temporal_coverage']:
@@ -663,7 +677,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
                 score += UNIT
             if quality['resources_documentation']:
                 score += UNIT
-        return score
+        return self.normalize_score(score)
 
     @classmethod
     def get(cls, id_or_slug):

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -416,8 +416,6 @@ class Defaults(object):
     # Datasets quality settings
     ###########################################################################
     QUALITY_DESCRIPTION_LENGTH = 100
-    QUALITY_MAX_SCORE = 10
-    QUALITY_CHECKS_NUMBER = 9
 
 
 class Testing(object):

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -59,6 +59,5 @@
     'MAX_LENGTH': config.TAG_MAX_LENGTH,
 }|tojson|urlencode }}" />
 <meta name="read-only-enabled" content="{{ 'true' if config.READ_ONLY_MODE else 'false' }}">
-<meta name="quality-max-score" content="{{ config.QUALITY_MAX_SCORE }}">
 
 {% endmacro %}

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -142,46 +142,46 @@ class DatasetModelTest:
             'score': 0
         }
 
-    def test_quality_next_update(self, quality_unit):
+    def test_quality_next_update(self):
         dataset = DatasetFactory(description='', frequency='weekly')
         assert dataset.quality['update_fulfilled_in_time'] is True
         assert dataset.quality['update_frequency'] is True
-        assert dataset.quality['score'] == quality_unit * 2
+        assert dataset.quality['score'] == Dataset.normalize_score(2)
 
-    def test_quality_description_length(self, quality_unit):
+    def test_quality_description_length(self):
         dataset = DatasetFactory(description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') - 1))
         assert dataset.quality['dataset_description_quality'] is False
         assert dataset.quality['score'] == 0
         dataset = DatasetFactory(description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') + 1))
         assert dataset.quality['dataset_description_quality'] is True
-        assert dataset.quality['score'] == quality_unit
+        assert dataset.quality['score'] == Dataset.normalize_score(1)
 
-    def test_quality_has_open_formats(self, quality_unit):
+    def test_quality_has_open_formats(self):
         dataset = DatasetFactory(description='', )
         dataset.add_resource(ResourceFactory(format='pdf'))
         assert not dataset.quality['has_open_format']
-        assert dataset.quality['score'] == quality_unit * 2
+        assert dataset.quality['score'] == Dataset.normalize_score(2)
 
-    def test_quality_has_opened_formats(self, quality_unit):
+    def test_quality_has_opened_formats(self):
         dataset = DatasetFactory(description='', )
         dataset.add_resource(ResourceFactory(format='pdf'))
         dataset.add_resource(ResourceFactory(format='csv'))
         assert dataset.quality['has_open_format']
-        assert dataset.quality['score'] == quality_unit * 3
+        assert dataset.quality['score'] == Dataset.normalize_score(3)
 
-    def test_quality_has_undefined_and_closed_format(self, quality_unit):
+    def test_quality_has_undefined_and_closed_format(self):
         dataset = DatasetFactory(description='', )
         dataset.add_resource(ResourceFactory(format=None))
         dataset.add_resource(ResourceFactory(format='xls'))
         assert not dataset.quality['has_open_format']
-        assert dataset.quality['score'] == quality_unit * 2
+        assert dataset.quality['score'] == Dataset.normalize_score(2)
 
-    def test_quality_all(self, quality_unit):
+    def test_quality_all(self):
         user = UserFactory()
         dataset = DatasetFactory(owner=user, frequency='weekly',
                                  tags=['foo', 'bar'], description='a' * 42)
         dataset.add_resource(ResourceFactory(format='pdf'))
-        assert dataset.quality['score'] == quality_unit * 4
+        assert dataset.quality['score'] == Dataset.normalize_score(4)
         assert sorted(dataset.quality.keys()) == [
             'all_resources_available',
             'dataset_description_quality',

--- a/udata/tests/plugin.py
+++ b/udata/tests/plugin.py
@@ -146,11 +146,6 @@ def enable_kafka(app):
     app.config['KAFKA_URI'] = 'localhost:9092'
 
 
-@pytest.fixture
-def quality_unit(app):
-    return app.config.get('QUALITY_MAX_SCORE') / app.config.get('QUALITY_CHECKS_NUMBER')
-
-
 class ApiClient(object):
     def __init__(self, client):
         self.client = client


### PR DESCRIPTION
This PR is a suggestion to improve score normalization logic.

Normalization is based on max score.
Max score is not configurable anymore, but is set in Dataset model directly.

What do you think of this logic @quaxsze?