### PR TITLE
Fix Topics missing count_discussions for discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add topic filter on datasets list [#2915](https://github.com/opendatateam/udata/pull/2915)
 - Topics: API v2 endpoints [#2913](https://github.com/opendatateam/udata/pull/2913)
+- Allow for discussions on Topics [#2922](https://github.com/opendatateam/udata/pull/2922)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -60,5 +60,9 @@ class Topic(db.Document, db.Owned):
     def display_url(self):
         return url_for('topics.display', topic=self)
 
+    def count_discussions(self):
+        # There are no metrics on Topic to store discussions count
+        pass
+
 
 pre_save.connect(Topic.pre_save, sender=Topic)


### PR DESCRIPTION
Discussions subject are generic, but on new/update/delete discussion, count_discussions is called and should be implemented.