### PR TITLE
Refactor `Activity.kwargs` into `Activity.extras` to facilitate its usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix, do not fail on spatial coverage harvesting exception and allow literal spatial BBOX from Arcgis [2998](https://github.com/opendatateam/udata/pull/2998)
+- `Activity`: rename `kwargs` into `extras` and make use of it [2999](https://github.com/opendatateam/udata/pull/2999)
 
 ## 7.0.5 (2024-03-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Current (in progress)
 
-- Fix, do not fail on spatial coverage harvesting exception and allow literal spatial BBOX from Arcgis [2998](https://github.com/opendatateam/udata/pull/2998)
-- `Activity`: rename `kwargs` into `extras` and make use of it [2999](https://github.com/opendatateam/udata/pull/2999)
+- Fix, do not fail on spatial coverage harvesting exception and allow literal spatial BBOX from Arcgis [#2998](https://github.com/opendatateam/udata/pull/2998)
+- Refactor `Activity.kwargs` into `Activity.extras` to facilitate its usage [#2999](https://github.com/opendatateam/udata/pull/2999)
 
 ## 7.0.5 (2024-03-20)
 

--- a/udata/core/activity/api.py
+++ b/udata/core/activity/api.py
@@ -37,7 +37,7 @@ activity_fields = api.model('Activity', {
         description='The key of the activity', required=True),
     'icon': fields.String(
         description='The icon of the activity', required=True),
-    'kwargs': fields.Raw(description='Some action specific context'),
+    'extras': fields.Raw(description='Extras attributes as key-value pairs'),
 })
 
 activity_page_fields = api.model('ActivityPage', fields.pager(activity_fields))

--- a/udata/core/activity/models.py
+++ b/udata/core/activity/models.py
@@ -37,7 +37,7 @@ class Activity(db.Document, metaclass=EmitNewActivityMetaClass):
     related_to = db.ReferenceField(db.DomainModel, required=True)
     created_at = db.DateTimeField(default=datetime.utcnow, required=True)
 
-    kwargs = db.DictField()
+    extras = db.ExtrasField()
 
     on_new = Signal()
 
@@ -65,8 +65,9 @@ class Activity(db.Document, metaclass=EmitNewActivityMetaClass):
         return cls.on_new.connect(func, sender=cls)
 
     @classmethod
-    def emit(cls, related_to, organization=None, **kwargs):
+    def emit(cls, related_to, organization=None, extras=None):
         new_activity.send(cls,
                           related_to=related_to,
                           actor=current_user._get_current_object(),
-                          organization=organization)
+                          organization=organization,
+                          extras=extras)

--- a/udata/core/activity/tasks.py
+++ b/udata/core/activity/tasks.py
@@ -9,22 +9,23 @@ log = logging.getLogger(__name__)
 
 
 @new_activity.connect
-def delay_activity(cls, related_to, actor, organization=None):
+def delay_activity(cls, related_to, actor, organization=None, extras=None):
     emit_activity.delay(
         cls.__name__,
         str(actor.id),
         related_to_cls=related_to.__class__.__name__,
         related_to_id=str(related_to.id),
         organization_id=str(organization.id) if organization else None,
+        extras=extras
     )
 
 
 @task
 def emit_activity(classname, actor_id, related_to_cls, related_to_id,
-                  organization_id=None):
-    log.debug('Emit new activity: %s %s %s %s %s',
+                  organization_id=None, extras=None):
+    log.debug('Emit new activity: %s %s %s %s %s %s',
               classname, actor_id, related_to_cls,
-              related_to_id, organization_id)
+              related_to_id, organization_id, extras)
     cls = db.resolve_model(classname)
     actor = User.objects.get(pk=actor_id)
     related_to = db.resolve_model(related_to_cls).objects.get(pk=related_to_id)
@@ -33,4 +34,4 @@ def emit_activity(classname, actor_id, related_to_cls, related_to_id,
     else:
         organization = None
     cls.objects.create(actor=actor, related_to=related_to,
-                       organization=organization)
+                       organization=organization, extras=extras)

--- a/udata/migrations/2024-03-22-migrate-activity-kwargs-to-extras.py
+++ b/udata/migrations/2024-03-22-migrate-activity-kwargs-to-extras.py
@@ -1,0 +1,16 @@
+"""
+Migrates `Activity.kwargs` to `Activity.extras`.
+"""
+import logging
+
+from mongoengine.connection import get_db
+
+log = logging.getLogger(__name__)
+
+def migrate(db):
+    log.info('Processing activity objects')
+
+    result = get_db().activity.update_many(filter={}, update={'$rename': {'kwargs': 'extras'}})
+
+    log.info(f'{result.modified_count} activity object(s) migrated')
+    log.info('Done')

--- a/udata/tests/test_activity.py
+++ b/udata/tests/test_activity.py
@@ -27,6 +27,18 @@ class ActivityTest(WebTestMixin, DBTestMixin, TestCase):
         self.assertEqual(len(activities), 1)
         self.assertIsInstance(activities[0], FakeActivity)
 
+    def test_create_and_retrieve_with_extras(self):
+        FakeActivity.objects.create(actor=self.user, related_to=self.fake, extras={'some_key': 'some_value',
+                                                                                   'other_key': 'other_value'})
+
+        activities = Activity.objects(actor=self.user)
+
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].extras['some_key'], 'some_value')
+        self.assertEqual(activities[0].extras['other_key'], 'other_value')
+        self.assertIsInstance(activities[0], FakeActivity)
+
+
     def test_create_and_retrieve_for_org(self):
         org = OrganizationFactory()
         FakeActivity.objects.create(


### PR DESCRIPTION
`Activity` model had a field called `kwargs` that was intended to hold additional info about events. By the looks of the code and [data.gouv.fr](https://www.data.gouv.fr/api/1/activity?page=1&page_size=20), it hasn't been really used while it could be very helpful.

When trying to incorporate this field, it appeared that its name clashes with `**kwargs` argument used in dependent libraries. To avoid issues, this field was renamed into `extras` along with changing its type to `ExtrasField` to make it aligned with other models.

Migration shouldn't be a problem due to the fact this field is not in use.

@maudetes Please let me know if you agree with this change and I can add a migration script and adjust tests.
