### PR TITLE
Use utcnow to handle utc datetimes all around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     - Upgrade flask-mongoengine 0.9.5 -> 1.0.0, now returning a ValidationError on get_or_404 on invalid id
     - Upgrade mongoengine 0.26.0 -> 0.27.0
 -  Prevent raising unecessary error in index command [#2851](https://github.com/opendatateam/udata/pull/2851)
+-  Use `datetime.utcnow` to make sure to handle utc datetimes [#2853](https://github.com/opendatateam/udata/pull/2853)
 
 ## 6.1.3 (2023-04-18)
 

--- a/udata/auth/forms.py
+++ b/udata/auth/forms.py
@@ -43,7 +43,7 @@ class ExtendedResetPasswordForm(ResetPasswordForm):
 
         if self.user.password_rotation_demanded:
             self.user.password_rotation_demanded = None
-            self.user.password_rotation_performed = datetime.datetime.now()
+            self.user.password_rotation_performed = datetime.datetime.utcnow()
             self.user.save()
 
         return True

--- a/udata/core/activity/models.py
+++ b/udata/core/activity/models.py
@@ -35,7 +35,7 @@ class Activity(db.Document, metaclass=EmitNewActivityMetaClass):
     actor = db.ReferenceField('User', required=True)
     organization = db.ReferenceField('Organization')
     related_to = db.ReferenceField(db.DomainModel, required=True)
-    created_at = db.DateTimeField(default=datetime.now, required=True)
+    created_at = db.DateTimeField(default=datetime.utcnow, required=True)
 
     kwargs = db.DictField()
 

--- a/udata/core/badges/models.py
+++ b/udata/core/badges/models.py
@@ -17,7 +17,7 @@ __all__ = ('Badge', 'BadgeMixin')
 
 class Badge(db.EmbeddedDocument):
     kind = db.StringField(required=True)
-    created = db.DateTimeField(default=datetime.now, required=True)
+    created = db.DateTimeField(default=datetime.utcnow, required=True)
     created_by = db.ReferenceField('User')
 
     def __str__(self):

--- a/udata/core/dataset/actions.py
+++ b/udata/core/dataset/actions.py
@@ -13,7 +13,7 @@ def archive(dataset, comment=False):
     """Archive a dataset"""
     if dataset.archived:
         log.warning('Dataset %s already archived, bumping date', dataset)
-    dataset.archived = datetime.now()
+    dataset.archived = datetime.utcnow()
     dataset.save()
 
     if comment:

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -210,7 +210,7 @@ class DatasetAPI(API):
         if dataset.deleted and request_deleted is not None:
             api.abort(410, 'Dataset has been deleted')
         DatasetEditPermission(dataset).test()
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         form = api.validate(DatasetForm, dataset)
         return form.save()
 
@@ -222,8 +222,8 @@ class DatasetAPI(API):
         if dataset.deleted:
             api.abort(410, 'Dataset has been deleted')
         DatasetEditPermission(dataset).test()
-        dataset.deleted = datetime.now()
-        dataset.last_modified_internal = datetime.now()
+        dataset.deleted = datetime.utcnow()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
         return '', 204
 
@@ -333,7 +333,7 @@ class ResourcesAPI(API):
             api.abort(400, 'This endpoint only supports remote resources')
         form.populate_obj(resource)
         dataset.add_resource(resource)
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
         return resource, 201
 
@@ -357,7 +357,7 @@ class ResourcesAPI(API):
 class UploadMixin(object):
     def handle_upload(self, dataset):
         prefix = '/'.join((dataset.slug,
-                           datetime.now().strftime('%Y%m%d-%H%M%S')))
+                           datetime.utcnow().strftime('%Y%m%d-%H%M%S')))
         infos = handle_upload(storages.resources, prefix)
         if 'html' in infos['mime']:
             api.abort(415, 'Incorrect file content type: HTML')
@@ -382,7 +382,7 @@ class UploadNewDatasetResource(UploadMixin, API):
         infos = self.handle_upload(dataset)
         resource = Resource(**infos)
         dataset.add_resource(resource)
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
         return resource, 201
 
@@ -429,7 +429,7 @@ class UploadDatasetResource(ResourceMixin, UploadMixin, API):
         for k, v in infos.items():
             resource[k] = v
         dataset.update_resource(resource)
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
         if fs_filename_to_remove is not None:
             storages.resources.delete(fs_filename_to_remove)
@@ -484,9 +484,9 @@ class ResourceAPI(ResourceMixin, API):
         # update_resource saves the updated resource dict to the database
         # the additional dataset.save is required as we update the last_modified date.
         form.populate_obj(resource)
-        resource.last_modified_internal = datetime.now()
+        resource.last_modified_internal = datetime.utcnow()
         dataset.update_resource(resource)
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
         return resource
 
@@ -497,7 +497,7 @@ class ResourceAPI(ResourceMixin, API):
         ResourceEditPermission(dataset).test()
         resource = self.get_resource_or_404(dataset, rid)
         dataset.remove_resource(resource)
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
         return '', 204
 
@@ -538,7 +538,7 @@ class CommunityResourcesAPI(API):
             })
         if not resource.organization:
             resource.owner = current_user._get_current_object()
-        resource.last_modified_internal = datetime.now()
+        resource.last_modified_internal = datetime.utcnow()
         resource.save()
         return resource, 201
 
@@ -566,7 +566,7 @@ class CommunityResourceAPI(API):
         form.populate_obj(community)
         if not community.organization and not community.owner:
             community.owner = current_user._get_current_object()
-        community.last_modified_internal = datetime.now()
+        community.last_modified_internal = datetime.utcnow()
         community.save()
         return community
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -73,7 +73,7 @@ def send_frequency_reminder(self):
     # We exclude irrelevant frequencies.
     frequencies = [f for f in UPDATE_FREQUENCIES.keys()
                    if f not in ('unknown', 'realtime', 'punctual', 'irregular', 'continuous')]
-    now = datetime.now()
+    now = datetime.utcnow()
     reminded_orgs = {}
     reminded_people = []
     allowed_delay = current_app.config['DELAY_BEFORE_REMINDER_NOTIFICATION']
@@ -141,7 +141,7 @@ def get_or_create_resource(r_info, model, dataset):
 
 
 def store_resource(csvfile, model, dataset):
-    timestr = datetime.now().strftime('%Y%m%d-%H%M%S')
+    timestr = datetime.utcnow().strftime('%Y%m%d-%H%M%S')
     filename = 'export-%s-%s.csv' % (model, timestr)
     prefix = '/'.join((dataset.slug, timestr))
     storage = storages.resources
@@ -187,7 +187,7 @@ def export_csv_for_model(model, dataset):
         # add it to the dataset
         if created:
             dataset.add_resource(resource)
-        dataset.last_modified_internal = datetime.now()
+        dataset.last_modified_internal = datetime.utcnow()
         dataset.save()
     finally:
         csvfile.close()

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -117,7 +117,7 @@ class DiscussionAPI(API):
         if close:
             CloseDiscussionPermission(discussion).test()
             discussion.closed_by = current_user._get_current_object()
-            discussion.closed = datetime.now()
+            discussion.closed = datetime.utcnow()
         discussion.save()
         if close:
             on_discussion_closed.send(discussion, message=message_idx)

--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -11,7 +11,7 @@ COMMENT_SIZE_LIMIT = 50000
 
 class Message(db.EmbeddedDocument):
     content = db.StringField(required=True)
-    posted_on = db.DateTimeField(default=datetime.now, required=True)
+    posted_on = db.DateTimeField(default=datetime.utcnow, required=True)
     posted_by = db.ReferenceField('User')
 
 
