### PR TITLE
Compile translations for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Compile translations for testing [#2845](https://github.com/opendatateam/udata/pull/2845)
 
 ## 6.1.3 (2023-04-18)
 

--- a/udata/tests/dataset/test_dataset_actions.py
+++ b/udata/tests/dataset/test_dataset_actions.py
@@ -21,4 +21,4 @@ class DatasetActionsTest:
         assert dataset.archived is not None
         discussions = Discussion.objects.filter(subject=dataset)
         assert len(discussions) == 1
-        assert 'archived' in discussions[0].discussion[0].content
+        assert discussions[0].discussion[0].posted_by == user

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -20,6 +20,7 @@ from udata.core.dataset.rdf import (
     temporal_from_rdf, frequency_to_rdf, frequency_from_rdf,
     EU_RDF_REQUENCIES
 )
+from udata.i18n import gettext as _
 from udata.rdf import DCAT, DCT, FREQ, SPDX, SCHEMA, SKOS
 from udata.utils import faker
 from udata.tests.helpers import assert200, assert_redirects
@@ -53,7 +54,7 @@ class DatasetToRdfTest:
         g = d.graph
 
         assert isinstance(d, RdfResource)
-        assert len(list(g.subjects(RDF.type, DCAT.Dataset))) is 1
+        assert len(list(g.subjects(RDF.type, DCAT.Dataset))) == 1
 
         assert g.value(d.identifier, RDF.type) == DCAT.Dataset
 
@@ -71,7 +72,7 @@ class DatasetToRdfTest:
         g = d.graph
 
         assert isinstance(d, RdfResource)
-        assert len(list(g.subjects(RDF.type, DCAT.Dataset))) is 1
+        assert len(list(g.subjects(RDF.type, DCAT.Dataset))) == 1
 
         assert g.value(d.identifier, RDF.type) == DCAT.Dataset
 
@@ -477,7 +478,7 @@ class RdfToDatasetTest:
         resource = resource_from_rdf(g)
         resource.validate()
 
-        assert resource.title == 'csv resource'
+        assert resource.title == _('{format} resource').format(format='csv')
 
     def test_resource_generic_title(self):
         node = BNode()
@@ -490,7 +491,7 @@ class RdfToDatasetTest:
         resource = resource_from_rdf(g)
         resource.validate()
 
-        assert resource.title == 'Nameless resource'
+        assert resource.title == _('Nameless resource')
 
     def test_resource_title_ignore_dynamic_url(self):
         node = BNode()
@@ -503,7 +504,7 @@ class RdfToDatasetTest:
         resource = resource_from_rdf(g)
         resource.validate()
 
-        assert resource.title == 'Nameless resource'
+        assert resource.title == _('Nameless resource')
 
     def test_match_existing_resource_by_url(self):
         dataset = DatasetFactory(resources=ResourceFactory.build_batch(3))

--- a/udata/tests/forms/test_current_user_field.py
+++ b/udata/tests/forms/test_current_user_field.py
@@ -7,6 +7,7 @@ from udata.auth import login_user
 from udata.auth.forms import ExtendedLoginForm, ExtendedRegisterForm
 from udata.core.user.factories import UserFactory, AdminFactory
 from udata.forms import ModelForm, fields
+from udata.i18n import gettext as _
 from udata.models import db, User
 from udata.tests import TestCase, DBTestMixin
 
@@ -197,7 +198,11 @@ class CurrentUserFieldTest(TestCase, DBTestMixin):
 
     def test_password_rotation(self):
         today = datetime.datetime.now()
-        user = UserFactory(password='password', password_rotation_demanded=today, confirmed_at=today)
+        user = UserFactory(
+            password='password',
+            password_rotation_demanded=today,
+            confirmed_at=today
+        )
 
         form = ExtendedLoginForm.from_json({
             'email': user.email,
@@ -206,7 +211,7 @@ class CurrentUserFieldTest(TestCase, DBTestMixin):
 
         form.validate()
 
-        self.assertIn('Password must be changed for security reasons', form.errors['password'])
+        self.assertIn(_('Password must be changed for security reasons'), form.errors['password'])
 
     def test_email_validation(self):
         self.app.config['SECURITY_EMAIL_VALIDATOR_ARGS'] = None

--- a/udata/tests/forms/test_model_field.py
+++ b/udata/tests/forms/test_model_field.py
@@ -3,6 +3,7 @@ import pytest
 from werkzeug.datastructures import MultiDict
 
 from udata.forms import ModelForm, fields
+from udata.i18n import gettext as _
 from udata.models import db
 
 
@@ -39,7 +40,7 @@ class Generic:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert form.errors['target'][0] == 'Expect both class and identifier'
+        assert form.errors['target'][0] == _('Expect both class and identifier')
 
     def test_error_with_identifier_only(self):
         expected_target = Target.objects.create()
@@ -52,7 +53,7 @@ class Generic:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert form.errors['target'][0] == 'Expect both class and identifier'
+        assert form.errors['target'][0] == _('Expect both class and identifier')
 
     def test_error_with_unknown_model(self):
         form = self.form.from_json({
@@ -67,7 +68,7 @@ class Generic:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert form.errors['target'][0] == 'Model "Unknown" does not exist'
+        assert form.errors['target'][0] == _('Model "Unknown" does not exist')
 
 
 class Explicit:
@@ -151,7 +152,7 @@ class Explicit:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert form.errors['target'][0] == 'Expect a "Target" class but "Wrong" was found'
+        assert form.errors['target'][0] == _('Expect a "Target" class but "Wrong" was found')
 
 
 class Required:
@@ -314,7 +315,7 @@ class CommonMixin:
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
         # assert 'Unsupported identifier' in form.errors['target'][0]
-        assert form.errors['target'][0] == 'Missing "id" field'
+        assert form.errors['target'][0] == _('Missing "id" field')
 
     def test_json_errors(self):
         form = self.form.from_json({
@@ -328,7 +329,7 @@ class CommonMixin:
 
         assert 'target' in form.errors
         assert len(form.errors['target']) == 1
-        assert form.errors['target'][0] == 'Missing "id" field'
+        assert form.errors['target'][0] == _('Missing "id" field')
 
     def test_bad_id(self):
         form = self.form.from_json({

--- a/udata/tests/reuse/test_reuse_model.py
+++ b/udata/tests/reuse/test_reuse_model.py
@@ -8,6 +8,7 @@ from udata.core.reuse.factories import ReuseFactory, VisibleReuseFactory
 from udata.core.dataset.factories import VisibleDatasetFactory
 from udata.core.user.factories import UserFactory
 from udata.core.discussions.factories import DiscussionFactory
+from udata.i18n import gettext as _
 from udata.tests.helpers import assert_emit
 
 from .. import TestCase, DBTestMixin
@@ -62,7 +63,7 @@ class ReuseModelTest(TestCase, DBTestMixin):
         with assert_emit(Reuse.on_delete):
             reuse.deleted = datetime.now()
             reuse.save()
-    
+
     def test_reuse_metrics(self):
         dataset = VisibleDatasetFactory()
         reuse = VisibleReuseFactory()
@@ -77,7 +78,7 @@ class ReuseModelTest(TestCase, DBTestMixin):
         with assert_emit(Reuse.on_update):
             reuse.datasets.append(dataset)
             reuse.save()
-        
+
         reuse.count_datasets()
         assert reuse.get_metrics()['datasets'] == 2
 
@@ -100,4 +101,4 @@ class ReuseModelTest(TestCase, DBTestMixin):
     def test_reuse_topic(self):
         reuse = ReuseFactory(topic='health')
         self.assertEqual(reuse.topic, 'health')
-        self.assertEqual(reuse.topic_label, 'Health')
+        self.assertEqual(reuse.topic_label, _('Health'))


### PR DESCRIPTION
Follow https://github.com/opendatateam/udata/pull/2841, where tests now use `fr` as default language.

Tests running in CI didn't have most translations since they hadn't been compiled, diverging from tests run locally with compiled translations.

Make sure to have compiled translations to use in tests, locally or in CI.