### PR TITLE
feat: add api /me/org_topics/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Improve URL validation errors [#3063](https://github.com/opendatateam/udata/pull/3063) [#2768](https://github.com/opendatateam/udata/pull/2768)
 - Do not return full dataset objects on dataservices endpoints [#3068](https://github.com/opendatateam/udata/pull/3068)
 - Update markdown base settings [#3067](https://github.com/opendatateam/udata/pull/3067)
-- Add api endpoint /me/org_topics/ [#370](https://github.com/opendatateam/udata/pull/3070)
+- Add api endpoint /me/org_topics/ [#3070](https://github.com/opendatateam/udata/pull/3070)
 
 ## 9.0.0 (2024-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improve URL validation errors [#3063](https://github.com/opendatateam/udata/pull/3063) [#2768](https://github.com/opendatateam/udata/pull/2768)
 - Do not return full dataset objects on dataservices endpoints [#3068](https://github.com/opendatateam/udata/pull/3068)
 - Update markdown base settings [#3067](https://github.com/opendatateam/udata/pull/3067)
+- Add api endpoint /me/org_topics/ [#370](https://github.com/opendatateam/udata/pull/3070)
 
 ## 9.0.0 (2024-06-07)
 
@@ -31,7 +32,7 @@
 - Allow for series in CSW ISO 19139 DCAT backend [#3028](https://github.com/opendatateam/udata/pull/3028)
 - Add `email` to membership request list API response, add `since` to org members API responses, add `email` to members of org on show org endpoint for org's admins and editors [#3038](https://github.com/opendatateam/udata/pull/3038)
 - Add `resources_downloads` to datasets metrics [#3042](https://github.com/opendatateam/udata/pull/3042)
-- Fix do not override resources extras on admin during update [#3043](https://github.com/opendatateam/udata/pull/3043) 
+- Fix do not override resources extras on admin during update [#3043](https://github.com/opendatateam/udata/pull/3043)
 - Endpoint /users is now protected by admin permissions [#3047](https://github.com/opendatateam/udata/pull/3047)
 - Fix trailing `/` inside `GeoZone` routes not redirecting. Disallow `/` inside `GeoZone` ids [#3045](https://github.com/opendatateam/udata/pull/3045)
 

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -323,6 +323,7 @@ def init_app(app):
     import udata.core.activity.api  # noqa
     import udata.core.spatial.api  # noqa
     import udata.core.user.api  # noqa
+    import udata.core.user.apiv2  # noqa
     import udata.core.dataset.api  # noqa
     import udata.core.dataset.apiv2  # noqa
     import udata.core.dataservices.api  # noqa

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -3,7 +3,7 @@ from mongoengine.signals import pre_save
 from udata.models import db, SpatialCoverage
 from udata.search import reindex
 from udata.tasks import as_task_param
-from udata.core.owned import Owned
+from udata.core.owned import Owned, OwnedQuerySet
 
 
 __all__ = ('Topic', )
@@ -36,7 +36,8 @@ class Topic(db.Document, Owned, db.Datetimed):
             'slug'
         ] + Owned.meta['indexes'],
         'ordering': ['-created_at'],
-        'auto_create_index_on_save': True
+        'auto_create_index_on_save': True,
+        'queryset_class': OwnedQuerySet,
     }
 
     def __str__(self):

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -11,10 +11,11 @@ class TopicApiParser(ModelApiParser):
         'last_modified': 'last_modified',
     }
 
-    def __init__(self):
+    def __init__(self, with_include_private=True):
         super().__init__()
+        if with_include_private:
+            self.parser.add_argument('include_private', type=bool, location='args')
         self.parser.add_argument('tag', type=str, location='args')
-        self.parser.add_argument('include_private', type=bool, location='args')
         self.parser.add_argument('geozone', type=str, location='args')
         self.parser.add_argument('granularity', type=str, location='args')
         self.parser.add_argument('organization', type=str, location='args')

--- a/udata/core/user/apiv2.py
+++ b/udata/core/user/apiv2.py
@@ -1,0 +1,28 @@
+from flask_security import current_user
+
+from udata.api import apiv2, API
+from udata.core.topic.apiv2 import topic_page_fields
+from udata.core.topic.parsers import TopicApiParser
+from udata.models import Topic
+
+me = apiv2.namespace('me', 'Connected user related operations (v2)')
+
+# we will force include_private to True, no need for this arg
+topic_parser = TopicApiParser(with_include_private=False)
+
+
+@me.route('/org_topics/', endpoint='my_org_topics')
+class MyOrgTopicsAPI(API):
+    @apiv2.secure
+    @apiv2.doc('my_org_topics')
+    @apiv2.expect(topic_parser.parser)
+    @apiv2.marshal_list_with(topic_page_fields)
+    def get(self):
+        '''List all topics related to me and my organizations.'''
+        args = topic_parser.parse()
+        args["include_private"] = True
+        owners = list(current_user.organizations) + [current_user.id]
+        topics = Topic.objects.owned_by(*owners)
+        topics = topic_parser.parse_filters(topics, args)
+        sort = args['sort'] or ('$text_score' if args['q'] else None) or '-last-modified'
+        return topics.order_by(sort).paginate(args['page'], args['page_size'])

--- a/udata/tests/apiv2/test_me_api.py
+++ b/udata/tests/apiv2/test_me_api.py
@@ -1,0 +1,40 @@
+from flask import url_for
+
+from udata.models import Member
+from udata.core.organization.factories import OrganizationFactory
+from udata.core.topic.factories import TopicFactory
+from udata.tests.api import APITestCase
+
+
+class MeAPIv2Test(APITestCase):
+    modules = []
+
+    def test_my_org_topics(self):
+        user = self.login()
+        member = Member(user=user, role='editor')
+        organization = OrganizationFactory(members=[member])
+        topics = [
+            TopicFactory(organization=organization, private=False, tags=['energy']),
+            TopicFactory(organization=organization, private=True),
+            TopicFactory(owner=user),
+        ]
+        # another topic that shouldn't pop up
+        TopicFactory()
+
+        response = self.get(url_for('apiv2.my_org_topics'))
+        assert response.status_code == 200
+        data = response.json['data']
+        assert len(data) == 3
+        assert all(
+            str(topic.id) in [remote_topic["id"] for remote_topic in data]
+            for topic in topics
+        )
+        assert 'rel' in data[0]['datasets']
+
+        # topic parser is already tested in topics test
+        # we're just making sure one of theme is working
+        response = self.get(url_for('apiv2.my_org_topics', tag='energy'))
+        assert response.status_code == 200
+        data = response.json['data']
+        assert len(data) == 1
+        assert data[0]['id'] == str(topics[0].id)


### PR DESCRIPTION
Adds a route `/api/2/me/org_topics`, similar to `/me/org_datasets`.

It returns a paginated list of all topics the connected has privileged access to: either its own topics or those of its organizations.

This is api v2 since the topics are serialized with the v2 format (rel for datasets and reuses).