### PR TITLE
Add items.dataset to HarvestJob indexes

### DIFF
--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -165,7 +165,8 @@ class HarvestJob(db.Document):
         'indexes': [
             '-created',
             'source',
-            ('source', '-created')
+            ('source', '-created'),
+            'items.dataset'
         ],
         'ordering': ['-created'],
     }


### PR DESCRIPTION
We're now encountering a performance issue when having many heavy HarvestJob when we purge datasets.
Indeed, the following lines take a lot of time (~3min) on demo (with many harvestJobs):
https://github.com/opendatateam/udata/blob/c00b2355caf5d07721ddd3e30bdcf96d4925ad2a/udata/core/dataset/tasks.py#L49

Adding an index could be a quickwin to solve this performance issue, even though we could probably consider a refactoring later on, probably on the way data is stored (see also: https://github.com/etalab/data.gouv.fr/issues/1046).