### PR TITLE
Use harvested date and not max with internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Make sure harvested resources are marked as remote [#2931](https://github.com/opendatateam/udata/pull/2931)
 - Use GET and POST harvest BaseBackend utility to have user-agent [#2930](https://github.com/opendatateam/udata/pull/2930)
 - Use LazyReferenceField on Topic datasets and reuses [#2924](https://github.com/opendatateam/udata/pull/2924)
+- Use harvested dates and not max with internal [#2932](https://github.com/opendatateam/udata/pull/2932)
 - :warning: **breaking change** Geozone refactor [#2878](https://github.com/opendatateam/udata/pull/2878):
   - Complete Geozone model refactor, keeping only fields `slug`, `name`, `code`, `level` and adding `uri`
   - Removed parent and validity concept

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -308,7 +308,7 @@ class ResourceMixin(object):
     @property
     def last_modified(self):
         if self.harvest and self.harvest.modified_at and to_naive_datetime(self.harvest.modified_at) < datetime.utcnow():
-            return max([self.last_modified_internal, to_naive_datetime(self.harvest.modified_at)])
+            return to_naive_datetime(self.harvest.modified_at)
         if self.filetype == 'remote' and self.extras.get('analysis:last-modified-at'):
             return to_naive_datetime(self.extras.get('analysis:last-modified-at'))
         return self.last_modified_internal
@@ -607,7 +607,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
     def last_modified(self):
         if (self.harvest and self.harvest.modified_at and
                 to_naive_datetime(self.harvest.modified_at) < datetime.utcnow()):
-            return max([self.last_modified_internal, to_naive_datetime(self.harvest.modified_at)])
+            return to_naive_datetime(self.harvest.modified_at)
         return self.last_modified_internal
 
     @property

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -1857,14 +1857,15 @@ class HarvestMetadataAPITest:
         response = api.get(url_for('api.dataset', dataset=dataset))
         assert200(response)
         assert response.json['created_at'] == creation_date.isoformat()
-        assert response.json['last_modified'] != modification_date.isoformat()
+        assert response.json['last_modified'] == modification_date.isoformat()
 
         resource_harvest_metadata = HarvestResourceMetadata(
             created_at=creation_date,
+            modified_at=modification_date,
         )
         dataset = DatasetFactory(resources=[ResourceFactory(harvest=resource_harvest_metadata)])
 
         response = api.get(url_for('api.dataset', dataset=dataset))
         assert200(response)
         assert response.json['resources'][0]['created_at'] == creation_date.isoformat()
-        assert response.json['resources'][0]['last_modified'] != modification_date.isoformat()
+        assert response.json['resources'][0]['last_modified'] == modification_date.isoformat()


### PR DESCRIPTION
* For the sake of simplicity
* More coherent than to pretend the dataset is recent when it is just newly harvested, ex [this dataset](https://www.data.gouv.fr/fr/datasets/elections-departementales-2015-1er-tour-angers-canton-5/).
* Trust source platforms
