### PR TITLE
Don't crash on files not found when purging resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Don't crash on files not found when purging resources [2858](https://github.com/opendatateam/udata/pull/2858)
 
 ## 6.1.5 (2023-06-19)
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -53,7 +53,10 @@ def purge_datasets(self):
         storage = storages.resources
         for resource in dataset.resources:
             if resource.fs_filename is not None:
-                storage.delete(resource.fs_filename)
+                try:
+                    storage.delete(resource.fs_filename)
+                except FileNotFoundError as e:
+                    log.warning(e)
             # Not removing the resource from dataset.resources
             # with `dataset.remove_resource` as removing elements
             # from a list while iterating causes random effects.


### PR DESCRIPTION
We still log a warning, since it should not happen. But we still want to go on with the purge.

Indeed, in some envs, files can't be found, thus the purge fails and they keep living, while marked `deleted`.