### PR TITLE
Handle None values in dataset and resource extras endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Handle None values in dataset and resource extras endpoints [#2805](https://github.com/opendatateam/udata/pull/2805)
 
 ## 6.0.1 (2023-01-18)
 

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -219,6 +219,12 @@ class DatasetExtrasAPI(API):
         if dataset.deleted:
             apiv2.abort(410, 'Dataset has been deleted')
         DatasetEditPermission(dataset).test()
+        # first remove extras key associated to a None value in payload
+        for key in [k for k in data if data[k] == None]:
+            if key in dataset.extras:
+                del dataset.extras[key]
+            data.pop(key)
+        # then update the extras with the remaining payload
         dataset.extras.update(data)
         dataset.save()
         return dataset.extras
@@ -329,6 +335,12 @@ class ResourceExtrasAPI(ResourceMixin, API):
             apiv2.abort(410, 'Dataset has been deleted')
         ResourceEditPermission(dataset).test()
         resource = self.get_resource_or_404(dataset, rid)
+        # first remove extras key associated to a None value in payload
+        for key in [k for k in data if data[k] == None]:
+            if key in resource.extras:
+                del resource.extras[key]
+            data.pop(key)
+        # then update the extras with the remaining payload
         resource.extras.update(data)
         resource.save()
         return resource.extras

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -336,8 +336,7 @@ class ResourceExtrasAPI(ResourceMixin, API):
         resource = self.get_resource_or_404(dataset, rid)
         # first remove extras key associated to a None value in payload
         for key in [k for k in data if data[k] == None]:
-            if key in resource.extras:
-                del resource.extras[key]
+            resource.extras.pop(key, None)
             data.pop(key)
         # then update the extras with the remaining payload
         resource.extras.update(data)

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -220,7 +220,7 @@ class DatasetExtrasAPI(API):
             apiv2.abort(410, 'Dataset has been deleted')
         DatasetEditPermission(dataset).test()
         # first remove extras key associated to a None value in payload
-        for key in [k for k in data if data[k] == None]:
+        for key in [k for k in data if data[k] is None]:
             if key in dataset.extras:
                 del dataset.extras[key]
             data.pop(key)

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -221,8 +221,7 @@ class DatasetExtrasAPI(API):
         DatasetEditPermission(dataset).test()
         # first remove extras key associated to a None value in payload
         for key in [k for k in data if data[k] is None]:
-            if key in dataset.extras:
-                del dataset.extras[key]
+            dataset.extras.pop(key, None)
             data.pop(key)
         # then update the extras with the remaining payload
         dataset.extras.update(data)

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -199,7 +199,10 @@ class DatasetExtrasAPITest(APITestCase):
         assert data['test::extra'] == 'test-value'
 
     def test_update_dataset_extras(self):
-        self.dataset.extras = {'test::extra': 'test-value', 'test::extra-second': 'test-value-second'}
+        self.dataset.extras = {
+            'test::extra': 'test-value',
+            'test::extra-second': 'test-value-second',
+        }
         self.dataset.save()
 
         data = ['test::extra-second', 'another::key']
@@ -207,7 +210,11 @@ class DatasetExtrasAPITest(APITestCase):
         self.assert400(response)
         assert response.json['message'] == 'Wrong payload format, dict expected'
 
-        data = {'test::extra-second': 'test-value-changed', 'another::key': 'another-value'}
+        data = {
+            'test::extra-second': 'test-value-changed',
+            'another::key': 'another-value',
+            'test::none': None,
+        }
         response = self.put(url_for('apiv2.dataset_extras', dataset=self.dataset), data)
         self.assert200(response)
 
@@ -215,6 +222,7 @@ class DatasetExtrasAPITest(APITestCase):
         assert self.dataset.extras['test::extra'] == 'test-value'
         assert self.dataset.extras['test::extra-second'] == 'test-value-changed'
         assert self.dataset.extras['another::key'] == 'another-value'
+        assert 'test::none' not in self.dataset.extras
 
     def test_delete_dataset_extras(self):
         self.dataset.extras = {'test::extra': 'test-value', 'another::key': 'another-value'}
@@ -265,7 +273,11 @@ class DatasetResourceExtrasAPITest(APITestCase):
         self.assert400(response)
         assert response.json['message'] == 'Wrong payload format, dict expected'
 
-        data = {'test::extra-second': 'test-value-changed', 'another::key': 'another-value'}
+        data = {
+            'test::extra-second': 'test-value-changed',
+            'another::key': 'another-value',
+            'test::none': None,
+        }
         response = self.put(url_for('apiv2.resource_extras', dataset=self.dataset,
                                     rid=resource.id), data)
         self.assert200(response)
@@ -274,6 +286,7 @@ class DatasetResourceExtrasAPITest(APITestCase):
         assert self.dataset.resources[0].extras['test::extra'] == 'test-value'
         assert self.dataset.resources[0].extras['test::extra-second'] == 'test-value-changed'
         assert self.dataset.resources[0].extras['another::key'] == 'another-value'
+        assert 'test::none' not in self.dataset.resources[0].extras
 
     def test_delete_resource_extras(self):
         resource = ResourceFactory()

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -202,6 +202,7 @@ class DatasetExtrasAPITest(APITestCase):
         self.dataset.extras = {
             'test::extra': 'test-value',
             'test::extra-second': 'test-value-second',
+            'test::none-will-be-deleted': 'test-value',
         }
         self.dataset.save()
 
@@ -214,6 +215,7 @@ class DatasetExtrasAPITest(APITestCase):
             'test::extra-second': 'test-value-changed',
             'another::key': 'another-value',
             'test::none': None,
+            'test::none-will-be-deleted': None,
         }
         response = self.put(url_for('apiv2.dataset_extras', dataset=self.dataset), data)
         self.assert200(response)
