### PR TITLE
Better rdf frequency resilience

### DIFF
--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -327,7 +327,8 @@ def frequency_from_rdf(term):
         if EUFREQ in term:
             return EU_RDF_REQUENCIES.get(term)
         _, _, freq = namespace_manager.compute_qname(term)
-        return freq.lower()
+        if freq.lower() in UPDATE_FREQUENCIES:
+            return freq.lower()
 
 
 def mime_from_rdf(resource):

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -43,6 +43,7 @@
         <dcat:keyword>Tag 3</dcat:keyword>
         <dcterms:abstract><![CDATA[<h1>h1 title</h1><h2>h2 title</h2><b>and bold text</b>]]></dcterms:abstract>
         <dcterms:title>Dataset 1</dcterms:title>
+        <dct:accrualPeriodicity><dcterms:Frequency rdf:about="http://purl.org/cld/freq/ThisTermDoesNotExist"></dcterms:Frequency></dct:accrualPeriodicity>
         <dct:temporal>
           <dcterms:PeriodOfTime>
             <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-01T00:00:00</dcat:startDate>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -296,6 +296,7 @@ class DcatBackendTest:
         assert dataset.temporal_coverage is not None
         assert dataset.temporal_coverage.start == date(2016, 1, 1)
         assert dataset.temporal_coverage.end == date(2016, 12, 5)
+        assert dataset.frequency is None
 
         assert len(dataset.resources) == 3
 


### PR DESCRIPTION
In case of a frequency term not supported, we should not make the dataset harvesting fail.