### PR TITLE
feat(topics): apiv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ data
 
 # PyCharm
 .idea
+
+# Pyenv
+.python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add topic filter on datasets list [#2915](https://github.com/opendatateam/udata/pull/2915)
+- Topics: API v2 endpoints [#](https://github.com/opendatateam/udata/pull/2913)
 
 ## 6.2.0 (2023-10-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Add topic filter on datasets list [#2915](https://github.com/opendatateam/udata/pull/2915)
-- Topics: API v2 endpoints [#](https://github.com/opendatateam/udata/pull/2913)
+- Topics: API v2 endpoints [#2913](https://github.com/opendatateam/udata/pull/2913)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -320,6 +320,7 @@ def init_app(app):
     import udata.core.site.api  # noqa
     import udata.core.tags.api  # noqa
     import udata.core.topic.api  # noqa
+    import udata.core.topic.apiv2  # noqa
     import udata.core.post.api  # noqa
     import udata.features.transfer.api  # noqa
     import udata.features.notifications.api  # noqa

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -1,10 +1,11 @@
 from udata.api import api, fields, API
-from udata.api.parsers import ModelApiParser
 from udata.core.dataset.api_fields import dataset_fields
 from udata.core.organization.api_fields import org_ref_fields
 from udata.core.reuse.api_fields import reuse_fields
 from udata.core.topic.permissions import TopicEditPermission
 from udata.core.user.api_fields import user_ref_fields
+
+from udata.core.topic.parsers import TopicApiParser
 
 from .models import Topic
 from .forms import TopicForm
@@ -45,33 +46,7 @@ topic_fields = api.model('Topic', {
     'extras': fields.Raw(description='Extras attributes as key-value pairs'),
 }, mask='*,datasets{id,title,uri,page},reuses{id,title, image, image_thumbnail,uri,page}')
 
-
 topic_page_fields = api.model('TopicPage', fields.pager(topic_fields))
-
-
-class TopicApiParser(ModelApiParser):
-    sorts = {
-        'name': 'name',
-        'created': 'created_at'
-    }
-
-    def __init__(self):
-        super().__init__()
-        self.parser.add_argument('tag', type=str, location='args')
-
-    @staticmethod
-    def parse_filters(topics, args):
-        if args.get('q'):
-            # Following code splits the 'q' argument by spaces to surround
-            # every word in it with quotes before rebuild it.
-            # This allows the search_text method to tokenise with an AND
-            # between tokens whereas an OR is used without it.
-            phrase_query = ' '.join([f'"{elem}"' for elem in args['q'].split(' ')])
-            topics = topics.search_text(phrase_query)
-        if args.get('tag'):
-            topics = topics.filter(tags=args['tag'])
-        return topics
-
 
 topic_parser = TopicApiParser()
 

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -3,9 +3,8 @@ from udata.core.dataset.api_fields import dataset_fields
 from udata.core.organization.api_fields import org_ref_fields
 from udata.core.reuse.api_fields import reuse_fields
 from udata.core.topic.permissions import TopicEditPermission
-from udata.core.user.api_fields import user_ref_fields
-
 from udata.core.topic.parsers import TopicApiParser
+from udata.core.user.api_fields import user_ref_fields
 
 from .models import Topic
 from .forms import TopicForm

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -115,9 +115,8 @@ class TopicDatasetsAPI(API):
     def get(self, topic):
         '''Get a given topic datasets, with filters'''
         args = dataset_parser.parse()
-        # FIXME: use `topic` filter in parser from https://github.com/opendatateam/udata/pull/2915
-        datasets = Dataset.objects.filter(id__in=[d.id for d in topic.datasets])
-        datasets = dataset_parser.parse_filters(datasets, args)
+        args['topic'] = topic.id
+        datasets = dataset_parser.parse_filters(Dataset.objects.visible(), args)
         sort = args['sort'] or ('$text_score' if args['q'] else None) or '-created_at_internal'
         return datasets.order_by(sort).paginate(args['page'], args['page_size'])
 

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -199,7 +199,6 @@ class TopicReusesAPI(API):
             id__in=[d.id for d in topic.reuses]
         )
         # warning: topic in reuse_parser is different from Topic
-        args.pop('topic', None)
         reuses = reuse_parser.parse_filters(reuses, args)
         sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
         return reuses.order_by(sort).paginate(args['page'], args['page_size'])

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -129,8 +129,7 @@ class TopicDatasetsAPI(API):
     def post(self, topic):
         '''Add datasets to a given topic from a list of dataset ids'''
         def add_dataset(topic, dataset):
-            # TODO: maybe a mongo query on Dataset would be faster?
-            if dataset.id not in (d.id for d in topic.datasets):
+            if dataset not in topic.datasets:
                 topic.datasets.append(dataset)
             return topic
 

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -1,0 +1,107 @@
+import logging
+
+from flask import url_for
+
+from udata.api import apiv2, API, fields
+from udata.core.dataset.apiv2 import dataset_page_fields
+from udata.core.dataset.models import Dataset
+from udata.core.organization.api_fields import org_ref_fields
+from udata.core.topic.models import Topic
+from udata.core.topic.parsers import TopicApiParser
+from udata.core.user.api_fields import user_ref_fields
+
+DEFAULT_SORTING = '-created_at'
+DEFAULT_PAGE_SIZE = 50
+
+log = logging.getLogger(__name__)
+
+ns = apiv2.namespace('topics', 'Topics related operations')
+
+topic_parser = TopicApiParser()
+datasets_parser = apiv2.page_parser()
+
+common_doc = {
+    'params': {'topic': 'The topic ID'}
+}
+
+topic_fields = apiv2.model('Topic', {
+    'id': fields.String(description='The topic identifier'),
+    'name': fields.String(description='The topic name', required=True),
+    'slug': fields.String(
+        description='The topic permalink string', readonly=True),
+    'description': fields.Markdown(
+        description='The topic description in Markdown', required=True),
+    'tags': fields.List(
+        fields.String, description='Some keywords to help in search', required=True),
+
+    'datasets': fields.Raw(attribute=lambda o: {
+        'rel': 'subsection',
+        'href': url_for('apiv2.dataset_search', topic=o.id, page=1,
+                        page_size=DEFAULT_PAGE_SIZE, _external=True),
+        'type': 'GET',
+        'total': len(o.datasets)
+        }, description='Link to the topic datasets'),
+    'reuses': fields.Raw(attribute=lambda o: {
+        'rel': 'subsection',
+        'href': url_for('apiv2.reuse_search', topic=o.id, page=1,
+                        page_size=DEFAULT_PAGE_SIZE, _external=True),
+        'type': 'GET',
+        'total': len(o.reuses)
+        }, description='Link to the topic reuses'),
+    'featured': fields.Boolean(description='Is the topic featured'),
+    'private': fields.Boolean(description='Is the topic private'),
+    'created_at': fields.ISODateTime(
+        description='The topic creation date', readonly=True),
+    'organization': fields.Nested(
+        org_ref_fields, allow_null=True,
+        description='The publishing organization', readonly=True),
+    'owner': fields.Nested(
+        user_ref_fields, description='The owner user', readonly=True,
+        allow_null=True),
+    'uri': fields.UrlFor(
+        'api.topic', lambda o: {'topic': o},
+        description='The topic API URI', readonly=True),
+    'page': fields.UrlFor(
+        'topics.display', lambda o: {'topic': o},
+        description='The topic page URL', readonly=True, fallback_endpoint='api.topic'),
+    'extras': fields.Raw(description='Extras attributes as key-value pairs'),
+})
+
+topic_page_fields = apiv2.model('TopicPage', fields.pager(topic_fields))
+
+
+@ns.route('/', endpoint='topics_list', doc=common_doc)
+class TopicsAPI(API):
+    @apiv2.expect(topic_parser.parser)
+    @apiv2.marshal_with(topic_page_fields)
+    def get(self):
+        '''List all topics'''
+        args = topic_parser.parse()
+        topics = Topic.objects()
+        topics = topic_parser.parse_filters(topics, args)
+        sort = args['sort'] or ('$text_score' if args['q'] else None) or DEFAULT_SORTING
+        return (topics.order_by(sort)
+                .paginate(args['page'], args['page_size']))
+
+
+@ns.route('/<topic:topic>/', endpoint='topic', doc=common_doc)
+@apiv2.response(404, 'Topic not found')
+class TopicAPI(API):
+    @apiv2.doc('get_topic')
+    @apiv2.marshal_with(topic_fields)
+    def get(self, topic):
+        '''Get a given topic'''
+        return topic
+
+
+@ns.route('/<topic:topic>/datasets/', endpoint='topic_datasets', doc=common_doc)
+class TopicDatasetsAPI(API):
+    @apiv2.doc('get_topic_datasets')
+    @apiv2.expect(datasets_parser)
+    @apiv2.marshal_with(dataset_page_fields)
+    def get(self, topic):
+        '''Get a given topic datasets'''
+        args = datasets_parser.parse_args()
+        return Dataset.objects.filter(
+            id__in=(d.id for d in topic.datasets)
+        ).paginate(args['page'], args['page_size'])

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -118,7 +118,8 @@ class TopicDatasetsAPI(API):
         '''Get a given topic datasets, with filters'''
         args = dataset_parser.parse()
         args['topic'] = topic.id
-        datasets = dataset_parser.parse_filters(Dataset.objects.visible(), args)
+        datasets = Dataset.objects(archived=None, deleted=None, private=False)
+        datasets = dataset_parser.parse_filters(datasets, args)
         sort = args['sort'] or ('$text_score' if args['q'] else None) or '-created_at_internal'
         return datasets.order_by(sort).paginate(args['page'], args['page_size'])
 
@@ -161,8 +162,6 @@ class TopicDatasetsAPI(API):
             topic = add_dataset(topic, dataset)
         topic.save()
 
-        # TODO: maybe we should return None, or the topics/datasets page
-        # but pagination might not match
         return topic, 201
 
 
@@ -242,8 +241,6 @@ class TopicReusesAPI(API):
             topic = add_reuse(topic, reuse)
         topic.save()
 
-        # TODO: maybe we should return None, or the topics/reuses page
-        # but pagination might not match
         return topic, 201
 
 

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -102,7 +102,7 @@ class TopicAPI(API):
 
 topic_add_items_fields = apiv2.model('TopicItemsAdd', {
     'id': fields.String(description='Id of the item to add', required=True),
-}, location="json")
+}, location='json')
 
 
 @ns.route('/<topic:topic>/datasets/', endpoint='topic_datasets', doc=common_doc)

--- a/udata/core/topic/factories.py
+++ b/udata/core/topic/factories.py
@@ -1,8 +1,8 @@
 import factory
 
 from udata import utils
-from udata.core.dataset.factories import DatasetFactory
-from udata.core.reuse.factories import ReuseFactory
+from udata.core.dataset.factories import VisibleDatasetFactory
+from udata.core.reuse.factories import VisibleReuseFactory
 from udata.factories import ModelFactory
 
 from .models import Topic
@@ -19,8 +19,8 @@ class TopicFactory(ModelFactory):
 
     @factory.lazy_attribute
     def datasets(self):
-        return DatasetFactory.create_batch(3)
+        return VisibleDatasetFactory.create_batch(3)
 
     @factory.lazy_attribute
     def reuses(self):
-        return ReuseFactory.create_batch(3)
+        return VisibleReuseFactory.create_batch(3)

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -1,0 +1,25 @@
+from udata.api.parsers import ModelApiParser
+
+
+class TopicApiParser(ModelApiParser):
+    sorts = {
+        'name': 'name',
+        'created': 'created_at'
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.parser.add_argument('tag', type=str, location='args')
+
+    @staticmethod
+    def parse_filters(topics, args):
+        if args.get('q'):
+            # Following code splits the 'q' argument by spaces to surround
+            # every word in it with quotes before rebuild it.
+            # This allows the search_text method to tokenise with an AND
+            # between tokens whereas an OR is used without it.
+            phrase_query = ' '.join([f'"{elem}"' for elem in args['q'].split(' ')])
+            topics = topics.search_text(phrase_query)
+        if args.get('tag'):
+            topics = topics.filter(tags=args['tag'])
+        return topics

--- a/udata/search/__init__.py
+++ b/udata/search/__init__.py
@@ -16,6 +16,8 @@ adapter_catalog = {}
 
 @task(route='high.search')
 def reindex(classname, id):
+    if not current_app.config['SEARCH_SERVICE_API_URL']:
+        return
     model = db.resolve_model(classname)
     obj = model.objects.get(pk=id)
     adapter_class = adapter_catalog.get(model)
@@ -46,6 +48,8 @@ def reindex(classname, id):
 
 @task(route='high.search')
 def unindex(classname, id):
+    if not current_app.config['SEARCH_SERVICE_API_URL']:
+        return
     model = db.resolve_model(classname)
     adapter_class = adapter_catalog.get(model)
     log.info('Unindexing %s (%s)', model.__name__, id)

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -1,5 +1,4 @@
 from flask import url_for
-import pytest
 
 from udata.tests.api import APITestCase
 

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -1,0 +1,66 @@
+from flask import url_for
+
+from udata.tests.api import APITestCase
+from udata.core.topic.factories import TopicFactory
+
+
+class TopicsAPITest(APITestCase):
+    modules = []
+
+    def test_topic_api_list(self):
+        '''It should fetch a topic list from the API'''
+        TopicFactory.create_batch(3)
+        tag_topic = TopicFactory(tags=['energy'])
+        name_topic = TopicFactory(name='topic-for-query')
+
+        response = self.get(url_for('apiv2.topics_list'))
+        self.assert200(response)
+        data = response.json['data']
+        self.assertEqual(len(data), 5)
+
+        assert all(k in data[0]["datasets"] for k in ["rel", "href", "type", "total"])
+        assert all(k in data[0]["reuses"] for k in ["rel", "href", "type", "total"])
+
+        response = self.get(url_for('apiv2.topics_list', q='topic-for'))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(name_topic.id))
+
+        response = self.get(url_for('apiv2.topics_list', tag='energy'))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(tag_topic.id))
+
+    def test_topic_api_get(self):
+        '''It should fetch a topic from the API'''
+        topic = TopicFactory()
+        topic_response = self.get(url_for('apiv2.topic', topic=topic))
+        self.assert200(topic_response)
+
+        response = self.get(topic_response.json['datasets']['href'])
+        data = response.json
+        assert all(str(d.id) in (_d['id'] for _d in data['data']) for d in topic.datasets)
+
+        response = self.get(topic_response.json['reuses']['href'])
+        data = response.json
+        assert all(str(r.id) in (_r['id'] for _r in data['data']) for r in topic.reuses)
+
+
+class TopicDatasetsAPITest(APITestCase):
+    def test_topic_datasets_list(self):
+        topic = TopicFactory()
+        response = self.get(url_for('apiv2.topic_datasets', topic=topic))
+        self.assert200(response)
+        data = response.json['data']
+        assert len(data) == 3
+        assert all(str(d.id) in (_d['id'] for _d in data) for d in topic.datasets)
+
+
+class TopicReusesAPITest(APITestCase):
+    def test_topic_datasets_list(self):
+        topic = TopicFactory()
+        response = self.get(url_for('apiv2.topic_reuses', topic=topic))
+        self.assert200(response)
+        data = response.json['data']
+        assert len(data) == 3
+        assert all(str(r.id) in (_r['id'] for _r in data) for r in topic.reuses)

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -122,7 +122,7 @@ class TopicDatasetAPITest(APITestCase):
         assert response.status_code == 204
         topic.reload()
         assert len(topic.datasets) == 2