@@ -20,7 +20,7 @@ class Discussion(db.Document):
     subject = db.GenericReferenceField()
     title = db.StringField(required=True)
     discussion = db.ListField(db.EmbeddedDocumentField(Message))
-    created = db.DateTimeField(default=datetime.now, required=True)
+    created = db.DateTimeField(default=datetime.utcnow, required=True)
     closed = db.DateTimeField()
     closed_by = db.ReferenceField('User')
     extras = db.ExtrasField()

--- a/udata/core/followers/api.py
+++ b/udata/core/followers/api.py
@@ -69,7 +69,7 @@ class FollowAPI(API):
         follow = Follow.objects.get_or_404(follower=current_user.id,
                                            following=model,
                                            until=None)
-        follow.until = datetime.now()
+        follow.until = datetime.utcnow()
         follow.save()
         count = Follow.objects.followers(model).count()
         return {'followers': count}, 200

--- a/udata/core/followers/models.py
+++ b/udata/core/followers/models.py
@@ -21,7 +21,7 @@ class FollowQuerySet(db.BaseQuerySet):
 class Follow(db.Document):
     follower = db.ReferenceField('User', required=True)
     following = db.GenericReferenceField()
-    since = db.DateTimeField(required=True, default=datetime.now)
+    since = db.DateTimeField(required=True, default=datetime.utcnow)
     until = db.DateTimeField()
 
     meta = {

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -144,7 +144,7 @@ class OrganizationAPI(API):
         if org.deleted:
             api.abort(410, 'Organization has been deleted')
         EditOrganizationPermission(org).test()
-        org.deleted = datetime.now()
+        org.deleted = datetime.utcnow()
         org.save()
         return '', 204
 
@@ -278,7 +278,7 @@ class MembershipAcceptAPI(MembershipAPI):
 
         membership_request.status = 'accepted'
         membership_request.handled_by = current_user._get_current_object()
-        membership_request.handled_on = datetime.now()
+        membership_request.handled_on = datetime.utcnow()
         member = Member(user=membership_request.user, role='editor')
 
         org.members.append(member)
@@ -303,7 +303,7 @@ class MembershipRefuseAPI(MembershipAPI):
         form = api.validate(MembershipRefuseForm)
         membership_request.status = 'refused'
         membership_request.handled_by = current_user._get_current_object()
-        membership_request.handled_on = datetime.now()
+        membership_request.handled_on = datetime.utcnow()
         membership_request.refusal_comment = form.comment.data
 
         org.save()

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -54,7 +54,7 @@ class Team(db.EmbeddedDocument):
 class Member(db.EmbeddedDocument):
     user = db.ReferenceField('User')
     role = db.StringField(choices=list(ORG_ROLES), default=DEFAULT_ROLE)
-    since = db.DateTimeField(default=datetime.now, required=True)
+    since = db.DateTimeField(default=datetime.utcnow, required=True)
 
     @property
     def label(self):
@@ -70,7 +70,7 @@ class MembershipRequest(db.EmbeddedDocument):
     status = db.StringField(
         choices=list(MEMBERSHIP_STATUS), default='pending')
 
-    created = db.DateTimeField(default=datetime.now, required=True)
+    created = db.DateTimeField(default=datetime.utcnow, required=True)
 
     handled_on = db.DateTimeField()
     handled_by = db.ReferenceField('User')

--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -122,7 +122,7 @@ class PublishPostAPI(API):
     @api.marshal_with(post_fields)
     def post(self, post):
         '''Publish an existing post'''
-        post.modify(published=datetime.now())
+        post.modify(published=datetime.utcnow())
         return post
 
     @api.secure(admin_permission)

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -142,7 +142,7 @@ class ReuseAPI(API):
         if reuse.deleted:
             api.abort(410, 'This reuse has been deleted')
         ReuseEditPermission(reuse).test()
-        reuse.deleted = datetime.now()
+        reuse.deleted = datetime.utcnow()
         reuse.save()
         return '', 204
 

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -138,7 +138,7 @@ def load(filename=DEFAULT_GEOZONES_FILE, drop=False):
 
     <filename> can be either a local path or a remote URL.
     '''
-    ts = datetime.now().isoformat().replace('-', '').replace(':', '').split('.')[0]
+    ts = datetime.utcnow().isoformat().replace('-', '').replace(':', '').split('.')[0]
     prefix = 'geozones-{0}'.format(ts)
     if filename.startswith('http'):
         log.info('Downloading GeoZones bundle: %s', filename)

--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -100,7 +100,7 @@ def save_chunk(file, args):
         'uuid': str(args['uuid']),
         'filename': args['filename'],
         'totalparts': args['totalparts'],
-        'lastchunk': datetime.now(),
+        'lastchunk': datetime.utcnow(),
     }), overwrite=True)
     raise UploadProgress()
 

--- a/udata/core/storages/tasks.py
+++ b/udata/core/storages/tasks.py
@@ -17,7 +17,7 @@ def purge_chunks(self):
     meta_files = (f for f in chunks.list_files() if f.endswith(META))
     for filename in meta_files:
         metadata = json.loads(chunks.read(filename))
-        if datetime.now() - parse(metadata['lastchunk']) >= max_retention:
+        if datetime.utcnow() - parse(metadata['lastchunk']) >= max_retention:
             uuid = metadata['uuid']
             log.info('Removing %s expired chunks', uuid)
             chunks.delete(uuid)

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -62,7 +62,7 @@ class User(WithMetrics, UserMixin, db.Document):
 
     apikey = db.StringField()
 
-    created_at = db.DateTimeField(default=datetime.now, required=True)
+    created_at = db.DateTimeField(default=datetime.utcnow, required=True)
 
     # The field below is required for Flask-security
     # when SECURITY_CONFIRMABLE is True
@@ -247,7 +247,7 @@ class User(WithMetrics, UserMixin, db.Document):
         self.about = None
         self.extras = None
         self.apikey = None
-        self.deleted = datetime.now()
+        self.deleted = datetime.utcnow()
         self.save()
         for organization in self.organizations:
             organization.members = [member

--- a/udata/features/transfer/actions.py
+++ b/udata/features/transfer/actions.py
@@ -33,7 +33,7 @@ def accept_transfer(transfer, comment=None):
     '''Accept an incoming a transfer request'''
     TransferResponsePermission(transfer).test()
 
-    transfer.responded = datetime.now()
+    transfer.responded = datetime.utcnow()
     transfer.responder = current_user._get_current_object()
     transfer.status = 'accepted'
     transfer.response_comment = comment
@@ -56,7 +56,7 @@ def refuse_transfer(transfer, comment=None):
     '''Refuse an incoming a transfer request'''
     TransferResponsePermission(transfer).test()
 
-    transfer.responded = datetime.now()
+    transfer.responded = datetime.utcnow()
     transfer.responder = current_user._get_current_object()
     transfer.status = 'refused'
     transfer.response_comment = comment

--- a/udata/features/transfer/models.py
+++ b/udata/features/transfer/models.py
@@ -24,7 +24,7 @@ class Transfer(db.Document):
     comment = db.StringField()
     status = db.StringField(choices=list(TRANSFER_STATUS), default='pending')
 
-    created = db.DateTimeField(default=datetime.now, required=True)
+    created = db.DateTimeField(default=datetime.utcnow, required=True)
 
     responded = db.DateTimeField()
     responder = db.ReferenceField('User')

--- a/udata/frontend/csv.py
+++ b/udata/frontend/csv.py
@@ -233,7 +233,7 @@ def stream(queryset_or_adapter, basename=None):
     else:
         raise ValueError('Unsupported object type')
 
-    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M')
+    timestamp = datetime.utcnow().strftime('%Y-%m-%d-%H-%M')
     headers = {
         'Content-Disposition': 'attachment; filename={0}-{1}.csv'.format(
             basename or 'export', timestamp),

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -102,7 +102,7 @@ def update_source(ident, data):
 def validate_source(ident, comment=None):
     '''Validate a source for automatic harvesting'''
     source = get_source(ident)
-    source.validation.on = datetime.now()
+    source.validation.on = datetime.utcnow()
     source.validation.comment = comment
     source.validation.state = VALIDATION_ACCEPTED
     if current_user.is_authenticated:
@@ -116,7 +116,7 @@ def validate_source(ident, comment=None):
 def reject_source(ident, comment):
     '''Reject a source for automatic harvesting'''
     source = get_source(ident)
-    source.validation.on = datetime.now()
+    source.validation.on = datetime.utcnow()
     source.validation.comment = comment
     source.validation.state = VALIDATION_REFUSED
     if current_user.is_authenticated:
@@ -128,7 +128,7 @@ def reject_source(ident, comment):
 def delete_source(ident):
     '''Delete an harvest source'''
     source = get_source(ident)
-    source.deleted = datetime.now()
+    source.deleted = datetime.utcnow()
     source.save()
     signals.harvest_source_deleted.send(source)
     return source
@@ -139,7 +139,7 @@ def clean_source(ident):
     source = get_source(ident)
     datasets = Dataset.objects.filter(harvest__source_id=str(source.id))
     for dataset in datasets:
-        dataset.deleted = datetime.now()
+        dataset.deleted = datetime.utcnow()
         dataset.save()
     return len(datasets)
 
@@ -161,7 +161,7 @@ def purge_sources():
 def purge_jobs():
     '''Delete jobs older than retention policy'''
     retention = current_app.config['HARVEST_JOBS_RETENTION_DAYS']
-    expiration = datetime.now() - timedelta(days=retention)
+    expiration = datetime.utcnow() - timedelta(days=retention)
     return HarvestJob.objects(created__lt=expiration).delete()
 
 
@@ -304,7 +304,7 @@ def attach(domain, filename):
             dataset.harvest.domain = domain
             dataset.harvest.remote_id = row['remote']
 
-            dataset.last_modified_internal = datetime.now()
+            dataset.last_modified_internal = datetime.utcnow()
             dataset.save()
             count += 1
 

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -134,7 +134,7 @@ class BaseBackend(object):
         log.debug('Initializing backend')
         factory = HarvestJob if self.dryrun else HarvestJob.objects.create
         self.job = factory(status='initializing',
-                           started=datetime.now(),
+                           started=datetime.utcnow(),
                            source=self.source)
 
         before_harvest_job.send(self)
@@ -180,7 +180,7 @@ class BaseBackend(object):
     def process_item(self, item):
         log.debug('Processing: %s', item.remote_id)
         item.status = 'started'
-        item.started = datetime.now()
+        item.started = datetime.utcnow()
         if not self.dryrun:
             self.job.save()
 
@@ -191,7 +191,7 @@ class BaseBackend(object):
             dataset.harvest.domain = self.source.domain
             dataset.harvest.remote_id = item.remote_id
             dataset.harvest.source_id = str(self.source.id)
-            dataset.harvest.last_update = datetime.now()
+            dataset.harvest.last_update = datetime.utcnow()
             dataset.harvest.backend = self.display_name
 
             # unset archived status if needed
@@ -232,7 +232,7 @@ class BaseBackend(object):
             item.errors.append(error)
             item.status = 'failed'
 
-        item.ended = datetime.now()
+        item.ended = datetime.utcnow()
         if not self.dryrun:
             self.job.save()
 
@@ -283,7 +283,7 @@ class BaseBackend(object):
         self.end()
 
     def end(self):
-        self.job.ended = datetime.now()
+        self.job.ended = datetime.utcnow()
         if not self.dryrun:
             self.job.save()
         after_harvest_job.send(self)

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -44,7 +44,7 @@ DEFAULT_HARVEST_ITEM_STATUS = 'pending'
 
 class HarvestError(db.EmbeddedDocument):
     '''Store harvesting errors'''
-    created_at = db.DateTimeField(default=datetime.now, required=True)
+    created_at = db.DateTimeField(default=datetime.utcnow, required=True)
     message = db.StringField()
     details = db.StringField()
 
@@ -54,7 +54,7 @@ class HarvestItem(db.EmbeddedDocument):
     dataset = db.ReferenceField(Dataset)
     status = db.StringField(choices=list(HARVEST_ITEM_STATUS),
                             default=DEFAULT_HARVEST_ITEM_STATUS, required=True)
-    created = db.DateTimeField(default=datetime.now, required=True)
+    created = db.DateTimeField(default=datetime.utcnow, required=True)
     started = db.DateTimeField()
     ended = db.DateTimeField()
     errors = db.ListField(db.EmbeddedDocumentField(HarvestError))
@@ -98,7 +98,7 @@ class HarvestSource(db.Owned, db.Document):
     config = db.DictField()
     periodic_task = db.ReferenceField('PeriodicTask',
                                       reverse_delete_rule=db.NULLIFY)
-    created_at = db.DateTimeField(default=datetime.now, required=True)
+    created_at = db.DateTimeField(default=datetime.utcnow, required=True)
     frequency = db.StringField(choices=list(HARVEST_FREQUENCIES),
                                default=DEFAULT_HARVEST_FREQUENCY,
                                required=True)
@@ -151,7 +151,7 @@ class HarvestSource(db.Owned, db.Document):
 
 class HarvestJob(db.Document):
     '''Keep track of harvestings'''
-    created = db.DateTimeField(default=datetime.now, required=True)
+    created = db.DateTimeField(default=datetime.utcnow, required=True)
     started = db.DateTimeField()
     ended = db.DateTimeField()
     status = db.StringField(choices=list(HARVEST_JOB_STATUS),
@@ -177,7 +177,7 @@ def archive_harvested_dataset(dataset, reason, dryrun=False):
     If `dryrun` is True, the dataset is not saved but validated only.
     '''
     log.debug('Archiving dataset %s', dataset.id)
-    archival_date = datetime.now()
+    archival_date = datetime.utcnow()
     dataset.archived = archival_date
     if not dataset.harvest:
         dataset.harvest = HarvestDatasetMetadata()

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -54,7 +54,7 @@ class HarvestActionsTest:
     def test_list_sources_exclude_deleted(self):
         assert actions.list_sources() == []
 
-        now = datetime.now()
+        now = datetime.utcnow()
         sources = HarvestSourceFactory.create_batch(3)
         deleted_sources = HarvestSourceFactory.create_batch(2, deleted=now)
 
@@ -70,7 +70,7 @@ class HarvestActionsTest:
     def test_list_sources_include_deleted(self):
         assert actions.list_sources() == []
 
-        now = datetime.now()
+        now = datetime.utcnow()
         sources = HarvestSourceFactory.create_batch(3)
         sources.extend(HarvestSourceFactory.create_batch(2, deleted=now))
 
@@ -132,7 +132,7 @@ class HarvestActionsTest:
 
     def test_paginate_sources_exclude_deleted(self):
         HarvestSourceFactory.create_batch(2)
-        HarvestSourceFactory(deleted=datetime.now())
+        HarvestSourceFactory(deleted=datetime.utcnow())
 
         result = actions.paginate_sources(page_size=2)
         assert isinstance(result, Paginable)
@@ -143,7 +143,7 @@ class HarvestActionsTest:
 
     def test_paginate_sources_include_deleted(self):
         HarvestSourceFactory.create_batch(2)
-        HarvestSourceFactory(deleted=datetime.now())
+        HarvestSourceFactory(deleted=datetime.utcnow())
 
         result = actions.paginate_sources(page_size=2, deleted=True)
         assert isinstance(result, Paginable)
@@ -388,7 +388,7 @@ class HarvestActionsTest:
             enabled=True,
             crontab=PeriodicTask.Crontab()
         )
