### PR TITLE
Topic: add filters in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Topic: add filters in API [#3007](https://github.com/opendatateam/udata/pull/3007)
 
 ## 7.0.6 (2024-03-29)
 

--- a/udata/core/topic/factories.py
+++ b/udata/core/topic/factories.py
@@ -16,6 +16,7 @@ class TopicFactory(ModelFactory):
     description = factory.Faker('text')
     tags = factory.LazyAttribute(lambda o: [utils.unique_string(16)
                                  for _ in range(3)])
+    private = False
 
     @factory.lazy_attribute
     def datasets(self):

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -7,7 +7,8 @@ from udata.api.parsers import ModelApiParser
 class TopicApiParser(ModelApiParser):
     sorts = {
         'name': 'name',
-        'created': 'created_at'
+        'created': 'created_at',
+        'last_modified': 'last_modified',
     }
 
     def __init__(self):

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -1,3 +1,6 @@
+from bson.objectid import ObjectId
+
+from udata.api import api
 from udata.api.parsers import ModelApiParser
 
 
@@ -10,6 +13,11 @@ class TopicApiParser(ModelApiParser):
     def __init__(self):
         super().__init__()
         self.parser.add_argument('tag', type=str, location='args')
+        self.parser.add_argument('include_private', type=bool, location='args')
+        self.parser.add_argument('geozone', type=str, location='args')
+        self.parser.add_argument('granularity', type=str, location='args')
+        self.parser.add_argument('organization', type=str, location='args')
+        self.parser.add_argument('owner', type=str, location='args')
 
     @staticmethod
     def parse_filters(topics, args):
@@ -22,4 +30,18 @@ class TopicApiParser(ModelApiParser):
             topics = topics.search_text(phrase_query)
         if args.get('tag'):
             topics = topics.filter(tags=args['tag'])
+        if not args.get('include_private'):
+            topics = topics.filter(private=False)
+        if args.get('geozone'):
+            topics = topics.filter(spatial__zones=args['geozone'])
+        if args.get('granularity'):
+            topics = topics.filter(spatial__granularity=args['granularity'])
+        if args.get('organization'):
+            if not ObjectId.is_valid(args['organization']):
+                api.abort(400, 'Organization arg must be an identifier')
+            topics = topics.filter(organization=args['organization'])
+        if args.get('owner'):
+            if not ObjectId.is_valid(args['owner']):
+                api.abort(400, 'Owner arg must be an identifier')
+            topics = topics.filter(owner=args['owner'])
         return topics


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/164

Add the following filter to Topic list APIs (v1 and v2):

- `include_private`
- `geozone`
- `granularity`
- `organization`
- `owner`

About `include_private`:

- called `include_private` instead of `private` because it either returns all topics, including privates, or only non-private ones
- I did not find any `private` or similar existing filter in other API, so I guess coherence is not a problem
- ⚠️ by default, the list will now only contains non-private topics: this is a change from previous behavior (but probably more coherent w/ the rest of data.gouv.fr)

This also adds a `last_modifed` sort.