### PR TITLE
Escape user content in selectize items in admin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
-            pip install setuptools==66.1.1
+            pip install --force-reinstall setuptools==66.1.1
             pip install -r requirements/develop.pip
             pip install -e .
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Fix XSS vulnerability: escape user content in selectize items in admin [#2843](https://github.com/opendatateam/udata/pull/2843)
 - Fix schema is undefined when checking for schema.url in admin resource form [#2837](https://github.com/opendatateam/udata/pull/2837)
 - Fix to_naive_datetime in harvest preview [#2835](https://github.com/opendatateam/udata/pull/2835)
 - :warning: Flask-Security update to enable `GenericResponses` [#2826](https://github.com/opendatateam/udata/pull/2826):

--- a/js/components/form/dataset-completer.vue
+++ b/js/components/form/dataset-completer.vue
@@ -5,12 +5,14 @@ import Dataset from 'models/dataset';
 import BaseCompleter from 'components/form/base-completer.vue';
 import DatasetCard from 'components/dataset/card.vue';
 
-const optTpl = `<div class="selectize-option">
-    <div class="logo pull-left">
-        <img src="{{image_url}}"/>
-    </div>
-    {{title}}
-</div>`;
+function render(data, escape) {
+    return `<div class="selectize-option">
+        <div class="logo pull-left">
+            <img src=" ${data.image_url} "/>
+        </div>
+        ${escape(data.title)}
+    </div>`;
+}
 
 
 function cardify(value, $el) {
@@ -50,11 +52,9 @@ export default {
             });
         },
         render: {
-            option: function(data, escape) {
-                return new Vue({data: data}).$interpolate(optTpl);
-            },
+            option: render,
             item: function(data, escape) {
-                return `<div class="card-input">${data.title}</div>`;
+                return `<div class="card-input">${escape(data.title)}</div>`;
             }
         },
     }

--- a/js/components/form/reuse-completer.vue
+++ b/js/components/form/reuse-completer.vue
@@ -5,12 +5,15 @@ import Reuse from 'models/reuse';
 import BaseCompleter from 'components/form/base-completer.vue';
 import ReuseCard from 'components/reuse/card.vue';
 
-const template = `<div class="selectize-option">
-    <div class="logo pull-left">
-        <img src="{{image_url}}"/>
-    </div>
-    {{title}}
-</div>`;
+
+function render(data, escape) {
+    return `<div class="selectize-option">
+        <div class="logo pull-left">
+            <img src=" ${data.image_url} "/>
+        </div>
+        ${escape(data.title)}
+    </div>`;
+}
 
 function cardify(value, $el) {
     var card = new Vue({
@@ -45,11 +48,9 @@ export default {
             });
         },
         render: {
-            option: function(data, escape) {
-                return new Vue({data: data}).$interpolate(template);
-            },
+            option: render,
             item: function(data, escape) {
-                return `<div class="card-input">${data.title}</div>`;
+                return `<div class="card-input">${escape(data.title)}</div>`;
             }
         }
     }

--- a/js/components/form/user-completer.vue
+++ b/js/components/form/user-completer.vue
@@ -3,17 +3,15 @@
 import Vue from 'vue';
 import API from 'api';
 import BaseCompleter from 'components/form/base-completer.vue';
-
-const template = `<div class="selectize-option">
-    <div class="logo pull-left">
-        <img src="{{ user | avatar_url 32 }}"/>
-    </div>
-    {{user.first_name}} {{user.last_name}}
-</div>`;
+import placeholders from 'helpers/placeholders';
 
 
-function render(user) {
-    return new Vue({data: {user: user}}).$interpolate(template);
+function render(user, escape) {
+    return `<div class="selectize-option">
+        <div class="logo pull-left">
+            <img src=" ${placeholders.user_avatar(user, 32)} "/>
+        </div> ${escape(user.first_name)} ${escape(user.last_name)}
+    </div>`;
 }
 
 export default {
@@ -26,8 +24,8 @@ export default {
         options: [],
         plugins: ['remove_button'],
         render: {
-            option: (data, escape) => render(data),
-            item: (data, escape) => render(data)
+            option: render,
+            item: render
         },
     },
     dataLoaded(data) {


### PR DESCRIPTION
We did not escape user content in custom rendering in Selectize components.
See https://selectize.dev/docs/usage#custom-rendering

It seems that directly returning a raw string instead of a `new Vue({data: data}).$interpolate(template);` works as well, allowing use to escape user content :)