### PR TITLE
Use rdf_value and replace mailto prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Improve search serialization perfs for datasets in big topics [#2937](https://github.com/opendatateam/udata/pull/2937)
-- Contact points feature [#2914](https://github.com/opendatateam/udata/pull/2914):
+- Contact points feature [#2914](https://github.com/opendatateam/udata/pull/2914) [#2943](https://github.com/opendatateam/udata/pull/2943):
   - Users and Organizations can now define a list of contact points
   - Api endpoint for creating, updating and deleting contact points
   - Datasets can define one contact point, among the list of the organization or the user owning the dataset.

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -315,10 +315,13 @@ def temporal_from_rdf(period_of_time):
 def contact_point_from_rdf(rdf, dataset):
     contact_point = rdf.value(DCAT.contactPoint)
     if contact_point:
-        name = contact_point.value(VCARD.fn)
-        email = (contact_point.value(VCARD.hasEmail)
-                 or contact_point.value(VCARD.email)
-                 or contact_point.value(DCAT.email))
+        name = rdf_value(contact_point, VCARD.fn) or ''
+        email = (rdf_value(contact_point, VCARD.hasEmail)
+                 or rdf_value(contact_point, VCARD.email)
+                 or rdf_value(contact_point, DCAT.email))
+        if not email:
+            return
+        email = email.replace('mailto:', '').strip()
         if dataset.organization:
             contact_point = ContactPoint.objects(
                 name=name, email=email, organization=dataset.organization).first()

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -97,7 +97,7 @@
   </dcat:Distribution>
   <vcard:Organization rdf:about="http://data.test.org/contacts/1">
     <vcard:fn>Organization contact</vcard:fn>
-    <vcard:hasEmail>hello@its.me</vcard:hasEmail>
+    <vcard:hasEmail>mailto: hello@its.me</vcard:hasEmail>
   </vcard:Organization>
   <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-2">
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-01T00:00:00</schema:startDate>


### PR DESCRIPTION
Supports OpenDataSoft contactPoint description, ex:
```
<dcat:contactPoint>
    <vcard:Organization>
        <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind" />
        <vcard:hasEmail rdf:resource="mailto:contact@agenceore.fr" />
    </vcard:Organization>
</dcat:contactPoint>
```
We make sure to use the string `mailto:contact@agenceore.fr` as value using `rdf_value` and then we strip `mailto:` prefix