### PR TITLE
Fix setuptools version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,11 @@ jobs:
           - py3-cache-v9-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
+          # FIXME: For now, we fix setuptools due to https://github.com/etalab/data.gouv.fr/issues/1041
           command: |
             virtualenv venv
             source venv/bin/activate
+            pip install setuptools==66.1.1
             pip install -r requirements/develop.pip
             pip install -e .
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix default license being selected in form in optional select group [#2809](https://github.com/opendatateam/udata/pull/2809)
 - Fix only SHA1 checksum is accepted when uploading resources [#2808](https://github.com/opendatateam/udata/pull/2808)
 - Fix organization metrics count [#2811](https://github.com/opendatateam/udata/pull/2811)
+- Fix setuptools version used in CI [#2813](https://github.com/opendatateam/udata/pull/2813)
 
 ## 6.0.1 (2023-01-18)
 


### PR DESCRIPTION
A solution for https://github.com/etalab/data.gouv.fr/issues/1041.

Since there are conflicts between latest celery (with their fix) and flask version, a proposed solution to make the CI work for now.