### PR TITLE
Parse IANA and EUROPA URIs format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add user arg to discussion list API [#2842](https://github.com/opendatateam/udata/pull/2842)
 - No more sending email, slug and user name to sentry [#2846](https://github.com/opendatateam/udata/pull/2846)
 - Add test for passwordless user [#2848](https://github.com/opendatateam/udata/pull/2848)
+- Parse IANA and EUROPA URIs format [#2849](https://github.com/opendatateam/udata/pull/2849)
 
 ## 6.1.3 (2023-04-18)
 

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -103,7 +103,11 @@
   </dcterms:PeriodOfTime>
   <dcat:Distribution rdf:about="http://data.test.org/datasets/1/resources/1">
     <dcterms:title>Resource 1-1</dcterms:title>
-    <dcterms:format>JSON</dcterms:format>
+    <dcterms:format>
+      <dcterms:MediaTypeOrExtent rdf:about="https://www.iana.org/assignments/media-types/application/json">
+        <rdf:type rdf:resource="http://purl.org/dc/terms/MediaTypeOrExtent" />
+      </dcterms:MediaTypeOrExtent>
+    </dcterms:format>
     <dcterms:description>A JSON resource</dcterms:description>
     <dcat:accessURL>http://data.test.org/datasets/1/resources/1/file.json</dcat:accessURL>
   </dcat:Distribution>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -276,6 +276,19 @@ class DcatBackendTest:
         assert dataset.temporal_coverage.start == date(2016, 1, 1)
         assert dataset.temporal_coverage.end == date(2016, 12, 5)
 
+        assert len(dataset.resources) == 2
+
+        resource_1 = next(res for res in dataset.resources if res.title == 'Resource 1-1')
+        # Format is a IANA URI
+        assert resource_1.format == 'json'
+        assert resource_1.description == 'A JSON resource'
+        assert resource_1.url == 'http://data.test.org/datasets/1/resources/1/file.json'
+
+        resource_2 = next(res for res in dataset.resources if res.title == 'Resource 1-2')
+        assert resource_2.format == 'json'
+        assert resource_2.description == 'A JSON resource'
+        assert resource_2.url == 'http://data.test.org/datasets/1/resources/2/file.json'
+
     def test_geonetwork_xml_catalog(self, rmock):
         url = mock_dcat(rmock, 'geonetwork.xml', path='catalog.xml')
         org = OrganizationFactory()

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -22,6 +22,8 @@ SPDX = Namespace('http://spdx.org/rdf/terms#')
 VCARD = Namespace('http://www.w3.org/2006/vcard/ns#')
 FREQ = Namespace('http://purl.org/cld/freq/')
 EUFREQ = Namespace('http://publications.europa.eu/resource/authority/frequency/')  # noqa: E501
+EUFORMAT = Namespace('http://publications.europa.eu/resource/authority/file-type/')
+IANAFORMAT = Namespace('https://www.iana.org/assignments/media-types/')
 DCT = DCTERMS  # More common usage
 
 namespace_manager = NamespaceManager(Graph())


### PR DESCRIPTION
We now can parse https://www.iana.org/assignments/media-types/application/json to fetch the `json` format.

We use `namespace_manager.compute_qname` to get the last part of the URI (a heuristic in the case of IANA).
See https://publications.europa.eu/resource/authority/file-type and https://www.iana.org/assignments/media-types/media-types.xhtml for the list of media and file types.

See also https://w3c.github.io/dxwg/dcat/#Property:distribution_format.