### PR TITLE
Fix default license being selected in form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Handle None values in dataset and resource extras endpoints [#2805](https://github.com/opendatateam/udata/pull/2805)
+- Fix default license being selected in form in optional select group [#2809](https://github.com/opendatateam/udata/pull/2809)
 
 ## 6.0.1 (2023-01-18)
 

--- a/js/components/form/select-input-group.vue
+++ b/js/components/form/select-input-group.vue
@@ -8,7 +8,7 @@
     :disabled="readonly"
     @change="onChange">
     <optgroup v-for="(group, ids) in field.groups" :label="group">
-        <option v-for="option in options | extract group" :value="option.value">
+        <option v-for="option in options | extract group" :value="option.value" :selected="option.value == value">
             {{option.text || option.value}}
         </option>
     </optgroup>
@@ -25,7 +25,9 @@ export default {
     props: {
         groups: {
             type: Object,
-            default: {}
+            default() {
+                return {}
+            }
         }
     },
     computed: {


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1034

Struggle to understand why it doesn't work exactly. It seems to be due to the optgroup tag.
Selecting the option explicitely using `:selected="option.value == value"` does the trick