### PR TITLE
Validate `owner` as an `ObjectId` in /sources endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add a filter to filter dataservices by dataset [#3056](https://github.com/opendatateam/udata/pull/3056)
 - Fix reuses' datasets references [#3057](https://github.com/opendatateam/udata/pull/3057)
 - Save and show harvest logs [#3053](https://github.com/opendatateam/udata/pull/3053)
+- Fix missing `ObjectId` validation on `/sources` endpoint [#3060](https://github.com/opendatateam/udata/pull/3060)
 
 ## 9.0.0 (2024-06-07)
 

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -1,3 +1,4 @@
+from bson import ObjectId
 from werkzeug.exceptions import BadRequest
 from flask import request
 
@@ -190,6 +191,10 @@ class SourcesAPI(API):
     def get(self):
         '''List all harvest sources'''
         args = source_parser.parse_args()
+
+        if args.get('owner') and not ObjectId.is_valid(args.get('owner')):
+            api.abort(400, '`owner` arg must be an identifier')
+
         return actions.paginate_sources(args.get('owner'),
                                         page=args['page'],
                                         page_size=args['page_size'],


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/141574