### PR TITLE
Add `udata harvest clean` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix default license being selected in form in optional select group [#2809](https://github.com/opendatateam/udata/pull/2809)
 - Fix only SHA1 checksum is accepted when uploading resources [#2808](https://github.com/opendatateam/udata/pull/2808)
 - Fix organization metrics count [#2811](https://github.com/opendatateam/udata/pull/2811)
+- Add `udata harvest clean` command [#2812](https://github.com/opendatateam/udata/pull/2812)
 
 ## 6.0.1 (2023-01-18)
 

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -139,7 +139,8 @@ def clean_source(ident):
     source = get_source(ident)
     datasets = Dataset.objects.filter(harvest__source_id=str(source.id))
     for dataset in datasets:
-        dataset.delete()
+        dataset.deleted = datetime.now()
+        dataset.save()    
     return len(datasets)
 
 

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -133,6 +133,7 @@ def delete_source(ident):
     signals.harvest_source_deleted.send(source)
     return source
 
+
 def clean_source(ident):
     '''Deletes all datasets linked to a harvest source'''
     source = get_source(ident)

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -133,6 +133,14 @@ def delete_source(ident):
     signals.harvest_source_deleted.send(source)
     return source
 
+def clean_source(ident):
+    '''Deletes all datasets linked to a harvest source'''
+    source = get_source(ident)
+    datasets = Dataset.objects.filter(harvest__source_id=str(source.id))
+    for dataset in datasets:
+        dataset.delete()
+    return len(datasets)
+
 
 def purge_sources():
     '''Permanently remove sources flagged as deleted'''

--- a/udata/harvest/commands.py
+++ b/udata/harvest/commands.py
@@ -57,6 +57,15 @@ def delete(identifier):
 
 
 @grp.command()
+@click.argument('identifier')
+def clean(identifier):
+    '''Delete all datasets linked to a harvest source'''
+    log.info(f'Cleaning source "{identifier}"')
+    num_of_datasets = actions.clean_source(identifier)
+    log.info(f'Cleaned source "{identifier}" - deleted {num_of_datasets} dataset(s)')
+
+
+@grp.command()
 @click.option('-s', '--scheduled', is_flag=True,
               help='list only scheduled source')
 def sources(scheduled=False):


### PR DESCRIPTION
Might be a minor thing, but I found it handy to have a command to clean a harvest source, namely delete all datasets that are linked to it:

`udata harvest clean <harvest_source_id>`
