### PR TITLE
Add user arg to discussion list api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix SelectField validation failure following WTForms upgrade [#2841](https://github.com/opendatateam/udata/pull/2841)
 - Add `format_timedelta` to `udata.i18n` [#2836](https://github.com/opendatateam/udata/pull/2836)
 - Improve send_mail resilience with refused address among recipients [#2840](https://github.com/opendatateam/udata/pull/2840)
+- Add user arg to discussion list API [#2842](https://github.com/opendatateam/udata/pull/2842)
 
 ## 6.1.2 (2023-03-28)
 

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -1,3 +1,4 @@
+from bson import ObjectId
 from datetime import datetime
 
 from flask_security import current_user
@@ -74,6 +75,9 @@ parser.add_argument(
 parser.add_argument(
     'for', type=str, location='args', action='append',
     help='Filter discussions for a given subject')
+parser.add_argument(
+    'user', type=str, location='args',
+    help='Filter discussions created by a user')
 parser.add_argument(
     'page', type=int, default=1, location='args', help='The page to fetch')
 parser.add_argument(
@@ -165,6 +169,8 @@ class DiscussionsAPI(API):
         discussions = Discussion.objects
         if args['for']:
             discussions = discussions.generic_in(subject=args['for'])
+        if args['user']:
+            discussions = discussions(discussion__posted_by=ObjectId(args['user']))
         if args['closed'] is False:
             discussions = discussions(closed=None)
         elif args['closed'] is True:

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -220,6 +220,35 @@ class DiscussionsTest(APITestCase):
 
         self.assertEqual(len(response.json['data']), len(discussions))
 
+    def test_list_discussions_user(self):
+        dataset = DatasetFactory()
+        discussions = []
+        for i in range(3):
+            user = UserFactory()
+            message = Message(content=faker.sentence(), posted_by=user)
+            discussion = Discussion.objects.create(
+                subject=dataset,
+                user=user,
+                title='test discussion {}'.format(i),
+                discussion=[message]
+            )
+            discussions.append(discussion)
+        user = UserFactory()
+        message = Message(content=faker.sentence(), posted_by=user)
+        Discussion.objects.create(
+            subject=DatasetFactory(),
+            user=user,
+            title='test discussion {}'.format(i+1),
+            discussion=[message]
+        )
+
+        kwargs = {'user': str(user.id)}
+        response = self.get(url_for('api.discussions', **kwargs))
+        self.assert200(response)
+
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['user']['id'], str(user.id))
+
     def test_get_discussion(self):
         dataset = Dataset.objects.create(title='Test dataset')
         user = UserFactory()


### PR DESCRIPTION
First step to https://github.com/etalab/data.gouv.fr/issues/1075
It allows to fetch all discussions created by a user.

We may want to rethink discussions endpoint (having /discussions, org/discussions) later on, but I don't think this contribution adds much debt.