### PR TITLE
Fix site title and keywords never get updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add harvesters count to site metrics [#2890](https://github.com/opendatateam/udata/pull/2890)
 - Return 400 instead of 500 in case of not ObjectID arg in API [#2889](https://github.com/opendatateam/udata/pull/2889)
 - Use a single session for reindex [#2891](https://github.com/opendatateam/udata/pull/2891)
+- Fix site title and keywords never get updated [#2900](https://github.com/opendatateam/udata/pull/2900)
 
 ## 6.1.7 (2023-09-01)
 

--- a/udata/core/site/models.py
+++ b/udata/core/site/models.py
@@ -1,5 +1,3 @@
-import logging
-
 from flask import g, current_app
 from werkzeug.local import LocalProxy
 


### PR DESCRIPTION
Currently changing `SITE_TITLE` and/or `SITE_KEYWORDS` settings doesn't have any effect as initial values stored in Mongo are taken. I'm not sure if this was done intentionally, but in my opinion such update might be needed every now and then, at least for keywords.

**Note:** `upsert` option could've been used in `modify()` to do everything in a single line but unfortunately this method doesn't seem to return the object. Maybe there's still a more elegant way that I'm overlooking.