### PR TITLE
There is no deleted field on a topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Topics changes:
   - Topics creation, update and deletion are now opened to all users [#2898](https://github.com/opendatateam/udata/pull/2898)
   - Topics are now `db.Owned` and searchable by `id` in dataset search [#2901](https://github.com/opendatateam/udata/pull/2901)
+  - Remove `deleted` api field that does not exist [#2903](https://github.com/opendatateam/udata/pull/2903)
 
 ## 6.1.7 (2023-09-01)
 

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -30,8 +30,6 @@ topic_fields = api.model('Topic', {
         description='The topic creation date', readonly=True),
     'last_modified': fields.ISODateTime(
         description='The topic last modification date', readonly=True),
-    'deleted': fields.ISODateTime(
-        description='The organization identifier', readonly=True),
     'organization': fields.Nested(
         org_ref_fields, allow_null=True,
         description='The publishing organization', readonly=True),


### PR DESCRIPTION
Fix https://github.com/opendatateam/udata/issues/2902

When deleting a Topic, it is removed immediately, contrary to datasets objects.