-        assert dataset not in (d.id for d in topic.datasets)
+        assert dataset.id not in (d.id for d in topic.datasets)
 
     def test_delete_dataset_perm(self):
         topic = TopicFactory(owner=UserFactory())
@@ -204,7 +204,7 @@ class TopicReuseAPITest(APITestCase):
         assert response.status_code == 204
         topic.reload()
         assert len(topic.reuses) == 2
-        assert reuse not in (d.id for d in topic.reuses)
+        assert reuse.id not in (d.id for d in topic.reuses)
 
     def test_delete_reuse_perm(self):
         topic = TopicFactory(owner=UserFactory())

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -14,28 +14,28 @@ class TopicsAPITest(APITestCase):
         name_topic = TopicFactory(name='topic-for-query')
 
         response = self.get(url_for('apiv2.topics_list'))
-        self.assert200(response)
+        assert response.status_code == 200
         data = response.json['data']
-        self.assertEqual(len(data), 5)
+        assert len(data) == 5
 
         assert all(k in data[0]["datasets"] for k in ["rel", "href", "type", "total"])
         assert all(k in data[0]["reuses"] for k in ["rel", "href", "type", "total"])
 
         response = self.get(url_for('apiv2.topics_list', q='topic-for'))
-        self.assert200(response)
-        self.assertEqual(len(response.json['data']), 1)
-        self.assertEqual(response.json['data'][0]['id'], str(name_topic.id))
+        assert response.status_code == 200
+        assert len(response.json['data']) == 1
+        assert response.json['data'][0]['id'] == str(name_topic.id)
 
         response = self.get(url_for('apiv2.topics_list', tag='energy'))
