### PR TITLE
Fix/fix slug overflow with index suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix slug overflow with index suffix when reaching max_length [#2874](https://github.com/opendatateam/udata/pull/2874)
 
 ## 6.1.6 (2023-07-19)
 

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -164,7 +164,7 @@ def populate_slug(instance, field):
 
         while exists(slug):
             # keep space for index suffix, trim slug if needed
-            slug_overflow = len(base_slug) + 1 + len(str(index)) - field.max_length
+            slug_overflow = len('{0}-{1}'.format(base_slug, index)) - field.max_length
             if slug_overflow >= 1:
                 base_slug = base_slug[:-slug_overflow]
             slug = '{0}-{1}'.format(base_slug, index)

--- a/udata/models/slug_fields.py
+++ b/udata/models/slug_fields.py
@@ -163,6 +163,10 @@ def populate_slug(instance, field):
             return qs(**{field.db_field: s}).clear_cls_query().limit(1).count(True) > 0
 
         while exists(slug):
+            # keep space for index suffix, trim slug if needed
+            slug_overflow = len(base_slug) + 1 + len(str(index)) - field.max_length
+            if slug_overflow >= 1:
+                base_slug = base_slug[:-slug_overflow]
             slug = '{0}-{1}'.format(base_slug, index)
             index += 1
 

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -200,6 +200,24 @@ class SlugFieldTest:
         assert len(obj.title) == SlugTester.slug.max_length + 1
         assert len(obj.slug) == SlugTester.slug.max_length
 
+    def test_crop_with_index(self):
+        '''SlugField should truncate itself to keep room for index suffix if not unique'''
+        first_obj = SlugTester(title='x' * (SlugTester.slug.max_length + 1))
+        first_obj.save()
+        assert len(first_obj.slug) == SlugTester.slug.max_length
+        assert first_obj.slug.endswith('x')
+        # Try adding a second obj with same title with a slug already at max_length
+        second_obj = SlugTester(title='x' * (SlugTester.slug.max_length + 1))
+        second_obj.save()
+        assert len(second_obj.slug) == SlugTester.slug.max_length
+        assert second_obj.slug.endswith('-1')
+        # We could even have 10+ obj with the same title that needs index suffix
+        [SlugTester(title='x' * (SlugTester.slug.max_length + 1)).save() for i in range(8)]
+        last_obj = SlugTester(title='x' * (SlugTester.slug.max_length + 1))
+        last_obj.save()
+        assert len(last_obj.slug) == SlugTester.slug.max_length
+        assert last_obj.slug.endswith('-10')
+
     def test_multiple_spaces(self):
         field = db.SlugField()
         assert field.slugify('a  b') == 'a-b'


### PR DESCRIPTION
Alternative to https://github.com/opendatateam/udata/pull/2873.

On slug generation, we have an issue with slugs that are duplicates and that need a suffix but are already at `field.max_length`.

This PR adds a check to crop slug if needed before adding suffix. It ensures that slug size is always <= `field.max_length`.