### PR TITLE
Improve harvest of mime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Improve DCAT harvest of mime type [#2857](https://github.com/opendatateam/udata/pull/2857)
 
 ## 6.1.5 (2023-06-19)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -4,7 +4,7 @@ This module centralize dataset helpers for RDF/DCAT serialization and parsing
 import calendar
 import logging
 
-from datetime import date, datetime
+from datetime import date
 from html.parser import HTMLParser
 from dateutil.parser import parse as parse_dt
 from flask import current_app
@@ -314,6 +314,17 @@ def frequency_from_rdf(term):
         return freq
 
 
+def mime_from_rdf(resource):
+    # DCAT.mediaType *should* only be used when defined as IANA
+    mime = rdf_value(resource, DCAT.mediaType)
+    if not mime:
+        return
+    if isinstance(mime, str):
+        return mime
+    if IANAFORMAT in mime:
+        return '/'.join(mime.split('/')[-2:])
+
+
 def format_from_rdf(resource):
     format = rdf_value(resource, DCT.format)
     if not format:
@@ -392,7 +403,7 @@ def resource_from_rdf(graph_or_distrib, dataset=None):
     resource.url = url
     resource.description = sanitize_html(distrib.value(DCT.description))
     resource.filesize = rdf_value(distrib, DCAT.bytesSize)
-    resource.mime = rdf_value(distrib, DCAT.mediaType)
+    resource.mime = mime_from_rdf(distrib)
     resource.format = format_from_rdf(distrib)
     checksum = distrib.value(SPDX.checksum)
     if checksum:
@@ -443,7 +454,9 @@ def dataset_from_rdf(graph, dataset=None, node=None):
     tags += [theme.toPython() for theme in d.objects(DCAT.theme) if not isinstance(theme, RdfResource)]
     dataset.tags = list(set(tags))
 
-    dataset.temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))
+    temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))
+    if temporal_coverage:
+        dataset.temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))
 
     licenses = set()
     for distrib in d.objects(DCAT.distribution | DCAT.distributions):

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -319,10 +319,10 @@ def mime_from_rdf(resource):
     mime = rdf_value(resource, DCAT.mediaType)
     if not mime:
         return
-    if isinstance(mime, str):
-        return mime
     if IANAFORMAT in mime:
         return '/'.join(mime.split('/')[-2:])
+    if isinstance(mime, str):
+        return mime
 
 
 def format_from_rdf(resource):

--- a/udata/harvest/tests/dcat/bnodes.jsonld
+++ b/udata/harvest/tests/dcat/bnodes.jsonld
@@ -147,6 +147,7 @@
     "http://purl.org/dc/terms/title": [{"@value": "Resource 1-1"}],
     "http://purl.org/dc/terms/description": [{"@value": "A JSON resource"}],
     "http://purl.org/dc/terms/format": [{"@value": "JSON"}],
+    "http://www.w3.org/ns/dcat#mediaType": [{"@value": "application/json"}],
     "http://www.w3.org/ns/dcat#accessURL": [
       {"@value": "http://data.test.org/datasets/1/resources/1/file.json"}
     ]

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -108,6 +108,7 @@
         <rdf:type rdf:resource="http://purl.org/dc/terms/MediaTypeOrExtent" />
       </dcterms:MediaTypeOrExtent>
     </dcterms:format>
+    <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/json" />
     <dcterms:description>A JSON resource</dcterms:description>
     <dcat:accessURL>http://data.test.org/datasets/1/resources/1/file.json</dcat:accessURL>
   </dcat:Distribution>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -115,6 +115,11 @@ class DcatBackendTest:
         assert len(datasets['2'].resources) == 2
         assert len(datasets['3'].resources) == 1
 
+        assert datasets['1'].resources[0].title == 'Resource 1-1'
+        assert datasets['1'].resources[0].description == 'A JSON resource'
+        assert datasets['1'].resources[0].format == 'json'
+        assert datasets['1'].resources[0].mime == 'application/json'
+
     def test_flat_with_blank_nodes_xml(self, rmock):
         filename = 'bnodes.xml'
         url = mock_dcat(rmock, filename)
@@ -281,6 +286,7 @@ class DcatBackendTest:
         resource_1 = next(res for res in dataset.resources if res.title == 'Resource 1-1')
         # Format is a IANA URI
         assert resource_1.format == 'json'
+        assert resource_1.mime == 'application/json'
         assert resource_1.description == 'A JSON resource'
         assert resource_1.url == 'http://data.test.org/datasets/1/resources/1/file.json'
 


### PR DESCRIPTION
Useful for https://github.com/etalab/data.gouv.fr/issues/1086.
Indeed, mime type exposed in dcat:MediaType are IANA resources (ex: https://www.iana.org/assignments/media-types/application/json). We should parse the `application/json` from this URI.
In a second iteration, we may want to use a fixed vocabulary on mime types.

Take advantage of this PR to prevent overwriting temporal coverage if not harvested.