### PR TITLE
Fix duplicate log in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix, do not fail on spatial coverage harvesting exception and allow literal spatial BBOX from Arcgis [2998](https://github.com/opendatateam/udata/pull/2998)
 - Mock calls to example.com [#3000](https://github.com/opendatateam/udata/pull/3000)
+- Fix duplicate logs in console commands [#2996](https://github.com/opendatateam/udata/pull/2996)
 
 ## 7.0.5 (2024-03-20)
 

--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -145,9 +145,6 @@ def init_logging(app):
     handler.setFormatter(CliFormatter())
     handler.setLevel(log_level)
 
-    logger = logging.getLogger()
-    logger.addHandler(handler)
-
     logger = logging.getLogger('__main__')
     logger.setLevel(log_level)
     logger.handlers = []


### PR DESCRIPTION
Trying to remove the duplicate log in console. It comes from adding the `handler` to the default logger (that doesn't seems to be used) and to the `app.logger`. I don't know which one is best to remove…