### PR TITLE
Add rotate password command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add rotate password command [#2966](https://github.com/opendatateam/udata/pull/2966)
 
 ## 7.0.3 (2024-02-15)
 

--- a/udata/core/user/commands.py
+++ b/udata/core/user/commands.py
@@ -88,3 +88,14 @@ def password(email):
     password = click.prompt('Enter new password', hide_input=True)
     user.password = hash_password(password)
     user.save()
+
+@grp.command()
+@click.argument('email')
+def rotate_password(email):
+    '''
+    Ask user for password rotation on next login and reset any current session
+    '''
+    user = datastore.find_user(email=email)
+    user.password_rotation_demanded = datetime.utcnow()
+    user.save()
+    datastore.set_uniquifier(user)

--- a/udata/core/user/commands.py
+++ b/udata/core/user/commands.py
@@ -98,4 +98,5 @@ def rotate_password(email):
     user = datastore.find_user(email=email)
     user.password_rotation_demanded = datetime.utcnow()
     user.save()
+    # Reset ongoing sessions by uniquifier
     datastore.set_uniquifier(user)


### PR DESCRIPTION
Useful command to activate password rotation for a user, as added in https://github.com/opendatateam/udata/pull/2551/.

It also shows an example usage of password rotation with session reset.
Calling `set_uniquifier` seems to be the way to go following https://github.com/Flask-Middleware/flask-security/pull/420.
