### PR TITLE
Use requests==2.32.3 everywhere for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix the version of udata-fixtures used by `udata import-fixtures` [#3114](https://github.com/opendatateam/udata/pull/3114)
 - Update to the version v2.0.0 of udata-fixtures (with the dataservices)
 - Add type hints [#3111](https://github.com/opendatateam/udata/pull/3111)
+- Make sure requests v2.32.3 is used everywhere consistently [#3116](https://github.com/opendatateam/udata/pull/3116)
 
 ## 9.1.2 (2024-07-29)
 

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -68,6 +68,7 @@ blinker==1.4
     #   flask-principal
     #   flask-security-too
     #   flask-sitemap
+    #   sentry-sdk
 boto3==1.26.102
     # via
     #   -c requirements/install.pip
@@ -103,6 +104,7 @@ certifi==2024.7.4
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   requests
+    #   sentry-sdk
 cffi==1.16.0
     # via
     #   -c requirements/install.pip
@@ -111,7 +113,7 @@ cffi==1.16.0
     #   cryptography
 cfgv==3.4.0
     # via pre-commit
-chardet==3.0.4
+charset-normalizer==3.3.2
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -152,7 +154,6 @@ cryptography==2.8
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   authlib
-    #   secretstorage
 decorator==5.1.1
     # via ipython
 distlib==0.3.8
@@ -207,6 +208,7 @@ flask==2.1.2
     #   flask-storage
     #   flask-wtf
     #   pytest-flask
+    #   sentry-sdk
 flask-babel==4.0.0
     # via
     #   -c requirements/install.pip
@@ -337,10 +339,6 @@ jaraco-classes==3.3.1
     # via keyring
 jedi==0.19.1
     # via ipython
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -c requirements/install.pip
@@ -388,6 +386,7 @@ markupsafe==2.1.2
     #   -c requirements/test.pip
     #   flask-storage
     #   jinja2
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 matplotlib-inline==0.1.6
@@ -454,6 +453,7 @@ pluggy==1.4.0
     #   pytest
 ply==3.11
     # via
+    #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   pycparser
 pre-commit==2.14.0
@@ -552,6 +552,7 @@ redis==4.5.2
     #   kombu
 referencing==0.35.1
     # via
+    #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   jsonschema
     #   jsonschema-specifications
@@ -560,7 +561,7 @@ regex==2024.5.15
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   awesome-slugify
-requests==2.24.0
+requests==2.32.3
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -578,6 +579,7 @@ rfc3986==2.0.0
     # via twine
 rpds-py==0.19.0
     # via
+    #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   jsonschema
     #   referencing
@@ -588,8 +590,11 @@ s3transfer==0.6.2
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   boto3
-secretstorage==3.3.3
-    # via keyring
+sentry-sdk[flask]==2.9.0
+    # via
+    #   -c requirements/install.pip
+    #   -c requirements/test.pip
+    #   -r requirements/install.in
 six==1.16.0
     # via
     #   -c requirements/install.pip
@@ -660,12 +665,13 @@ urlextract==0.14.0
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   -r requirements/install.in
-urllib3==1.25.11
+urllib3==1.26.19
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   botocore
     #   requests
+    #   sentry-sdk
 vine==5.1.0
     # via
     #   -c requirements/install.pip

--- a/requirements/doc.pip
+++ b/requirements/doc.pip
@@ -66,6 +66,7 @@ blinker==1.4
     #   flask-principal
     #   flask-security-too
     #   flask-sitemap
+    #   sentry-sdk
 boto3==1.26.102
     # via
     #   -c requirements/install.pip
@@ -99,13 +100,14 @@ certifi==2024.7.4
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   requests
+    #   sentry-sdk
 cffi==1.16.0
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   bcrypt
     #   cryptography
-chardet==3.0.4
+charset-normalizer==3.3.2
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -185,6 +187,7 @@ flask==2.1.2
     #   flask-sitemap
     #   flask-storage
     #   flask-wtf
+    #   sentry-sdk
 flask-babel==4.0.0
     # via
     #   -c requirements/install.pip
@@ -344,6 +347,7 @@ markupsafe==2.1.2
     #   flask-storage
     #   jinja2
     #   mkdocs
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 mergedeep==1.3.4
@@ -464,7 +468,7 @@ regex==2024.5.15
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   awesome-slugify
-requests==2.24.0
+requests==2.32.3
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -480,6 +484,11 @@ s3transfer==0.6.2
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   boto3
+sentry-sdk[flask]==2.9.0
+    # via
+    #   -c requirements/install.pip
+    #   -c requirements/test.pip
+    #   -r requirements/install.in
 six==1.16.0
     # via
     #   -c requirements/install.pip
@@ -532,12 +541,13 @@ urlextract==0.14.0
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   -r requirements/install.in
-urllib3==1.25.11
+urllib3==1.26.19
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   botocore
     #   requests
+    #   sentry-sdk
 vine==5.1.0
     # via
     #   -c requirements/install.pip

--- a/requirements/install.in
+++ b/requirements/install.in
@@ -41,7 +41,7 @@ python-dateutil==2.8.2
 pytz==2024.1
 redis==4.5.2
 rdflib==6.0.0
-requests==2.24.0
+requests==2.32.3
 sentry-sdk[flask]==2.9.0
 speaklater==1.3
 StringDist==1.0.9

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -36,6 +36,7 @@ blinker==1.4
     #   flask-principal
     #   flask-security-too
     #   flask-sitemap
+    #   sentry-sdk
 boto3==1.26.102
     # via
     #   -r requirements/install.in
@@ -53,12 +54,14 @@ celery==5.3.1
 celerybeat-mongo==0.2.0
     # via -r requirements/install.in
 certifi==2024.7.4
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 cffi==1.16.0
     # via
     #   bcrypt
     #   cryptography
-chardet==3.0.4
+charset-normalizer==3.3.2
     # via requests
 click==8.1.2
     # via
@@ -110,6 +113,7 @@ flask==2.1.2
     #   flask-sitemap
     #   flask-storage
     #   flask-wtf
+    #   sentry-sdk
 flask-babel==4.0.0
     # via -r requirements/install.in
 flask-caching==2.0.2
@@ -188,6 +192,7 @@ markupsafe==2.1.2
     # via
     #   flask-storage
     #   jinja2
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 mistune==0.8.4
@@ -253,7 +258,7 @@ rpds-py==0.19.0
     #   referencing
 s3transfer==0.6.2
     # via boto3
-sentry-sdk==2.9.0
+sentry-sdk[flask]==2.9.0
     # via -r requirements/install.in
 six==1.16.0
     # via
@@ -285,6 +290,7 @@ urllib3==1.26.19
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 vine==5.1.0
     # via
     #   amqp

--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -66,6 +66,7 @@ blinker==1.4
     #   flask-principal
     #   flask-security-too
     #   flask-sitemap
+    #   sentry-sdk
 boto3==1.26.102
     # via
     #   -c requirements/install.pip
@@ -99,13 +100,14 @@ certifi==2024.7.4
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   requests
+    #   sentry-sdk
 cffi==1.16.0
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   bcrypt
     #   cryptography
-chardet==3.0.4
+charset-normalizer==3.3.2
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -191,6 +193,7 @@ flask==2.1.2
     #   flask-storage
     #   flask-wtf
     #   pytest-flask
+    #   sentry-sdk
 flask-babel==4.0.0
     # via
     #   -c requirements/install.pip
@@ -352,6 +355,7 @@ markupsafe==2.1.2
     #   -c requirements/test.pip
     #   flask-storage
     #   jinja2
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 mccabe==0.6.1
@@ -499,7 +503,7 @@ regex==2024.5.15
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   awesome-slugify
-requests==2.24.0
+requests==2.32.3
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -520,6 +524,11 @@ s3transfer==0.6.2
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   boto3
+sentry-sdk[flask]==2.9.0
+    # via
+    #   -c requirements/install.pip
+    #   -c requirements/test.pip
+    #   -r requirements/install.in
 six==1.16.0
     # via
     #   -c requirements/install.pip
@@ -577,12 +586,13 @@ urlextract==0.14.0
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   -r requirements/install.in
-urllib3==1.25.11
+urllib3==1.26.19
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   botocore
     #   requests
+    #   sentry-sdk
 vine==5.1.0
     # via
     #   -c requirements/install.pip

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -55,6 +55,7 @@ blinker==1.4
     #   flask-principal
     #   flask-security-too
     #   flask-sitemap
+    #   sentry-sdk
 boto3==1.26.102
     # via
     #   -c requirements/install.pip
@@ -82,12 +83,13 @@ certifi==2024.7.4
     # via
     #   -c requirements/install.pip
     #   requests
+    #   sentry-sdk
 cffi==1.16.0
     # via
     #   -c requirements/install.pip
     #   bcrypt
     #   cryptography
-chardet==3.0.4
+charset-normalizer==3.3.2
     # via
     #   -c requirements/install.pip
     #   requests
@@ -156,6 +158,7 @@ flask==2.1.2
     #   flask-storage
     #   flask-wtf
     #   pytest-flask
+    #   sentry-sdk
 flask-babel==4.0.0
     # via
     #   -c requirements/install.pip
@@ -285,6 +288,7 @@ markupsafe==2.1.2
     #   -c requirements/install.pip
     #   flask-storage
     #   jinja2
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 mistune==0.8.4
@@ -321,7 +325,9 @@ pillow==9.2.0
 pluggy==1.4.0
     # via pytest
 ply==3.11
-    # via pycparser
+    # via
+    #   -c requirements/install.pip
+    #   pycparser
 prompt-toolkit==3.0.47
     # via
     #   -c requirements/install.pip
@@ -383,13 +389,14 @@ redis==4.5.2
     #   kombu
 referencing==0.35.1
     # via
+    #   -c requirements/install.pip
     #   jsonschema
     #   jsonschema-specifications
 regex==2024.5.15
     # via
     #   -c requirements/install.pip
     #   awesome-slugify
-requests==2.24.0
+requests==2.32.3
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
@@ -398,12 +405,17 @@ requests-mock==1.10.0
     # via -r requirements/test.in
 rpds-py==0.19.0
     # via
+    #   -c requirements/install.pip
     #   jsonschema
     #   referencing
 s3transfer==0.6.2
     # via
     #   -c requirements/install.pip
     #   boto3
+sentry-sdk[flask]==2.9.0
+    # via
+    #   -c requirements/install.pip
+    #   -r requirements/install.in
 six==1.16.0
     # via
     #   -c requirements/install.pip
@@ -450,11 +462,12 @@ urlextract==0.14.0
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
-urllib3==1.25.11
+urllib3==1.26.19
     # via
     #   -c requirements/install.pip
     #   botocore
     #   requests
+    #   sentry-sdk
 vine==5.1.0
     # via
     #   -c requirements/install.pip


### PR DESCRIPTION
This fixes the "urllib3 is the wrong version down the line" issue when installing the project from scratch.
This goes hand in hand with the commit on udata-front: https://github.com/datagouv/udata-front/pull/455