### PR TITLE
Version fixtures

### DIFF
--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -39,9 +39,8 @@ COMMUNITY_RES_URL = "/api/1/datasets/community_resources"
 DISCUSSION_URL = "/api/1/discussions"
 
 
-DEFAULT_FIXTURE_FILE: str = (
-    "https://raw.githubusercontent.com/opendatateam/udata-fixtures/main/results.json"  # noqa
-)
+DEFAULT_FIXTURE_FILE_TAG: str = "v1.0.0"
+DEFAULT_FIXTURE_FILE: str = f"https://raw.githubusercontent.com/opendatateam/udata-fixtures/{DEFAULT_FIXTURE_FILE_TAG}/results.json"  # noqa
 
 DEFAULT_FIXTURES_RESULTS_FILENAME: str = "results.json"
 
@@ -199,6 +198,9 @@ def import_fixtures(source):
                         MessageDiscussionFactory(**message, posted_by=user) for message in messages
                     ],
                 )
+            if "dataservices" not in fixture:
+                # For backwards compatibility.
+                continue
             for dataservice in fixture["dataservices"]:
                 dataservice = remove_unwanted_keys(dataservice, "dataservice")
                 if not dataservice["contact_point"]:

--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -198,10 +198,8 @@ def import_fixtures(source):
                         MessageDiscussionFactory(**message, posted_by=user) for message in messages
                     ],
                 )
-            if "dataservices" not in fixture:
-                # For backwards compatibility.
-                continue
-            for dataservice in fixture["dataservices"]:
+            for dataservice in fixture.get("dataservices", []):
+                # We may be missing dataservices in older fixtures.
                 dataservice = remove_unwanted_keys(dataservice, "dataservice")
                 if not dataservice["contact_point"]:
                     DataserviceFactory(**dataservice, datasets=[dataset])

--- a/udata/commands/tests/test_fixtures.py
+++ b/udata/commands/tests/test_fixtures.py
@@ -7,6 +7,7 @@ import werkzeug.test
 from pytest_mock import MockerFixture
 from werkzeug.wrappers.response import Response
 
+import udata.commands.fixtures
 from udata import models
 from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import (
@@ -69,4 +70,5 @@ class FixturesTest:
         assert models.Dataset.objects.count() > 0
         assert models.Reuse.objects.count() > 0
         assert models.User.objects.count() > 0
-        assert models.Dataservice.objects.count() > 0
+        if udata.commands.fixtures.DEFAULT_FIXTURE_FILE_TAG > "v1.0.0":
+            assert models.Dataservice.objects.count() > 0


### PR DESCRIPTION
Since #3106 the fixtures are generated differently (the whole json is stored, instead of filtering it before saving it to file), and since #3112 the `dataservices` are expected in the fixtures.

This causes issues in other services and repositories counting on the [udata-fixtures](https://github.com/opendatateam/udata-fixtures/blob/main/results.json) to stay compatible.

This PR does two things:

1. add a tag to the default `results.json` url, so udata-fixtures can be updated without impacting other repositories
2. treat the `dataservices` entry in the `results.json` optional, so newer versions of the `import-fixtures` command can still function properly with the "legacy" `results.json`.

In the future, when all repositories have been updated to use the version of udata that has the "fixed tag for fixtures", we'll be able to update the udata-fixtures.