### PR TITLE
Mock calls to example.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix, do not fail on spatial coverage harvesting exception and allow literal spatial BBOX from Arcgis [2998](https://github.com/opendatateam/udata/pull/2998)
+- Mock calls to example.com [#3000](https://github.com/opendatateam/udata/pull/3000)
 
 ## 7.0.5 (2024-03-20)
 

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -1791,7 +1791,8 @@ class DatasetSchemasAPITest:
         assert response.json == []
 
     @pytest.mark.options(SCHEMA_CATALOG_URL='https://example.com/notfound')
-    def test_dataset_schemas_api_list_not_found(self, api):
+    def test_dataset_schemas_api_list_not_found(self, api, rmock):
+        rmock.get('https://example.com/notfound', status_code=404)
         response = api.get(url_for('api.schemas'))
         assert404(response)
 

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -524,7 +524,8 @@ class LicenseModelTest:
 
 class ResourceSchemaTest:
     @pytest.mark.options(SCHEMA_CATALOG_URL='https://example.com/notfound')
-    def test_resource_schema_objects_404_endpoint(self):
+    def test_resource_schema_objects_404_endpoint(self, rmock):
+        rmock.get('https://example.com/notfound', status_code=404)
         with pytest.raises(SchemasCatalogNotFoundException):
             ResourceSchema.objects()
 


### PR DESCRIPTION
example.com seems to currently be returning a 500 on non-existing pages instead of 404.
```
curl --head 'https://example.com/notfound'
HTTP/2 500
```
It leads to failing tests ([example in our CI](https://app.circleci.com/pipelines/github/opendatateam/udata/3942/workflows/db155770-d007-47eb-a2f4-77592eb4c794/jobs/28223)).
We shouldn't actually need to call `example.com` and should mock these calls instead.

(It's #3000 :rocket:)