### PR TITLE
Make sure harvested resources are marked as remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow for discussions on Topics [#2922](https://github.com/opendatateam/udata/pull/2922)
 - Support skos.Concept themes for tags [#2926](https://github.com/opendatateam/udata/pull/2926)
 - Raise for status on DCAT harvester calls [#2927](https://github.com/opendatateam/udata/pull/2927)
+- Make sure harvested resources are marked as remote [#2931](https://github.com/opendatateam/udata/pull/2931)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -424,6 +424,7 @@ def resource_from_rdf(graph_or_distrib, dataset=None):
         resource = Resource()
         if dataset:
             dataset.resources.append(resource)
+    resource.filetype = 'remote'
     resource.title = title_from_rdf(distrib, url)
     resource.url = url
     resource.description = sanitize_html(distrib.value(DCT.description))

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -300,6 +300,7 @@ class DcatBackendTest:
         assert len(dataset.resources) == 2
 
         resource_1 = next(res for res in dataset.resources if res.title == 'Resource 1-1')
+        assert resource_1.filetype == 'remote'
         # Format is a IANA URI
         assert resource_1.format == 'json'
         assert resource_1.mime == 'application/json'


### PR DESCRIPTION
Fix for https://github.com/opendatateam/udata-ods/issues/250, for DCAT harvester.
ODS harvester should be replaced by DCAT soon.