### PR TITLE
Fix dataset with duplicate long title cannot be added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix dataset with duplicate long title cannot be added
 
 ## 6.1.6 (2023-07-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Fix dataset with duplicate long title cannot be added
+- Fix dataset with duplicate long title cannot be added [#2873](https://github.com/opendatateam/udata/pull/2873)
 
 ## 6.1.6 (2023-07-19)
 

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -20,7 +20,7 @@ class SlugField(StringField):
     _auto_gen = True
 
     def __init__(self, populate_from=None, update=False, lower_case=True,
-                 separator='-', follow=False, **kwargs):
+                 separator='-', follow=False, max_identical_slugs=999, **kwargs):
         kwargs.setdefault('unique', True)
         self.populate_from = populate_from
         self.update = update
@@ -28,7 +28,7 @@ class SlugField(StringField):
         self.separator = separator
         self.follow = follow
         self.instance = None
-        self.max_identical_slugs = 999
+        self.max_identical_slugs = max_identical_slugs
         super(SlugField, self).__init__(**kwargs)
 
     def __get__(self, instance, owner):

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -1,7 +1,6 @@
 import logging
 import slugify
 
-from flask import current_app
 from flask_mongoengine import Document
 from mongoengine.fields import StringField
 from mongoengine.signals import pre_save, post_delete
@@ -29,7 +28,7 @@ class SlugField(StringField):
         self.separator = separator
         self.follow = follow
         self.instance = None
-        self.max_identical_slugs = current_app.config['MAX_IDENTICAL_SLUGS']
+        self.max_identical_slugs = 999
         super(SlugField, self).__init__(**kwargs)
 
     def __get__(self, instance, owner):

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -164,7 +164,7 @@ def populate_slug(instance, field, max_identical_slugs):
         def exists(s):
             return qs(**{field.db_field: s}).clear_cls_query().limit(1).count(True) > 0
 
-        while exists := exists(slug) and index <= max_identical_slugs:
+        while (exists := exists(slug)) and index <= max_identical_slugs:
             slug = '{0}-{1}'.format(base_slug, index)
             index += 1
 

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -164,11 +164,11 @@ def populate_slug(instance, field, max_identical_slugs):
         def exists(s):
             return qs(**{field.db_field: s}).clear_cls_query().limit(1).count(True) > 0
 
-        while (exists := exists(slug)) and index <= max_identical_slugs:
+        while (slug_exists := exists(slug)) and index <= max_identical_slugs:
             slug = '{0}-{1}'.format(base_slug, index)
             index += 1
 
-        if exists:
+        if slug_exists:
             raise ValueError(f"Limit of identical slugs is reached for '{field.populate_from}'")
 
         if is_uuid(slug):

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -437,11 +437,6 @@ class Defaults(object):
     ###########################################################################
     QUALITY_DESCRIPTION_LENGTH = 100
 
-    # Max number of identical slugs
-    ###########################################################################
-    # Defines, among other things, how many datasets with identical titles can be added
-    MAX_IDENTICAL_SLUGS = 999
-
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''
     TESTING = True

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -437,6 +437,10 @@ class Defaults(object):
     ###########################################################################
     QUALITY_DESCRIPTION_LENGTH = 100
 
+    # Max number of identical slugs
+    ###########################################################################
+    # Defines, among other things, how many datasets with identical titles can be added
+    MAX_IDENTICAL_SLUGS = 999
 
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -437,6 +437,7 @@ class Defaults(object):
     ###########################################################################
     QUALITY_DESCRIPTION_LENGTH = 100
 
+
 class Testing(object):
     '''Sane values for testing. Should be applied as override'''
     TESTING = True


### PR DESCRIPTION
This issue is related to slug generation in general but is easily seen with datasets.

In case a dataset with a title longer than max allowed slug length is added, an attempt of adding a dataset with an identical long title will result in an error: `mongoengine.errors.ValidationError: ValidationError (Dataset:None) (String value is too long: ['slug'])`

This is due to the fact we don't preserve some space for index postfix that will be added in case of duplicate slugs.

This PR adds an optional `max_identical_slugs` parameter to `SlugField` class that allows for limiting the number of identical slugs that will be handled without errors. Default value is set to 999 which should be more than sufficient for most use cases. This value can be exposed to settings in the future if needed.