### PR TITLE
Merge multiple polygons during spatial coverage harvesting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Allow for series in CSW ISO 19139 DCAT backend [#3028](https://github.com/opendatateam/udata/pull/3028)
 - Add `resources_downloads` to datasets metrics [#3042](https://github.com/opendatateam/udata/pull/3042)
 - Fix do not override resources extras on admin during update [#3043](https://github.com/opendatateam/udata/pull/3043) 
+- Merge multiple polygons in spatial coverage harvesting [#3039](https://github.com/opendatateam/udata/pull/3039)
 
 ## 8.0.0 (2024-04-23)
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -394,6 +394,9 @@ def spatial_from_rdf(graph):
     # if there is other types of spatial coverage worth integrating (points? line strings?). But these other
     # formats are not compatible to be merge in the unique stored representation in MongoDB, we'll deal with them in a second pass.
     # The merging lose the properties and other information inside the GeoJSON…
+    # Note that having multiple `Polygon` is not really the DCAT way of doing things, the standard require that you use 
+    # a `MultiPolygon` in this case. We support this right now, and wait and see if it raises problems in the future for
+    # people following the standard. (see https://github.com/datagouv/data.gouv.fr/issues/1362#issuecomment-2112774115)
     polygons = []
     for geojson in geojsons:
         if geojson['type'] == 'Polygon':

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -381,23 +381,48 @@ def spatial_from_rdf(graph):
                     else:
                         continue
 
-                    if geojson['type'] == 'Polygon':
-                        geojson['type'] = 'MultiPolygon'
-                        geojson['coordinates'] = [geojson['coordinates']]
-
                     geojsons.append(geojson)
         except Exception as e:
             log.exception(f"Exception during `spatial_from_rdf` for term {term}: {e}", stack_info=True)
 
+    if not geojsons:
+        return None
+
+    # We first try to build a big MultiPolygon with all the spatial coverages found in RDF.
+    # We deduplicate the coordinates because some backend provides the same coordinates multiple
+    # times in different format. We only support in this first pass Polygons and MultiPolygons. Not sure
+    # if there is other types of spatial coverage worth integrating (points? line strings?). But these other
+    # formats are not compatible to be merge in the unique stored representation in MongoDB, we'll deal with them in a second pass.
+    # The merging lose the properties and other information inside the GeoJSON…
+    polygons = []
     for geojson in geojsons:
-        spatial_coverage = SpatialCoverage(geom=geojson)
-        try:
-            spatial_coverage.clean()
-            return spatial_coverage
-        except ValidationError:
+        if geojson['type'] == 'Polygon':
+            if geojson['coordinates'] not in polygons:
+                polygons.append(geojson['coordinates'])
+        elif geojson['type'] == 'MultiPolygon':
+            for coordinates in geojson['coordinates']:
+                if coordinates not in polygons:
+                    polygons.append(coordinates)
+        else:
+            log.warning(f"Unknown GeoJSON type '{geojson['type']}'")
             continue
 
-    return None
+    if not polygons:
+        log.warning(f"Only unknown types inside GeoJSON data.")
+        return None
+
+    spatial_coverage = SpatialCoverage(geom={
+        'type': 'MultiPolygon',
+        'coordinates': polygons,
+    })
+
+    try:
+        spatial_coverage.clean()
+        return spatial_coverage
+    except ValidationError as e:
+        log.warning(f"Cannot save the spatial coverage {coordinates} (error was {e})")
+        return None
+
 
 def frequency_from_rdf(term):
     if isinstance(term, str):

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -391,8 +391,8 @@ def spatial_from_rdf(graph):
     # We first try to build a big MultiPolygon with all the spatial coverages found in RDF.
     # We deduplicate the coordinates because some backend provides the same coordinates multiple
     # times in different format. We only support in this first pass Polygons and MultiPolygons. Not sure
-    # if there is other types of spatial coverage worth integrating (points? line strings?). But these other
-    # formats are not compatible to be merge in the unique stored representation in MongoDB, we'll deal with them in a second pass.
+    # if there are other types of spatial coverage worth integrating (points? line strings?). But these other
+    # formats are not compatible to be merged in the unique stored representation in MongoDB, we'll deal with them in a second pass.
     # The merging lose the properties and other information inside the GeoJSON…
     # Note that having multiple `Polygon` is not really the DCAT way of doing things, the standard require that you use 
     # a `MultiPolygon` in this case. We support this right now, and wait and see if it raises problems in the future for
@@ -407,11 +407,11 @@ def spatial_from_rdf(graph):
                 if coordinates not in polygons:
                     polygons.append(coordinates)
         else:
-            log.warning(f"Unknown GeoJSON type '{geojson['type']}'")
+            log.warning(f"Unsupported GeoJSON type '{geojson['type']}'")
             continue
 
     if not polygons:
-        log.warning(f"Only unknown types inside GeoJSON data.")
+        log.warning(f"No supported types found in the GeoJSON data.")
         return None
 
     spatial_coverage = SpatialCoverage(geom={

--- a/udata/harvest/tests/dcat/bnodes.xml
+++ b/udata/harvest/tests/dcat/bnodes.xml
@@ -7,6 +7,7 @@
   xmlns:dct="http://purl.org/dc/terms/"
   xmlns:ogc="http://www.opengis.net/ogc"
   xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
+  xmlns:locn="http://www.w3.org/ns/locn#"
   xmlns:dcterms="http://purl.org/dc/terms/"
   xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
   xmlns:schema="http://schema.org/"
@@ -89,8 +90,16 @@
         <dcterms:title>Dataset 2</dcterms:title>
         <dct:spatial>
             <ogc:Polygon>
+                <locn:geometry rdf:datatype="https://www.iana.org/assignments/media-types/application/vnd.geo+json"><![CDATA[{"type":"Polygon","coordinates":[[[-6.4664422,51.91456168],[10.99449709,51.91456168],[10.99449709,40.9877682],[-6.4664422,40.9877682],[-6.4664422,51.91456168]]]}]]></locn:geometry>
+                <geo:asWKT rdf:datatype="http://www.opengis.net/rdf#wktLiteral">
+                    Polygon((159.35111223 -25.02143478, 159.35111223 -11.252615, 212.55423544 -11.252615, 212.55423544 -25.02143478, 159.35111223 -25.02143478))
+                </geo:asWKT>
                 <geo:asWKT rdf:datatype="http://www.opengis.net/rdf#wktLiteral">
                     Polygon((4.44641288 45.54214467, 4.44641288 46.01316963, 4.75655252 46.01316963, 4.75655252 45.54214467, 4.44641288 45.54214467))
+                </geo:asWKT>
+                <locn:geometry rdf:datatype="https://www.iana.org/assignments/media-types/application/vnd.geo+json"><![CDATA[{"type":"Polygon","coordinates":[[[4.44641288, 45.54214467], [4.44641288, 46.01316963], [4.75655252, 46.01316963], [4.75655252, 45.54214467], [4.44641288, 45.54214467]]]}]]></locn:geometry>
+                <geo:asWKT rdf:datatype="http://www.opengis.net/rdf#wktLiteral">
+                    Polygon((159.35111223 -25.02143478, 159.35111223 -11.252615, 212.55423544 -11.252615, 212.55423544 -25.02143478, 159.35111223 -25.02143478))
                 </geo:asWKT>
             </ogc:Polygon>
         </dct:spatial>

--- a/udata/harvest/tests/dcat/bnodes.xml
+++ b/udata/harvest/tests/dcat/bnodes.xml
@@ -90,16 +90,16 @@
         <dcterms:title>Dataset 2</dcterms:title>
         <dct:spatial>
             <ogc:Polygon>
-                <locn:geometry rdf:datatype="https://www.iana.org/assignments/media-types/application/vnd.geo+json"><![CDATA[{"type":"Polygon","coordinates":[[[-6.4664422,51.91456168],[10.99449709,51.91456168],[10.99449709,40.9877682],[-6.4664422,40.9877682],[-6.4664422,51.91456168]]]}]]></locn:geometry>
+                <locn:geometry rdf:datatype="https://www.iana.org/assignments/media-types/application/vnd.geo+json"><![CDATA[{"type":"Polygon","coordinates":[[[-6,51],[10,51],[10,40],[-6,40],[-6,51]]]}]]></locn:geometry>
                 <geo:asWKT rdf:datatype="http://www.opengis.net/rdf#wktLiteral">
-                    Polygon((159.35111223 -25.02143478, 159.35111223 -11.252615, 212.55423544 -11.252615, 212.55423544 -25.02143478, 159.35111223 -25.02143478))
+                    Polygon((159 -25, 159 -11, 212 -11, 212 -25, 159 -25))
                 </geo:asWKT>
                 <geo:asWKT rdf:datatype="http://www.opengis.net/rdf#wktLiteral">
-                    Polygon((4.44641288 45.54214467, 4.44641288 46.01316963, 4.75655252 46.01316963, 4.75655252 45.54214467, 4.44641288 45.54214467))
+                    Polygon((4 45, 4 46, 4 46, 4 45, 4 45))
                 </geo:asWKT>
-                <locn:geometry rdf:datatype="https://www.iana.org/assignments/media-types/application/vnd.geo+json"><![CDATA[{"type":"Polygon","coordinates":[[[4.44641288, 45.54214467], [4.44641288, 46.01316963], [4.75655252, 46.01316963], [4.75655252, 45.54214467], [4.44641288, 45.54214467]]]}]]></locn:geometry>
+                <locn:geometry rdf:datatype="https://www.iana.org/assignments/media-types/application/vnd.geo+json"><![CDATA[{"type":"Polygon","coordinates":[[[4, 45], [4, 46], [4, 46], [4, 45], [4, 45]]]}]]></locn:geometry>
                 <geo:asWKT rdf:datatype="http://www.opengis.net/rdf#wktLiteral">
-                    Polygon((159.35111223 -25.02143478, 159.35111223 -11.252615, 212.55423544 -11.252615, 212.55423544 -25.02143478, 159.35111223 -25.02143478))
+                    Polygon((159 -25, 159 -11, 212 -11, 212 -25, 159 -25))
                 </geo:asWKT>
             </ogc:Polygon>
         </dct:spatial>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -255,7 +255,7 @@ class DcatBackendTest:
         datasets = {d.harvest.dct_identifier: d for d in Dataset.objects}
 
         assert datasets['1'].spatial == None
-        assert datasets['2'].spatial.geom == {'type': 'MultiPolygon', 'coordinates': [[[[4.44641288, 45.54214467], [4.44641288, 46.01316963], [4.75655252, 46.01316963], [4.75655252, 45.54214467], [4.44641288, 45.54214467]]]]}
+        assert datasets['2'].spatial.geom == {'type': 'MultiPolygon', 'coordinates': [[[[-6.4664422,51.91456168],[10.99449709,51.91456168],[10.99449709,40.9877682],[-6.4664422,40.9877682],[-6.4664422,51.91456168]]], [[[4.44641288, 45.54214467], [4.44641288, 46.01316963], [4.75655252, 46.01316963], [4.75655252, 45.54214467], [4.44641288, 45.54214467]]], [[[159.35111223, -25.02143478], [159.35111223, -11.252615], [212.55423544, -11.252615], [212.55423544, -25.02143478], [159.35111223, -25.02143478]]]]}
         assert datasets['3'].spatial == None
 
     @pytest.mark.options(SCHEMA_CATALOG_URL='https://example.com/schemas')

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -268,7 +268,7 @@ class DcatBackendTest:
         datasets = {d.harvest.dct_identifier: d for d in Dataset.objects}
 
         assert datasets['1'].spatial == None
-        assert datasets['2'].spatial.geom == {'type': 'MultiPolygon', 'coordinates': [[[[-6.4664422,51.91456168],[10.99449709,51.91456168],[10.99449709,40.9877682],[-6.4664422,40.9877682],[-6.4664422,51.91456168]]], [[[4.44641288, 45.54214467], [4.44641288, 46.01316963], [4.75655252, 46.01316963], [4.75655252, 45.54214467], [4.44641288, 45.54214467]]], [[[159.35111223, -25.02143478], [159.35111223, -11.252615], [212.55423544, -11.252615], [212.55423544, -25.02143478], [159.35111223, -25.02143478]]]]}
+        assert datasets['2'].spatial.geom == {'type': 'MultiPolygon', 'coordinates': [[[[-6,51],[10,51],[10,40],[-6,40],[-6,51]]], [[[4, 45], [4, 46], [4, 46], [4, 45], [4, 45]]], [[[159, -25.], [159, -11], [212, -11], [212, -25.], [159, -25.]]]]}
         assert datasets['3'].spatial == None
 
     @pytest.mark.options(SCHEMA_CATALOG_URL='https://example.com/schemas')


### PR DESCRIPTION
Fix https://github.com/datagouv/data.gouv.fr/issues/1362

The goal of this PR is to support when there is multiple geometries. Instead of saving the first one, save a `MultiPolygon`  merging all geometries. Deduplicates the geometries because some backends provide the same geometry in multiple formats.