-        self.assert200(response)
-        self.assertEqual(len(response.json['data']), 1)
-        self.assertEqual(response.json['data'][0]['id'], str(tag_topic.id))
+        assert response.status_code == 200
+        assert len(response.json['data']) == 1
+        assert response.json['data'][0]['id'] == str(tag_topic.id)
 
     def test_topic_api_get(self):
         '''It should fetch a topic from the API'''
         topic = TopicFactory()
         topic_response = self.get(url_for('apiv2.topic', topic=topic))
-        self.assert200(topic_response)
+        assert topic_response.status_code == 200
 
         response = self.get(topic_response.json['datasets']['href'])
         data = response.json
@@ -50,7 +50,7 @@ class TopicDatasetsAPITest(APITestCase):
     def test_topic_datasets_list(self):
         topic = TopicFactory()
         response = self.get(url_for('apiv2.topic_datasets', topic=topic))
-        self.assert200(response)
+        assert response.status_code == 200
         data = response.json['data']
         assert len(data) == 3
         assert all(str(d.id) in (_d['id'] for _d in data) for d in topic.datasets)
@@ -60,7 +60,7 @@ class TopicReusesAPITest(APITestCase):
     def test_topic_datasets_list(self):
         topic = TopicFactory()
         response = self.get(url_for('apiv2.topic_reuses', topic=topic))