-        now = datetime.now()
+        now = datetime.utcnow()
         to_delete = HarvestSourceFactory.create_batch(2, deleted=now)
         to_delete.append(
             HarvestSourceFactory(periodic_task=periodic_task, deleted=now)
@@ -411,7 +411,7 @@ class HarvestActionsTest:
 
     @pytest.mark.options(HARVEST_JOBS_RETENTION_DAYS=2)
     def test_purge_jobs(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         retention = now - timedelta(days=2)
         too_old = retention - timedelta(days=1)
         to_delete = HarvestJobFactory.create_batch(3, created=too_old)
@@ -459,7 +459,7 @@ class HarvestActionsTest:
                 domain='test.org',
                 remote_id=str(i)
             )
-            dataset.last_modified_internal = datetime.now()
+            dataset.last_modified_internal = datetime.utcnow()
             dataset.save()
             attached_datasets.append(dataset)
 

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -49,7 +49,7 @@ class HarvestAPITest(MockBackendsMixin):
 
     def test_list_sources_exclude_deleted(self, api):
         sources = HarvestSourceFactory.create_batch(3)
-        HarvestSourceFactory.create_batch(2, deleted=datetime.now())
+        HarvestSourceFactory.create_batch(2, deleted=datetime.utcnow())
 
         response = api.get(url_for('api.harvest_sources'))
         assert200(response)
@@ -57,7 +57,7 @@ class HarvestAPITest(MockBackendsMixin):
 
     def test_list_sources_include_deleted(self, api):
         sources = HarvestSourceFactory.create_batch(3)
-        sources.extend(HarvestSourceFactory.create_batch(2, deleted=datetime.now()))
+        sources.extend(HarvestSourceFactory.create_batch(2, deleted=datetime.utcnow()))
 
         response = api.get(url_for('api.harvest_sources', deleted=True))
         assert200(response)

--- a/udata/harvest/tests/test_base_backend.py
+++ b/udata/harvest/tests/test_base_backend.py
@@ -67,7 +67,7 @@ class HarvestFilterTest:
 @pytest.mark.usefixtures('clean_db')
 class BaseBackendTest:
     def test_simple_harvest(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         nb_datasets = 3
         source = HarvestSourceFactory(config={'nb_datasets': nb_datasets})
         backend = FakeBackend(source)
@@ -157,7 +157,7 @@ class BaseBackendTest:
         dataset = Dataset.objects.first()
 
         assert dataset.last_modified_internal == last_modified
-        assert_equal_dates(dataset.harvest.last_update, datetime.now())
+        assert_equal_dates(dataset.harvest.last_update, datetime.utcnow())
 
     def test_dont_overwrite_last_modified_even_if_set_to_same(self, mocker):
         last_modified = faker.date_time_between(start_date='-30y', end_date='-1y')
@@ -170,7 +170,7 @@ class BaseBackendTest:
         dataset = Dataset.objects.first()
 
         assert dataset.last_modified_internal == last_modified
-        assert_equal_dates(dataset.harvest.last_update, datetime.now())
+        assert_equal_dates(dataset.harvest.last_update, datetime.utcnow())
 
     def test_autoarchive(self, app):
         nb_datasets = 3
@@ -179,7 +179,7 @@ class BaseBackendTest:
 
         # create a dangling dataset to be archived
         limit = app.config['HARVEST_AUTOARCHIVE_GRACE_DAYS']
-        last_update = datetime.now() - timedelta(days=limit + 1)
+        last_update = datetime.utcnow() - timedelta(days=limit + 1)
         dataset_arch = DatasetFactory(harvest={
                 'domain': source.domain,
                 'source_id': str(source.id),
@@ -189,7 +189,7 @@ class BaseBackendTest:
 
         # create a dangling dataset that _won't_ be archived because of grace period
         limit = app.config['HARVEST_AUTOARCHIVE_GRACE_DAYS']
-        last_update = datetime.now() - timedelta(days=limit - 1)
+        last_update = datetime.utcnow() - timedelta(days=limit - 1)
         dataset_no_arch = DatasetFactory(harvest={
                 'domain': source.domain,
                 'source_id': str(source.id),
@@ -221,9 +221,9 @@ class BaseBackendTest:
         # test unarchive: archive manually then relaunch harvest
         q = {'harvest__remote_id': 'fake-1'}
         dataset = Dataset.objects.get(**q)
-        dataset.archived = datetime.now()
+        dataset.archived = datetime.utcnow()
         dataset.harvest.archived = 'not-on-remote'
-        dataset.harvest.archived_at = datetime.now()
+        dataset.harvest.archived_at = datetime.utcnow()
         dataset.save()
         backend.harvest()
         dataset.reload()

--- a/udata/linkchecker/backends.py
+++ b/udata/linkchecker/backends.py
@@ -18,7 +18,7 @@ class NoCheckLinkchecker(object):
         return {
             'check:status': 204,
             'check:available': True,
-            'check:date': datetime.now()
+            'check:date': datetime.utcnow()
         }
 
 

--- a/udata/migrations/__init__.py
+++ b/udata/migrations/__init__.py
@@ -126,7 +126,7 @@ class Record(dict):
             {'plugin': self.plugin, 'filename': self.filename},
             {
                 '$push': {'ops': {
-                    'date': datetime.now(),
+                    'date': datetime.utcnow(),
                     'type': _type,
                     'script': script,
                     'output': output,
@@ -256,7 +256,7 @@ class Migration:
             self.db_query,
             {
                 '$push': {'ops': {
-                    'date': datetime.now(),
+                    'date': datetime.utcnow(),
                     'type': type,
                     'script': script,
                     'output': output,

--- a/udata/models/datetime_fields.py
+++ b/udata/models/datetime_fields.py
@@ -57,13 +57,13 @@ class DateRange(EmbeddedDocument):
 
 class Datetimed(object):
     created_at = DateTimeField(verbose_name=_('Creation date'),
-                               default=datetime.now, required=True)
+                               default=datetime.utcnow, required=True)
     last_modified = DateTimeField(verbose_name=_('Last modification date'),
-                                  default=datetime.now, required=True)
+                                  default=datetime.utcnow, required=True)
 
 
 @pre_save.connect
 def set_modified_datetime(sender, document, **kwargs):
     changed = document._get_changed_fields()
     if isinstance(document, Datetimed) and 'last_modified' not in changed:
-        document.last_modified = datetime.now()
+        document.last_modified = datetime.utcnow()

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -130,7 +130,7 @@ def index(models=None, reindex=True, from_datetime=None):
         log.error('Missing URL for search service')
         sys.exit(-1)
 
-    start = datetime.now()
+    start = datetime.utcnow()
     if from_datetime:
         from_datetime = datetime.strptime(from_datetime, TIMESTAMP_FORMAT)
 

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -229,7 +229,7 @@ class DatasetAPITest(APITestCase):
 
     def test_dataset_api_get_deleted(self):
         '''It should not fetch a deleted dataset from the API and raise 410'''
-        dataset = VisibleDatasetFactory(deleted=datetime.now())
+        dataset = VisibleDatasetFactory(deleted=datetime.utcnow())
 
         response = self.get(url_for('api.dataset', dataset=dataset))
         self.assert410(response)
@@ -238,7 +238,7 @@ class DatasetAPITest(APITestCase):
         '''It should a deleted dataset from the API if user is authorized'''
         self.login()
         dataset = VisibleDatasetFactory(owner=self.user,
-                                        deleted=datetime.now())
+                                        deleted=datetime.utcnow())
 
         response = self.get(url_for('api.dataset', dataset=dataset))
         self.assert200(response)
@@ -534,7 +534,7 @@ class DatasetAPITest(APITestCase):
     def test_dataset_api_update_deleted(self):
         '''It should not update a deleted dataset from the API and raise 401'''
         user = self.login()
-        dataset = DatasetFactory(owner=user, deleted=datetime.now())
+        dataset = DatasetFactory(owner=user, deleted=datetime.utcnow())
         data = dataset.to_dict()
         data['description'] = 'new description'
         response = self.put(url_for('api.dataset', dataset=dataset), data)
@@ -560,7 +560,7 @@ class DatasetAPITest(APITestCase):
     def test_dataset_api_delete_deleted(self):
         '''It should delete a deleted dataset from the API and raise 410'''
         user = self.login()
-        dataset = VisibleDatasetFactory(owner=user, deleted=datetime.now())
+        dataset = VisibleDatasetFactory(owner=user, deleted=datetime.utcnow())
         response = self.delete(url_for('api.dataset', dataset=dataset))
 
         self.assert410(response)
@@ -1272,7 +1272,7 @@ class DatasetArchivedAPITest(APITestCase):
     def test_dataset_api_search_archived(self):
         '''It should search datasets from the API, excluding archived ones'''
         VisibleDatasetFactory(archived=None)
-        dataset = VisibleDatasetFactory(archived=datetime.now())
+        dataset = VisibleDatasetFactory(archived=datetime.utcnow())
 
         response = self.get(url_for('api.datasets', q=''))
         self.assert200(response)
@@ -1282,7 +1282,7 @@ class DatasetArchivedAPITest(APITestCase):
 
     def test_dataset_api_get_archived(self):
         '''It should fetch an archived dataset from the API and return 200'''
-        dataset = VisibleDatasetFactory(archived=datetime.now())
+        dataset = VisibleDatasetFactory(archived=datetime.utcnow())
         response = self.get(url_for('api.dataset', dataset=dataset))
         self.assert200(response)
 

--- a/udata/tests/api/test_fields.py
+++ b/udata/tests/api/test_fields.py
@@ -9,7 +9,7 @@ from . import APITestCase
 
 class FieldTest(APITestCase):
     def test_iso_date_time_field_format(self):
-        datetime_date_naive = datetime.now()
+        datetime_date_naive = datetime.utcnow()
         datetime_date_aware = pytz.utc.localize(datetime_date_naive)
         datetime_date_aware_string = datetime_date_aware.isoformat()
         date_date = date.today()

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -39,7 +39,7 @@ class MeAPITest(APITestCase):
         member = Member(user=user, role='editor')
         org = OrganizationFactory(members=[member])
         deleted_org = OrganizationFactory(members=[member],
-                                          deleted=datetime.now())
+                                          deleted=datetime.utcnow())
         response = self.get(url_for('api.me'))
         self.assert200(response)
         orgs = [o['id'] for o in response.json['organizations']]

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -51,7 +51,7 @@ class OrganizationAPITest:
 
     def test_organization_api_get_deleted(self, api):
         '''It should not fetch a deleted organization from the API'''
-        organization = OrganizationFactory(deleted=datetime.now())
+        organization = OrganizationFactory(deleted=datetime.utcnow())
         response = api.get(url_for('api.organization', org=organization))
         assert410(response)
 
@@ -59,7 +59,7 @@ class OrganizationAPITest:
         '''It should fetch a deleted organization from the API if authorized'''
         user = api.login()
         member = Member(user=user, role='editor')
-        organization = OrganizationFactory(deleted=datetime.now(),
+        organization = OrganizationFactory(deleted=datetime.utcnow(),
                                            members=[member])
         response = api.get(url_for('api.organization', org=organization))
         assert200(response)
@@ -92,7 +92,7 @@ class OrganizationAPITest:
 
     def test_organization_api_update_deleted(self, api):
         '''It should not update a deleted organization from the API'''
-        org = OrganizationFactory(deleted=datetime.now())
+        org = OrganizationFactory(deleted=datetime.utcnow())
         data = org.to_dict()
         data['description'] = 'new description'
         api.login()
@@ -124,7 +124,7 @@ class OrganizationAPITest:
     def test_organization_api_delete_deleted(self, api):
         '''It should not delete a deleted organization from the API'''
         api.login()
-        organization = OrganizationFactory(deleted=datetime.now())
+        organization = OrganizationFactory(deleted=datetime.utcnow())
         response = api.delete(url_for('api.organization', org=organization))
         assert410(response)
         assert Organization.objects[0].deleted is not None

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -92,14 +92,14 @@ class ReuseAPITest:
 
     def test_reuse_api_get_deleted(self, api):
         '''It should not fetch a deleted reuse from the API and raise 410'''
-        reuse = ReuseFactory(deleted=datetime.now())
+        reuse = ReuseFactory(deleted=datetime.utcnow())
         response = api.get(url_for('api.reuse', reuse=reuse))
         assert410(response)
 
     def test_reuse_api_get_deleted_but_authorized(self, api):
         '''It should fetch a deleted reuse from the API if authorized'''
         user = api.login()
-        reuse = ReuseFactory(deleted=datetime.now(), owner=user)
+        reuse = ReuseFactory(deleted=datetime.utcnow(), owner=user)
         response = api.get(url_for('api.reuse', reuse=reuse))
         assert200(response)
 
@@ -157,7 +157,7 @@ class ReuseAPITest:
     def test_reuse_api_update_deleted(self, api):
         '''It should not update a deleted reuse from the API and raise 410'''
         api.login()
-        reuse = ReuseFactory(deleted=datetime.now())
+        reuse = ReuseFactory(deleted=datetime.utcnow())
         response = api.put(url_for('api.reuse', reuse=reuse), {})
         assert410(response)
 
@@ -173,7 +173,7 @@ class ReuseAPITest:
     def test_reuse_api_delete_deleted(self, api):
         '''It should not delete a deleted reuse from the API and raise 410'''
         api.login()
-        reuse = ReuseFactory(deleted=datetime.now())
+        reuse = ReuseFactory(deleted=datetime.utcnow())
         response = api.delete(url_for('api.reuse', reuse=reuse))
         assert410(response)
 

--- a/udata/tests/cli/test_db_cli.py
+++ b/udata/tests/cli/test_db_cli.py
@@ -8,7 +8,7 @@ def migrations(db):
     db.migrations.insert_one({
         'plugin': 'udata',
         'filename': 'test.py',
-        'date': datetime.now(),
+        'date': datetime.utcnow(),
         'script': 'print("ok")',
         'output': 'ok',
     })

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -130,50 +130,50 @@ class DatasetModelTest:
     def test_next_update_hourly(self):
         dataset = DatasetFactory(frequency='hourly')
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(hours=1))
+                           datetime.utcnow() + timedelta(hours=1))
 
     @pytest.mark.parametrize('freq', ['fourTimesADay', 'threeTimesADay', 'semidaily', 'daily'])
     def test_next_update_daily(self, freq):
         dataset = DatasetFactory(frequency=freq)
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=1))
+                           datetime.utcnow() + timedelta(days=1))
 
     @pytest.mark.parametrize('freq', ['fourTimesAWeek', 'threeTimesAWeek', 'semiweekly', 'weekly'])
     def test_next_update_weekly(self, freq):
         dataset = DatasetFactory(frequency=freq)
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=7))
+                           datetime.utcnow() + timedelta(days=7))
 
     def test_next_update_biweekly(self):
         dataset = DatasetFactory(frequency='biweekly')
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(weeks=2))
+                           datetime.utcnow() + timedelta(weeks=2))
 
     def test_next_update_quarterly(self):
         dataset = DatasetFactory(frequency='quarterly')
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=365/4))
+                           datetime.utcnow() + timedelta(days=365/4))
 
     @pytest.mark.parametrize('freq', ['threeTimesAYear', 'semiannual', 'annual'])
     def test_next_update_annual(self, freq):
         dataset = DatasetFactory(frequency=freq)
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=365))
+                           datetime.utcnow() + timedelta(days=365))
 
     def test_next_update_biennial(self):
         dataset = DatasetFactory(frequency='biennial')
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=365*2))
+                           datetime.utcnow() + timedelta(days=365*2))
 
     def test_next_update_triennial(self):
         dataset = DatasetFactory(frequency='triennial')
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=365*3))
+                           datetime.utcnow() + timedelta(days=365*3))
 
     def test_next_update_quinquennial(self):
         dataset = DatasetFactory(frequency='quinquennial')
         assert_equal_dates(dataset.next_update,
-                           datetime.now() + timedelta(days=365*5))
+                           datetime.utcnow() + timedelta(days=365*5))
 
     @pytest.mark.parametrize('freq', ['continuous', 'punctual', 'irregular', 'unknown'])
     def test_next_update_undefined(self, freq):
