### PR TITLE
Fix ISODateTime field with aware string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix edge case on aware datetime string [#2827](https://github.com/opendatateam/udata/pull/2827)
 
 ## 6.1.0 (2023-03-07)
 

--- a/udata/api/fields.py
+++ b/udata/api/fields.py
@@ -18,7 +18,7 @@ class ISODateTime(String):
     def format(self, value):
         if isinstance(value, str):
             value = parse(value)
-        elif isinstance(value, datetime.date) and not isinstance(value, datetime.datetime) or value.tzinfo:
+        if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime) or value.tzinfo:
             return value.isoformat()
         return pytz.utc.localize(value).isoformat()
 

--- a/udata/tests/api/test_fields.py
+++ b/udata/tests/api/test_fields.py
@@ -11,6 +11,7 @@ class FieldTest(APITestCase):
     def test_iso_date_time_field_format(self):
         datetime_date_naive = datetime.now()
         datetime_date_aware = pytz.utc.localize(datetime_date_naive)
+        datetime_date_aware_string = datetime_date_aware.isoformat()
         date_date = date.today()
 
         result = ISODateTime().format(str(datetime_date_naive))
@@ -21,6 +22,9 @@ class FieldTest(APITestCase):
 
         result = ISODateTime().format(datetime_date_aware)
         self.assertEqual(result, datetime_date_aware.isoformat())
+
+        result = ISODateTime().format(datetime_date_aware_string)
+        self.assertEqual(result, datetime_date_aware_string)
 
         result = ISODateTime().format(date_date)
         self.assertEqual(result, date_date.isoformat())


### PR DESCRIPTION
Follows https://github.com/opendatateam/udata/pull/2810

It fails on harvest preview with timezone aware strings. Ex on: https://demo.data.gouv.fr/fr/admin/harvester/640a0a5cb4cc1032951b1372
Indeed, we shouldn't have an `elif` condition, since value is updated in the first `if` case.