### PR TITLE
Feat/clean inactive harvest datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix image URLs for suggest endpoints [#2761](https://github.com/opendatateam/udata/pull/2761)
+- Clean inactive harvest datasets. :warning: a migration archives datasets linked to inactive harvest sources [#2764](https://github.com/opendatateam/udata/pull/2764)
 
 ## 4.1.2 (2022-09-01)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -778,6 +778,17 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
         self.metrics['followers'] = Follow.objects(until=None).followers(self).count()
         self.save()
 
+    def archive(self, reason, save=True):
+        log.debug('Archiving dataset %s', self.id)
+        archival_date = datetime.now()
+        self.archived = archival_date
+        self.extras['harvest:archived'] = reason
+        self.extras['harvest:archived_at'] = archival_date
+        if save:
+            self.save()
+        else:
+            self.validate()
+
 
 pre_save.connect(Dataset.pre_save, sender=Dataset)
 post_save.connect(Dataset.post_save, sender=Dataset)

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -778,17 +778,6 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
         self.metrics['followers'] = Follow.objects(until=None).followers(self).count()
         self.save()
 
-    def archive(self, reason, save=True):
-        log.debug('Archiving dataset %s', self.id)
-        archival_date = datetime.now()
-        self.archived = archival_date
-        self.extras['harvest:archived'] = reason
-        self.extras['harvest:archived_at'] = archival_date
-        if save:
-            self.save()
-        else:
-            self.validate()
-
 
 pre_save.connect(Dataset.pre_save, sender=Dataset)
 post_save.connect(Dataset.post_save, sender=Dataset)

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -13,7 +13,7 @@ from udata.models import User, Organization, PeriodicTask, Dataset
 from . import backends, signals
 from .models import (
     HarvestSource, HarvestJob, DEFAULT_HARVEST_FREQUENCY,
-    VALIDATION_ACCEPTED, VALIDATION_REFUSED
+    VALIDATION_ACCEPTED, VALIDATION_REFUSED, archive_harvested_dataset
 )
 from .tasks import harvest
 
@@ -295,19 +295,3 @@ def attach(domain, filename):
             count += 1
 
     return AttachResult(count, errors)
-
-
-def archive_harvested_dataset(dataset, reason, dryrun=False):
-    '''
-    Archive an harvested dataset, setting extras accordingly.
-    If `dryrun` is True, the dataset is not saved but validated only.
-    '''
-    log.debug('Archiving dataset %s', dataset.id)
-    archival_date = datetime.now()
-    dataset.archived = archival_date
-    dataset.extras['harvest:archived'] = reason
-    dataset.extras['harvest:archived_at'] = archival_date
-    if dryrun:
-        dataset.validate()
-    else:
-        dataset.save()

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -140,6 +140,9 @@ def purge_sources():
     for source in sources:
         if source.periodic_task:
             source.periodic_task.delete()
+        datasets = Dataset.objects.filter(**{'extras__harvest:source_id': str(source.id)})
+        for dataset in datasets:
+            dataset.archive(reason='harvester-deleted', save=True)
         source.delete()
     return count
 

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -12,9 +12,8 @@ from voluptuous import MultipleInvalid, RequiredFieldInvalid
 from udata.models import Dataset
 from udata.utils import safe_unicode
 
-from ..actions import archive_harvested_dataset
 from ..exceptions import HarvestException, HarvestSkipException, HarvestValidationError
-from ..models import HarvestItem, HarvestJob, HarvestError
+from ..models import HarvestItem, HarvestJob, HarvestError, archive_harvested_dataset
 from ..signals import before_harvest_job, after_harvest_job
 
 log = logging.getLogger(__name__)

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -250,16 +250,7 @@ class BaseBackend(object):
 
         for dataset in local_items_not_on_remote:
             if not dataset.extras.get('harvest:archived_at'):
-                log.debug('Archiving dataset %s', dataset.id)
-                archival_date = datetime.now()
-                dataset.archived = archival_date
-                dataset.extras['harvest:archived'] = 'not-on-remote'
-                dataset.extras['harvest:archived_at'] = archival_date
-                if self.dryrun:
-                    dataset.validate()
-                else:
-                    dataset.save()
-
+                dataset.archive(reason='not-on-remote', save=not self.dryrun)
             # add a HarvestItem to the job list (useful for report)
             # even when archiving has already been done (useful for debug)
             item = self.add_item(dataset.extras['harvest:remote_id'])

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -251,7 +251,7 @@ class BaseBackend(object):
 
         for dataset in local_items_not_on_remote:
             if not dataset.extras.get('harvest:archived_at'):
-                archive_harvested_dataset(dataset, reason='not-on-remote', dryrun=dryrun)
+                archive_harvested_dataset(dataset, reason='not-on-remote', dryrun=self.dryrun)
             # add a HarvestItem to the job list (useful for report)
             # even when archiving has already been done (useful for debug)
             item = self.add_item(dataset.extras['harvest:remote_id'])

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -12,6 +12,7 @@ from voluptuous import MultipleInvalid, RequiredFieldInvalid
 from udata.models import Dataset
 from udata.utils import safe_unicode
 
+from ..actions import archive_harvested_dataset
 from ..exceptions import HarvestException, HarvestSkipException, HarvestValidationError
 from ..models import HarvestItem, HarvestJob, HarvestError
 from ..signals import before_harvest_job, after_harvest_job
@@ -250,7 +251,7 @@ class BaseBackend(object):
 
         for dataset in local_items_not_on_remote:
             if not dataset.extras.get('harvest:archived_at'):
-                dataset.archive(reason='not-on-remote', save=not self.dryrun)
+                archive_harvested_dataset(dataset, reason='not-on-remote', dryrun=dryrun)
             # add a HarvestItem to the job list (useful for report)
             # even when archiving has already been done (useful for debug)
             item = self.add_item(dataset.extras['harvest:remote_id'])

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -12,7 +12,7 @@ from udata.models import Dataset, PeriodicTask
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.user.factories import UserFactory
 from udata.core.dataset.factories import DatasetFactory
-from udata.tests.helpers import assert_emit
+from udata.tests.helpers import assert_emit, assert_equal_dates
 from udata.utils import faker, Paginable
 
 from .factories import (
@@ -394,6 +394,7 @@ class HarvestActionsTest:
         assert HarvestJob.objects(id=harvest_job.id).count() == 0
         assert 'harvest:archived' in dataset_to_archive.extras
         assert dataset_to_archive.extras['harvest:archived'] == 'harvester-deleted'
+        assert_equal_dates(dataset_to_archive.archived, now)
 
     @pytest.mark.options(HARVEST_JOBS_RETENTION_DAYS=2)
     def test_purge_jobs(self):

--- a/udata/migrations/2022-09-22-clean-inactive-harvest-datasets.py
+++ b/udata/migrations/2022-09-22-clean-inactive-harvest-datasets.py
@@ -1,0 +1,29 @@
+'''
+Datasets linked to an inactive harvester are archived
+'''
+import logging
+
+from udata.models import Dataset
+from udata.harvest.actions import archive_harvested_dataset
+from udata.harvest.models import HarvestSource
+
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info('Computing the list of datasets linked to an inactive harvester.')
+
+    active_sources = [str(source.id) for source in HarvestSource.objects(active=True)]
+    dangling_datasets = Dataset.objects(**{
+        'extras__harvest:source_id__exists': True,
+        'extras__harvest:source_id__nin': active_sources,
+        'archived': None
+    })
+
+    log.info(f'{dangling_datasets.count()} datasets to archive.')
+
+    for dataset in dangling_datasets:
+        archive_harvested_dataset(dataset, reason='harvester-inactive', dryrun=False)
+
+    log.info('Done')


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/820

* Migration to archive dangling datasets (linked to inactive or deleted harvester)
* On harvester deletion, archive its datasets.