@@ -264,7 +264,7 @@ class DatasetModelTest:
     def test_send_on_delete(self):
         dataset = DatasetFactory()
         with assert_emit(Dataset.on_delete):
-            dataset.deleted = datetime.now()
+            dataset.deleted = datetime.utcnow()
             dataset.save()
 
     def test_ignore_post_save_signal(self):
@@ -596,16 +596,16 @@ class HarvestMetadataTest:
 
         harvest_metadata = HarvestDatasetMetadata(
             backend='DCAT',
-            created_at=datetime.now(),
-            modified_at=datetime.now(),
+            created_at=datetime.utcnow(),
+            modified_at=datetime.utcnow(),
             source_id='source_id',
             remote_id='remote_id',
             domain='domain.gouv.fr',
-            last_update=datetime.now(),
+            last_update=datetime.utcnow(),
             remote_url='http://domain.gouv.fr/dataset/remote_url',
             uri='http://domain.gouv.fr/dataset/uri',
             dct_identifier='http://domain.gouv.fr/dataset/identifier',
-            archived_at=datetime.now(),
+            archived_at=datetime.utcnow(),
             archived='not-on-remote'
         )
         dataset.harvest = harvest_metadata
@@ -630,8 +630,8 @@ class HarvestMetadataTest:
         dataset = DatasetFactory()
 
         harvest_metadata = HarvestDatasetMetadata(
-            created_at=datetime.now(),
-            modified_at=datetime.now()+timedelta(days=1)
+            created_at=datetime.utcnow(),
+            modified_at=datetime.utcnow()+timedelta(days=1)
         )
         dataset.harvest = harvest_metadata
         dataset.save()
