### PR TITLE
Add try catch in migration if a dataset validation fail and log error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix image URLs for suggest endpoints [#2761](https://github.com/opendatateam/udata/pull/2761)
 - Switch from `Flask-restplus` to its fork `Flask-rest-x` [2770](https://github.com/opendatateam/udata/pull/2770)
-- Clean inactive harvest datasets. :warning: a migration archives datasets linked to inactive harvest sources [#2764](https://github.com/opendatateam/udata/pull/2764) [#2773](https://github.com/opendatateam/udata/pull/2773)
+- Clean inactive harvest datasets. :warning: a migration archives datasets linked to inactive harvest sources [#2764](https://github.com/opendatateam/udata/pull/2764) [#2773](https://github.com/opendatateam/udata/pull/2773) [#2777](https://github.com/opendatateam/udata/pull/2777)
 - Fix alt attribute not shown on image [#2776](https://github.com/opendatateam/udata/pull/2776)
 
 ## 4.1.2 (2022-09-01)

--- a/udata/migrations/2022-09-22-clean-inactive-harvest-datasets.py
+++ b/udata/migrations/2022-09-22-clean-inactive-harvest-datasets.py
@@ -3,6 +3,8 @@ Datasets linked to an inactive harvester are archived
 '''
 import logging
 
+from mongoengine.errors import ValidationError
+
 from udata.models import Dataset
 from udata.harvest.actions import archive_harvested_dataset
 from udata.harvest.models import HarvestSource
@@ -24,6 +26,9 @@ def migrate(db):
     log.info(f'{dangling_datasets.count()} datasets to archive.')
 
     for dataset in dangling_datasets:
-        archive_harvested_dataset(dataset, reason='harvester-inactive', dryrun=False)
+        try:
+            archive_harvested_dataset(dataset, reason='harvester-inactive', dryrun=False)
+        except ValidationError as e:
+            log.error(f'Error on dataset {dataset.id}: {e}')
 
     log.info('Done')


### PR DESCRIPTION
Add a try/catch on migration introduced in https://github.com/opendatateam/udata/pull/2764.

Some datasets may fail validation, making migration fail. We log any error that might occur.