### PR TITLE
Replace mongo legacy image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   python:
     docker:
       - image: udata/circleci:2-alpine
-      - image: circleci/mongo:3.6-stretch-ram
+      - image: mongo:3.6
       - image: redis:alpine
     environment:
        BASH_ENV: /root/.bashrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Replace mongo legacy image in CI [#2754](https://github.com/opendatateam/udata/pull/2754)
 
 ## 4.1.1 (2022-07-08)
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/597.

Even if in [this documentation](https://circleci.com/docs/circleci-images#legacy-service-images), they list mongodb under:
> CircleCI maintains legacy images for the services below

We have different information [in this post](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034#deprecated-images-3), where it is mentioned that
>  The following images will be deprecated without next-gen equivalents

In any case, I tested using mongo:3.6 raw image instead and it seems to work correctly:
- Build time is roughly the same.
- We don't need any of the additional tools the previous image was packaged with.

However, if we want to build our own image for optimization purpose, we can take a look at [current layers](https://hub.docker.com/layers/mongo/circleci/mongo/3.6-stretch-ram/images/sha256-55bdbd8f610cd78b5a801b50c36a766f0c215a47a446f69a5f371608e9266268?context=explore) for circleci/mongo:3.6-stretch-ram.

# TODO & Questions

- [ ] any other side effects to look out for?
- [x] apply same changes for every CI using the deprecated image.
- [x] do we want to use one specific patch version for deterministic builds? Ex: 3.6.23. -> Nope, we're keeping with the previous logic, using patches.