### PR TITLE
Allow for id attribute in a tags in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow for discussions on Topics [#2922](https://github.com/opendatateam/udata/pull/2922)
 - Support skos.Concept themes for tags [#2926](https://github.com/opendatateam/udata/pull/2926)
 - Raise for status on DCAT harvester calls [#2927](https://github.com/opendatateam/udata/pull/2927)
+- Allow for id attribute in a tags in markdown [#2929](https://github.com/opendatateam/udata/pull/2929)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -199,7 +199,7 @@ class Defaults(object):
     ]
 
     MD_ALLOWED_ATTRIBUTES = {
-        'a': ['href', 'title', 'rel', 'data-tooltip'],
+        'a': ['href', 'title', 'rel', 'data-tooltip', 'id'],
         'abbr': ['title'],
         'acronym': ['title'],
         'img': ['alt', 'src', 'title']


### PR DESCRIPTION
This would allow for adding anchors in markdown contents.
Exemple :
```
# Cookie <a id="cookie"></a>

We want a section full of cookies (the edible ones).
```
We could then use the anchor as `/posts/my-post-about-food/#cookie`

### Notes
I haven't found any other simpler way to add anchors with our markdown parser.
I haven't checked yet for security warning on adding these.