### PR TITLE
Do not fail on RecipientsRefused in sendmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - Upgrade WTForms-json 0.3.3 -> 0.3.5
     - New security email template for existing users
 - Add `format_timedelta` to `udata.i18n` [#2836](https://github.com/opendatateam/udata/pull/2836)
+- Improve send_mail resilience with refused address among recipients [#2840](https://github.com/opendatateam/udata/pull/2840)
 
 ## 6.1.2 (2023-03-28)
 

--- a/udata/mail.py
+++ b/udata/mail.py
@@ -6,6 +6,8 @@ from blinker import signal
 from flask import current_app, render_template
 from flask_mail import Mail, Message
 
+from smtplib import SMTPException
+
 from udata import i18n
 
 
@@ -65,4 +67,7 @@ def send(subject, recipients, template_base, **kwargs):
                 msg.html = render_template(
                     f'{tpl_path}.html', subject=subject,
                     sender=sender, recipient=recipient, **kwargs)
-                conn.send(msg)
+                try:
+                    conn.send(msg)
+                except SMTPException as e:
+                    log.error(f'Error sending mail {e}')

--- a/udata/tests/test_mail.py
+++ b/udata/tests/test_mail.py
@@ -1,0 +1,56 @@
+from contextlib import contextmanager
+from smtplib import SMTPRecipientsRefused
+
+import pytest
+
+from udata.core.user.factories import UserFactory
+from udata.mail import send, mail_sent
+from udata.tests import TestCase, DBTestMixin
+from udata.tests.helpers import assert_emit, assert_not_emit
+
+
+SMTPRecipientsRefusedList = [
+    'not-found@udata',
+    'not-found-either@udata'
+]
+
+
+class FakeSender():
+    def send(self, msg):
+        if all(recipient in SMTPRecipientsRefusedList for recipient in msg.recipients):
+            raise SMTPRecipientsRefused(msg.recipients)
+        mail_sent.send(msg)
+
+
+class FakeMail():
+    @contextmanager
+    def connect(*args, **kw):
+        yield FakeSender()
+
+
+class MailSendTest(TestCase, DBTestMixin):
+    def create_app(self):
+        app = super().create_app()
+        app.config['SEND_MAIL'] = True
+        return app
+
+    @pytest.fixture(autouse=True)
+    def patch_mail(self, mocker):
+        mocker.patch('udata.mail.mail', FakeMail())
+
+    def test_send_mail(self):
+        with assert_emit(mail_sent):
+            send('subject', [UserFactory(email='recipient@udata')], 'base')
+
+    def test_send_mail_to_not_found_recipients(self):
+        with assert_not_emit(mail_sent):
+            send('subject', [UserFactory(email='not-found@udata')], 'base')
+
+    def test_send_mail_to_multiple_recipients_with_some_not_found(self):
+        recipients = [
+            UserFactory(email='not-found@udata'),
+            UserFactory(email='recipient@udata'),
+            UserFactory(email='not-found-either@udata')
+        ]
+        with assert_emit(mail_sent):
+            send('subject', recipients, 'base')


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1074

See underlying logic that sends the `SMTPRecipientsRefused` error (`The server rejected ALL recipients (no mail was sent)`): https://github.com/python/cpython/blob/3.11/Lib/smtplib.py#L808`
Add minimal test case on the send mail functionality, with refused recipients case.