### PR TITLE
No more sending email, slug and name to sentry

### DIFF
--- a/js/models/me.js
+++ b/js/models/me.js
@@ -18,9 +18,6 @@ class Me extends User {
         if (config.sentry) {
             Raven.setUserContext({
                 id: response.obj.id,
-                email: response.obj.email,
-                slug: response.obj.slug,
-                fullname: `${response.obj.first_name} ${response.obj.last_name}`,
                 is_authenticated: true,
                 is_anonymous: false
             });


### PR DESCRIPTION
In admin, we setUserContext with user personal info for Sentry, let's reduce unnecessary personal info we send around.

If needed, we can get these back based on the user id anyway :)