### PR TITLE
Fix exception in harvest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - Organization can nom define a custom metadata of a choosen type
   - Dataset belonging to the organization can assign a value to the defined metadata
   - Metadata value must match the choosen type by the organization
-- Harvest DCAT conformsTo into schemas for resources and datasets [#2949](https://github.com/opendatateam/udata/pull/2949) [#2970](https://github.com/opendatateam/udata/pull/2970) [#2972](https://github.com/opendatateam/udata/pull/2972)
+- Harvest DCAT conformsTo into schemas for resources and datasets [#2949](https://github.com/opendatateam/udata/pull/2949) [#2970](https://github.com/opendatateam/udata/pull/2970) [#2972](https://github.com/opendatateam/udata/pull/2972) [#2976](https://github.com/opendatateam/udata/pull/2976)
 - Better reporting in spam detection (show the writer of the discussion/message) [#2965](https://github.com/opendatateam/udata/pull/2965)
 - Fix: spam lang detection not lowering input resulting in false positives [#2965](https://github.com/opendatateam/udata/pull/2965)
 - Fix: do not send mail about discussions when there is no owner / no organisation members [#2962](https://github.com/opendatateam/udata/pull/2962)

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -40,7 +40,7 @@ class SchemaForm(ModelForm):
         validation = super().validate(extra_validators)
 
         try:
-            Schema(url=self.url.data, name=self.name.data, version=self.version.data).clean()
+            Schema(url=self.url.data, name=self.name.data, version=self.version.data).clean(check_schema_in_catalog=True)
         except FieldValidationError as err:
             field = getattr(self, err.field)
             field.errors.append(err.message)

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -212,12 +212,12 @@ class Schema(db.EmbeddedDocument):
         # We know this schema so we can do some checks
         existing_schema = ResourceSchema.get_schema_by_name(self.name)
         if not existing_schema:
-            message = _('Schema name "{schema}" is not an allowed value. Allowed values: {values}')
+            message = _('Schema name "{schema}" is not an allowed value. Allowed values: {values}').format(
+                schema=self.name,
+                values=', '.join(map(lambda schema: schema['name'], catalog_schemas))
+            )
             if check_schema_in_catalog:
-                raise FieldValidationError(message.format(
-                    schema=self.name,
-                    values=', '.join(map(lambda schema: schema['name'], catalog_schemas))
-                ), field='name')
+                raise FieldValidationError(message, field='name')
             else:
                 log.warning(message)
                 return
@@ -227,15 +227,13 @@ class Schema(db.EmbeddedDocument):
             allowed_versions.append('latest')
 
             if self.version not in allowed_versions:
-                message = _(
-                    'Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {'
-                    'values}')
+                message = _('Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {values}').format(
+                    version=self.version,
+                    name=self.name,
+                    values=', '.join(allowed_versions)
+                )
                 if check_schema_in_catalog:
-                    raise FieldValidationError(message.format(
-                        version=self.version,
-                        name=self.name,
-                        values=', '.join(allowed_versions)
-                    ), field='version')
+                    raise FieldValidationError(message, field='version')
                 else:
                     log.warning(message)
                     return

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -211,10 +211,12 @@ class Schema(db.EmbeddedDocument):
         existing_schema = ResourceSchema.get_schema_by_name(self.name)
         if not existing_schema:
             message = _('Schema name "{schema}" is not an allowed value. Allowed values: {values}')
-            raise FieldValidationError(message.format(
-                schema=self.name,
-                values=', '.join(map(lambda schema: schema['name'], catalog_schemas))
-            ), field='name')
+            log.warning(message)
+            return
+            # raise FieldValidationError(message.format(
+            #     schema=self.name,
+            #     values=', '.join(map(lambda schema: schema['name'], catalog_schemas))
+            # ), field='name')
 
         if self.version:
             allowed_versions = list(map(lambda version: version['version_name'], existing_schema['versions']))
@@ -224,11 +226,13 @@ class Schema(db.EmbeddedDocument):
                 message = _(
                     'Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {'
                     'values}')
-                raise FieldValidationError(message.format(
-                    version=self.version,
-                    name=self.name,
-                    values=', '.join(allowed_versions)
-                ), field='version')
+                log.warning(message)
+                return
+                # raise FieldValidationError(message.format(
+                #     version=self.version,
+                #     name=self.name,
+                #     values=', '.join(allowed_versions)
+                # ), field='version')
 
 
 class License(db.Document):

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -738,17 +738,17 @@ class DatasetAPITest(APITestCase):
         self.assert400(response)
         assert response.json['errors']['resources'][0]['schema']['url'] == [_('Invalid URL')]
 
-        # resource_data['schema'] = {'name': 'unknown-schema'}
-        # data['resources'].append(resource_data)
-        # response = self.put(url_for('api.dataset', dataset=dataset), data)
-        # self.assert400(response)
-        # assert response.json['errors']['resources'][0]['schema']['name'] == [_('Schema name "{schema}" is not an allowed value. Allowed values: {values}').format(schema='unknown-schema', values='etalab/schema-irve-statique, 139bercy/format-commande-publique')]
+        resource_data['schema'] = {'name': 'unknown-schema'}
+        data['resources'].append(resource_data)
+        response = self.put(url_for('api.dataset', dataset=dataset), data)
+        self.assert400(response)
+        assert response.json['errors']['resources'][0]['schema']['name'] == [_('Schema name "{schema}" is not an allowed value. Allowed values: {values}').format(schema='unknown-schema', values='etalab/schema-irve-statique, 139bercy/format-commande-publique')]
 
-        # resource_data['schema'] = {'name': 'etalab/schema-irve-statique', 'version': '42.0.0'}
-        # data['resources'].append(resource_data)
-        # response = self.put(url_for('api.dataset', dataset=dataset), data)
-        # self.assert400(response)
-        # assert response.json['errors']['resources'][0]['schema']['version'] == [_('Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {values}').format(version='42.0.0', name='etalab/schema-irve-statique', values='2.2.0, 2.2.1, latest')]
+        resource_data['schema'] = {'name': 'etalab/schema-irve-statique', 'version': '42.0.0'}
+        data['resources'].append(resource_data)
+        response = self.put(url_for('api.dataset', dataset=dataset), data)
+        self.assert400(response)
+        assert response.json['errors']['resources'][0]['schema']['version'] == [_('Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {values}').format(version='42.0.0', name='etalab/schema-irve-statique', values='2.2.0, 2.2.1, latest')]
 
         resource_data['schema'] = {'url': 'http://example.com', 'name': 'etalab/schema-irve-statique'}
         data['resources'].append(resource_data)

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -738,17 +738,17 @@ class DatasetAPITest(APITestCase):
         self.assert400(response)
         assert response.json['errors']['resources'][0]['schema']['url'] == [_('Invalid URL')]
 
-        resource_data['schema'] = {'name': 'unknown-schema'}
-        data['resources'].append(resource_data)
-        response = self.put(url_for('api.dataset', dataset=dataset), data)
-        self.assert400(response)
-        assert response.json['errors']['resources'][0]['schema']['name'] == [_('Schema name "{schema}" is not an allowed value. Allowed values: {values}').format(schema='unknown-schema', values='etalab/schema-irve-statique, 139bercy/format-commande-publique')]
+        # resource_data['schema'] = {'name': 'unknown-schema'}
+        # data['resources'].append(resource_data)
+        # response = self.put(url_for('api.dataset', dataset=dataset), data)
+        # self.assert400(response)
+        # assert response.json['errors']['resources'][0]['schema']['name'] == [_('Schema name "{schema}" is not an allowed value. Allowed values: {values}').format(schema='unknown-schema', values='etalab/schema-irve-statique, 139bercy/format-commande-publique')]
 
-        resource_data['schema'] = {'name': 'etalab/schema-irve-statique', 'version': '42.0.0'}
-        data['resources'].append(resource_data)
-        response = self.put(url_for('api.dataset', dataset=dataset), data)
-        self.assert400(response)
-        assert response.json['errors']['resources'][0]['schema']['version'] == [_('Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {values}').format(version='42.0.0', name='etalab/schema-irve-statique', values='2.2.0, 2.2.1, latest')]
+        # resource_data['schema'] = {'name': 'etalab/schema-irve-statique', 'version': '42.0.0'}
+        # data['resources'].append(resource_data)
+        # response = self.put(url_for('api.dataset', dataset=dataset), data)
+        # self.assert400(response)
+        # assert response.json['errors']['resources'][0]['schema']['version'] == [_('Version "{version}" is not an allowed value for the schema "{name}". Allowed versions: {values}').format(version='42.0.0', name='etalab/schema-irve-statique', values='2.2.0, 2.2.1, latest')]
 
         resource_data['schema'] = {'url': 'http://example.com', 'name': 'etalab/schema-irve-statique'}
         data['resources'].append(resource_data)

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -601,9 +601,13 @@ class ResourceSchemaTest:
         resource.schema = Schema(name='some-name', url='https://example.com')
         resource.validate()
 
-        # with pytest.raises(db.ValidationError):
-        resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
-        resource.validate()
+        with pytest.raises(db.ValidationError):
+            resource.schema = Schema(name='some-name')
+            resource.validate()
+
+        with pytest.raises(db.ValidationError):
+            resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
+            resource.validate()
 
         with pytest.raises(db.ValidationError):
             resource.schema = Schema(version='2.0.0')

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -601,9 +601,9 @@ class ResourceSchemaTest:
         resource.schema = Schema(name='some-name', url='https://example.com')
         resource.validate()
 
-        with pytest.raises(db.ValidationError):
-            resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
-            resource.validate()
+        # with pytest.raises(db.ValidationError):
+        resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
+        resource.validate()
 
         with pytest.raises(db.ValidationError):
             resource.schema = Schema(version='2.0.0')

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -601,18 +601,37 @@ class ResourceSchemaTest:
         resource.schema = Schema(name='some-name', url='https://example.com')
         resource.validate()
 
-        with pytest.raises(db.ValidationError):
-            resource.schema = Schema(name='some-name')
-            resource.validate()
+        resource.schema = Schema(name='etalab/schema-irve-statique')
+        resource.schema.clean(check_schema_in_catalog=True)
 
-        with pytest.raises(db.ValidationError):
-            resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
-            resource.validate()
+        resource.schema = Schema(url='https://example.com')
+        resource.schema.clean(check_schema_in_catalog=True)
+
+        resource.schema = Schema(name='some-name', url='https://example.com')
+        resource.schema.clean(check_schema_in_catalog=True)
+
+        # Check that no exception is raised when we do not ask for schema check for schema errors
+        resource.schema = Schema(name='some-name')
+        resource.validate()
+
+        resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
+        resource.validate()
 
         with pytest.raises(db.ValidationError):
             resource.schema = Schema(version='2.0.0')
             resource.validate()
 
+        with pytest.raises(db.ValidationError):
+            resource.schema = Schema(name='some-name')
+            resource.schema.clean(check_schema_in_catalog=True)
+
+        with pytest.raises(db.ValidationError):
+            resource.schema = Schema(name='etalab/schema-irve-statique', version='1337.42.0')
+            resource.schema.clean(check_schema_in_catalog=True)
+
+        with pytest.raises(db.ValidationError):
+            resource.schema = Schema(version='2.0.0')
+            resource.schema.clean(check_schema_in_catalog=True)
 
 class HarvestMetadataTest:
     def test_harvest_dataset_metadata_validate_success(self):


### PR DESCRIPTION
Some schemas inside the database are unknown so we may disable the hard check and only warn the problem right now to have logs and allow to save these datasets.

The part in RDF parsing is to avoid failing to import a dataset if the schema is not correct. It doesn't do much right now (since I've disabled the raising of the exception inside the `clean()` but we want to keep this when we re-enable the exception)