@@ -641,8 +641,8 @@ class HarvestMetadataTest:
         dataset = DatasetFactory()
 
         harvest_metadata = HarvestDatasetMetadata(
-            created_at=datetime.now(),
-            modified_at=datetime.now(),
+            created_at=datetime.utcnow(),
+            modified_at=datetime.utcnow(),
         )
         dataset.harvest = harvest_metadata
         dataset.save()
@@ -652,8 +652,8 @@ class HarvestMetadataTest:
         resource = ResourceFactory()
 
         harvest_metadata = HarvestResourceMetadata(
-            created_at=datetime.now(),
-            modified_at=datetime.now(),
+            created_at=datetime.utcnow(),
+            modified_at=datetime.utcnow(),
             uri='http://domain.gouv.fr/dataset/uri'
         )
         resource.harvest = harvest_metadata
@@ -676,7 +676,7 @@ class HarvestMetadataTest:
 
     def test_harvest_resource_metadata_future_modifed_at(self):
         resource = ResourceFactory()
-        harvest_metadata = HarvestResourceMetadata(modified_at=datetime.now()+timedelta(days=1))
+        harvest_metadata = HarvestResourceMetadata(modified_at=datetime.utcnow()+timedelta(days=1))
         resource.harvest = harvest_metadata
         resource.validate()
 
