### PR TITLE
Fix/uri validation error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix URLField validation error message [#2831](https://github.com/opendatateam/udata/pull/2831)
 
 ## 6.1.1 (2023-03-17)
 

--- a/udata/models/url_field.py
+++ b/udata/models/url_field.py
@@ -42,4 +42,4 @@ class URLField(StringField):
         try:
             uris.validate(value, **kwargs)
         except uris.ValidationError as e:
-            self.error(e.message)
+            self.error(str(e))

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -347,7 +347,7 @@ class URLFieldTest:
 
     def test_not_valid(self):
         obj = URLTester(url='invalid')
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match='Invalid URL'):
             obj.save()
 
     def test_strip_spaces(self):
@@ -365,7 +365,7 @@ class URLFieldTest:
     def test_public_private(self):
         url = 'http://10.10.0.2/path/'
         PrivateURLTester(url=url).save()
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match='private URL'):
             URLTester(url=url).save()
 
 

--- a/udata/tests/test_uris.py
+++ b/udata/tests/test_uris.py
@@ -193,38 +193,38 @@ def test_default_should_validate_default_schemes(scheme):
 @pytest.mark.parametrize('scheme', CUSTOM_SCHEMES)
 def test_default_should_not_validate_non_default_schemes(scheme):
     url = '{0}://somewhere.com'.format(scheme)
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='Invalid scheme'):
         uris.validate(url)
 
 
 @pytest.mark.parametrize('tld', CUSTOM_TLDS)
 def test_default_should_not_validate_unknown_tlds(tld):
     url = 'http://somewhere.{0}'.format(tld)
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='Invalid TLD'):
         uris.validate(url)
 
 
 @pytest.mark.parametrize('url', PRIVATE)
 def test_default_should_not_validate_private_urls(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='private URL'):
         uris.validate(url)
 
 
 @pytest.mark.parametrize('url', LOCAL_HOSTS)
 def test_default_should_not_validate_local_hosts(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='local URL'):
         uris.validate(url)
 
 
 @pytest.mark.parametrize('url', INVALID)
 def test_should_not_validate_bad_urls(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='Invalid URL'):
         uris.validate(url)
 
 
 @pytest.mark.parametrize('url', MULTICAST)
 def test_should_not_validate_multicast_urls(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='multicast IP'):
         uris.validate(url)
 
 
@@ -235,7 +235,7 @@ def test_private_should_validate_public_and_private_urls(url):
 
 @pytest.mark.parametrize('url', LOCAL)
 def test_private_should_not_validate_local_urls(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='local URL'):
         uris.validate(url, private=True)
 
 
@@ -246,7 +246,7 @@ def test_local_should_validate_public_and_local_urls(url):
 
 @pytest.mark.parametrize('url', PRIVATE)
 def test_local_should_not_validate_private_urls(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='private URL'):
         uris.validate(url, local=True)
 
 
@@ -264,7 +264,7 @@ def test_custom_schemes(scheme):
 @pytest.mark.parametrize('scheme', DEFAULT_SCHEMES)
 def test_custom_schemes_should_not_validate_defaults(scheme):
     url = '{0}://somewhere.com'.format(scheme)
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='Invalid scheme'):
         uris.validate(url, schemes=CUSTOM_SCHEMES)
 
 
@@ -277,7 +277,7 @@ def test_custom_tlds(tld):
 @pytest.mark.parametrize('tld', DEFAULT_TLDS)
 def test_custom_tlds_should_not_validate_defaults(tld):
     url = 'http://somewhere.{0}'.format(tld)
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='Invalid TLD'):
         uris.validate(url, tlds=CUSTOM_TLDS)
 
 
@@ -288,6 +288,5 @@ def test_with_credentials(url):
 
 @pytest.mark.parametrize('url', WITH_CREDENTIALS)
 def test_with_credentials_disabled(url):
-    with pytest.raises(uris.ValidationError):
+    with pytest.raises(uris.ValidationError, match='Credentials in URL are not allowed'):
         uris.validate(url, credentials=False)
-


### PR DESCRIPTION
Fix URLField validation message.
Instead of showing an explicit validation error message such as `Invalid TLD`, `Invalid URL `, etc. it was showing `ValidationError (Dataset:6372520d69c531b5f066b766) (9.url.'ValidationError' object has no attribute 'message' 11.url.'ValidationError' object has no attribute 'message': ['resources'])`
Indeed, `uris.ValidationError` doesn't have a `message` attribute.

See https://errors.data.gouv.fr/organizations/sentry/issues/15/events/3c89a5b0dc954987a3cb17a15e0f4f04/?project=3&referrer=events-table%2F%3Fproject%3D3&statsPeriod=14d