### PR TITLE
Fix harvest uri validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix resource harvest uri validation error [#2780](https://github.com/opendatateam/udata/pull/2780)
 
 ## 5.0.0 (2022-11-14)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -146,7 +146,7 @@ class HarvestDatasetMetadata(DynamicEmbeddedDocument):
 class HarvestResourceMetadata(DynamicEmbeddedDocument):
     created_at = db.DateTimeField()
     modified_at = db.DateTimeField()
-    uri = db.URLField()
+    uri = db.StringField()
 
 
 class License(db.Document):

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -22,7 +22,7 @@
         <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T18:59:02.737480</dcterms:issued>
         <dcterms:description>Dataset 3 description</dcterms:description>
         <dcat:keyword>Tag 1</dcat:keyword>
-        <dcat:distribution rdf:resource="http://data.test.org/datasets/3/resources/1"/>
+        <dcat:distribution rdf:resource="datasets/3/resources/1"/>
         <dct:license>Licence Ouverte Version 2.0</dct:license>
         <dcat:landingPage>http://data.test.org/datasets/3</dcat:landingPage>
         <dct:accrualPeriodicity xmlns:dct="http://purl.org/dc/terms/">daily</dct:accrualPeriodicity>
@@ -111,7 +111,7 @@
     <dcterms:format>JSON</dcterms:format>
     <dcterms:description>A JSON resource</dcterms:description>
   </dcat:Distribution>
-  <dcat:Distribution rdf:about="http://data.test.org/datasets/3/resources/1">
+  <dcat:Distribution rdf:about="datasets/3/resources/1">
     <dcterms:format>JSON</dcterms:format>
     <dcterms:title>Resource 3-1</dcterms:title>
     <dcterms:description>A JSON resource</dcterms:description>


### PR DESCRIPTION
`uri` field in resource and dataset harvest metadata should both be `StringField` and not `URLField`.

Make test fail with an URI failing URL validation as distribution identifier and add fix.
