### PR TITLE
Fix default community resource sort parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix site title and keywords never get updated [#2900](https://github.com/opendatateam/udata/pull/2900)
 - Reuse's extras are now exposed by API [#2905](https://github.com/opendatateam/udata/pull/2905)
 - Add German to udata translations [2899](https://github.com/opendatateam/udata/pull/2899)[2909](https://github.com/opendatateam/udata/pull/2909)
+- Fix default community resource sort parser [#2908](https://github.com/opendatateam/udata/pull/2908)
 
 ## 6.1.7 (2023-09-01)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -143,7 +143,7 @@ dataset_parser = DatasetApiParser()
 
 community_parser = api.parser()
 community_parser.add_argument(
-    'sort', type=str, default='-created', location='args',
+    'sort', type=str, default='-created_at_internal', location='args',
     help='The sorting attribute')
 community_parser.add_argument(
     'page', type=int, default=1, location='args', help='The page to fetch')

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -1323,6 +1323,21 @@ class CommunityResourceAPITest(APITestCase):
         data = json.loads(response.data)
         self.assertEqual(data['id'], str(community_resource.id))
 
+    def test_resources_api_list(self):
+        '''It should list community resources from the API'''
+        community_resources = [CommunityResourceFactory() for _ in range(40)]
+        response = self.get(url_for('api.community_resources'))
+        self.assert200(response)
+        resources = json.loads(response.data)['data']
+
+        response = self.get(url_for('api.community_resources', page=2))
+        self.assert200(response)
+        resources += json.loads(response.data)['data']
+
+        self.assertEqual(len(resources), len(community_resources))
+        # Assert we don't have duplicates
+        self.assertEqual(len(set(res['id'] for res in resources)), len(community_resources))
+
     def test_community_resource_api_get_from_string_id(self):
         '''It should fetch a community resource from the API'''
         community_resource = CommunityResourceFactory()


### PR DESCRIPTION
Due to [the mongoengine pagination bug](https://github.com/etalab/data.gouv.fr/issues/1072), if we sort on a non-existing field, the order is indeterminate.