### PR TITLE
Fix SelectField validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Upgrade WTForms 2.2.1 -> 3.0.1
     - Upgrade WTForms-json 0.3.3 -> 0.3.5
     - New security email template for existing users
+- Fix SelectField validation failure following WTForms upgrade [#2841](https://github.com/opendatateam/udata/pull/2841)
 - Add `format_timedelta` to `udata.i18n` [#2836](https://github.com/opendatateam/udata/pull/2836)
 - Improve send_mail resilience with refused address among recipients [#2840](https://github.com/opendatateam/udata/pull/2840)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -454,7 +454,7 @@ class Testing(object):
     CACHE_NO_NULL_WARNING = True
     DEBUG_TOOLBAR = False
     SERVER_NAME = 'local.test'
-    DEFAULT_LANGUAGE = 'en'
+    DEFAULT_LANGUAGE = 'fr'
     ACTIVATE_TERRITORIES = False
     LOGGER_HANDLER_POLICY = 'never'
     CELERYD_HIJACK_ROOT_LOGGER = False

--- a/udata/tests/forms/test_model_field.py
+++ b/udata/tests/forms/test_model_field.py
@@ -164,7 +164,7 @@ class Required:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert 'required' in form.errors['target'][0]
+        assert 'requis' in form.errors['target'][0]
 
     def test_none(self):
         form = self.form.from_json({
@@ -176,7 +176,7 @@ class Required:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert 'required' in form.errors['target'][0]
+        assert 'requis' in form.errors['target'][0]
 
     def test_with_initial_object_none(self):
         model = self.model(target=Target.objects.create())
@@ -190,7 +190,7 @@ class Required:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert 'required' in form.errors['target'][0]
+        assert 'requis' in form.errors['target'][0]
 
 
 class Optionnal:


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/2826 and wtforms upgrade, we now have an error on SelectField Validation : https://errors.data.gouv.fr/organizations/sentry/issues/1667/?alert_rule_id=3&alert_timestamp=1680857196717&environment=production&project=3.
Calling the `PUT api/1/datasets/<dataset-id>` leads to this error for example.

The underlying SelectField validation behavior has changed in wtforms.
The code has changed from [2.2.1](https://github.com/wtforms/wtforms/blob/7152845801e88ab6a9c7d719b73d41bef6464b5d/wtforms/fields/core.py#L470) to [3.0.1](https://github.com/wtforms/wtforms/blob/94a5c268cd914798172ab6b6e85375c9447e3b70/src/wtforms/fields/choices.py#L134), leading to `iter_choices` being called when it wasn't before, where the issue occurs.

It seems the the lazystring created by `_(label)` in `localized_choices` is broken, which is why it fails with `unhashable type: '_LazyString'`.

This fix is a workaround. It checks if the label is lazystring already, preventing applying lazy_gettext twice, leading to a broken lazystring:
```
>>> from udata.i18n import lazy_gettext as _
>>> _('dataset')
l'jeu de données'
>>> _(_('dataset'))
<_LazyString broken>
```
___
However, two questions are left open before merging:
- [x] why doesn't it fail in tests when the exact same form validation should be applied? We have an issue if we have different behavior between tests and run
    - Because double translations do not fail in English, which is DEFAULT_LANGUAGE. We have turned it to `fr` in tests, to make sure to apply translations logic all around
- [x] I've seen lazy_gettext being applied twice without issues when debugging, why does it fail in this case?
    - If translation language is English, double translations do not fail (translation of dataset is dataset, and again and again?)