### PR TITLE
Improve search serialization perfs for datasets in big topics

### DIFF
--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -64,7 +64,7 @@ class DatasetSearch(ModelSearchAdapter):
         organization = None
         owner = None
 
-        topics = Topic.objects(datasets=dataset)
+        topics = Topic.objects(datasets=dataset).only('id')
 
         if dataset.organization:
             org = Organization.objects(id=dataset.organization.id).first()


### PR DESCRIPTION
We only need `id` from topics in search serialize.

On demo env (with big topics), we gain **considerable** time by requiring `id` only for a dataset in one of these big topics.
```
>>> timeit.timeit(lambda: [str(t.id) for t in Topic.objects(datasets=dat)], number=10)
9.804051486775279
```

```
>>> timeit.timeit(lambda: [str(t.id) for t in Topic.objects(datasets=dat).only('id')], number=10)
0.09499026276171207
```