### PR TITLE
Allow for series in CSW ISO 19139 DCAT backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add dataservices in beta [#2986](https://github.com/opendatateam/udata/pull/2986)
 - Remove deprecated `metrics_for` route [#3022](https://github.com/opendatateam/udata/pull/3022)
 - Fix spatial coverage fetching perfs. Need to schedule `compute-geozones-metrics` [#3018](https://github.com/opendatateam/udata/pull/3018)
+- Allow for series in CSW ISO 19139 DCAT backend [#3028](https://github.com/opendatateam/udata/pull/3028)
 
 ## 8.0.0 (2024-04-23)
 

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -268,7 +268,6 @@ class CswDcatBackend(DcatBackend):
                           headers=headers).content)
 
         return graphs
-    
 
 
 class CswIso19139DcatBackend(DcatBackend):
@@ -295,6 +294,7 @@ class CswIso19139DcatBackend(DcatBackend):
         transform = ET.XSLT(xsl)
 
         # Start querying and parsing graph
+        # Filter on dataset or serie records
         body = '''<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                                   xmlns:gmd="http://www.isotc211.org/2005/gmd"
                                   service="CSW" version="2.0.2" resultType="results"
@@ -304,10 +304,16 @@ class CswIso19139DcatBackend(DcatBackend):
                         <csw:ElementSetName>full</csw:ElementSetName>
                         <csw:Constraint version="1.1.0">
                             <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+                                <ogc:Or xmlns:ogc="http://www.opengis.net/ogc">
                                 <ogc:PropertyIsEqualTo>
                                     <ogc:PropertyName>dc:type</ogc:PropertyName>
                                     <ogc:Literal>dataset</ogc:Literal>
                                 </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>dc:type</ogc:PropertyName>
+                                    <ogc:Literal>series</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                </ogc:Or>
                             </ogc:Filter>
                         </csw:Constraint>
                     </csw:Query>
@@ -319,7 +325,7 @@ class CswIso19139DcatBackend(DcatBackend):
         start = 1
 
         response = self.post(url, data=body.format(start=start, schema=self.ISO_SCHEMA),
-                            headers=headers)
+                             headers=headers)
         response.raise_for_status()
 
         tree_before_transform = ET.fromstring(response.content)
@@ -351,12 +357,12 @@ class CswIso19139DcatBackend(DcatBackend):
             next_record = self.next_record_if_should_continue(start, search_results)
             if not next_record:
                 break
-            
+
             start = next_record
             page += 1
 
             response = self.post(url, data=body.format(start=start, schema=self.ISO_SCHEMA),
-                          headers=headers)
+                                 headers=headers)
             response.raise_for_status()
 
             tree_before_transform = ET.fromstring(response.content)

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -305,14 +305,14 @@ class CswIso19139DcatBackend(DcatBackend):
                         <csw:Constraint version="1.1.0">
                             <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
                                 <ogc:Or xmlns:ogc="http://www.opengis.net/ogc">
-                                <ogc:PropertyIsEqualTo>
-                                    <ogc:PropertyName>dc:type</ogc:PropertyName>
-                                    <ogc:Literal>dataset</ogc:Literal>
-                                </ogc:PropertyIsEqualTo>
-                                <ogc:PropertyIsEqualTo>
-                                    <ogc:PropertyName>dc:type</ogc:PropertyName>
-                                    <ogc:Literal>series</ogc:Literal>
-                                </ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyIsEqualTo>
+                                        <ogc:PropertyName>dc:type</ogc:PropertyName>
+                                        <ogc:Literal>dataset</ogc:Literal>
+                                    </ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyIsEqualTo>
+                                        <ogc:PropertyName>dc:type</ogc:PropertyName>
+                                        <ogc:Literal>series</ogc:Literal>
+                                    </ogc:PropertyIsEqualTo>
                                 </ogc:Or>
                             </ogc:Filter>
                         </csw:Constraint>


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/2982, we've added some filters on records to fetch dataset only.

It was added due to [this discussion](https://github.com/opendatateam/udata/pull/2982#discussion_r1513353040), where we decided to filter out records that could cause issues but that wouldn't get used.

In this PR, we add `series` records that get converted to dcat:Dataset in the current SEMIeu XSLT. See the logic [here](https://github.com/SEMICeu/iso-19139-to-dcat-ap/blob/34b64006053087e7b2674604312419d09a7af826/iso-19139-to-dcat-ap.xsl#L1100). They are currently harvested as a standard dataset.

Since [dcat:DatasetSeries](https://w3c.github.io/dxwg/dcat/#Class:Dataset_Series) have been added in DCAT 3, this mapping will probably be updated in the upcoming revision.

