### PR TITLE
Fix doc name duplicate on rdf endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Clean up event code [#2751](https://github.com/opendatateam/udata/pull/2751)
 - Replace mongo legacy image in CI [#2754](https://github.com/opendatateam/udata/pull/2754)
 - Fixes test `test_suggest_datasets_api` by modifying condition [#2759](https://github.com/opendatateam/udata/pull/2759)
+- Fix doc name duplicate on rdf endpoints [#2763](https://github.com/opendatateam/udata/pull/2763)
 
 ## 4.1.1 (2022-07-08)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -265,7 +265,7 @@ class DatasetRdfAPI(API):
 @api.response(404, 'Dataset not found')
 @api.response(410, 'Dataset has been deleted')
 class DatasetRdfFormatAPI(API):
-    @api.doc('rdf_dataset')
+    @api.doc('rdf_dataset_format')
     def get(self, dataset, format):
         if not DatasetEditPermission(dataset).can():
             if dataset.private:

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -164,7 +164,7 @@ class OrganizationRdfAPI(API):
 @api.response(404, 'Organization not found')
 @api.response(410, 'Organization has been deleted')
 class OrganizationRdfFormatAPI(API):
-    @api.doc('rdf_organization')
+    @api.doc('rdf_organization_format')
     def get(self, org, format):
         if org.deleted:
             api.abort(410)


### PR DESCRIPTION
Fix https://github.com/etalab/doc.data.gouv.fr/issues/116

[This validator](https://apitools.dev/swagger-parser/online/?url=https%3A%2F%2Fwww.data.gouv.fr%2Fapi%2F1%2Fswagger.json) returns a success once the duplicate doc names have been fixed.