-        self.assert200(response)
+        assert response.status_code == 200
         data = response.json['data']
         assert len(data) == 3
         assert all(str(r.id) in (_r['id'] for _r in data) for r in topic.reuses)

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -139,3 +139,22 @@ class TopicReusesAPITest(APITestCase):
         data = response.json['data']
         assert len(data) == 3
         assert all(str(r.id) in (_r['id'] for _r in data) for r in topic.reuses)
+
+
+class TopicReuseAPITest(APITestCase):
+    def test_delete_reuse(self):
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        reuse = topic.reuses[0]
+        response = self.delete(url_for('apiv2.topic_reuse', topic=topic, reuse=reuse))
+        assert response.status_code == 204
+        topic.reload()
+        assert len(topic.reuses) == 2
+        assert reuse not in (d.id for d in topic.reuses)
+
+    def test_delete_reuse_perm(self):
+        topic = TopicFactory(owner=UserFactory())
+        reuse = topic.reuses[0]
+        self.login()
+        response = self.delete(url_for('apiv2.topic_reuse', topic=topic, reuse=reuse))
+        assert response.status_code == 403

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -1,7 +1,9 @@
 from flask import url_for
 
 from udata.tests.api import APITestCase
+from udata.core.dataset.factories import DatasetFactory
 from udata.core.topic.factories import TopicFactory
