### PR TITLE
Fix dataset list default sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve DCAT harvest of mime type [#2857](https://github.com/opendatateam/udata/pull/2857)
 - Don't crash on files not found when purging resources [2858](https://github.com/opendatateam/udata/pull/2858)
 - Add optionnal harvest validation form [#2864](https://github.com/opendatateam/udata/pull/2864)
+- Fix dataset list default sorting [#2867](https://github.com/opendatateam/udata/pull/2867)
 
 ## 6.1.5 (2023-06-19)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -586,7 +586,7 @@ class CommunityResourceAPI(API):
 
 @ns.route('/<id>/followers/', endpoint='dataset_followers')
 @ns.doc(get={'id': 'list_dataset_followers'},
-        post={'i    d': 'follow_dataset'},
+        post={'id': 'follow_dataset'},
         delete={'id': 'unfollow_dataset'})
 class DatasetFollowersAPI(FollowAPI):
     model = Dataset

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -113,7 +113,8 @@ class DatasetApiParser(ModelApiParser):
         if args.get('granularity'):
             datasets = datasets.filter(spatial__granularity=args['granularity'])
         if args.get('temporal_coverage'):
-            datasets = datasets.filter(temporal_coverage__start__gte=args['temporal_coverage'][:9], temporal_coverage__start__lte=args['temporal_coverage'][11:])
+            datasets = datasets.filter(temporal_coverage__start__gte=args['temporal_coverage'][:9],
+                                       temporal_coverage__start__lte=args['temporal_coverage'][11:])
         if args.get('featured'):
             datasets = datasets.filter(featured=args['featured'])
         if args.get('organization'):
@@ -362,7 +363,8 @@ class UploadMixin(object):
         if 'html' in infos['mime']:
             api.abort(415, 'Incorrect file content type: HTML')
         infos['title'] = os.path.basename(infos['filename'])
-        checksum_type = next(checksum_type for checksum_type in CHECKSUM_TYPES if checksum_type in infos)
+        checksum_type = next(checksum_type for checksum_type in CHECKSUM_TYPES
+                             if checksum_type in infos)
         infos['checksum'] = Checksum(type=checksum_type, value=infos.pop(checksum_type))
         infos['filesize'] = infos.pop('size')
         del infos['filename']
@@ -584,7 +586,7 @@ class CommunityResourceAPI(API):
 
 @ns.route('/<id>/followers/', endpoint='dataset_followers')
 @ns.doc(get={'id': 'list_dataset_followers'},
-        post={'id': 'follow_dataset'},
+        post={'i    d': 'follow_dataset'},
         delete={'id': 'unfollow_dataset'})
 class DatasetFollowersAPI(FollowAPI):
     model = Dataset
@@ -608,14 +610,18 @@ class DatasetSuggestAPI(API):
         '''Datasets suggest endpoint using mongoDB contains'''
         args = suggest_parser.parse_args()
         datasets_query = Dataset.objects(archived=None, deleted=None, private=False)
-        datasets = datasets_query.filter(Q(title__icontains=args['q']) | Q(acronym__icontains=args['q']))
+        datasets = datasets_query.filter(
+            Q(title__icontains=args['q']) | Q(acronym__icontains=args['q']))
         return [
             {
                 'id': dataset.id,
                 'title': dataset.title,
                 'acronym': dataset.acronym,
                 'slug': dataset.slug,
-                'image_url': dataset.organization.logo if dataset.organization else dataset.owner.avatar if dataset.owner else None
+                'image_url': (
+                    dataset.organization.logo if dataset.organization
+                    else dataset.owner.avatar if dataset.owner else None
+                )
             }
             for dataset in datasets.order_by(SUGGEST_SORTING).limit(args['size'])
         ]
@@ -628,7 +634,8 @@ class FormatsSuggestAPI(API):
     def get(self):
         '''Suggest file formats'''
         args = suggest_parser.parse_args()
-        results = [{'text': i} for i in current_app.config['ALLOWED_RESOURCES_EXTENSIONS'] if args['q'] in i]
+        results = [{'text': i} for i in current_app.config['ALLOWED_RESOURCES_EXTENSIONS']
+                   if args['q'] in i]
         results = results[:args['size']]
         return sorted(results, key=lambda o: len(o['text']))
 
@@ -640,7 +647,8 @@ class MimesSuggestAPI(API):
     def get(self):
         '''Suggest mime types'''
         args = suggest_parser.parse_args()
-        results = [{'text': i} for i in current_app.config['ALLOWED_RESOURCES_MIMES'] if args['q'] in i]
+        results = [{'text': i} for i in current_app.config['ALLOWED_RESOURCES_MIMES']
+                   if args['q'] in i]
         results = results[:args['size']]
         return sorted(results, key=lambda o: len(o['text']))
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -67,7 +67,7 @@ from .exceptions import (
 from .rdf import dataset_to_rdf
 
 
-DEFAULT_SORTING = '-created_at'
+DEFAULT_SORTING = '-created_at_internal'
 SUGGEST_SORTING = '-metrics.followers'
 
 

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -27,7 +27,6 @@ from .permissions import DatasetEditPermission, ResourceEditPermission
 from .search import DatasetSearch
 
 DEFAULT_PAGE_SIZE = 50
-DEFAULT_SORTING = '-created_at'
 
 #: Default mask to make it lightweight by default
 DEFAULT_MASK_APIV2 = ','.join((

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -81,13 +81,15 @@ dataset_fields = apiv2.model('Dataset', {
                           readonly=True),
     'resources': fields.Raw(attribute=lambda o: {
         'rel': 'subsection',
-        'href': url_for('apiv2.resources', dataset=o.id, page=1, page_size=DEFAULT_PAGE_SIZE, _external=True),
+        'href': url_for('apiv2.resources', dataset=o.id, page=1,
+                        page_size=DEFAULT_PAGE_SIZE, _external=True),
         'type': 'GET',
         'total': len(o.resources)
         }, description='Link to the dataset resources'),
     'community_resources': fields.Raw(attribute=lambda o: {
         'rel': 'subsection',
-        'href': url_for('api.community_resources', dataset=o.id, page=1, page_size=DEFAULT_PAGE_SIZE, _external=True),
+        'href': url_for('api.community_resources', dataset=o.id, page=1,
+                        page_size=DEFAULT_PAGE_SIZE, _external=True),
         'type': 'GET',
         'total': len(o.community_resources)
         }, description='Link to the dataset community resources'),
@@ -256,8 +258,9 @@ class ResourcesAPI(API):
         args = resources_parser.parse_args()
         page = args['page']
         page_size = args['page_size']
-        next_page = f"{url_for('apiv2.resources', dataset=dataset.id, _external=True)}?page={page + 1}&page_size={page_size}"
-        previous_page = f"{url_for('apiv2.resources', dataset=dataset.id, _external=True)}?page={page - 1}&page_size={page_size}"
+        list_resources_url = url_for('apiv2.resources', dataset=dataset.id, _external=True)
+        next_page = f"{list_resources_url}?page={page + 1}&page_size={page_size}"
+        previous_page = f"{list_resources_url}?page={page - 1}&page_size={page_size}"
         res = dataset.resources
 
         if args['type']:
@@ -334,7 +337,7 @@ class ResourceExtrasAPI(ResourceMixin, API):
         ResourceEditPermission(dataset).test()
         resource = self.get_resource_or_404(dataset, rid)
         # first remove extras key associated to a None value in payload
-        for key in [k for k in data if data[k] == None]:
+        for key in [k for k in data if data[k] is None]:
             resource.extras.pop(key, None)
             data.pop(key)
         # then update the extras with the remaining payload

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -119,6 +119,15 @@ class DatasetAPITest(APITestCase):
         self.assert200(response)
         self.assertEqual(response.json['data'][0]['id'], str(first.id))
 
+    def test_dataset_api_default_sorting(self):
+        # Default sort should be -created
+        self.login()
+        [VisibleDatasetFactory(title="some created dataset") for i in range(10)]
+        last = VisibleDatasetFactory(title="last created dataset")
+        response = self.get(url_for('api.datasets'))
+        self.assert200(response)
+        self.assertEqual(response.json['data'][0]['id'], str(last.id))
+
     def test_dataset_api_list_with_filters(self):
         '''Should filters datasets results based on query filters'''
         owner = UserFactory()


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/1072#issuecomment-1622098825.

When using datasets list, if we're not specifying a sort value, the default one should be used, being `-created_at_internal`.
Since all objects have `created_at_internal` property, the pagination bug should not occur.
But the `DEFAULT_SORTING` hadn't been updated following https://github.com/opendatateam/udata/pull/2815, thus leading to the pagination bug described in issue.

Fixing `DEFAULT_SORTING` solves the issue for default sort :)