@@ -223,6 +225,7 @@ class DatasetExtrasAPITest(APITestCase):
         assert self.dataset.extras['test::extra-second'] == 'test-value-changed'
         assert self.dataset.extras['another::key'] == 'another-value'
         assert 'test::none' not in self.dataset.extras
+        assert 'test::none-will-be-deleted' not in self.dataset.extras
 
     def test_delete_dataset_extras(self):
         self.dataset.extras = {'test::extra': 'test-value', 'another::key': 'another-value'}
@@ -263,7 +266,11 @@ class DatasetResourceExtrasAPITest(APITestCase):
 
     def test_update_resource_extras(self):
         resource = ResourceFactory()
-        resource.extras = {'test::extra': 'test-value', 'test::extra-second': 'test-value-second'}
+        resource.extras = {
+            'test::extra': 'test-value',
+            'test::extra-second': 'test-value-second',
+            'test::none-will-be-deleted': 'test-value',
+        }
         self.dataset.resources.append(resource)
         self.dataset.save()
 
@@ -277,6 +284,7 @@ class DatasetResourceExtrasAPITest(APITestCase):
             'test::extra-second': 'test-value-changed',
             'another::key': 'another-value',
             'test::none': None,
+            'test::none-will-be-deleted': None,
         }
         response = self.put(url_for('apiv2.resource_extras', dataset=self.dataset,
                                     rid=resource.id), data)
@@ -287,6 +295,7 @@ class DatasetResourceExtrasAPITest(APITestCase):
         assert self.dataset.resources[0].extras['test::extra-second'] == 'test-value-changed'
         assert self.dataset.resources[0].extras['another::key'] == 'another-value'
         assert 'test::none' not in self.dataset.resources[0].extras
+        assert 'test::none-will-be-deleted' not in self.dataset.resources[0].extras
 
     def test_delete_resource_extras(self):
         resource = ResourceFactory()


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1001

- If key does not exist: ignore
- If key exists: delete