### PR TITLE
Add default value to schema catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Dataset belonging to the organization can assign a value to the defined metadata
   - Metadata value must match the choosen type by the organization
 - Harvest DCAT conformsTo into schemas for resources and datasets
+- Add default catalog for `SCHEMA_CATALOG_URL` [#2969](https://github.com/opendatateam/udata/pull/2969)
 - Better reporting in spam detection (show the writer of the discussion/message) [#2965](https://github.com/opendatateam/udata/pull/2965)
 - Fix: spam lang detection not lowering input resulting in false positives [#2965](https://github.com/opendatateam/udata/pull/2965)
 - Fix: do not send mail about discussions when there is no owner / no organisation members [#2962](https://github.com/opendatateam/udata/pull/2962)

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -422,7 +422,7 @@ class Defaults(object):
 
     # Schemas parameters
     ####################
-    SCHEMA_CATALOG_URL = None
+    SCHEMA_CATALOG_URL = 'https://schema.data.gouv.fr/schemas/schemas.json'
 
     API_DOC_EXTERNAL_LINK = 'https://guides.data.gouv.fr/publier-des-donnees/guide-data.gouv.fr/api/reference'
 


### PR DESCRIPTION
Since https://github.com/opendatateam/udata/pull/2949 the catalog is used to check the names of the schemas. It raises a lot of problems with CI / tests in `udata-front` since the catalog is often missing in the config (and we try to create resources with schemas). 