### PR TITLE
Fix organization metrics count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Handle None values in dataset and resource extras endpoints [#2805](https://github.com/opendatateam/udata/pull/2805)
 - Fix default license being selected in form in optional select group [#2809](https://github.com/opendatateam/udata/pull/2809)
 - Fix only SHA1 checksum is accepted when uploading resources [#2808](https://github.com/opendatateam/udata/pull/2808)
+- Fix organization metrics count [#2811](https://github.com/opendatateam/udata/pull/2811)
 
 ## 6.0.1 (2023-01-18)
 

--- a/udata/core/metrics/commands.py
+++ b/udata/core/metrics/commands.py
@@ -94,6 +94,7 @@ def update(site=False, organizations=False, users=False, datasets=False,
                     organization.count_datasets()
                     organization.count_reuses()
                     organization.count_followers()
+                    organization.count_members()
                 except Exception as e:
                     log.info(f'Error during update: {e}')
                     continue

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -357,6 +357,7 @@ class MemberAPI(API):
         member = org.member(user)
         if member:
             Organization.objects(id=org.id).update_one(pull__members=member)
+            org.reload()
             org.count_members()
             return '', 204
         else:

--- a/udata/core/organization/forms.py
+++ b/udata/core/organization/forms.py
@@ -39,6 +39,7 @@ class OrganizationForm(ModelForm):
             user = current_user._get_current_object()
             member = Member(user=user, role='admin')
             org.members.append(member)
+            org.count_members()
 
         if commit:
             org.save()

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -271,7 +271,7 @@ class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
 
     def count_reuses(self):
         from udata.models import Reuse
-        self.metrics['reuses'] = Reuse.objects(organization=self).count()
+        self.metrics['reuses'] = Reuse.objects(organization=self).visible().count()
         self.save()
 
     def count_followers(self):

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -105,6 +105,10 @@ from udata.features.territories.models import *  # noqa
 # Load HarvestSource model as harvest for catalog
 from udata.harvest.models import HarvestSource as Harvest  # noqa
 
+# Load metrics
+import udata.core.organization.metrics  # noqa
+import udata.core.followers.metrics  # noqa
+
 import udata.linkchecker.models  # noqa
 
 

--- a/udata/models/__init__.py
+++ b/udata/models/__init__.py
@@ -105,10 +105,6 @@ from udata.features.territories.models import *  # noqa
 # Load HarvestSource model as harvest for catalog
 from udata.harvest.models import HarvestSource as Harvest  # noqa
 
-# Load metrics
-import udata.core.organization.metrics  # noqa
-import udata.core.followers.metrics  # noqa
-
 import udata.linkchecker.models  # noqa
 
 

--- a/udata/tests/api/test_follow_api.py
+++ b/udata/tests/api/test_follow_api.py
@@ -12,6 +12,9 @@ from . import APITestCase
 class Fake(db.Document):
     name = db.StringField()
 
+    def count_followers(self):
+        pass
+
 
 @api.route('/fake/<id>/follow/', endpoint='follow_fake')
 class FollowFakeAPI(FollowAPI):

--- a/udata/tests/api/test_follow_api.py
+++ b/udata/tests/api/test_follow_api.py
@@ -9,7 +9,7 @@ from udata.core.followers.signals import on_follow, on_unfollow
 from . import APITestCase
 
 
-class Fake(db.Document):
+class FakeModel(db.Document):
     name = db.StringField()
 
     def count_followers(self):
@@ -18,7 +18,7 @@ class Fake(db.Document):
 
 @api.route('/fake/<id>/follow/', endpoint='follow_fake')
 class FollowFakeAPI(FollowAPI):
-    model = Fake
+    model = FakeModel
 
 
 class FollowAPITest(APITestCase):
@@ -32,7 +32,7 @@ class FollowAPITest(APITestCase):
     def test_follow(self):
         '''It should follow on POST'''
         user = self.login()
-        to_follow = Fake.objects.create()
+        to_follow = FakeModel.objects.create()
 
         with on_follow.connected_to(self.handler):
             response = self.post(url_for('api.follow_fake', id=to_follow.id))
@@ -53,7 +53,7 @@ class FollowAPITest(APITestCase):
     def test_follow_already_followed(self):
         '''It should do nothing when following an already followed object'''
         user = self.login()
-        to_follow = Fake.objects.create()
+        to_follow = FakeModel.objects.create()
         Follow.objects.create(follower=user, following=to_follow)
 
         with on_follow.connected_to(self.handler):
@@ -70,7 +70,7 @@ class FollowAPITest(APITestCase):
     def test_unfollow(self):
         '''It should unfollow on DELETE'''
         user = self.login()
-        to_follow = Fake.objects.create()
+        to_follow = FakeModel.objects.create()
         Follow.objects.create(follower=user, following=to_follow)
 
         with on_unfollow.connected_to(self.handler):
@@ -91,7 +91,7 @@ class FollowAPITest(APITestCase):
     def test_unfollow_not_existing(self):
         '''It should raise 404 when trying to unfollow a not followed object'''
         self.login()
-        to_follow = Fake.objects.create()
+        to_follow = FakeModel.objects.create()
 
         response = self.delete(url_for('api.follow_fake', id=to_follow.id))
         self.assert404(response)

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -76,6 +76,7 @@ class OrganizationAPITest:
         member = org.member(user)
         assert member is not None, 'Current user should be a member'
         assert member.role == 'admin', 'Current user should be an administrator'
+        assert org.get_metrics()['members'] == 1
 
     def test_organization_api_update(self, api):
         '''It should update an organization from the API'''
@@ -345,6 +346,7 @@ class MembershipAPITest:
         organization.reload()
         assert organization.is_member(added_user)
         assert organization.is_admin(added_user)
+        assert organization.get_metrics()['members'] == 2
 
     def test_only_admin_can_create_member(self, api):
         user = api.login()
@@ -430,6 +432,7 @@ class MembershipAPITest:
 
         organization.reload()
         assert not organization.is_member(deleted_user)
+        assert organization.get_metrics()['members'] == 1
 
     def test_only_admin_can_delete_member(self, api):
         user = api.login()

--- a/udata/tests/organization/test_organization_model.py
+++ b/udata/tests/organization/test_organization_model.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+from udata.core.dataset.factories import DatasetFactory, VisibleDatasetFactory
+from udata.core.organization.factories import OrganizationFactory
+from udata.core.followers.signals import on_follow, on_unfollow
+from udata.core.reuse.factories import ReuseFactory, VisibleReuseFactory
+from udata.core.user.factories import UserFactory
+from udata.models import Dataset, Reuse, Follow, Member
+from udata.tests.helpers import assert_emit
+
+from .. import TestCase, DBTestMixin
+
+
+class OrganizationModelTest(TestCase, DBTestMixin):
+
+    def test_organization_metrics(self):
+        # Members count update are in API calls, thus being tested in API dedicated tests
+
+        member = Member(user=UserFactory(), role='admin')
+        org = OrganizationFactory(members=[member])
+
+        with assert_emit(Reuse.on_create):
+            reuse = VisibleReuseFactory(organization=org)
+            ReuseFactory(organization=org)
+        with assert_emit(Dataset.on_create):
+            dataset = VisibleDatasetFactory(organization=org)
+            DatasetFactory(organization=org)
+        with assert_emit(on_follow):
+            follow = Follow.objects.create(following=org, follower=UserFactory(),
+                                           since=datetime.now())
+
+        assert org.get_metrics()['datasets'] == 1
+        assert org.get_metrics()['reuses'] == 1
+        assert org.get_metrics()['followers'] == 1
+
+        with assert_emit(Reuse.on_delete):
+            reuse.deleted = datetime.now()
+            reuse.save()
+        with assert_emit(Dataset.on_delete):
+            dataset.deleted = datetime.now()
+            dataset.save()
+        with assert_emit(on_unfollow):
+            follow.until = datetime.now()
+            follow.save()
+
+        assert org.get_metrics()['datasets'] == 0
+        assert org.get_metrics()['reuses'] == 0
+        assert org.get_metrics()['followers'] == 0

--- a/udata/tests/organization/test_organization_model.py
+++ b/udata/tests/organization/test_organization_model.py
@@ -13,6 +13,10 @@ from .. import TestCase, DBTestMixin
 
 class OrganizationModelTest(TestCase, DBTestMixin):
 
+    # Load metrics
+    import udata.core.organization.metrics  # noqa
+    import udata.core.followers.metrics  # noqa
+
     def test_organization_metrics(self):
         # Members count update are in API calls, thus being tested in API dedicated tests
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/999
Fix https://github.com/etalab/data.gouv.fr/issues/1021

* Add tests on all organization metrics
* Add some count_members() and reload org if needed
* Filter on visible reuses only
* Recompute organization members count on `udata metrics update` command

Since organization and followers metrics are now loaded in a test, I've updated Fake Follow model to succeed when signals are now called.