### PR TITLE
Use a single session for reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Return 400 instead of 500 in case of not ObjectID arg in API [#2889](https://github.com/opendatateam/udata/pull/2889)
+- Use a single session for reindex [#2891](https://github.com/opendatateam/udata/pull/2891)
 
 ## 6.1.7 (2023-09-01)
 
@@ -16,7 +17,6 @@
 - Add a dict of URIs to replace in a RDF graph at harvest time [#2884](https://github.com/opendatateam/udata/pull/2884)
 - Fix duplicate recipients in new comments mail [#2886](https://github.com/opendatateam/udata/pull/2886)
 - Add type to resource csv adapter [#2888](https://github.com/opendatateam/udata/pull/2888)
-- Return 400 instead of 500 in case of not ObjectID arg in API [#2889](https://github.com/opendatateam/udata/pull/2889)
 
 ## 6.1.6 (2023-07-19)
 

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -68,25 +68,26 @@ def index_model(adapter, start, reindex=False, from_datetime=None):
 
     docs = iter_qs(qs, adapter)
     for indexable, doc in docs:
-        try:
-            if indexable:
-                payload = {
-                    'document': doc,
-                    'index': index_name
-                }
-                url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/{adapter.model.__name__.lower()}s/index"
-                r = requests.post(url, json=payload)
-                r.raise_for_status()
-            elif not indexable and not reindex:
-                url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/{adapter.model.__name__.lower()}s/{doc['id']}/unindex"
-                r = requests.delete(url)
-                if r.status_code != 404:  # We don't want to raise on 404
+        with requests.Session() as session:
+            try:
+                if indexable:
+                    payload = {
+                        'document': doc,
+                        'index': index_name
+                    }
+                    url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/{adapter.model.__name__.lower()}s/index"
+                    r = session.post(url, json=payload)
                     r.raise_for_status()
-            else:
-                continue
-        except Exception as e:
-            log.error('Unable to index %s "%s": %s', model, str(doc['id']),
-                      str(e), exc_info=True)
+                elif not indexable and not reindex:
+                    url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/{adapter.model.__name__.lower()}s/{doc['id']}/unindex"
+                    r = session.delete(url)
+                    if r.status_code != 404:  # We don't want to raise on 404
+                        r.raise_for_status()
+                else:
+                    continue
+            except Exception as e:
+                log.error('Unable to index %s "%s": %s', model, str(doc['id']),
+                          str(e), exc_info=True)
 
 
 def finalize_reindex(models, start):

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -49,6 +49,7 @@ def iter_qs(qs, adapter):
 def index_model(adapter, start, reindex=False, from_datetime=None):
     '''Index or unindex all objects given a model'''
     model = adapter.model
+    search_service_url = current_app.config['SEARCH_SERVICE_API_URL']
     log.info('Indexing %s objects', model.__name__)
     qs = model.objects
     if from_datetime:
@@ -56,13 +57,14 @@ def index_model(adapter, start, reindex=False, from_datetime=None):
                          if model.__name__.lower() in ['dataset']
                          else 'last_modified')
         qs = qs.filter(**{f'{date_property}__gte': from_datetime})
-    index_name = adapter.model.__name__.lower()
+    model_name = adapter.model.__name__.lower()
+    index_name = model_name
     if reindex:
         index_name += '-' + default_index_suffix_name(start)
         payload = {
             'index': index_name
         }
-        url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/create-index"
+        url = f"{search_service_url}/create-index"
         r = requests.post(url, json=payload)
         r.raise_for_status()
 
@@ -75,11 +77,11 @@ def index_model(adapter, start, reindex=False, from_datetime=None):
                         'document': doc,
                         'index': index_name
                     }
-                    url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/{adapter.model.__name__.lower()}s/index"
+                    url = f"{search_service_url}/{model_name}s/index"
                     r = session.post(url, json=payload)
                     r.raise_for_status()
                 elif not indexable and not reindex:
-                    url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/{adapter.model.__name__.lower()}s/{doc['id']}/unindex"
+                    url = f"{search_service_url}/{model_name}s/{doc['id']}/unindex"
                     r = session.delete(url)
                     if r.status_code != 404:  # We don't want to raise on 404
                         r.raise_for_status()
@@ -108,7 +110,9 @@ def finalize_reindex(models, start):
             date_property = ('last_modified_internal'
                              if adapter.model.__name__.lower() in ['dataset']
                              else 'last_modified')
-            modified_since_reindex += adapter.model.objects(**{f'{date_property}__gte': start}).count()
+            modified_since_reindex += adapter.model.objects(
+                **{f'{date_property}__gte': start}
+            ).count()
 
     log.warning(
         f'{modified_since_reindex} documents have been modified since reindexation start. '

--- a/udata/tests/search/test_adapter.py
+++ b/udata/tests/search/test_adapter.py
@@ -109,7 +109,8 @@ class IndexingLifecycleTest(APITestCase):
 
         reindex.run(*as_task_param(fake_data))
 
-        url = f"{current_app.config['SEARCH_SERVICE_API_URL']}{DatasetSearch.search_url}/{str(fake_data.id)}/unindex"
+        search_service_url = current_app.config['SEARCH_SERVICE_API_URL']
+        url = f'{search_service_url}{DatasetSearch.search_url}/{str(fake_data.id)}/unindex'
         mock_req.assert_called_with(url)
 
     @patch('requests.post')
@@ -124,7 +125,7 @@ class IndexingLifecycleTest(APITestCase):
         url = f"{current_app.config['SEARCH_SERVICE_API_URL']}{DatasetSearch.search_url}/index"
         mock_req.assert_called_with(url, json=expected_value)
 
-    @patch('requests.post')
+    @patch('requests.Session.post')
     def test_index_model(self, mock_req):
         fake_data = VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1211')
 
@@ -137,7 +138,7 @@ class IndexingLifecycleTest(APITestCase):
         url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/datasets/index"
         mock_req.assert_called_with(url, json=expected_value)
 
-    @patch('requests.post')
+    @patch('requests.Session.post')
     def test_reindex_model(self, mock_req):
         fake_data = VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1211')
 
@@ -150,10 +151,12 @@ class IndexingLifecycleTest(APITestCase):
         url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/datasets/index"
         mock_req.assert_called_with(url, json=expected_value)
 
-    @patch('requests.post')
+    @patch('requests.Session.post')
     def test_index_model_from_datetime(self, mock_req):
-        VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1211', last_modified_internal=datetime.datetime(2020, 1, 1))
-        fake_data = VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1212', last_modified_internal=datetime.datetime(2022, 1, 1))
+        VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1211',
+                              last_modified_internal=datetime.datetime(2020, 1, 1))
+        fake_data = VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1212',
+                                          last_modified_internal=datetime.datetime(2022, 1, 1))
 
         index_model(DatasetSearch, start=None, from_datetime=datetime.datetime(2023, 1, 1))
         mock_req.assert_not_called()

--- a/udata/tests/search/test_adapter.py
+++ b/udata/tests/search/test_adapter.py
@@ -138,18 +138,27 @@ class IndexingLifecycleTest(APITestCase):
         url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/datasets/index"
         mock_req.assert_called_with(url, json=expected_value)
 
+    @patch('requests.post')
     @patch('requests.Session.post')
-    def test_reindex_model(self, mock_req):
+    def test_reindex_model(self, mock_session, mock_req):
         fake_data = VisibleDatasetFactory(id='61fd30cb29ea95c7bc0e1211')
 
         index_model(DatasetSearch, start=datetime.datetime(2022, 2, 20, 20, 2), reindex=True)
 
+        # Create index
+        expected_value = {
+            'index': 'dataset-2022-02-20-20-02'
+        }
+        url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/create-index"
+        mock_req.assert_called_with(url, json=expected_value)
+
+        # Index document
         expected_value = {
             'document': DatasetSearch.serialize(fake_data),
             'index': 'dataset-2022-02-20-20-02'
         }
         url = f"{current_app.config['SEARCH_SERVICE_API_URL']}/datasets/index"
-        mock_req.assert_called_with(url, json=expected_value)
+        mock_session.assert_called_with(url, json=expected_value)
 
     @patch('requests.Session.post')
     def test_index_model_from_datetime(self, mock_req):


### PR DESCRIPTION
Prevent starting a new connection for every document to index