### PR TITLE
Allow for being one day late on update fulfilled in time

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -684,8 +684,10 @@ class Dataset(WithMetrics, BadgeMixin, db.Owned, db.Document):
 
         result['update_frequency'] = self.frequency and self.frequency != 'unknown'
         if self.next_update:
+            # Allow for being one day late on update.
+            # We may have up to one day delay due to harvesting for example
             result['update_fulfilled_in_time'] = (
-                True if -(self.next_update - datetime.utcnow()).days <= 0 else False
+                True if (self.next_update - datetime.utcnow()).days >= -1 else False
             )
         elif self.frequency in ['continuous', 'irregular', 'punctual']:
             # For these frequencies, we don't expect regular updates or can't quantify them.

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -202,6 +202,22 @@ class DatasetModelTest:
         assert dataset.quality['update_fulfilled_in_time'] is True
         assert dataset.quality['score'] == Dataset.normalize_score(2)
 
+    def test_quality_frequency_update_one_day_late(self):
+        dataset = DatasetFactory(
+            description='', frequency="daily",
+            last_modified_internal=datetime.utcnow() - timedelta(days=1, hours=1))
+        assert dataset.quality['update_frequency'] is True
+        assert dataset.quality['update_fulfilled_in_time'] is True
+        assert dataset.quality['score'] == Dataset.normalize_score(2)
+
+    def test_quality_frequency_update_two_days_late(self):
+        dataset = DatasetFactory(
+            description='', frequency="daily",
+            last_modified_internal=datetime.utcnow() - timedelta(days=2, hours=1))
+        assert dataset.quality['update_frequency'] is True
+        assert dataset.quality['update_fulfilled_in_time'] is False
+        assert dataset.quality['score'] == Dataset.normalize_score(1)
+
     def test_quality_description_length(self):
         dataset = DatasetFactory(description='a' * (current_app.config.get('QUALITY_DESCRIPTION_LENGTH') - 1))
         assert dataset.quality['dataset_description_quality'] is False


### PR DESCRIPTION
We may have up to one day delay due to harvesting causing misleading warnings.

Indeed with a dataset harvested daily, we are not immediately aware of a resource update. It would be more cautious to wait for an additional day before lowering the quality score.

What do you think of this @agarrone ?