### PR TITLE
Fix refuse second org access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix reuses inside database without private information (default to public)
 - Fix: you can now remove schema from a resource in the admin
+- Fix: refuse an organisation access request when multiple access requests are pending
 
 ## 7.0.2 (2024-01-23)
 

--- a/js/components/organization/members.vue
+++ b/js/components/organization/members.vue
@@ -104,7 +104,7 @@
                     </button>
                 </div>
             </div>
-            <div v-if="request.refused">
+            <div v-show="request.refused">
                 <form>
                     <textarea v-el:textarea class="form-control" rows="3" required></textarea>
                 </form>


### PR DESCRIPTION
The `v-if` destroy the `textarea` so when querying it with `this.$el.querySelectorAll('textarea')[index].value` there are not all present (so the index is wrong). Using `v-show` instead is a quick fix because it leave the `textarea` in the DOM, so we can query all of them and keep the correct index.

Fix https://github.com/etalab/data.gouv.fr/issues/664