### PR TITLE
Remove active filter on clean inactive harvest migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Fix image URLs for suggest endpoints [#2761](https://github.com/opendatateam/udata/pull/2761)
-- Clean inactive harvest datasets. :warning: a migration archives datasets linked to inactive harvest sources [#2764](https://github.com/opendatateam/udata/pull/2764)
+- Clean inactive harvest datasets. :warning: a migration archives datasets linked to inactive harvest sources [#2764](https://github.com/opendatateam/udata/pull/2764) [#2773](https://github.com/opendatateam/udata/pull/2773)
 
 ## 4.1.2 (2022-09-01)
 

--- a/udata/migrations/2022-09-22-clean-inactive-harvest-datasets.py
+++ b/udata/migrations/2022-09-22-clean-inactive-harvest-datasets.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 def migrate(db):
     log.info('Computing the list of datasets linked to an inactive harvester.')
 
-    active_sources = [str(source.id) for source in HarvestSource.objects(active=True)]
+    active_sources = [str(source.id) for source in HarvestSource.objects()]
     dangling_datasets = Dataset.objects(**{
         'extras__harvest:source_id__exists': True,
         'extras__harvest:source_id__nin': active_sources,


### PR DESCRIPTION
Remove useless `active` filter in migration introduced in https://github.com/opendatateam/udata/pull/2764.

Indeed `active` doesn't have any effect, and some datasets are still being harvested with `active` being False.