+from udata.core.user.factories import UserFactory
 
 
 class TopicsAPITest(APITestCase):
@@ -18,8 +20,9 @@ class TopicsAPITest(APITestCase):
         data = response.json['data']
         assert len(data) == 5
 
-        assert all(k in data[0]["datasets"] for k in ["rel", "href", "type", "total"])
-        assert all(k in data[0]["reuses"] for k in ["rel", "href", "type", "total"])
+        hateoas_fields = ["rel", "href", "type", "total"]
+        assert all(k in data[0]["datasets"] for k in hateoas_fields)
+        assert all(k in data[0]["reuses"] for k in hateoas_fields)
 
         response = self.get(url_for('apiv2.topics_list', q='topic-for'))
         assert response.status_code == 200
@@ -47,7 +50,7 @@ class TopicsAPITest(APITestCase):
 
 
 class TopicDatasetsAPITest(APITestCase):
-    def test_topic_datasets_list(self):
+    def test_list(self):
         topic = TopicFactory()
         response = self.get(url_for('apiv2.topic_datasets', topic=topic))
         assert response.status_code == 200
@@ -55,9 +58,81 @@ class TopicDatasetsAPITest(APITestCase):
         assert len(data) == 3
         assert all(str(d.id) in (_d['id'] for _d in data) for d in topic.datasets)
 
