### PR TITLE
feat(oauth): allow wildcards in redirect_uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     - `udata spatial migrate` to migrate datasets geozones to new ones
     - Reindex datasets
   - Removed forgotten fields in search [#2934](https://github.com/opendatateam/udata/pull/2934)
+- Allow wildcards in redirect_uris for Oauth2Client [#2935](https://github.com/opendatateam/udata/pull/2935)
 
 ## 6.2.0 (2023-10-26)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -153,6 +153,7 @@ class Defaults(object):
         'password': 30 * 24 * HOUR,
         'client_credentials': 30 * 24 * HOUR
     }
+    OAUTH2_ALLOW_WILDCARD_IN_REDIRECT_URI = False
 
     MD_ALLOWED_TAGS = [
         'a',

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -51,13 +51,14 @@ def basic_header(client):
 @pytest.fixture
 def oauth(app, request):
     marker = request.node.get_closest_marker('oauth')
-    kwargs = marker.kwargs if marker else {}
-    return OAuth2Client.objects.create(
+    custom_kwargs = marker.kwargs if marker else {}
+    kwargs = dict(
         name='test-client',
         owner=UserFactory(),
         redirect_uris=['https://test.org/callback'],
-        **kwargs
     )
+    kwargs.update(custom_kwargs)
+    return OAuth2Client.objects.create(**kwargs)
 
 
 @pytest.mark.usefixtures('clean_db')
@@ -237,6 +238,76 @@ class APIAuthTest:
         uri, params = response.location.split('?')
 
         assert uri == oauth.default_redirect_uri
+
+    @pytest.mark.options(OAUTH2_ALLOW_WILDCARD_IN_REDIRECT_URI=True)
+    @pytest.mark.oauth(redirect_uris=['https://*.test.org/callback'])
+    def test_authorization_accept_wildcard(self, client, oauth):
+        '''Should redirect to the redirect_uri on authorization accepted
+        with wildcard enabled and used in config'''
+        client.login()
+
+        redirect_uri = 'https://subdomain.test.org/callback'
+
+        response = client.post(url_for(
+            'oauth.authorize',
+            response_type='code',
+            client_id=oauth.client_id,
+            redirect_uri=redirect_uri,
+        ), {
+            'scope': 'default',
+            'accept': '',
+        })
+
+        assert_status(response, 302)
+        uri, _ = response.location.split('?')
+
+        assert uri == redirect_uri
+
+    @pytest.mark.options(OAUTH2_ALLOW_WILDCARD_IN_REDIRECT_URI=False)
+    @pytest.mark.oauth(redirect_uris=['https://*.test.org/callback'])
+    def test_authorization_accept_no_wildcard(self, client, oauth):
+        '''Should not redirect to the redirect_uri on authorization accepted
+        without wildcard enabled while used in config'''
+        client.login()
+
+        redirect_uri = 'https://subdomain.test.org/callback'
+
+        response = client.post(url_for(
+            'oauth.authorize',
+            response_type='code',
+            client_id=oauth.client_id,
+            redirect_uri=redirect_uri,
+        ), {
+            'scope': 'default',
+            'accept': '',
+        })
+
+        assert_status(response, 400)
+        assert 'error' in response.json
+        assert 'redirect_uri' in response.json['error_description']
+
+    @pytest.mark.options(OAUTH2_ALLOW_WILDCARD_IN_REDIRECT_URI=True)
+    @pytest.mark.oauth(redirect_uris=['https://*.test.org/callback'])
+    def test_authorization_accept_wrong_wildcard(self, client, oauth):
+        '''Should not redirect to the redirect_uri on authorization accepted
+        with wildcard enabled but mismatched from config'''
+        client.login()
+
+        redirect_uri = 'https://subdomain.example.com/callback'
+
+        response = client.post(url_for(
+            'oauth.authorize',
+            response_type='code',
+            client_id=oauth.client_id,
+            redirect_uri=redirect_uri,
+        ), {
+            'scope': 'default',
+            'accept': '',
+        })
+
+        assert_status(response, 400)
+        assert 'error' in response.json
+        assert 'redirect_uri' in response.json['error_description']
 
     def test_authorization_grant_token(self, client, oauth):
         client.login()


### PR DESCRIPTION
This add a setting and logic to allow wildcards in `redirect_uris` for an `OAuth2Client`.

On Ecosphères, it will be very useful to be able to use OAuth when testing PR previews that have URLs like https://deploy-preview-205--ecospheres.netlify.app. We could authorize `*ecospheres.netlify.app/login/callback` for our client.

Since this might be dangerous security-wise, it's behind a flag that is `False` by default. I suggest enabling it only on dev/demo instances and not in production.