### PR TITLE
fix(dataset): add topic filter on list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add topic filter on datasets list [#2915](https://github.com/opendatateam/udata/pull/2915)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -54,6 +54,7 @@ from .api_fields import (
     schema_fields,
 )
 from udata.linkchecker.checker import check_resource
+from udata.core.topic.models import Topic
 from .models import (
     Dataset, Resource, Checksum, License, UPDATE_FREQUENCIES,
     CommunityResource, RESOURCE_TYPES, ResourceSchema, get_resource
@@ -95,6 +96,7 @@ class DatasetApiParser(ModelApiParser):
         self.parser.add_argument('format', type=str, location='args')
         self.parser.add_argument('schema', type=str, location='args')
         self.parser.add_argument('schema_version', type=str, location='args')
+        self.parser.add_argument('topic', type=str, location='args')
 
     @staticmethod
     def parse_filters(datasets, args):
@@ -132,6 +134,13 @@ class DatasetApiParser(ModelApiParser):
             datasets = datasets.filter(resources__schema__name=args['schema'])
         if args.get('schema_version'):
             datasets = datasets.filter(resources__schema__version=args['schema_version'])
+        if args.get('topic'):
+            try:
+                topic = Topic.objects.get(id=args['topic'])
+            except Topic.DoesNotExist:
+                pass
+            else:
+                datasets = datasets.filter(id__in=[d.id for d in topic.datasets])
         return datasets
 
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -135,6 +135,8 @@ class DatasetApiParser(ModelApiParser):
         if args.get('schema_version'):
             datasets = datasets.filter(resources__schema__version=args['schema_version'])
         if args.get('topic'):
+            if not ObjectId.is_valid(args['topic']):
+                api.abort(400, 'Topic arg must be an identifier')
             try:
                 topic = Topic.objects.get(id=args['topic'])
             except Topic.DoesNotExist:

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -245,6 +245,10 @@ class DatasetAPITest(APITestCase):
         self.assert200(response)
         self.assertTrue(len(response.json['data']) > 0)
 
+        # filter on non id for topic
+        response = self.get(url_for('api.datasets', topic='xxx'))
+        self.assert400(response)
+
     def test_dataset_api_get(self):
         '''It should fetch a dataset from the API'''
         resources = [ResourceFactory() for _ in range(2)]

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -21,6 +21,7 @@ from udata.core.dataset.models import (HarvestDatasetMetadata,
                                        HarvestResourceMetadata, ResourceMixin)
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.spatial.factories import SpatialCoverageFactory
+from udata.core.topic.factories import TopicFactory
 from udata.core.user.factories import AdminFactory, UserFactory
 from udata.i18n import gettext as _
 from udata.models import (LEGACY_FREQUENCIES, RESOURCE_TYPES,
@@ -139,6 +140,8 @@ class DatasetAPITest(APITestCase):
         license_dataset = VisibleDatasetFactory(license=LicenseFactory(id='cc-by'))
         format_dataset = DatasetFactory(resources=[ResourceFactory(format='my-format')])
         featured_dataset = VisibleDatasetFactory(featured=True)
+        topic_dataset = VisibleDatasetFactory()
+        topic = TopicFactory(datasets=[topic_dataset])
 
         paca, _, _ = create_geozones_fixtures()
         geozone_dataset = VisibleDatasetFactory(spatial=SpatialCoverageFactory(zones=[paca.id]))
@@ -230,6 +233,17 @@ class DatasetAPITest(APITestCase):
         self.assert200(response)
         self.assertEqual(len(response.json['data']), 1)
         self.assertEqual(response.json['data'][0]['id'], str(schema_version2_dataset.id))
+
+        # filter on topic
+        response = self.get(url_for('api.datasets', topic=topic.id))
+        self.assert200(response)
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['id'], str(topic_dataset.id))
+
+        # filter on non existing topic
+        response = self.get(url_for('api.datasets', topic=topic_dataset.id))
+        self.assert200(response)
+        self.assertTrue(len(response.json['data']) > 0)
 
     def test_dataset_api_get(self):
         '''It should fetch a dataset from the API'''


### PR DESCRIPTION
Related to https://github.com/opendatateam/udata-search-service/pull/43

This adds the `topic` filter to the dataset list, thus mapping to the external search index capability linked above.