### PR TITLE
Add DCAT-AP HVD properties in RDF output if the dataset is tagged hvd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add DCAT-AP HVD properties in RDF output if the dataset is tagged hvd [#3050](https://github.com/opendatateam/udata/pull/3050)
 
 ## 8.0.1 (2024-05-28)
 

--- a/udata/core/site/api.py
+++ b/udata/core/site/api.py
@@ -105,7 +105,10 @@ class SiteRdfCatalogFormat(API):
         params = multi_to_dict(request.args)
         page = int(params.get('page', 1))
         page_size = int(params.get('page_size', 100))
-        datasets = Dataset.objects.visible().paginate(page, page_size)
+        datasets = Dataset.objects.visible()
+        if 'tag' in params:
+            datasets = datasets.filter(tags=params.get('tag', ''))
+        datasets = datasets.paginate(page, page_size)
         catalog = build_catalog(current_site, datasets, format=format)
         # bypass flask-restplus make_response, since graph_response
         # is handling the content negociation directly

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 # Extra Namespaces
 ADMS = Namespace('http://www.w3.org/ns/adms#')
 DCAT = Namespace('http://www.w3.org/ns/dcat#')
+DCATAP = Namespace('http://data.europa.eu/r5r/')
 HYDRA = Namespace('http://www.w3.org/ns/hydra/core#')
 SCHEMA = Namespace('http://schema.org/')
 SCV = Namespace('http://purl.org/NET/scovo#')
@@ -35,6 +36,7 @@ VCARD = Namespace('http://www.w3.org/2006/vcard/ns#')
 
 namespace_manager = NamespaceManager(Graph())
 namespace_manager.bind('dcat', DCAT)
+namespace_manager.bind('dcatap', DCATAP)
 namespace_manager.bind('dct', DCT)
 namespace_manager.bind('foaf', FOAF)
 namespace_manager.bind('foaf', FOAF)
@@ -97,6 +99,8 @@ RDF_EXTENSIONS = {
 
 # Includes control characters, unicode surrogate characters and unicode end-of-plane non-characters
 ILLEGAL_XML_CHARS = '[\x00-\x08\x0b\x0c\x0e-\x1F\uD800-\uDFFF\uFFFE\uFFFF]'
+
+HVD_LEGISLATION = 'http://data.europa.eu/eli/reg_impl/2023/138/oj'
 
 
 def guess_format(string):

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -18,11 +18,11 @@ from udata.core.dataset.factories import (
 from udata.core.dataset.rdf import (
     dataset_to_rdf, dataset_from_rdf, resource_to_rdf, resource_from_rdf,
     temporal_from_rdf, frequency_to_rdf, frequency_from_rdf,
-    EU_RDF_REQUENCIES
+    EU_RDF_REQUENCIES, TAG_TO_EU_HVD_CATEGORIES
 )
 from udata.core.organization.factories import OrganizationFactory
 from udata.i18n import gettext as _
-from udata.rdf import DCAT, DCT, FREQ, SPDX, SCHEMA, SKOS
+from udata.rdf import DCAT, DCATAP, DCT, FREQ, SPDX, SCHEMA, SKOS, HVD_LEGISLATION
 from udata.utils import faker
 from udata.tests.helpers import assert200, assert_redirects
 
@@ -180,6 +180,21 @@ class DatasetToRdfTest:
         assert isinstance(d.identifier, URIRef)
         assert str(d.identifier) == 'https://somewhere.org/dataset'
         assert d.value(DCT.identifier) == Literal('an-identifier')
+
+    def test_hvd_dataset(self):
+        '''Test that a dataset tagged hvd has appropriate DCAT-AP HVD properties'''
+        dataset = DatasetFactory(
+            resources=ResourceFactory.build_batch(3),
+            tags=['hvd', 'mobilite', 'test']
+        )
+        d = dataset_to_rdf(dataset)
+
+        assert d.value(DCATAP.applicableLegislation).identifier == URIRef(HVD_LEGISLATION)
+        assert d.value(DCATAP.hvdCategory).identifier == URIRef(
+            TAG_TO_EU_HVD_CATEGORIES['mobilite']
+        )
+        for distrib in d.objects(DCAT.distribution):
+            assert distrib.value(DCATAP.applicableLegislation).identifier == URIRef(HVD_LEGISLATION)
 
 
 @pytest.mark.usefixtures('clean_db')


### PR DESCRIPTION
* DCATAP.applicableLegislation (at the dataset and distribution level). See in particular this [DCAT-AP HVD specification](https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/#denoting-a-hvd-dataset).
* DCATAP.hvdCategory (at the dataset level). See in particular this [DCAT-AP HVD specification](https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/#c2).

These properties should be added on dataservices when exposed as well.

We've added a support for tag filtering on the catalog, in order to do http://dev.local:7000/api/1/site/catalog.xml?tag=hvd.
You can test using this output locally, and by having datasets tagged `hvd` and `mobilite` for example.

> [!NOTE]  
> We rely heavily on `EU_HVD_CATEGORIES` french vocabulary as pivot for keywods. Should we move it to `settings.py` to be overriden in other udata instances?

Iterate on https://github.com/datagouv/data.gouv.fr/issues/1371.