@@ -684,7 +684,7 @@ class HarvestMetadataTest:
 
     def test_harvest_resource_metadata_past_modifed_at(self):
         resource = ResourceFactory()
-        harvest_metadata = HarvestResourceMetadata(modified_at=datetime.now())
+        harvest_metadata = HarvestResourceMetadata(modified_at=datetime.utcnow())
         resource.harvest = harvest_metadata
         resource.validate()
 

--- a/udata/tests/forms/test_current_user_field.py
+++ b/udata/tests/forms/test_current_user_field.py
@@ -197,7 +197,7 @@ class CurrentUserFieldTest(TestCase, DBTestMixin):
         self.assertEqual(len(form.errors['owner']), 1)
 
     def test_password_rotation(self):
-        today = datetime.datetime.now()
+        today = datetime.datetime.utcnow()
         user = UserFactory(
             password='password',
             password_rotation_demanded=today,
@@ -237,7 +237,7 @@ class CurrentUserFieldTest(TestCase, DBTestMixin):
         form.validate()
         self.assertIn('Invalid email address', form.errors['email'])
 
-        today = datetime.datetime.now()
+        today = datetime.datetime.utcnow()
         user = UserFactory(email='b@fake.com', password='password', confirmed_at=today)
         form = ExtendedLoginForm.from_json({
             'email': user.email,

--- a/udata/tests/forms/test_dict_field.py
+++ b/udata/tests/forms/test_dict_field.py
@@ -36,7 +36,7 @@ class DictFieldTest:
     def test_with_valid_data(self):
         Fake, FakeForm = self.factory()
 
-        now = datetime.now()
+        now = datetime.utcnow()
         today = date.today()
 
         fake = Fake()

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -37,7 +37,7 @@ class ExtrasFieldTest:
     def test_with_valid_data(self):
         Fake, FakeForm = self.factory()
 
-        now = datetime.now()
+        now = datetime.utcnow()
         today = date.today()
 
         fake = Fake()

--- a/udata/tests/organization/test_organization_model.py
+++ b/udata/tests/organization/test_organization_model.py
@@ -31,20 +31,20 @@ class OrganizationModelTest(TestCase, DBTestMixin):
             DatasetFactory(organization=org)
         with assert_emit(on_follow):
             follow = Follow.objects.create(following=org, follower=UserFactory(),
-                                           since=datetime.now())
+                                           since=datetime.utcnow())
 
         assert org.get_metrics()['datasets'] == 1
         assert org.get_metrics()['reuses'] == 1
         assert org.get_metrics()['followers'] == 1
 
         with assert_emit(Reuse.on_delete):
-            reuse.deleted = datetime.now()
+            reuse.deleted = datetime.utcnow()
             reuse.save()
         with assert_emit(Dataset.on_delete):
-            dataset.deleted = datetime.now()
+            dataset.deleted = datetime.utcnow()
             dataset.save()
         with assert_emit(on_unfollow):
-            follow.until = datetime.now()
+            follow.until = datetime.utcnow()
             follow.save()
 
         assert org.get_metrics()['datasets'] == 0

--- a/udata/tests/reuse/test_reuse_model.py
+++ b/udata/tests/reuse/test_reuse_model.py
@@ -61,7 +61,7 @@ class ReuseModelTest(TestCase, DBTestMixin):
     def test_send_on_delete(self):
         reuse = ReuseFactory()
         with assert_emit(Reuse.on_delete):
-            reuse.deleted = datetime.now()
+            reuse.deleted = datetime.utcnow()
             reuse.save()
 
     def test_reuse_metrics(self):

--- a/udata/tests/site/test_site_model.py
+++ b/udata/tests/site/test_site_model.py
@@ -14,7 +14,7 @@ class SiteModelTest(DBTestMixin, TestCase):
         current_site.save()
 
         dataset = current_site.settings.home_datasets[1]
-        dataset.deleted = datetime.now()
+        dataset.deleted = datetime.utcnow()
         dataset.save()
 
         current_site.reload()
@@ -28,7 +28,7 @@ class SiteModelTest(DBTestMixin, TestCase):
         current_site.save()
 
         reuse = current_site.settings.home_reuses[1]
-        reuse.deleted = datetime.now()
+        reuse.deleted = datetime.utcnow()
         reuse.save()
 
         current_site.reload()

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -148,7 +148,7 @@ class DiscussionsTest(APITestCase):
                 user=user,
                 title='test discussion {}'.format(i),
                 discussion=[message],
-                closed=datetime.now(),
+                closed=datetime.utcnow(),
                 closed_by=user
             )
             closed_discussions.append(discussion)
@@ -181,7 +181,7 @@ class DiscussionsTest(APITestCase):
                 user=user,
                 title='test discussion {}'.format(i),
                 discussion=[message],
-                closed=datetime.now(),
+                closed=datetime.utcnow(),
                 closed_by=user
             )
             closed_discussions.append(discussion)