+    def test_add_datasets(self):
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        d1, d2 = DatasetFactory.create_batch(2)
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), [
+            {'id': d1.id}, {'id': d2.id}
+        ])
+        assert response.status_code == 201
+        topic.reload()
+        assert len(topic.datasets) == 5
+        assert all(d.id in (_d.id for _d in topic.datasets) for d in (d1, d2))
+
+    def test_add_datasets_double(self):
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        dataset = DatasetFactory()
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), [
+            {'id': dataset.id}, {'id': dataset.id}
+        ])
+        assert response.status_code == 201
+        topic.reload()
+        assert len(topic.datasets) == 4
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), [
+            {'id': dataset.id}
+        ])
+        assert response.status_code == 201
+        topic.reload()
+        assert len(topic.datasets) == 4
+
+    def test_add_datasets_perm(self):
+        user = UserFactory()
+        topic = TopicFactory(owner=user)
+        dataset = DatasetFactory()
+        self.login()
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), [
+            {'id': dataset.id}
+        ])
+        assert response.status_code == 403
+
+    def test_add_datasets_wrong_payload(self):
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), [
+            {'id': 'xxx'}
+        ])
+        assert response.status_code == 400
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), [
+            {'nain': 'portekoi'}
+        ])
+        assert response.status_code == 400
+        response = self.post(url_for('apiv2.topic_datasets', topic=topic), {'non': 'mais'})
+        assert response.status_code == 400
+
+
+class TopicDatasetAPITest(APITestCase):
+    def test_delete_dataset(self):
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        dataset = topic.datasets[0]
+        response = self.delete(url_for('apiv2.topic_dataset', topic=topic, dataset=dataset))
+        assert response.status_code == 204
+        topic.reload()
+        assert len(topic.datasets) == 2
+        assert dataset not in (d.id for d in topic.datasets)
+
+    def test_delete_dataset_perm(self):
+        topic = TopicFactory(owner=UserFactory())
+        dataset = topic.datasets[0]
+        self.login()
+        response = self.delete(url_for('apiv2.topic_dataset', topic=topic, dataset=dataset))
+        assert response.status_code == 403
+
 
 class TopicReusesAPITest(APITestCase):
-    def test_topic_datasets_list(self):
+    def test_list(self):
         topic = TopicFactory()
         response = self.get(url_for('apiv2.topic_reuses', topic=topic))
         assert response.status_code == 200

--- a/udata/tests/search/test_adapter.py
+++ b/udata/tests/search/test_adapter.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from flask import current_app
 from flask_restx import inputs
 from flask_restx.reqparse import RequestParser
@@ -101,6 +103,7 @@ class SearchAdaptorTest:
         assertHasArgument(parser, 'page_size', int)
 
 
+@pytest.mark.options(SEARCH_SERVICE_API_URL="smtg")
 class IndexingLifecycleTest(APITestCase):
 
     @patch('requests.delete')


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-front/issues/52

Adds the following endpoints:
- GET `/api/2/topics/` with a HATEOAS payload for datasets and reuses
- GET `/api/2/topics/{id}/` with same payload
- POST `/api/2/topics/{id}/datasets/` to add a list of datasets to a topic
- POST `/api/2/topics/{id}/reuses/` to add a list of reuses to a topic
- DELETE `/api/2/topics/{id}/datasets/{did}/` to delete a dataset from a topic
- DELETE `/api/2/topics/{id}/reuses/{rid}/` to delete a reuse from a topic

Endpoints are tested, and secured when needed.

Bonus: a conditional on search adapter index/unindex methods because I had some errors popping up from there when running the tests (which have `SEARCH_SERVICE_API_URL = None` setting by default).