### PR TITLE
Raise for status on DCAT harvester calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Topics: API v2 endpoints [#2913](https://github.com/opendatateam/udata/pull/2913)
 - Allow for discussions on Topics [#2922](https://github.com/opendatateam/udata/pull/2922)
 - Support skos.Concept themes for tags [#2926](https://github.com/opendatateam/udata/pull/2926)
+- Raise for status on DCAT harvester first head call [#2927](https://github.com/opendatateam/udata/pull/2927)
 
 ## 6.2.0 (2023-10-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Topics: API v2 endpoints [#2913](https://github.com/opendatateam/udata/pull/2913)
 - Allow for discussions on Topics [#2922](https://github.com/opendatateam/udata/pull/2922)
 - Support skos.Concept themes for tags [#2926](https://github.com/opendatateam/udata/pull/2926)
-- Raise for status on DCAT harvester first head call [#2927](https://github.com/opendatateam/udata/pull/2927)
+- Raise for status on DCAT harvester calls [#2927](https://github.com/opendatateam/udata/pull/2927)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -71,6 +71,7 @@ class DcatBackend(BaseBackend):
         # we fallback on the declared Content-Type
         if not fmt:
             response = requests.head(self.source.url)
+            response.raise_for_status()
             mime_type = response.headers.get('Content-Type', '').split(';', 1)[0]
             if not mime_type:
                 msg = 'Unable to detect format from extension or mime type'

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -91,7 +91,9 @@ class DcatBackend(BaseBackend):
         page = 0
         while url:
             subgraph = Graph(namespace_manager=namespace_manager)
-            data = requests.get(url).text
+            response = requests.get(url)
+            response.raise_for_status()
+            data = response.text
             for old_uri, new_uri in URIS_TO_REPLACE.items():
                 data = data.replace(old_uri, new_uri)
             subgraph.parse(data=data, format=fmt)

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -424,6 +424,33 @@ class DcatBackendTest:
         assert len(job.items) == 0
         assert job.status == 'done'
 
+    def test_target_404(self, rmock):
+        filename = 'obvious-format.jsonld'
+        url = url=DCAT_URL_PATTERN.format(path=filename, domain=TEST_DOMAIN)
+        rmock.get(url, status_code=404)
+
+        source = HarvestSourceFactory(backend='dcat', url=url, organization=OrganizationFactory())
+        actions.run(source.slug)
+        source.reload()
+
+        job = source.get_last_job()
+        assert job.status == "failed"
+        assert len(job.errors) == 1
+        assert "404 Client Error" in job.errors[0].message
+
+        filename = 'need-to-head-to-guess-format'
+        url = url=DCAT_URL_PATTERN.format(path=filename, domain=TEST_DOMAIN)
+        rmock.head(url, status_code=404)
+
+        source = HarvestSourceFactory(backend='dcat', url=url, organization=OrganizationFactory())
+        actions.run(source.slug)
+        source.reload()
+
+        job = source.get_last_job()
+        assert job.status == "failed"
+        assert len(job.errors) == 1
+        assert "404 Client Error" in job.errors[0].message
+
         
 @pytest.mark.usefixtures('clean_db')
 @pytest.mark.options(PLUGINS=['csw-dcat'])


### PR DESCRIPTION
Prevents having `Unsupported mime type “text/html”` as harvester error (either at guess_format or parse_graph time).
On 404, we now get explicit `404 Client Error: Not Found for url: ...`