@@ -493,7 +493,7 @@ class DiscussionsNotificationsTest(TestCase, DBTestMixin):
             user=user,
             title=faker.sentence(),
             discussion=[message],
-            closed=datetime.now(),
+            closed=datetime.utcnow(),
             closed_by=user
         )
 
@@ -532,7 +532,7 @@ class DiscussionsNotificationsTest(TestCase, DBTestMixin):
             user=user,
             title=faker.sentence(),
             discussion=[message],
-            closed=datetime.now(),
+            closed=datetime.utcnow(),
             closed_by=user
         )
 

--- a/udata/tests/test_linkchecker.py
+++ b/udata/tests/test_linkchecker.py
@@ -33,7 +33,7 @@ def test_check_resource_creates_no_activity(activity_app, mocker):
     user = UserFactory()
     login_user(user)
     check_res = {'check:status': 200, 'check:available': True,
-                 'check:date': datetime.now()}
+                 'check:date': datetime.utcnow()}
 
     class DummyLinkchecker:
         def check(self, _):
@@ -63,7 +63,7 @@ class LinkcheckerTest(TestCase):
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_check_resource_linkchecker_ok(self, mock_fn):
         check_res = {'check:status': 200, 'check:available': True,
-                     'check:date': datetime.now()}
+                     'check:date': datetime.utcnow()}
 
         class DummyLinkchecker:
             def check(self, _):
@@ -141,7 +141,7 @@ class LinkcheckerTest(TestCase):
 
     def test_is_need_check(self):
         self.resource.extras = {'check:available': True,
-                                'check:date': datetime.now(),
+                                'check:date': datetime.utcnow(),
                                 'check:status': 42}
         self.assertFalse(self.resource.need_check())
 
@@ -152,13 +152,13 @@ class LinkcheckerTest(TestCase):
     def test_is_need_check_cache_expired(self):
         self.resource.extras = {
             'check:available': True,
-            'check:date': datetime.now() - timedelta(seconds=3600),
+            'check:date': datetime.utcnow() - timedelta(seconds=3600),
             'check:status': 42
         }
         self.assertTrue(self.resource.need_check())
 
     def test_is_need_check_date_string(self):
-        check_date = (datetime.now() - timedelta(seconds=3600)).isoformat()
+        check_date = (datetime.utcnow() - timedelta(seconds=3600)).isoformat()
         self.resource.extras = {
             'check:available': True,
             'check:date': check_date,
@@ -189,7 +189,7 @@ class LinkcheckerTest(TestCase):
             # should need a new check after 100 * 30s = 3000s < 3600s
             'check:count-availability': 100,
             'check:available': True,
-            'check:date': datetime.now() - timedelta(seconds=3600),
+            'check:date': datetime.utcnow() - timedelta(seconds=3600),
             'check:status': 42
         }
         self.assertTrue(self.resource.need_check())
@@ -199,7 +199,7 @@ class LinkcheckerTest(TestCase):
             # should need a new check after 150 * 30s = 4500s > 3600s
             'check:count-availability': 150,
             'check:available': True,
-            'check:date': datetime.now() - timedelta(seconds=3600),
+            'check:date': datetime.utcnow() - timedelta(seconds=3600),
             'check:status': 42
         }
         self.assertFalse(self.resource.need_check())
@@ -210,7 +210,7 @@ class LinkcheckerTest(TestCase):
             # count-availability is below threshold
             'check:count-availability': 95,
             'check:available': False,
-            'check:date': datetime.now() - timedelta(seconds=3600),
+            'check:date': datetime.utcnow() - timedelta(seconds=3600),
             'check:status': 42
         }
         self.assertTrue(self.resource.need_check())
@@ -218,7 +218,7 @@ class LinkcheckerTest(TestCase):
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_count_availability_increment(self, mock_fn):
         check_res = {'check:status': 200, 'check:available': True,
-                     'check:date': datetime.now()}
+                     'check:date': datetime.utcnow()}
 
         class DummyLinkchecker:
             def check(self, _):
@@ -234,10 +234,10 @@ class LinkcheckerTest(TestCase):
     @mock.patch('udata.linkchecker.checker.get_linkchecker')
     def test_count_availability_reset(self, mock_fn):
         self.resource.extras = {'check:status': 200, 'check:available': True,
-                                'check:date': datetime.now(),
+                                'check:date': datetime.utcnow(),
                                 'check:count-availability': 2}
         check_res = {'check:status': 200, 'check:available': False,
-                     'check:date': datetime.now()}
+                     'check:date': datetime.utcnow()}
 
         class DummyLinkchecker:
             def check(self, _):
@@ -253,7 +253,7 @@ class LinkcheckerTest(TestCase):
             'check:available': False,
             # if it weren't above threshold, should need check (>30s)
             # and we're still below max_cache 101 * 0.5 < 100
-            'check:date': datetime.now() - timedelta(seconds=60),
+            'check:date': datetime.utcnow() - timedelta(seconds=60),
             'check:count-availability': 101
         }
         self.assertFalse(self.resource.need_check())
@@ -265,7 +265,7 @@ class LinkcheckerTest(TestCase):
             # next check should be at 300 * 0.5 = 150min
             # but we are above max cache duration 150min > 100min
             # and 120m > 100 min so we should need a new check
-            'check:date': datetime.now() - timedelta(minutes=120),
+            'check:date': datetime.utcnow() - timedelta(minutes=120),
             'check:count-availability': 300
         }
         self.assertTrue(self.resource.need_check())

