### PR TITLE
fix fixtures generation

### DIFF
--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -73,7 +73,7 @@ class Discussion(SpamMixin, db.Document):
         from udata.core.dataset.permissions import OwnablePermission
         from udata.core.owned import Owned
 
-        if not current_user.is_authenticated:
+        if not current_user or not current_user.is_authenticated:
             return False
 
         if not isinstance(self.subject, Owned):


### PR DESCRIPTION
During fixture generation, discussions are saved without a logged in user that break on the spam check for a whitelisted user