### PR TITLE
Optimize DCAT harvesting on large multiple-paged catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Exhaustive list of changes [here](https://flask-security-too.readthedocs.io/en/stable/changelog.html#version-4-0-0).
 - Fix apiv2 swagger with harvest metadata and add apiv2 swagger tests [#2782](https://github.com/opendatateam/udata/pull/2782)
 - Add quality score to csv catalogs [#2785](https://github.com/opendatateam/udata/pull/2785)
-- Optimize DCAT harvesting on large multiple-paged catalogs [#2781](https://github.com/opendatateam/udata/pull/2781)
+- Optimize DCAT harvesting on large multiple-paged catalogs, introduce `HARVEST_MAX_ITEMS` development setting [#2781](https://github.com/opendatateam/udata/pull/2781)
 
 ## 5.0.1 (2022-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Exhaustive list of changes [here](https://flask-security-too.readthedocs.io/en/stable/changelog.html#version-4-0-0).
 - Fix apiv2 swagger with harvest metadata and add apiv2 swagger tests [#2782](https://github.com/opendatateam/udata/pull/2782)
 - Add quality score to csv catalogs [#2785](https://github.com/opendatateam/udata/pull/2785)
+- Optimize DCAT harvesting on large multiple-paged catalogs [#2781](https://github.com/opendatateam/udata/pull/2781)
 
 ## 5.0.1 (2022-11-14)
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -262,6 +262,12 @@ HANDLED_LEVELS = ('fr:commune', 'fr:departement', 'fr:region')
 
 The number of items to fetch while previewing an harvest source
 
+### HARVEST_MAX_ITEMS
+
+**default**: `None`
+
+The max number of items to fetch when harvesting (development setting)
+
 ### HARVEST_DEFAULT_SCHEDULE
 
 **default**: `0 0 * * *`

--- a/udata/commands/dcat.py
+++ b/udata/commands/dcat.py
@@ -13,6 +13,7 @@ from udata.rdf import namespace_manager
 
 log = logging.getLogger(__name__)
 
+
 @cli.group('dcat')
 def grp():
     '''DCAT diagnosis operations'''
@@ -49,12 +50,14 @@ def parse_url(url, quiet=False, rid=''):
     backend.job = MockJob()
     format = backend.get_format()
     echo(yellow('Detected format: {}'.format(format)))
-    graph = backend.parse_graph(url, format)
+    graphs = backend.parse_graph(url, format)
 
     # serialize/unserialize graph like in the job mechanism
-    _graph = graph.serialize(format=format, indent=None)
     graph = Graph(namespace_manager=namespace_manager)
-    graph.parse(data=_graph, format=format)
+    for subgraph in graphs:
+        serialized = subgraph.serialize(format=format, indent=None)
+        _subgraph = Graph(namespace_manager=namespace_manager)
+        graph += _subgraph.parse(data=serialized, format=format)
 
     for item in backend.job.items:
         if not rid or rid in item.remote_id:
@@ -69,7 +72,9 @@ def parse_url(url, quiet=False, rid=''):
             echo('License: {}'.format(yellow(dataset.license)))
             echo('Description: {}'.format(yellow(dataset.description)))
             echo('Tags: {}'.format(yellow(dataset.tags)))
-            echo('Resources: {}'.format(yellow([(r.title, r.format, r.url) for r in dataset.resources])))
+            echo('Resources: {}'.format(yellow(
+                [(r.title, r.format, r.url) for r in dataset.resources]
+            )))
 
             try:
                 dataset.validate()

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -90,7 +90,7 @@ class BaseBackend(object):
             self.source = source_or_job
             self.job = None
         self.dryrun = dryrun
-        self.max_items = max_items
+        self.max_items = max_items or current_app.config['HARVEST_MAX_ITEMS']
 
     @property
     def config(self):

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -4,6 +4,7 @@ import requests
 
 from rdflib import Graph, URIRef, BNode
 from rdflib.namespace import RDF
+from typing import List
 
 from udata.rdf import (
     DCAT, DCT, HYDRA, SPDX, namespace_manager, guess_format, url_from_rdf
@@ -70,7 +71,11 @@ class DcatBackend(BaseBackend):
                 raise ValueError(msg)
         return fmt
 
-    def parse_graph(self, url, fmt):
+    def parse_graph(self, url, fmt) -> List[Graph]:
+        """
+        Returns an instance of rdflib.Graph for each detected page
+        The index in the list is the page number
+        """
         graphs = []
         page = 0
         while url:

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -22,10 +22,11 @@ def harvest(self, ident):
     if items > 0:
         finalize = harvest_job_finalize.s(backend.job.id)
         items = [
-            harvest_job_item.s(backend.job.id, item.remote_id)
+            (backend.job.id, item.remote_id)
             for item in backend.job.items
         ]
-        chord(items)(finalize)
+        chunks = harvest_job_item.chunks(items, 10)
+        chord(chunks.group())(finalize)
     elif items == 0:
         backend.finalize()
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -25,8 +25,7 @@ def harvest(self, ident):
             (backend.job.id, item.remote_id)
             for item in backend.job.items
         ]
-        chunks = harvest_job_item.chunks(items, 10)
-        chord(chunks.group())(finalize)
+        chord(items)(finalize)
     elif items == 0:
         backend.finalize()
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -22,7 +22,7 @@ def harvest(self, ident):
     if items > 0:
         finalize = harvest_job_finalize.s(backend.job.id)
         items = [
-            (backend.job.id, item.remote_id)
+            harvest_job_item.s(backend.job.id, item.remote_id)
             for item in backend.job.items
         ]
         chord(items)(finalize)

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -629,6 +629,16 @@ class ExecutionTestMixin(MockBackendsMixin):
         assert len(HarvestJob.objects) == 1
         assert len(Dataset.objects) == 0
 
+    @pytest.mark.options(HARVEST_MAX_ITEMS=5)
+    def test_harvest_max_items(self):
+        org = OrganizationFactory()
+        source = HarvestSourceFactory(backend='factory',
+                                      organization=org,
+                                      config={'count': 10})
+
+        self.action(source.slug)
+        assert len(Dataset.objects) == 5
+
 
 class HarvestLaunchTest(ExecutionTestMixin):
     def action(self, *args, **kwargs):

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -225,6 +225,10 @@ class Defaults(object):
     DELAY_BEFORE_REMINDER_NOTIFICATION = 30  # Days
 
     HARVEST_PREVIEW_MAX_ITEMS = 20
+
+    # Development setting to allow minimizing the number of harvested items
+    HARVEST_MAX_ITEMS = None
+
     # Harvesters are scheduled at midnight by default
     HARVEST_DEFAULT_SCHEDULE = '0 0 * * *'
 


### PR DESCRIPTION
This results in:
- successful preview on large multiple-paged DCAT catalogs
- fastest harvesting times on large multiple-paged DCAT catalogs

This is done through a different structure in `HarvestJob.data`. Previously we were storing the whole concatenated catalog in `HarvestJob.data.graph`, even when parsing multiple pages, and deserialising the whole catalog for each `HarvestItem`. Now we're storing a paged `HarvestJob.data.graphs` with one graph element for each page. Thus we only need to deserialise the right page when processing an `HarvestItem `.

This leads to 2x fastest overall speed for a 500 datasets catalog with five pages. I've also seen harvest process task being 3x fastest on larger catalogs.

This also introduces `HARVEST_MAX_ITEMS` setting, allowing to limit the number of harvested items per source on development platforms.

---

We could probably optimize more, for instance:
- store the relevant part of the graph for each `HarvestIem` before queuing the `harvest_job_item`, but I'm not sure how this would work DCAT-wise: could we have a small enough object? We also need to dig into `dataset_from_rdf` which probably won't be easy. We could also introduce bugs while manipulating the remote catalog, as it is we feed it straight to `dataset_from_rdf`
- create a `PageHarvestJob` with only the graph for the page stored in it, but this is heavy work since we would need to reconcile this with our current architecture and UI
- bulk process `HarvestItem` instead of one by one, but once again heavy work and impact on architecture and UI

For the preview part, we just stop iterating on pagination when we have enough objects. The drawback is that a faulty page somewhere in the catalog won't be catched when preview is ran, but I think we can live with it.