### PR TITLE
Consider acronym when suggesting organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Topics creation, update and deletion are now opened to all users [#2898](https://github.com/opendatateam/udata/pull/2898)
   - Topics are now `db.Owned` and searchable by `id` in dataset search [#2901](https://github.com/opendatateam/udata/pull/2901)
   - Remove `deleted` api field that does not exist [#2903](https://github.com/opendatateam/udata/pull/2903)
+- Consider acronym when suggesting organization [#2918](https://github.com/opendatateam/udata/pull/2918)
 
 ## 6.1.7 (2023-09-01)
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from flask import request, url_for, redirect, make_response
+from mongoengine.queryset.visitor import Q
 
 from udata.api import api, API, errors
 from udata.api.parsers import ModelApiParser
@@ -389,7 +390,7 @@ class OrganizationSuggestAPI(API):
     def get(self):
         '''Organizations suggest endpoint using mongoDB contains'''
         args = suggest_parser.parse_args()
-        orgs = Organization.objects(deleted=None, name__icontains=args['q'])
+        orgs = Organization.objects(Q(name__icontains=args['q']) | Q(acronym__icontains=args['q']), deleted=None)
         return [
             {
                 'id': org.id,

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -643,19 +643,18 @@ class MembershipAPITest:
         for i in range(3):
             OrganizationFactory(
                 name=faker.word(),
-                acronym=f'TEST{i}' if i % 2 else faker.word(),
+                acronym=f'UDATA{i}' if i % 2 else faker.word(),
                 metrics={"followers": i})
         max_follower_organization = OrganizationFactory(
             name=faker.word(),
-            acronym='TEST4',
+            acronym='UDATA4',
             metrics={"followers": 10}
         )
         response = api.get(url_for('api.suggest_organizations'),
-                           qs={'q': 'tEsT', 'size': '5'})
+                           qs={'q': 'uDaTa', 'size': '5'})
         assert200(response)
 
-        assert len(response.json) <= 5
-        assert len(response.json) > 1
+        assert len(response.json) == 2
 
         for suggestion in response.json:
             assert 'id' in suggestion
@@ -663,7 +662,7 @@ class MembershipAPITest:
             assert 'name' in suggestion
             assert 'image_url' in suggestion
             assert 'acronym' in suggestion
-            assert 'TEST' in suggestion['acronym']
+            assert 'UDATA' in suggestion['acronym']
             assert response.json[0]['id'] == str(max_follower_organization.id)
 
 

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -637,6 +637,35 @@ class MembershipAPITest:
         for suggestion in response.json:
             assert suggestion['name'] == 'homonym'
 
+    def test_suggest_organizations_acronym(self, api):
+        '''Should suggest organizations based on acronym'''
+
+        for i in range(3):
+            OrganizationFactory(
+                name=faker.word(),
+                acronym=f'TEST{i}' if i % 2 else faker.word(),
+                metrics={"followers": i})
+        max_follower_organization = OrganizationFactory(
+            name=faker.word(),
+            acronym='TEST4',
+            metrics={"followers": 10}
+        )
+        response = api.get(url_for('api.suggest_organizations'),
+                           qs={'q': 'tEsT', 'size': '5'})
+        assert200(response)
+
+        assert len(response.json) <= 5
+        assert len(response.json) > 1
+
+        for suggestion in response.json:
+            assert 'id' in suggestion
+            assert 'slug' in suggestion
+            assert 'name' in suggestion
+            assert 'image_url' in suggestion
+            assert 'acronym' in suggestion
+            assert 'TEST' in suggestion['acronym']
+            assert response.json[0]['id'] == str(max_follower_organization.id)
+
 
 class OrganizationDatasetsAPITest:
     modules = []


### PR DESCRIPTION
Some organizations are mostly known by their abbreviations, so it would be beneficial to allow for suggesting organizations based on both names and acronyms.