### PR TITLE
Filter out datapackage schema

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -113,6 +113,7 @@ CLOSED_FORMATS = ('pdf', 'doc', 'docx', 'word', 'xls', 'excel', 'xlsx')
 MAX_DISTANCE = 2
 
 SCHEMA_CACHE_DURATION = 60 * 5  # In seconds
+IGNORED_SCHEMA_TYPES = ('datapackage', )
 
 TITLE_SIZE_LIMIT = 350
 DESCRIPTION_SIZE_LIMIT = 100000
@@ -919,6 +920,7 @@ class ResourceSchema(object):
                     'label': s['title'],
                     'versions': [d['version_name'] for d in s['versions']],
                 } for s in schemas
+                if s.get('schema_type') not in IGNORED_SCHEMA_TYPES
             ]
             cache.set(cache_key, content)
         # no cached version or no content

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -203,10 +203,12 @@ class DatasetModelTest:
         assert dataset.quality['score'] == Dataset.normalize_score(2)
 
     def test_quality_description_length(self):
-        dataset = DatasetFactory(description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') - 1))
+        dataset = DatasetFactory(
+            description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') - 1))
         assert dataset.quality['dataset_description_quality'] is False
         assert dataset.quality['score'] == 0
-        dataset = DatasetFactory(description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') + 1))
+        dataset = DatasetFactory(
+            description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') + 1))
         assert dataset.quality['dataset_description_quality'] is True
         assert dataset.quality['score'] == Dataset.normalize_score(1)
 
@@ -406,7 +408,7 @@ class LicenseModelTest:
         assert license.id == found.id
 
     def test_exact_match_by_title_with_mismatch_slug(self):
-        license = LicenseFactory(title="Licence Ouverte v2", slug="licence-2")
+        license = LicenseFactory(title='Licence Ouverte v2', slug='licence-2')
         found = License.guess(license.title)
         assert isinstance(found, License)
         assert license.id == found.id
@@ -509,19 +511,19 @@ class ResourceSchemaTest:
     @pytest.mark.options(SCHEMA_CATALOG_URL='https://example.com/schemas')
     def test_resource_schema_objects(self, app, rmock):
         rmock.get('https://example.com/schemas', json={
-            "schemas": [
+            'schemas': [
                 {
-                    "name": "etalab/schema-irve",
-                    "title": "Schéma IRVE",
-                    "versions": [
+                    'name': 'etalab/schema-irve',
+                    'title': 'Schéma IRVE',
+                    'versions': [
                         {
-                            "version_name": "1.0.0"
+                            'version_name': '1.0.0'
                         },
                         {
-                            "version_name": "1.0.1"
+                            'version_name': '1.0.1'
                         },
                         {
-                            "version_name": "1.0.2"
+                            'version_name': '1.0.2'
                         }
                     ]
                 }
@@ -530,12 +532,42 @@ class ResourceSchemaTest:
 
         assert ResourceSchema.objects() == [
             {
-                "id": "etalab/schema-irve",
-                "label": "Schéma IRVE",
-                "versions": [
-                    "1.0.0",
-                    "1.0.1",
-                    "1.0.2"
+                'id': 'etalab/schema-irve',
+                'label': 'Schéma IRVE',
+                'versions': [
+                    '1.0.0',
+                    '1.0.1',
+                    '1.0.2'
+                ]
+            }
+        ]
+
+    @pytest.mark.options(SCHEMA_CATALOG_URL='https://example.com/schemas')
+    def test_resource_schema_objects_ignored_type(self, app, rmock):
+        # datapackage schema should be ignored
+        rmock.get('https://example.com/schemas', json={
+            'schemas': [
+                {
+                    'name': 'schema-tableschema',
+                    'title': 'Schéma IRVE',
+                    'versions': [{'version_name': '1.0.0'}],
+                    'schema_type': 'tableschema'
+                },
+                {
+                    'name': 'schema-datapackage',
+                    'title': 'Schéma IRVE',
+                    'versions': [{'version_name': '1.0.0'}],
+                    'schema_type': 'datapackage'
+                }
+            ]
+        })
+
+        assert ResourceSchema.objects() == [
+            {
+                'id': 'schema-tableschema',
+                'label': 'Schéma IRVE',
+                'versions': [
+                    '1.0.0'
                 ]
             }
         ]
@@ -551,19 +583,19 @@ class ResourceSchemaTest:
 
         # fill cache
         rmock.get('https://example.com/schemas', json={
-            "schemas": [
+            'schemas': [
                 {
-                    "name": "etalab/schema-irve",
-                    "title": "Schéma IRVE",
-                    "versions": [
+                    'name': 'etalab/schema-irve',
+                    'title': 'Schéma IRVE',
+                    'versions': [
                         {
-                            "version_name": "1.0.0"
+                            'version_name': '1.0.0'
                         },
                         {
-                            "version_name": "1.0.1"
+                            'version_name': '1.0.1'
                         },
                         {
-                            "version_name": "1.0.2"
+                            'version_name': '1.0.2'
                         }
                     ]
                 }
@@ -692,7 +724,7 @@ class HarvestMetadataTest:
 
     def test_resource_metadata_extra_modifed_at(self):
         resource = ResourceFactory(filetype='remote')
-        resource.extras.update({'analysis:last-modified-at': datetime(2023,1,1)})
+        resource.extras.update({'analysis:last-modified-at': datetime(2023, 1, 1)})
         resource.validate()
 
         assert resource.last_modified == resource.extras['analysis:last-modified-at']


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/1148

Add an IGNORED_SCHEMA_TYPES variable to ignore some schema types (datapackage). Felt more secure to have an exclude instead of an include logic.

:warning: The front filter doesn't use the /schema route. Instead it loads the catalog directly with `getCatalog`: https://github.com/etalab/udata-front/blob/38ed004ebb5df3dd2f93c749d25b0ff1e0440975/udata_front/theme/gouvfr/assets/js/components/search/schema-filter.vue#L33C11-L33C11.
- [ ] We need to use the /schema endpoint from the front