### PR TITLE
Fix url params being stripped in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Specify *public* datasets and reuses in admin count [#2852](https://github.com/opendatateam/udata/pull/2852)
+- Fix url params being stripped in markdown for internal URLs [#2855](https://github.com/opendatateam/udata/pull/2855)
 
 ## 6.1.4 (2023-05-16)
 

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -44,10 +44,11 @@ def nofollow_callback(attrs, new=False):
     parsed_url = urlparse(attrs[(None, 'href')])
     if parsed_url.netloc in ('', current_app.config['SERVER_NAME']):
         path = parsed_url.path
-        attrs[(None, 'href')] = '{scheme}://{netloc}{path}'.format(
+        attrs[(None, 'href')] = '{scheme}://{netloc}{path}{query}'.format(
             scheme='https' if request.is_secure else 'http',
             netloc=current_app.config['SERVER_NAME'],
-            path=path if path.startswith('/') else f'/{path}')
+            path=path if path.startswith('/') else f'/{path}',
+            query='?' + parsed_url.query if parsed_url.query else '')
         return attrs
     else:
         rel = [x for x in attrs.get((None, 'rel'), '').split(' ') if x]

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -89,7 +89,8 @@ class MarkdownTest:
         assert el.firstChild.data == 'http://example.net/path'
 
     @pytest.mark.parametrize('link,expected', [
-        ('/', 'http://local.test/'), ('bar', 'http://local.test/bar')
+        ('/', 'http://local.test/'), ('bar', 'http://local.test/bar'),
+        ('/?tag=test&sort=-followers', 'http://local.test/?tag=test&sort=-followers')
     ])
     def test_markdown_linkify_relative(self, md2dom, link, expected):
         '''Markdown filter should transform relative urls to external ones'''


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1096

Internal URL (netloc == SERVER_NAME) were built without the query in markdown sanitizing.
Re-add the query params.

I'm wondering if we should sanitize these params somehow.