--- a/udata/tests/test_migrations.py
+++ b/udata/tests/test_migrations.py
@@ -123,7 +123,7 @@ def test_get_record(db):
         'plugin': 'test',
         'filename': 'filename.py',
         'ops': [{
-            'date': datetime.now(),
+            'date': datetime.utcnow(),
             'type': 'migrate',
             'script': 'script',
             'output': 'output',
@@ -468,7 +468,7 @@ def test_unrecord_migration(db):
         'plugin': 'test',
         'filename': 'filename.py',
         'ops': [{
-            'date': datetime.now(),
+            'date': datetime.utcnow(),
             'type': 'migrate',
             'script': 'script',
             'output': 'output',

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -375,21 +375,21 @@ class DatetimedTest:
         assert isinstance(DatetimedTester.last_modified, db.DateTimeField)
 
     def test_new_instance(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         datetimed = DatetimedTester()
 
-        assert now <= datetimed.created_at <= datetime.now()
-        assert now <= datetimed.last_modified <= datetime.now()
+        assert now <= datetimed.created_at <= datetime.utcnow()
+        assert now <= datetimed.last_modified <= datetime.utcnow()
 
     def test_save_new_instance(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         datetimed = DatetimedTester.objects.create()
 
-        assert now <= datetimed.created_at <= datetime.now()
-        assert now <= datetimed.last_modified <= datetime.now()
+        assert now <= datetimed.created_at <= datetime.utcnow()
+        assert now <= datetimed.last_modified <= datetime.utcnow()
 
     def test_save_last_modified_instance(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         earlier = now - timedelta(days=1)
         datetimed = DatetimedTester.objects.create(
             created_at=earlier, last_modified=earlier)
@@ -401,7 +401,7 @@ class DatetimedTest:
         assert_equal_dates(datetimed.last_modified, now)
 
     def test_save_last_modified_instance_manually_set(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         manual = now - timedelta(days=1)
         earlier = now - timedelta(days=2)
         datetimed = DatetimedTester.objects.create(created_at=earlier, last_modified=earlier)
@@ -414,7 +414,7 @@ class DatetimedTest:
         assert_equal_dates(datetimed.last_modified, manual)
 
     def test_save_last_modified_instance_manually_set_same_value(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         manual = now - timedelta(days=1)
         earlier = now - timedelta(days=2)
         datetimed = DatetimedTester.objects.create(created_at=earlier, last_modified=earlier)
@@ -436,7 +436,7 @@ class ExtrasFieldTest:
         class Tester(db.Document):
             extras = db.ExtrasField()
 
-        now = datetime.now()
+        now = datetime.utcnow()
         today = date.today()
 
         tester = Tester(extras={
@@ -469,7 +469,7 @@ class ExtrasFieldTest:
         (db.IntField, 42),
         (db.FloatField, 0.42),
         (db.BooleanField, True),
-        (db.DateTimeField, datetime.now()),
+        (db.DateTimeField, datetime.utcnow()),
         (db.DateField, date.today()),
     ])
     def test_validate_registered_db_type(self, dbtype, value):
@@ -481,8 +481,8 @@ class ExtrasFieldTest:
         Tester(extras={'test': value}).validate()
 
     @pytest.mark.parametrize('dbtype,value', [
-        (db.IntField, datetime.now()),
-        (db.FloatField, datetime.now()),
+        (db.IntField, datetime.utcnow()),
+        (db.FloatField, datetime.utcnow()),
         (db.BooleanField, 42),
         (db.DateTimeField, 42),
         (db.DateField, 42),

--- a/udata/tests/test_notifications.py
+++ b/udata/tests/test_notifications.py
@@ -32,7 +32,7 @@ class NotificationsActionsTest(NotificationsMixin, TestCase, DBTestMixin):
         self.assertIn('fake', actions.list_providers())
 
     def test_registered_provider_provide_values(self):
-        dt = datetime.now()
+        dt = datetime.utcnow()
 
         def fake_provider(user):
             return [(dt, {'some': 'value'})]
@@ -58,7 +58,7 @@ class NotificationsAPITest(NotificationsMixin, APITestCase):
 
     def test_has_notifications(self):
         self.login()
-        dt = datetime.now(pytz.utc)
+        dt = datetime.utcnow()
 
         @actions.notifier('fake')
         def fake_notifier(user):
@@ -70,7 +70,7 @@ class NotificationsAPITest(NotificationsMixin, APITestCase):
         self.assertEqual(len(response.json), 2)
 
         for notification in response.json:
-            self.assertEqual(notification['created_on'], dt.isoformat())
+            self.assertEqual(notification['created_on'], pytz.utc.localize(dt).isoformat())
             self.assertEqual(notification['type'], 'fake')
         self.assertEqual(response.json[0]['details'], {'some': 'value'})
         self.assertEqual(response.json[1]['details'], {'another': 'value'})

--- a/udata/tests/test_storages.py
+++ b/udata/tests/test_storages.py
@@ -223,7 +223,7 @@ class ChunksRetentionTest:
             'uuid': str(uuid),
             'filename': faker.file_name(),
             'totalparts': nb + 1,
-            'lastchunk': last or datetime.now(),
+            'lastchunk': last or datetime.utcnow(),
         }))
 
     @pytest.mark.options(UPLOAD_MAX_RETENTION=0)
@@ -236,8 +236,8 @@ class ChunksRetentionTest:
 
     @pytest.mark.options(UPLOAD_MAX_RETENTION=60 * 60)  # 1 hour
     def test_chunks_kept_before_max_retention(self, client):
-        not_expired = datetime.now()
-        expired = datetime.now() - timedelta(hours=2)
+        not_expired = datetime.utcnow()
+        expired = datetime.utcnow() - timedelta(hours=2)
         expired_uuid = str(uuid4())
         active_uuid = str(uuid4())
         parts = 3

--- a/udata/tests/test_utils.py
+++ b/udata/tests/test_utils.py
@@ -57,11 +57,11 @@ class DateRangeTest:
         assert daterange_end(today) == today
 
     def test_parse_daterange_start_datetime(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         assert daterange_start(now) == now.date()
 
     def test_parse_daterange_end_datetime(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         assert daterange_end(now) == now.date()
 
     def test_parse_daterange_start_full_iso(self):
@@ -238,7 +238,7 @@ class SafeUnicodeTest(object):
 
 class AwareDateTest:
     def test_aware_datetime_to_naiva_datetime(self):
-        aware_date = datetime.now(timezone.utc)
+        aware_date = datetime.utcnow()
         naive_date = to_naive_datetime(aware_date)
         assert naive_date.tzname() is None
 


### PR DESCRIPTION
Fix https://github.com/etalab/transport-site/issues/3152

Since https://github.com/opendatateam/udata/pull/2810, we're now returning timezone aware datetimes.
We're currently expecting utc times stored in mongo. But `datetime.now()`, use as default values all around generates date in the current timezone.

This PR replaces it by `datetime.utcnow()`, to make sure to store utc datetimes in mongo.
This fix would only apply to future objects being created/modified.

Similar PRs have been opened in other udata plugins:
* https://github.com/etalab/udata-front/pull/251
* https://github.com/opendatateam/udata-search-service/pull/42
* https://github.com/opendatateam/udata-ckan/pull/246

For existing objects, we could apply a migration, but it may not be trivial, since some dates could have been supplied by the user, or when the servers used a different timezone?
My guess is it would not add much user value. Indeed, the bug is currently mostly visible on recent contents, not on days or years-old contents.
:arrow_right: I would be willing to have your opinion on this @AntoineAugusti :pray: