### PR TITLE
Fix only SHA1 checksum is accepted when uploading resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Handle None values in dataset and resource extras endpoints [#2805](https://github.com/opendatateam/udata/pull/2805)
-- Fix only SHA1 checksum is accepted when uploading resources
+- Fix only SHA1 checksum is accepted when uploading resources [#2808](https://github.com/opendatateam/udata/pull/2808)
 
 ## 6.0.1 (2023-01-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Handle None values in dataset and resource extras endpoints [#2805](https://github.com/opendatateam/udata/pull/2805)
+- Fix only SHA1 checksum is accepted when uploading resources
 
 ## 6.0.1 (2023-01-18)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -29,6 +29,7 @@ from udata.auth import admin_permission
 from udata.api import api, API, errors
 from udata.api.parsers import ModelApiParser
 from udata.core import storages
+from udata.core.dataset.models import CHECKSUM_TYPES
 from udata.core.storages.api import handle_upload, upload_parser
 from udata.core.badges import api as badges_api
 from udata.core.followers.api import FollowAPI
@@ -362,7 +363,10 @@ class UploadMixin(object):
         if 'html' in infos['mime']:
             api.abort(415, 'Incorrect file content type: HTML')
         infos['title'] = os.path.basename(infos['filename'])
-        infos['checksum'] = Checksum(type='sha1', value=infos.pop('sha1'))
+        for checksum_type in CHECKSUM_TYPES:
+            if checksum_type in infos:
+                infos['checksum'] = Checksum(type=checksum_type, value=infos.pop(checksum_type))
+                break
         infos['filesize'] = infos.pop('size')
         del infos['filename']
         return infos

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -363,10 +363,8 @@ class UploadMixin(object):
         if 'html' in infos['mime']:
             api.abort(415, 'Incorrect file content type: HTML')
         infos['title'] = os.path.basename(infos['filename'])
-        for checksum_type in CHECKSUM_TYPES:
-            if checksum_type in infos:
-                infos['checksum'] = Checksum(type=checksum_type, value=infos.pop(checksum_type))
-                break
+        checksum_type = next(checksum_type for checksum_type in CHECKSUM_TYPES if checksum_type in infos)
+        infos['checksum'] = Checksum(type=checksum_type, value=infos.pop(checksum_type))
         infos['filesize'] = infos.pop('size')
         del infos['filename']
         return infos

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -151,9 +151,8 @@ def store_resource(csvfile, model, dataset):
     r_info['fs_filename'] = stored_filename
     checksum = r_info.pop('checksum')
     algo, checksum = checksum.split(':', 1)
-    r_info[algo] = checksum
     r_info['format'] = storages.utils.extension(stored_filename)
-    r_info['checksum'] = Checksum(type='sha1', value=r_info.pop('sha1'))
+    r_info['checksum'] = Checksum(type=algo, value=checksum)
     r_info['filesize'] = r_info.pop('size')
     del r_info['filename']
     r_info['title'] = filename


### PR DESCRIPTION
Depending on the storage type and settings, it might happen that resource metadata will provide a non-SHA1 checksum. At the moment it causes an exception. This MR fixes that and makes resource uploader accept all other supported checksum types.

In addition, a similar inconsistency is fixed within CSV export implementation.