### PR TITLE
Support skos.Concept themes for tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add topic filter on datasets list [#2915](https://github.com/opendatateam/udata/pull/2915)
 - Topics: API v2 endpoints [#2913](https://github.com/opendatateam/udata/pull/2913)
 - Allow for discussions on Topics [#2922](https://github.com/opendatateam/udata/pull/2922)
+- Support skos.Concept themes for tags [#2926](https://github.com/opendatateam/udata/pull/2926)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -389,6 +389,15 @@ def remote_url_from_rdf(rdf):
             except uris.ValidationError:
                 pass
 
+def theme_labels_from_rdf(rdf):
+    for theme in rdf.objects(DCAT.theme):
+        if isinstance(theme, RdfResource):
+            label = rdf_value(theme, SKOS.prefLabel)
+        else:
+            label = theme.toPython()
+        if label:
+            yield label
+
 
 def resource_from_rdf(graph_or_distrib, dataset=None):
     '''
@@ -467,8 +476,7 @@ def dataset_from_rdf(graph, dataset=None, node=None):
         dataset.acronym = acronym
 
     tags = [tag.toPython() for tag in d.objects(DCAT.keyword)]
-    tags += [theme.toPython() for theme in d.objects(DCAT.theme)
-             if not isinstance(theme, RdfResource)]
+    tags += theme_labels_from_rdf(d)
     dataset.tags = list(set(tags))
 
     temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -452,7 +452,8 @@ class CswDcatBackendTest:
         assert dataset.title == 'Localisation des accidents de la circulation routière en 2017'
         assert dataset.description == 'Accidents corporels de la circulation en Hauts de France (2017)'
         assert set(dataset.tags) == set([
-            'donnee-ouverte', 'accidentologie', 'accident'
+            'donnee-ouverte', 'accidentologie', 'accident', 'reseaux-de-transport', 'accident-de-la-route',
+            'hauts-de-france', 'nord', 'pas-de-calais', 'oise', 'somme', 'aisne'
         ])
         assert dataset.harvest.created_at.date() == date(2017, 1, 1)
         assert len(dataset.resources) == 1


### PR DESCRIPTION
Read the `skos.prefLabel` from the resource. See [this usage section on theme](https://w3c.github.io/dxwg/dcat/#classifying-datasets) in DCAT 3.0.
It is used in GeoNetwork v4 catalogs, ex the [DCAT export for naturefrance](https://data.naturefrance.fr/geonetwork/srv/eng/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetRecords&outputSchema=http://www.w3.org/ns/dcat%23&typenames=gmd:MD_Metadata&elementSetName=full&resultType=results&startPosition=1).

We don't keep the URI or the ontology, we only keep the label and store it as a `tag`.

Related to https://github.com/etalab/data.gouv.fr/issues/765.