### PR TITLE
Move ORG_BID_FORMAT to settings and display it in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add extra field to topic model and add it to the dataset search adapter [#2876](https://github.com/opendatateam/udata/pull/2876)
 - Upgrade pyyaml in develop and doc deps [#2880](https://github.com/opendatateam/udata/pull/2880)
 - Expose dataset's `*_internal` dates in a nested `internal` nested field in api marshalling [#2862](https://github.com/opendatateam/udata/pull/2862)
-- Add `business_number_id` metadata for organizations [#2871](https://github.com/opendatateam/udata/pull/2871)
+- Add `business_number_id` metadata for organizations [#2871](https://github.com/opendatateam/udata/pull/2871) [#2887](https://github.com/opendatateam/udata/pull/2887)
 - Return 403 when posting comment on discussion closed [#2881](https://github.com/opendatateam/udata/pull/2881)
 - Ensure rdf parsed frequency is lowercase [#2883](https://github.com/opendatateam/udata/pull/2883)
 - Add a dict of URIs to replace in a RDF graph at harvest time [#2884](https://github.com/opendatateam/udata/pull/2884)

--- a/js/components/organization/form.vue
+++ b/js/components/organization/form.vue
@@ -5,6 +5,7 @@
 <script>
 import Organization from 'models/organization';
 import VForm from 'components/form/vertical-form.vue';
+import config from '../../config';
 
 export default {
     components: {VForm},
@@ -26,7 +27,8 @@ export default {
                     label: this._('Acronym')
                 }, {
                     id: 'business_number_id',
-                    label: this._('Business id')
+                    label: this._('Business id') +
+                         (config.org_bid_format ? ' (' + config.org_bid_format.toUpperCase() + ')' : '')
                 }, {
                     id: 'description',
                     label: this._('Description')

--- a/js/config.js
+++ b/js/config.js
@@ -155,6 +155,11 @@ export const harvest_validation_contact_form = _meta('harvest-validation-contact
 export const dataset_max_resources_uncollapsed = _jsonMeta('dataset-max-resources-uncollapsed');
 
 /**
+ * The expected business identification format
+ */
+export const org_bid_format = _meta('org-bid-format')
+
+/**
  * Markdown configuration.
  */
 export const markdown = _jsonMeta('markdown-config');
@@ -198,6 +203,7 @@ export default {
     license_groups,
     harvest_validation_contact_form,
     dataset_max_resources_uncollapsed,
+    org_bid_format,
     is_search_autocomplete_enabled,
     search_autocomplete_debounce,
     markdown,

--- a/udata/core/organization/forms.py
+++ b/udata/core/organization/forms.py
@@ -1,10 +1,12 @@
+from flask import current_app
+
 from udata.auth import current_user
 from udata.forms import Form, ModelForm, fields, validators
 from udata.i18n import lazy_gettext as _
 
 from .models import (
     Organization, MembershipRequest, Member, LOGO_SIZES, ORG_ROLES,
-    TITLE_SIZE_LIMIT, DESCRIPTION_SIZE_LIMIT, ORG_BID_SIZE_LIMIT, ORG_BID_FORMAT
+    TITLE_SIZE_LIMIT, DESCRIPTION_SIZE_LIMIT
 )
 
 __all__ = (
@@ -18,7 +20,7 @@ __all__ = (
 def org_bid_check(form, field):
     if field.data:
         # EID checks are country dependant. Following one is suitable for France.
-        if ORG_BID_FORMAT == 'siret':
+        if current_app.config.get('ORG_BID_FORMAT') == 'siret':
             siret_number = str(field.data)
             # Length control done here instead of using WTForm validator because field must remain optional.
             if len(siret_number) != 14:

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -41,7 +41,6 @@ TITLE_SIZE_LIMIT = 350
 DESCRIPTION_SIZE_LIMIT = 100000
 
 ORG_BID_SIZE_LIMIT = 14
-ORG_BID_FORMAT = 'siret'
 
 
 class Team(db.EmbeddedDocument):

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -364,6 +364,11 @@ class Defaults(object):
     # Default pagination size on listing
     POST_DEFAULT_PAGINATION = 20
 
+    # Organization settings
+    ###########################################################################
+    # The business identification format to use for validation
+    ORG_BID_FORMAT = 'siret'
+
     # Dataset settings
     ###########################################################################
     # Max number of resources to display uncollapsed in dataset view

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -48,6 +48,9 @@
 <meta name="search-autocomplete-enabled" content="{{ 'true' if config.SEARCH_AUTOCOMPLETE_ENABLED else 'false' }}">
 <meta name="search-autocomplete-debounce" content="{{ config.SEARCH_AUTOCOMPLETE_DEBOUNCE }}">
 <meta name="dataset-max-resources-uncollapsed" content="{{ config.DATASET_MAX_RESOURCES_UNCOLLAPSED }}">
+{% if config.ORG_BID_FORMAT %}
+    <meta name="org-bid-format" content="{{ config.ORG_BID_FORMAT }}">
+{% endif %}
 <meta name="markdown-config" content="{{ {
     'tags': config.MD_ALLOWED_TAGS,
     'attributes': config.MD_ALLOWED_ATTRIBUTES,


### PR DESCRIPTION
We now show the `ORG_BID_FORMAT` in admin form, useful to tell users what's expected.
Wording in English is now ` Business id (SIRET) `.