### PR TITLE
Topic: add last_modified field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow harvesting of big catalog (bigger than 16MB) [#2980](https://github.com/opendatateam/udata/pull/2980) [2985](https://github.com/opendatateam/udata/pull/2985)
 - Add downloads' count to organizations CSV [#2973](https://github.com/opendatateam/udata/pull/2973)
 - Prevent geozones listed ad `deleted` to be loaded [#2983](https://github.com/opendatateam/udata/pull/2983)
+- Topic: add last_modified field [#2987](https://github.com/opendatateam/udata/pull/2987)
 
 ## 7.0.4 (2024-02-27)
 

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -37,6 +37,8 @@ topic_fields = api.model('Topic', {
     'private': fields.Boolean(description='Is the topic private'),
     'created_at': fields.ISODateTime(
         description='The topic creation date', readonly=True),
+    'last_modified': fields.ISODateTime(
+        description='The topic last modification date', readonly=True),
     'organization': fields.Nested(
         org_ref_fields, allow_null=True,
         description='The publishing organization', readonly=True),

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -63,6 +63,8 @@ topic_fields = apiv2.model('Topic', {
     'private': fields.Boolean(description='Is the topic private'),
     'created_at': fields.ISODateTime(
         description='The topic creation date', readonly=True),
+    'last_modified': fields.ISODateTime(
+        description='The topic last modification date', readonly=True),
     'organization': fields.Nested(
         org_ref_fields, allow_null=True,
         description='The publishing organization', readonly=True),

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -1,6 +1,4 @@
-from datetime import datetime
 from flask import url_for
-from mongoengine.fields import DateTimeField
 from mongoengine.signals import pre_save
 from udata.models import db
 from udata.search import reindex
@@ -10,7 +8,7 @@ from udata.tasks import as_task_param
 __all__ = ('Topic', )
 
 
-class Topic(db.Document, db.Owned):
+class Topic(db.Document, db.Owned, db.Datetimed):
     name = db.StringField(required=True)
     slug = db.SlugField(max_length=255, required=True, populate_from='name',
                         update=True, follow=True)
@@ -27,8 +25,6 @@ class Topic(db.Document, db.Owned):
     featured = db.BooleanField()
     private = db.BooleanField()
     extras = db.ExtrasField()
-
-    created_at = DateTimeField(default=datetime.utcnow, required=True)
 
     meta = {
         'indexes': [

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -65,6 +65,9 @@ class TopicsAPITest(APITestCase):
             self.assertIsNotNone(reuse['page'])
             self.assertIsNotNone(reuse['uri'])
 
+        self.assertIsNotNone(data.get('created_at'))
+        self.assertIsNotNone(data.get('last_modified'))
+
     def test_topic_api_create(self):
         '''It should create a topic from the API'''
         data = TopicFactory.as_dict()
@@ -106,7 +109,9 @@ class TopicsAPITest(APITestCase):
         response = self.put(url_for('api.topic', topic=topic), data)
         self.assert200(response)
         self.assertEqual(Topic.objects.count(), 1)
-        self.assertEqual(Topic.objects.first().description, 'new description')
+        topic = Topic.objects.first()
+        self.assertEqual(topic.description, 'new description')
+        self.assertGreater(topic.last_modified, topic.created_at)
 
     def test_topic_api_update_perm(self):
         '''It should not update a topic from the API'''

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -41,6 +41,9 @@ class TopicsAPITest(APITestCase):
         topic_response = self.get(url_for('apiv2.topic', topic=topic))
         assert topic_response.status_code == 200
 
+        assert topic_response.json['created_at'] is not None
+        assert topic_response.json['last_modified'] is not None
+
         response = self.get(topic_response.json['datasets']['href'])
         data = response.json
         assert all(str(d.id) in (_d['id'] for _d in data['data']) for d in topic.datasets)


### PR DESCRIPTION
Add `last_modified` field to `Topic` and expose it in the APIs.

Auto-handled by `db.Datetimed` with `created_at`.