### PR TITLE
Fix the `extend-select` ruff.toml config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,6 @@ repos:
     hooks:
       # Run the linter
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix, --select, I]
+        args: [--fix, --exit-non-zero-on-fix]
       # Run the formatter
       - id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix many linting issues reported by ruff [#3118](https://github.com/opendatateam/udata/pull/3118)
 
 ## 9.1.3 (2024-08-01)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,12 @@ Once this is done, code formatting and linting, as well as import sorting, will 
 
 If you cannot use pre-commit, it is necessary to format, lint, and sort imports with [Ruff](https://docs.astral.sh/ruff/) before committing:
 ```bash
-ruff check --fix --select I .
+ruff check --fix .
+ruff format .
 ```
+
+> WARNING: running `ruff` on the codebase will lint and format all of it, whereas using `pre-commit` will
+  only be done on the staged files.
 
 ### JavaScript style guide
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
 line-length = 100
 
 [lint]
-select = ["I"] # also sort imports with an isort rule
+extend-select = ["I"] # also sort imports with an isort rule

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -1,5 +1,4 @@
 import inspect
-import itertools
 import logging
 import urllib.parse
 from functools import wraps
@@ -18,7 +17,7 @@ from flask import (
 from flask_restx import Api, Resource
 from flask_storage import UnauthorizedFileType
 
-from udata import cors, entrypoints, tracking
+from udata import entrypoints, tracking
 from udata.app import csrf
 from udata.auth import Permission, PermissionDenied, RoleNeed, current_user, login_user
 from udata.i18n import get_locale

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -325,7 +325,7 @@ def init_app(app):
     import udata.harvest.api  # noqa
 
     for module in entrypoints.get_enabled("udata.apis", app).values():
-        api_module = module if inspect.ismodule(module) else import_module(module)
+        module if inspect.ismodule(module) else import_module(module)
 
     # api.init_app(app)
     app.register_blueprint(apiv1_blueprint)

--- a/udata/api/commands.py
+++ b/udata/api/commands.py
@@ -4,7 +4,6 @@ import os
 import click
 from flask import current_app, json
 from flask_restx import schemas
-from werkzeug.security import gen_salt
 
 from udata.api import api
 from udata.api.oauth2 import OAuth2Client

--- a/udata/api/fields.py
+++ b/udata/api/fields.py
@@ -4,7 +4,28 @@ import logging
 import pytz
 from dateutil.parser import parse
 from flask import request, url_for
-from flask_restx.fields import *  # noqa
+
+# Explicitly import all of flask_restx fields so they're available throughout the codebase as api.fields
+from flask_restx.fields import Arbitrary as Arbitrary
+from flask_restx.fields import Boolean as Boolean
+from flask_restx.fields import ClassName as ClassName
+from flask_restx.fields import Date as Date
+from flask_restx.fields import DateTime as DateTime
+from flask_restx.fields import Fixed as Fixed
+from flask_restx.fields import Float as Float
+from flask_restx.fields import FormattedString as FormattedString
+from flask_restx.fields import Integer as Integer
+from flask_restx.fields import List as List
+from flask_restx.fields import MarshallingError as MarshallingError
+from flask_restx.fields import MinMaxMixin as MinMaxMixin
+from flask_restx.fields import Nested as Nested
+from flask_restx.fields import NumberMixin as NumberMixin
+from flask_restx.fields import Polymorph as Polymorph
+from flask_restx.fields import Raw as Raw
+from flask_restx.fields import String as String
+from flask_restx.fields import StringMixin as StringMixin
+from flask_restx.fields import Url as Url
+from flask_restx.fields import Wildcard as Wildcard
 
 from udata.uris import endpoint_for
 from udata.utils import multi_to_dict

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -67,13 +67,16 @@ def convert_db_to_field(key, field, info={}):
         field_read, field_write = convert_db_to_field(
             f"{key}.inner", field.field, info.get("inner_field_info", {})
         )
+
         def constructor_read(**kwargs):
             return restx_fields.List(field_read, **kwargs)
+
         def constructor_write(**kwargs):
             return restx_fields.List(field_write, **kwargs)
     elif isinstance(
         field, (mongo_fields.GenericReferenceField, mongoengine.fields.GenericLazyReferenceField)
     ):
+
         def constructor(**kwargs):
             return restx_fields.Nested(lazy_reference, **kwargs)
     elif isinstance(field, mongo_fields.ReferenceField):
@@ -86,6 +89,7 @@ def convert_db_to_field(key, field, info={}):
             # If there is no `nested_fields` convert the object to the string representation.
             constructor_read = restx_fields.String
         else:
+
             def constructor_read(**kwargs):
                 return restx_fields.Nested(nested_fields, **kwargs)
 
@@ -94,11 +98,14 @@ def convert_db_to_field(key, field, info={}):
     elif isinstance(field, mongo_fields.EmbeddedDocumentField):
         nested_fields = info.get("nested_fields")
         if nested_fields is not None:
+
             def constructor(**kwargs):
                 return restx_fields.Nested(nested_fields, **kwargs)
         elif hasattr(field.document_type_obj, "__read_fields__"):
+
             def constructor_read(**kwargs):
                 return restx_fields.Nested(field.document_type_obj.__read_fields__, **kwargs)
+
             def constructor_write(**kwargs):
                 return restx_fields.Nested(field.document_type_obj.__write_fields__, **kwargs)
         else:

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -67,12 +67,15 @@ def convert_db_to_field(key, field, info={}):
         field_read, field_write = convert_db_to_field(
             f"{key}.inner", field.field, info.get("inner_field_info", {})
         )
-        constructor_read = lambda **kwargs: restx_fields.List(field_read, **kwargs)
-        constructor_write = lambda **kwargs: restx_fields.List(field_write, **kwargs)
+        def constructor_read(**kwargs):
+            return restx_fields.List(field_read, **kwargs)
+        def constructor_write(**kwargs):
+            return restx_fields.List(field_write, **kwargs)
     elif isinstance(
         field, (mongo_fields.GenericReferenceField, mongoengine.fields.GenericLazyReferenceField)
     ):
-        constructor = lambda **kwargs: restx_fields.Nested(lazy_reference, **kwargs)
+        def constructor(**kwargs):
+            return restx_fields.Nested(lazy_reference, **kwargs)
     elif isinstance(field, mongo_fields.ReferenceField):
         # For reference we accept while writing a String representing the ID of the referenced model.
         # For reading, if the user supplied a `nested_fields` (RestX model), we use it to convert
@@ -83,21 +86,21 @@ def convert_db_to_field(key, field, info={}):
             # If there is no `nested_fields` convert the object to the string representation.
             constructor_read = restx_fields.String
         else:
-            constructor_read = lambda **kwargs: restx_fields.Nested(nested_fields, **kwargs)
+            def constructor_read(**kwargs):
+                return restx_fields.Nested(nested_fields, **kwargs)
 
         write_params["description"] = "ID of the reference"
         constructor_write = restx_fields.String
     elif isinstance(field, mongo_fields.EmbeddedDocumentField):
         nested_fields = info.get("nested_fields")
         if nested_fields is not None:
-            constructor = lambda **kwargs: restx_fields.Nested(nested_fields, **kwargs)
+            def constructor(**kwargs):
+                return restx_fields.Nested(nested_fields, **kwargs)
         elif hasattr(field.document_type_obj, "__read_fields__"):
-            constructor_read = lambda **kwargs: restx_fields.Nested(
-                field.document_type_obj.__read_fields__, **kwargs
-            )
-            constructor_write = lambda **kwargs: restx_fields.Nested(
-                field.document_type_obj.__write_fields__, **kwargs
-            )
+            def constructor_read(**kwargs):
+                return restx_fields.Nested(field.document_type_obj.__read_fields__, **kwargs)
+            def constructor_write(**kwargs):
+                return restx_fields.Nested(field.document_type_obj.__write_fields__, **kwargs)
         else:
             raise ValueError(
                 f"EmbeddedDocumentField `{key}` requires a `nested_fields` param to serialize/deserialize or a `@generate_fields()` definition."

--- a/udata/app.py
+++ b/udata/app.py
@@ -206,7 +206,6 @@ def register_extensions(app):
         mail,
         models,
         mongo,
-        notifications,
         routing,
         search,
         sentry,

--- a/udata/app.py
+++ b/udata/app.py
@@ -206,6 +206,7 @@ def register_extensions(app):
         mail,
         models,
         mongo,
+        notifications,  # noqa
         routing,
         search,
         sentry,

--- a/udata/auth/__init__.py
+++ b/udata/auth/__init__.py
@@ -2,19 +2,26 @@ import logging
 
 from flask import current_app, render_template
 from flask_principal import Permission as BasePermission
-from flask_principal import (
-    PermissionDenied,  # noqa: facade pattern
-    RoleNeed,
-    UserNeed,  # noqa: facade pattern
-    identity_loaded,  # noqa: facade pattern
-)
-from flask_security import (  # noqa
-    Security,  # noqa
-    current_user,
-    login_required,
-    login_user,
-)
+from flask_principal import PermissionDenied as PermissionDenied
+from flask_principal import RoleNeed as RoleNeed
+from flask_principal import UserNeed as UserNeed
+from flask_principal import identity_loaded as identity_loaded
+from flask_security import Security as Security
+from flask_security import current_user as current_user
+from flask_security import login_required as login_required
+from flask_security import login_user as login_user
 from werkzeug.utils import import_string
+
+__all__ = [
+    "PermissionDenied",
+    "UserNeed",
+    "identity_loaded",
+    "Security",
+    "render_security_template",
+    "Permission",
+    "admin_permission",
+    "init_app",
+]
 
 log = logging.getLogger(__name__)
 

--- a/udata/auth/__init__.py
+++ b/udata/auth/__init__.py
@@ -12,17 +12,6 @@ from flask_security import login_required as login_required
 from flask_security import login_user as login_user
 from werkzeug.utils import import_string
 
-__all__ = [
-    "PermissionDenied",
-    "UserNeed",
-    "identity_loaded",
-    "Security",
-    "render_security_template",
-    "Permission",
-    "admin_permission",
-    "init_app",
-]
-
 log = logging.getLogger(__name__)
 
 

--- a/udata/commands/db.py
+++ b/udata/commands/db.py
@@ -159,10 +159,10 @@ def check_references(models_to_check):
     references = []
     for model in set(_models):
         if model.__name__ == "Activity":
-            print(f"Skipping Activity model, scheduled for deprecation")
+            print("Skipping Activity model, scheduled for deprecation")
             continue
         if model.__name__ == "GeoLevel":
-            print(f"Skipping GeoLevel model, scheduled for deprecation")
+            print("Skipping GeoLevel model, scheduled for deprecation")
             continue
 
         if models_to_check and model.__name__ not in models_to_check:
@@ -367,7 +367,7 @@ def check_references(models_to_check):
                                     )
                         else:
                             print_and_save(f'Unknown ref type {reference["type"]}')
-                    except mongoengine.errors.FieldDoesNotExist as e:
+                    except mongoengine.errors.FieldDoesNotExist:
                         print_and_save(
                             f"[ERROR for {model.__name__} {obj.id}] {traceback.format_exc()}"
                         )

--- a/udata/commands/dcat.py
+++ b/udata/commands/dcat.py
@@ -33,7 +33,7 @@ def parse_url(url, csw, iso, quiet=False, rid=""):
     """Parse the datasets in a DCAT format located at URL (debug)"""
     if quiet:
         verbose_loggers = ["rdflib", "udata.core.dataset"]
-        [logging.getLogger(l).setLevel(logging.ERROR) for l in verbose_loggers]
+        [logging.getLogger(logger).setLevel(logging.ERROR) for logger in verbose_loggers]
 
     class MockSource:
         url = ""

--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -16,7 +16,6 @@ from udata.commands import cli
 from udata.core.contact_point.factories import ContactPointFactory
 from udata.core.contact_point.models import ContactPoint
 from udata.core.dataservices.factories import DataserviceFactory
-from udata.core.dataservices.models import Dataservice
 from udata.core.dataset.factories import (
     CommunityResourceFactory,
     DatasetFactory,

--- a/udata/commands/tests/test_fixtures.py
+++ b/udata/commands/tests/test_fixtures.py
@@ -1,10 +1,7 @@
-import json
 from tempfile import NamedTemporaryFile
 
 import pytest
 import requests
-import werkzeug.test
-from pytest_mock import MockerFixture
 from werkzeug.wrappers.response import Response
 
 import udata.commands.fixtures
@@ -17,7 +14,7 @@ from udata.core.dataset.factories import (
 )
 from udata.core.discussions.factories import DiscussionFactory, MessageDiscussionFactory
 from udata.core.organization.factories import OrganizationFactory
-from udata.core.organization.models import Member, Organization
+from udata.core.organization.models import Member
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import UserFactory
 

--- a/udata/core/activity/tasks.py
+++ b/udata/core/activity/tasks.py
@@ -1,7 +1,7 @@
 import logging
 
 from udata.models import Organization, User, db
-from udata.tasks import celery, task
+from udata.tasks import task
 
 from .signals import new_activity
 

--- a/udata/core/badges/models.py
+++ b/udata/core/badges/models.py
@@ -3,11 +3,9 @@ from datetime import datetime
 
 from mongoengine.signals import post_save
 
-from udata.api_fields import field
 from udata.auth import current_user
 from udata.mongo import db
 
-from .fields import badge_fields
 from .signals import on_badge_added, on_badge_removed
 
 log = logging.getLogger(__name__)

--- a/udata/core/contact_point/api.py
+++ b/udata/core/contact_point/api.py
@@ -1,10 +1,8 @@
 from udata.api import API, api
 from udata.api.parsers import ModelApiParser
-from udata.auth import admin_permission
 
-from .api_fields import contact_point_fields, contact_point_page_fields
+from .api_fields import contact_point_fields
 from .forms import ContactPointForm
-from .models import ContactPoint
 
 
 class ContactPointApiParser(ModelApiParser):

--- a/udata/core/dataservices/tasks.py
+++ b/udata/core/dataservices/tasks.py
@@ -3,7 +3,7 @@ from celery.utils.log import get_task_logger
 from udata.core.dataservices.models import Dataservice
 
 # from udata.harvest.models import HarvestJob
-from udata.models import Activity, Discussion, Follow, Transfer
+from udata.models import Discussion, Follow, Transfer
 from udata.tasks import job
 
 log = get_task_logger(__name__)

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -1,5 +1,3 @@
-from mongoengine import ValidationError
-
 from udata.core.spatial.forms import SpatialCoverageField
 from udata.core.storages import resources
 from udata.forms import ModelForm, fields, validators

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -256,8 +256,8 @@ class License(db.Document):
 
         if license is None:
             # Try to single match `slug` with a low Damerau-Levenshtein distance
-            computed = ((l, rdlevenshtein(l.slug, slug)) for l in cls.objects)
-            candidates = [l for l, d in computed if d <= MAX_DISTANCE]
+            computed = ((license_, rdlevenshtein(license_.slug, slug)) for license_ in cls.objects)
+            candidates = [license_ for license_, d in computed if d <= MAX_DISTANCE]
             # If there is more that one match, we cannot determinate
             # which one is closer to safely choose between candidates
             if len(candidates) == 1:
@@ -265,8 +265,10 @@ class License(db.Document):
 
         if license is None:
             # Try to match `title` with a low Damerau-Levenshtein distance
-            computed = ((l, rdlevenshtein(l.title.lower(), text)) for l in cls.objects)
-            candidates = [l for l, d in computed if d <= MAX_DISTANCE]
+            computed = (
+                (license_, rdlevenshtein(license_.title.lower(), text)) for license_ in cls.objects
+            )
+            candidates = [license_ for license_, d in computed if d <= MAX_DISTANCE]
             # If there is more that one match, we cannot determinate
             # which one is closer to safely choose between candidates
             if len(candidates) == 1:
@@ -275,11 +277,11 @@ class License(db.Document):
         if license is None:
             # Try to single match `alternate_titles` with a low Damerau-Levenshtein distance
             computed = (
-                (l, rdlevenshtein(cls.slug.slugify(t), slug))
-                for l in cls.objects
-                for t in l.alternate_titles
+                (license_, rdlevenshtein(cls.slug.slugify(title_), slug))
+                for license_ in cls.objects
+                for title_ in license_.alternate_titles
             )
-            candidates = [l for l, d in computed if d <= MAX_DISTANCE]
+            candidates = [license_ for license_, distance_ in computed if distance_ <= MAX_DISTANCE]
             # If there is more that one license matching, we cannot determinate
             # which one is closer to safely choose between candidates
             if len(set(candidates)) == 1:

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -998,7 +998,7 @@ class ResourceSchema(object):
                     f"Schemas catalog does not exist at {endpoint}"
                 )
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException:
             log.exception(f"Error while getting schema catalog from {endpoint}")
             schemas = cache.get(cache_key)
         else:
@@ -1006,7 +1006,7 @@ class ResourceSchema(object):
             cache.set(cache_key, schemas)
         # no cached version or no content
         if not schemas:
-            log.error(f"No content found inc. from cache for schema catalog")
+            log.error("No content found inc. from cache for schema catalog")
             raise SchemasCacheUnavailableException("No content in cache for schema catalog")
 
         return schemas

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -387,7 +387,7 @@ def spatial_from_rdf(graph):
             continue
 
     if not polygons:
-        log.warning(f"No supported types found in the GeoJSON data.")
+        log.warning("No supported types found in the GeoJSON data.")
         return None
 
     spatial_coverage = SpatialCoverage(

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -152,7 +152,7 @@ class DiscussionAPI(API):
 
 @ns.route("/<id>/comments/<int:cidx>/spam", endpoint="discussion_comment_spam")
 @ns.doc(delete={"id": "unspam"})
-class DiscussionSpamAPI(SpamAPIMixin):
+class DiscussionCommentSpamAPI(SpamAPIMixin):
     def get_model(self, id, cidx):
         discussion = Discussion.objects.get_or_404(id=id_or_404(id))
         if len(discussion.discussion) <= cidx:

--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -20,7 +20,7 @@ class Message(SpamMixin, db.EmbeddedDocument):
         return [self.content]
 
     def spam_report_message(self, breadcrumb):
-        message = f"Spam potentiel dans le message"
+        message = "Spam potentiel dans le message"
         if self.posted_by:
             message += f" de [{self.posted_by.fullname}]({self.posted_by.external_url})"
 
@@ -34,7 +34,7 @@ class Message(SpamMixin, db.EmbeddedDocument):
         discussion = breadcrumb[0]
         if not isinstance(discussion, Discussion):
             log.warning(
-                f"`spam_report_message` called on message with a breadcrumb not containing a Discussion at index 0.",
+                "`spam_report_message` called on message with a breadcrumb not containing a Discussion at index 0.",
                 extra={"breadcrumb": breadcrumb},
             )
             return message

--- a/udata/core/discussions/tasks.py
+++ b/udata/core/discussions/tasks.py
@@ -5,7 +5,7 @@ from udata.core.reuse.models import Reuse
 from udata.i18n import lazy_gettext as _
 from udata.tasks import connect, get_logger
 
-from .models import Discussion, Message
+from .models import Discussion
 from .signals import on_discussion_closed, on_new_discussion, on_new_discussion_comment
 
 log = get_logger(__name__)

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -8,6 +8,8 @@ from udata.api.parsers import ModelApiParser
 from udata.auth import admin_permission, current_user
 from udata.core.badges import api as badges_api
 from udata.core.badges.fields import badge_fields
+from udata.core.contact_point.api import ContactPointApiParser
+from udata.core.contact_point.api_fields import contact_point_page_fields
 from udata.core.dataset.api import DatasetApiParser
 from udata.core.dataset.api_fields import dataset_page_fields
 from udata.core.dataset.models import Dataset
@@ -21,6 +23,7 @@ from udata.core.storages.api import (
     parse_uploaded_image,
     uploaded_image_fields,
 )
+from udata.models import ContactPoint
 from udata.rdf import RDF_EXTENSIONS, graph_response, negociate_content
 from udata.utils import multi_to_dict
 
@@ -206,10 +209,6 @@ class OrganizationBadgeAPI(API):
         """Delete a badge for a given organization"""
         return badges_api.remove(org, badge_kind)
 
-
-from udata.core.contact_point.api import ContactPointApiParser
-from udata.core.contact_point.api_fields import contact_point_page_fields
-from udata.models import ContactPoint
 
 contact_point_parser = ContactPointApiParser()
 

--- a/udata/core/organization/api_fields.py
+++ b/udata/core/organization/api_fields.py
@@ -41,7 +41,8 @@ org_ref_fields = api.inherit(
     },
 )
 
-from udata.core.user.api_fields import user_ref_fields  # noqa: required
+# This import is not at the top of the file to avoid circular imports
+from udata.core.user.api_fields import user_ref_fields  # noqa
 
 
 def check_can_access_email():

--- a/udata/core/organization/apiv2.py
+++ b/udata/core/organization/apiv2.py
@@ -7,7 +7,7 @@ from udata.core.contact_point.api_fields import contact_point_fields
 from udata.utils import multi_to_dict
 
 from .api_fields import member_fields, org_fields, org_page_fields
-from .permissions import EditOrganizationPermission, OrganizationPrivatePermission
+from .permissions import EditOrganizationPermission
 from .search import OrganizationSearch
 
 apiv2.inherit("OrganizationPage", org_page_fields)

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -177,8 +177,8 @@ def migrate():
 
     level_summary = "\n".join(
         [
-            " - {0}: {1}".format(l.id, counter[l.id])
-            for l in GeoLevel.objects.order_by("admin_level")
+            " - {0}: {1}".format(geolevel.id, counter[geolevel.id])
+            for geolevel in GeoLevel.objects.order_by("admin_level")
         ]
     )
     summary = "\n".join(

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -188,7 +188,7 @@ def migrate():
     Summary
     =======
     Processed {zones} zones in {datasets} datasets:\
-    """.format(level_summary, **counter)
+    """.format(**counter)
             ),
             level_summary,
         ]

--- a/udata/core/spatial/factories.py
+++ b/udata/core/spatial/factories.py
@@ -2,7 +2,7 @@ import factory
 from faker.providers import BaseProvider
 from geojson.utils import generate_random
 
-from udata.factories import DateRangeFactory, ModelFactory
+from udata.factories import ModelFactory
 from udata.utils import faker_provider
 
 from . import geoids

--- a/udata/core/spatial/forms.py
+++ b/udata/core/spatial/forms.py
@@ -62,7 +62,7 @@ class GeomField(Field):
                     self.data = geojson.loads(value)
                 else:
                     self.data = geojson.GeoJSON.to_instance(value)
-            except:
+            except Exception:
                 self.data = None
                 log.exception("Unable to parse GeoJSON")
                 raise ValueError(self.gettext("Not a valid GeoJSON"))

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -120,7 +120,7 @@ class GeoZone(WithMetrics, db.Document):
 @cache.memoize()
 def get_spatial_granularities(lang):
     with language(lang):
-        return [(l.id, _(l.name)) for l in GeoLevel.objects] + [
+        return [(geolevel.id, _(geolevel.name)) for geolevel in GeoLevel.objects] + [
             (id, str(label)) for id, label in BASE_GRANULARITIES
         ]
 
@@ -130,7 +130,7 @@ spatial_granularities = LocalProxy(lambda: get_spatial_granularities(get_locale(
 
 @cache.cached(timeout=50, key_prefix="admin_levels")
 def get_spatial_admin_levels():
-    return dict((l.id, l.admin_level) for l in GeoLevel.objects)
+    return dict((geolevel.id, geolevel.admin_level) for geolevel in GeoLevel.objects)
 
 
 admin_levels = LocalProxy(get_spatial_admin_levels)

--- a/udata/core/spatial/tests/test_models.py
+++ b/udata/core/spatial/tests/test_models.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from udata.tests import DBTestMixin, TestCase
 
-from ..factories import GeoLevelFactory, GeoZoneFactory
+from ..factories import GeoZoneFactory
 from ..models import GeoZone, SpatialCoverage
 
 A_YEAR = timedelta(days=365)

--- a/udata/core/spatial/translations.py
+++ b/udata/core/spatial/translations.py
@@ -2,6 +2,7 @@
 def _(s):
     return s  # noqa: force translations
 
+
 TRANSLATIONS = (
     _("French region"),
     _("French intermunicipal (EPCI)"),

--- a/udata/core/spatial/translations.py
+++ b/udata/core/spatial/translations.py
@@ -1,5 +1,6 @@
 # Here to force translations by gettext
-_ = lambda s: s  # noqa: force translations
+def _(s):
+    return s  # noqa: force translations
 
 TRANSLATIONS = (
     _("French region"),

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -4,7 +4,6 @@ from slugify import slugify
 from udata.api import API, api
 from udata.api.parsers import ModelApiParser
 from udata.auth import admin_permission
-from udata.core import storages
 from udata.core.dataset.api_fields import community_resource_fields, dataset_fields
 from udata.core.discussions.actions import discussions_for
 from udata.core.discussions.api import discussion_fields

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -320,9 +320,10 @@ class UserAPI(API):
         return "", 204
 
 
-from udata.core.contact_point.api import ContactPointApiParser
-from udata.core.contact_point.api_fields import contact_point_page_fields
-from udata.models import ContactPoint
+# These imports are not at the top of the file to avoid circular imports
+from udata.core.contact_point.api import ContactPointApiParser  # noqa
+from udata.core.contact_point.api_fields import contact_point_page_fields  # noqa
+from udata.models import ContactPoint  # noqa
 
 contact_point_parser = ContactPointApiParser()
 

--- a/udata/core/user/metrics.py
+++ b/udata/core/user/metrics.py
@@ -1,6 +1,6 @@
 from udata.core.followers.signals import on_follow, on_unfollow
 from udata.core.owned import Owned
-from udata.models import Dataset, Reuse, User, db
+from udata.models import Dataset, Reuse, User
 
 
 @Dataset.on_create.connect

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -177,7 +177,7 @@ def purge_jobs():
         bucket = current_app.config.get("HARVEST_GRAPHS_S3_BUCKET")
         if bucket is None:
             log.error(
-                f"Bucket isn't configured anymore, but jobs still exist with external filenames. Could not delete them."
+                "Bucket isn't configured anymore, but jobs still exist with external filenames. Could not delete them."
             )
             break
 

--- a/udata/harvest/backends/__init__.py
+++ b/udata/harvest/backends/__init__.py
@@ -14,4 +14,4 @@ def get_all(app):
     return get_enabled("udata.harvesters", app)
 
 
-from .base import BaseBackend, HarvestFeature, HarvestFilter  # flake8: noqa
+from .base import BaseBackend, HarvestFeature, HarvestFilter  # noqa

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -1,4 +1,3 @@
-from celery import chord
 from flask import current_app
 
 from udata.tasks import get_logger, job, task

--- a/udata/harvest/tests/factories.py
+++ b/udata/harvest/tests/factories.py
@@ -3,8 +3,6 @@ import pytest
 from factory.fuzzy import FuzzyChoice
 from flask.signals import Namespace
 
-from udata.core.dataset.factories import DatasetFactory
-from udata.core.dataset.models import Dataset
 from udata.factories import ModelFactory
 
 from .. import backends

--- a/udata/harvest/tests/test_base_backend.py
+++ b/udata/harvest/tests/test_base_backend.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
 import pytest
-from dateutil.parser import parse
 from voluptuous import Schema
 
 from udata.core.dataset import tasks

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -4,7 +4,6 @@ import re
 import xml.etree.ElementTree as ET
 from datetime import date
 
-import boto3
 import pytest
 from flask import current_app
 

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -244,7 +244,7 @@ class DcatBackendTest:
 
         datasets = {d.harvest.dct_identifier: d for d in Dataset.objects}
 
-        assert datasets["1"].schema == None
+        assert datasets["1"].schema is None
         resources_by_title = {resource["title"]: resource for resource in datasets["1"].resources}
 
         # Schema with wrong version are considered as external. Maybe we could change this in the future
@@ -252,8 +252,8 @@ class DcatBackendTest:
             resources_by_title["Resource 1-2"].schema.url
             == "https://schema.data.gouv.fr/schemas/etalab/schema-irve-statique/1337.42.0/schema-statique.json"
         )
-        assert resources_by_title["Resource 1-2"].schema.name == None
-        assert resources_by_title["Resource 1-2"].schema.version == None
+        assert resources_by_title["Resource 1-2"].schema.name is None
+        assert resources_by_title["Resource 1-2"].schema.version is None
 
         assert datasets["2"].schema.name == "RGF93 / Lambert-93 (EPSG:2154)"
         assert (
@@ -265,17 +265,17 @@ class DcatBackendTest:
         # Unknown schema are kept as they were provided
         assert resources_by_title["Resource 2-1"].schema.name == "Example Schema"
         assert resources_by_title["Resource 2-1"].schema.url == "https://example.org/schema.json"
-        assert resources_by_title["Resource 2-1"].schema.version == None
+        assert resources_by_title["Resource 2-1"].schema.version is None
 
-        assert resources_by_title["Resource 2-2"].schema == None
+        assert resources_by_title["Resource 2-2"].schema is None
 
-        assert datasets["3"].schema == None
+        assert datasets["3"].schema is None
         resources_by_title = {resource["title"]: resource for resource in datasets["3"].resources}
 
         # If there is just the URL, and it matches a known schema inside the catalog, only set the name and the version
         # (discard the URL)
         assert resources_by_title["Resource 3-1"].schema.name == "etalab/schema-irve-statique"
-        assert resources_by_title["Resource 3-1"].schema.url == None
+        assert resources_by_title["Resource 3-1"].schema.url is None
         assert resources_by_title["Resource 3-1"].schema.version == "2.2.0"
 
         job = HarvestJob.objects.order_by("-id").first()
@@ -320,7 +320,7 @@ class DcatBackendTest:
 
         datasets = {d.harvest.dct_identifier: d for d in Dataset.objects}
 
-        assert datasets["1"].spatial == None
+        assert datasets["1"].spatial is None
         assert datasets["2"].spatial.geom == {
             "type": "MultiPolygon",
             "coordinates": [
@@ -329,7 +329,7 @@ class DcatBackendTest:
                 [[[159, -25.0], [159, -11], [212, -11], [212, -25.0], [159, -25.0]]],
             ],
         }
-        assert datasets["3"].spatial == None
+        assert datasets["3"].spatial is None
 
     @pytest.mark.options(SCHEMA_CATALOG_URL="https://example.com/schemas")
     def test_harvest_schemas(self, rmock):
@@ -344,7 +344,7 @@ class DcatBackendTest:
 
         datasets = {d.harvest.dct_identifier: d for d in Dataset.objects}
 
-        assert datasets["1"].schema == None
+        assert datasets["1"].schema is None
         resources_by_title = {resource["title"]: resource for resource in datasets["1"].resources}
 
         # Schema with wrong version are considered as external. Maybe we could change this in the future
@@ -352,8 +352,8 @@ class DcatBackendTest:
             resources_by_title["Resource 1-2"].schema.url
             == "https://schema.data.gouv.fr/schemas/etalab/schema-irve-statique/1337.42.0/schema-statique.json"
         )
-        assert resources_by_title["Resource 1-2"].schema.name == None
-        assert resources_by_title["Resource 1-2"].schema.version == None
+        assert resources_by_title["Resource 1-2"].schema.name is None
+        assert resources_by_title["Resource 1-2"].schema.version is None
 
         assert datasets["2"].schema.name == "RGF93 / Lambert-93 (EPSG:2154)"
         assert (
@@ -365,17 +365,17 @@ class DcatBackendTest:
         # Unknown schema are kept as they were provided
         assert resources_by_title["Resource 2-1"].schema.name == "Example Schema"
         assert resources_by_title["Resource 2-1"].schema.url == "https://example.org/schema.json"
-        assert resources_by_title["Resource 2-1"].schema.version == None
+        assert resources_by_title["Resource 2-1"].schema.version is None
 
-        assert resources_by_title["Resource 2-2"].schema == None
+        assert resources_by_title["Resource 2-2"].schema is None
 
-        assert datasets["3"].schema == None
+        assert datasets["3"].schema is None
         resources_by_title = {resource["title"]: resource for resource in datasets["3"].resources}
 
         # If there is just the URL, and it matches a known schema inside the catalog, only set the name and the version
         # (discard the URL)
         assert resources_by_title["Resource 3-1"].schema.name == "etalab/schema-irve-statique"
-        assert resources_by_title["Resource 3-1"].schema.url == None
+        assert resources_by_title["Resource 3-1"].schema.url is None
         assert resources_by_title["Resource 3-1"].schema.version == "2.2.0"
 
     def test_simple_nested_attributes(self, rmock):

--- a/udata/migrations/2020-07-24-remove-s-from-scope-oauth.py
+++ b/udata/migrations/2020-07-24-remove-s-from-scope-oauth.py
@@ -18,7 +18,7 @@ def migrate(db):
     oauth_clients = db.oauth2_client
     oauth_clients.update_many({}, {"$rename": {"scopes": "scope"}})
     for client in oauth_clients.find():
-        if type(client["scope"]) == list:
+        if type(client["scope"]) is list:
             scope_str = " ".join(client["scope"])
             client["scope"] = scope_str
             oauth_clients.save(client)

--- a/udata/migrations/2021-07-05-remove-unused-badges.py
+++ b/udata/migrations/2021-07-05-remove-unused-badges.py
@@ -4,7 +4,6 @@ The purpose here is to update every resource's metadata 'schema' name.
 
 import logging
 
-from udata.core.reuse.models import Reuse
 from udata.models import Dataset, Reuse
 
 log = logging.getLogger(__name__)

--- a/udata/migrations/2023-02-08-rename-internal-dates.py
+++ b/udata/migrations/2023-02-08-rename-internal-dates.py
@@ -6,8 +6,6 @@ import logging
 
 from mongoengine.connection import get_db
 
-from udata.models import Dataset
-
 log = logging.getLogger(__name__)
 
 

--- a/udata/migrations/2024-06-11-fix-reuse-datasets-references.py
+++ b/udata/migrations/2024-06-11-fix-reuse-datasets-references.py
@@ -4,7 +4,6 @@ Add a default topic to all reuses in db
 
 import logging
 
-import mongoengine
 from bson import DBRef
 
 from udata.models import Reuse

--- a/udata/search/commands.py
+++ b/udata/search/commands.py
@@ -93,7 +93,7 @@ def finalize_reindex(models, start):
         r = requests.post(url, json=payload)
         r.raise_for_status()
     except Exception:
-        log.exception(f"Unable to set alias for index")
+        log.exception("Unable to set alias for index")
 
     modified_since_reindex = 0
     for adapter in iter_adapters():

--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -3,7 +3,7 @@ import logging
 import urllib.parse
 
 import requests
-from flask import current_app, request, url_for
+from flask import current_app, request
 
 from udata.search.result import SearchResult
 

--- a/udata/tests/api/test_base_api.py
+++ b/udata/tests/api/test_base_api.py
@@ -1,7 +1,7 @@
 from flask import url_for
 
 from udata.api import API, api
-from udata.forms import Form, fields
+from udata.forms import Form
 
 from . import APITestCase
 

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -20,7 +20,7 @@ class ContactPointAPITest:
         data["email"] = "new.email@newdomain.com"
         response = api.put(url_for("api.contact_point", contact_point=contact_point), data)
         assert200(response)
-        assert ContactPoint.objects.count() is 1
+        assert ContactPoint.objects.count() == 1
         assert ContactPoint.objects.first().email == "new.email@newdomain.com"
 
     def test_contact_point_api_delete(self, api):
@@ -28,4 +28,4 @@ class ContactPointAPITest:
         contact_point = ContactPointFactory()
         response = api.delete(url_for("api.contact_point", contact_point=contact_point))
         assert204(response)
-        assert ContactPoint.objects.count() is 0
+        assert ContactPoint.objects.count() == 0

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -14,7 +14,7 @@ class ContactPointAPITest:
     modules = []
 
     def test_contact_point_api_update(self, api):
-        user = api.login()
+        api.login()
         contact_point = ContactPointFactory()
         data = contact_point.to_dict()
         data["email"] = "new.email@newdomain.com"
@@ -24,7 +24,7 @@ class ContactPointAPITest:
         assert ContactPoint.objects.first().email == "new.email@newdomain.com"
 
     def test_contact_point_api_delete(self, api):
-        user = api.login()
+        api.login()
         contact_point = ContactPointFactory()
         response = api.delete(url_for("api.contact_point", contact_point=contact_point))
         assert204(response)

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -42,7 +42,7 @@ from udata.i18n import gettext as _
 from udata.models import CommunityResource, Dataset, Follow, Member, db
 from udata.tags import MAX_TAG_LENGTH, MIN_TAG_LENGTH
 from udata.tests.features.territories import create_geozones_fixtures
-from udata.tests.helpers import assert200, assert204, assert404
+from udata.tests.helpers import assert200, assert404
 from udata.utils import faker, unique_string
 
 from . import APITestCase

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -839,7 +839,7 @@ class DatasetAPITest(APITestCase):
         dataset.reload()
         assert dataset.resources[0].schema["url"] == "http://example.com"
         assert dataset.resources[0].schema["name"] == "etalab/schema-irve-statique"
-        assert dataset.resources[0].schema["version"] == None
+        assert dataset.resources[0].schema["version"] is None
 
         resource_data["schema"] = {"name": "etalab/schema-irve-statique"}
         data["resources"].append(resource_data)
@@ -848,8 +848,8 @@ class DatasetAPITest(APITestCase):
 
         dataset.reload()
         assert dataset.resources[0].schema["name"] == "etalab/schema-irve-statique"
-        assert dataset.resources[0].schema["url"] == None
-        assert dataset.resources[0].schema["version"] == None
+        assert dataset.resources[0].schema["url"] is None
+        assert dataset.resources[0].schema["version"] is None
 
         resource_data["schema"] = {"name": "etalab/schema-irve-statique", "version": "2.2.0"}
         data["resources"].append(resource_data)
@@ -858,7 +858,7 @@ class DatasetAPITest(APITestCase):
 
         dataset.reload()
         assert dataset.resources[0].schema["name"] == "etalab/schema-irve-statique"
-        assert dataset.resources[0].schema["url"] == None
+        assert dataset.resources[0].schema["url"] is None
         assert dataset.resources[0].schema["version"] == "2.2.0"
 
         resource_data["schema"] = {
@@ -870,7 +870,7 @@ class DatasetAPITest(APITestCase):
 
         dataset.reload()
         assert dataset.resources[0].schema["name"] == "etalab/schema-irve-statique"
-        assert dataset.resources[0].schema["url"] == None
+        assert dataset.resources[0].schema["url"] is None
         assert dataset.resources[0].schema["version"] == "2.2.1"
 
         # Putting `None` as the schema argument do not remove the schema
@@ -884,7 +884,7 @@ class DatasetAPITest(APITestCase):
 
         dataset.reload()
         assert dataset.resources[0].schema["name"] == "etalab/schema-irve-statique"
-        assert dataset.resources[0].schema["url"] == None
+        assert dataset.resources[0].schema["url"] is None
         assert dataset.resources[0].schema["version"] == "2.2.1"
 
         # Putting `None` as the schema name and version remove the schema
@@ -897,9 +897,9 @@ class DatasetAPITest(APITestCase):
         self.assert200(response)
 
         dataset.reload()
-        assert dataset.resources[0].schema["name"] == None
-        assert dataset.resources[0].schema["url"] == None
-        assert dataset.resources[0].schema["version"] == None
+        assert dataset.resources[0].schema["name"] is None
+        assert dataset.resources[0].schema["url"] is None
+        assert dataset.resources[0].schema["version"] is None
 
 
 class DatasetBadgeAPITest(APITestCase):

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -72,7 +72,7 @@ class OrganizationAPITest:
         user = api.login()
         response = api.post(url_for("api.organizations"), data)
         assert201(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
 
         org = Organization.objects.first()
         member = org.member(user)
@@ -89,7 +89,7 @@ class OrganizationAPITest:
         data["description"] = "new description"
         response = api.put(url_for("api.organization", org=org), data)
         assert200(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
         assert Organization.objects.first().description == "new description"
 
     def test_organization_api_update_business_number_id(self, api):
@@ -101,7 +101,7 @@ class OrganizationAPITest:
         data["business_number_id"] = "13002526500013"
         response = api.put(url_for("api.organization", org=org), data)
         assert200(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
         assert Organization.objects.first().business_number_id == "13002526500013"
 
     def test_organization_api_update_business_number_id_failing(self, api):
@@ -147,7 +147,7 @@ class OrganizationAPITest:
         api.login()
         response = api.put(url_for("api.organization", org=org), data)
         assert403(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
         assert Organization.objects.first().description == org.description
 
     def test_organization_api_delete(self, api):
@@ -157,7 +157,7 @@ class OrganizationAPITest:
         org = OrganizationFactory(members=[member])
         response = api.delete(url_for("api.organization", org=org))
         assert204(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
         assert Organization.objects[0].deleted is not None
 
     def test_organization_api_delete_deleted(self, api):
@@ -175,7 +175,7 @@ class OrganizationAPITest:
         org = OrganizationFactory(members=[member])
         response = api.delete(url_for("api.organization", org=org))
         assert403(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
         assert Organization.objects[0].deleted is None
 
     def test_organization_api_delete_as_non_member_forbidden(self, api):
@@ -184,7 +184,7 @@ class OrganizationAPITest:
         org = OrganizationFactory()
         response = api.delete(url_for("api.organization", org=org))
         assert403(response)
-        assert Organization.objects.count() is 1
+        assert Organization.objects.count() == 1
         assert Organization.objects[0].deleted is None
 
 
@@ -200,10 +200,10 @@ class MembershipAPITest:
         assert201(response)
 
         organization.reload()
-        assert len(organization.requests) is 1
-        assert len(organization.pending_requests) is 1
-        assert len(organization.refused_requests) is 0
-        assert len(organization.accepted_requests) is 0
+        assert len(organization.requests) == 1
+        assert len(organization.pending_requests) == 1
+        assert len(organization.refused_requests) == 0
+        assert len(organization.accepted_requests) == 0
 
         request = organization.requests[0]
         assert request.user == user
@@ -223,10 +223,10 @@ class MembershipAPITest:
         assert200(response)
 
         organization.reload()
-        assert len(organization.requests) is 1
-        assert len(organization.pending_requests) is 1
-        assert len(organization.refused_requests) is 0
-        assert len(organization.accepted_requests) is 0
+        assert len(organization.requests) == 1
+        assert len(organization.pending_requests) == 1
+        assert len(organization.refused_requests) == 0
+        assert len(organization.accepted_requests) == 0
 
         request = organization.requests[0]
         assert request.user == user
@@ -326,10 +326,10 @@ class MembershipAPITest:
         assert response.json["role"] == "editor"
 
         organization.reload()
-        assert len(organization.requests) is 1
-        assert len(organization.pending_requests) is 0
-        assert len(organization.refused_requests) is 0
-        assert len(organization.accepted_requests) is 1
+        assert len(organization.requests) == 1
+        assert len(organization.pending_requests) == 0
+        assert len(organization.refused_requests) == 0
+        assert len(organization.accepted_requests) == 1
         assert organization.is_member(applicant)
 
         request = organization.requests[0]
@@ -380,10 +380,10 @@ class MembershipAPITest:
         assert200(response)
 
         organization.reload()
-        assert len(organization.requests) is 1
-        assert len(organization.pending_requests) is 0
-        assert len(organization.refused_requests) is 1
-        assert len(organization.accepted_requests) is 0
+        assert len(organization.requests) == 1
+        assert len(organization.pending_requests) == 0
+        assert len(organization.refused_requests) == 1
+        assert len(organization.accepted_requests) == 0
         assert not organization.is_member(applicant)
 
         request = organization.requests[0]
@@ -548,12 +548,12 @@ class MembershipAPITest:
         to_follow.count_followers()
         assert to_follow.get_metrics()["followers"] == 1
 
-        assert Follow.objects.following(to_follow).count() is 0
-        assert Follow.objects.followers(to_follow).count() is 1
+        assert Follow.objects.following(to_follow).count() == 0
+        assert Follow.objects.followers(to_follow).count() == 1
         follow = Follow.objects.followers(to_follow).first()
         assert isinstance(follow.following, Organization)
-        assert Follow.objects.following(user).count() is 1
-        assert Follow.objects.followers(user).count() is 0
+        assert Follow.objects.following(user).count() == 1
+        assert Follow.objects.followers(user).count() == 0
 
     def test_unfollow_org(self, api):
         """It should unfollow the organization on DELETE"""
@@ -567,12 +567,12 @@ class MembershipAPITest:
 
         nb_followers = Follow.objects.followers(to_follow).count()
 
-        assert nb_followers is 0
+        assert nb_followers == 0
         assert response.json["followers"] == nb_followers
 
-        assert Follow.objects.following(to_follow).count() is 0
-        assert Follow.objects.following(user).count() is 0
-        assert Follow.objects.followers(user).count() is 0
+        assert Follow.objects.following(to_follow).count() == 0
+        assert Follow.objects.following(user).count() == 0
+        assert Follow.objects.followers(user).count() == 0
 
     def test_suggest_organizations_api(self, api):
         """It should suggest organizations"""
@@ -658,13 +658,13 @@ class MembershipAPITest:
 
         response = api.get(url_for("api.suggest_organizations"), qs={"q": "xxxxxx", "size": "5"})
         assert200(response)
-        assert len(response.json) is 0
+        assert len(response.json) == 0
 
     def test_suggest_organizations_api_empty(self, api):
         """It should not provide organization suggestion if no data"""
         response = api.get(url_for("api.suggest_organizations"), qs={"q": "xxxxxx", "size": "5"})
         assert200(response)
-        assert len(response.json) is 0
+        assert len(response.json) == 0
 
     def test_suggest_organizations_homonyms(self, api):
         """It should suggest organizations and not deduplicate homonyms"""
@@ -673,7 +673,7 @@ class MembershipAPITest:
         response = api.get(url_for("api.suggest_organizations"), qs={"q": "homonym", "size": "5"})
         assert200(response)
 
-        assert len(response.json) is 2
+        assert len(response.json) == 2
 
         for suggestion in response.json:
             assert suggestion["name"] == "homonym"
@@ -749,7 +749,7 @@ class OrganizationDatasetsAPITest:
         response = api.get(url_for("api.org_datasets", org=org), qs={"page_size": 2})
 
         assert200(response)
-        assert len(response.json["data"]) is 2
+        assert len(response.json["data"]) == 2
 
 
 class OrganizationReusesAPITest:
@@ -841,7 +841,7 @@ class OrganizationBadgeAPITest:
             response = api.post(url, data)
             assert201(response)
         self.organization.reload()
-        assert len(self.organization.badges) is 1
+        assert len(self.organization.badges) == 1
 
     def test_create_same(self, api):
         data = self.factory.as_dict()
@@ -852,7 +852,7 @@ class OrganizationBadgeAPITest:
             response = api.post(url, data)
             assert200(response)
         self.organization.reload()
-        assert len(self.organization.badges) is 1
+        assert len(self.organization.badges) == 1
 
     def test_create_2nd(self, api):
         # Explicitely setting the kind to avoid collisions given the
@@ -865,7 +865,7 @@ class OrganizationBadgeAPITest:
         response = api.post(url, data)
         assert201(response)
         self.organization.reload()
-        assert len(self.organization.badges) is 2
+        assert len(self.organization.badges) == 2
 
     def test_delete(self, api):
         badge = self.factory()
@@ -876,7 +876,7 @@ class OrganizationBadgeAPITest:
             response = api.delete(url)
             assert204(response)
         self.organization.reload()
-        assert len(self.organization.badges) is 0
+        assert len(self.organization.badges) == 0
 
     def test_delete_404(self, api):
         kind = str(self.factory().kind)

--- a/udata/tests/api/test_tags_api.py
+++ b/udata/tests/api/test_tags_api.py
@@ -61,10 +61,10 @@ class TagsAPITest:
 
         response = api.get(url_for("api.suggest_tags"), qs={"q": "bbbb", "size": "5"})
         assert200(response)
-        assert len(response.json) is 0
+        assert len(response.json) == 0
 
     def test_suggest_tags_api_empty(self, api):
         """It should not provide tag suggestion if no data"""
         response = api.get(url_for("api.suggest_tags"), qs={"q": "bbbb", "size": "5"})
         assert200(response)
-        assert len(response.json) is 0
+        assert len(response.json) == 0

--- a/udata/tests/api/test_transfer_api.py
+++ b/udata/tests/api/test_transfer_api.py
@@ -58,7 +58,7 @@ class TransferAPITest(APITestCase):
         self.assertEqual(data["status"], "pending")
 
     def test_400_on_bad_subject(self):
-        user = self.login()
+        self.login()
         recipient = UserFactory()
         comment = faker.sentence()
 

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -83,7 +83,7 @@ class DatasetResourceAPIV2Test(APITestCase):
         assert data["total"] == len(resources)
         assert data["page"] == 1
         assert data["page_size"] == DEFAULT_PAGE_SIZE
-        assert data["next_page"] == None
+        assert data["next_page"] is None
         assert data["previous_page"] is None
 
     def test_get_missing_param(self):
@@ -97,7 +97,7 @@ class DatasetResourceAPIV2Test(APITestCase):
         assert data["total"] == len(resources)
         assert data["page"] == 1
         assert data["page_size"] == DEFAULT_PAGE_SIZE
-        assert data["next_page"] == None
+        assert data["next_page"] is None
         assert data["previous_page"] is None
 
     def test_get_next_page(self):
@@ -129,7 +129,7 @@ class DatasetResourceAPIV2Test(APITestCase):
         assert data["total"] == len(resources)
         assert data["page"] == 2
         assert data["page_size"] == DEFAULT_PAGE_SIZE
-        assert data["next_page"] == None
+        assert data["next_page"] is None
         assert data["previous_page"] == url_for(
             "apiv2.resources",
             dataset=dataset.id,
@@ -196,7 +196,7 @@ class DatasetResourceAPIV2Test(APITestCase):
         assert data["total"] == nb_resources__of_specific_type
         assert data["page"] == 2
         assert data["page_size"] == DEFAULT_PAGE_SIZE
-        assert data["next_page"] == None
+        assert data["next_page"] is None
         assert data["previous_page"] == url_for(
             "apiv2.resources",
             dataset=dataset.id,

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -301,15 +301,15 @@ class DatasetModelTest:
 
     def test_dataset_without_private(self):
         dataset = DatasetFactory()
-        assert dataset.private == False
+        assert dataset.private is False
 
         dataset.private = None
         dataset.save()
-        assert dataset.private == False
+        assert dataset.private is False
 
         dataset.private = True
         dataset.save()
-        assert dataset.private == True
+        assert dataset.private is True
 
 
 class ResourceModelTest:

--- a/udata/tests/frontend/__init__.py
+++ b/udata/tests/frontend/__init__.py
@@ -1,8 +1,6 @@
 import json
 import re
 
-import pytest
-
 from udata.tests import DBTestMixin, TestCase, WebTestMixin
 
 

--- a/udata/tests/frontend/test_auth.py
+++ b/udata/tests/frontend/test_auth.py
@@ -11,7 +11,6 @@ class AuthTest(FrontTestCase):
 
     def test_change_mail(self):
         user = self.login(AdminFactory())
-        url = url_for("security.change_email")
 
         new_email = "test@test.com"
 

--- a/udata/tests/organization/test_csv_adapter.py
+++ b/udata/tests/organization/test_csv_adapter.py
@@ -1,8 +1,6 @@
 import pytest
 
-from udata.core.dataset.csv import DatasetCsvAdapter, ResourcesCsvAdapter
 from udata.core.dataset.factories import DatasetFactory, ResourceFactory
-from udata.core.dataset.models import Dataset
 from udata.core.organization.csv import OrganizationCsvAdapter
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Organization

--- a/udata/tests/organization/test_notifications.py
+++ b/udata/tests/organization/test_notifications.py
@@ -17,11 +17,11 @@ class OrganizationNotificationsTest:
         members = [Member(user=editor, role="editor"), Member(user=admin, role="admin")]
         org = OrganizationFactory(members=members, requests=[request])
 
-        assert len(membership_request_notifications(applicant)) is 0
-        assert len(membership_request_notifications(editor)) is 0
+        assert len(membership_request_notifications(applicant)) == 0
+        assert len(membership_request_notifications(editor)) == 0
 
         notifications = membership_request_notifications(admin)
-        assert len(notifications) is 1
+        assert len(notifications) == 1
         dt, details = notifications[0]
         assert_equal_dates(dt, request.created)
         assert details["id"] == request.id

--- a/udata/tests/reuse/test_reuse_model.py
+++ b/udata/tests/reuse/test_reuse_model.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 
 from udata.core.dataset import tasks as dataset_tasks

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -254,9 +254,7 @@ class SiteRdfViewsTest:
         dataset_b = DatasetFactory.create()
         dataset_c = DatasetFactory.create()
 
-        DataserviceFactory.create(
-            datasets=[dataset_a.id], harvest=HarvestMetadataFactory()
-        )
+        DataserviceFactory.create(datasets=[dataset_a.id], harvest=HarvestMetadataFactory())
         dataservice_b = DataserviceFactory.create(datasets=[dataset_b.id])
         dataservice_x = DataserviceFactory.create(datasets=[dataset_a.id, dataset_c.id])
         dataservice_y = DataserviceFactory.create(datasets=[])

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -254,7 +254,7 @@ class SiteRdfViewsTest:
         dataset_b = DatasetFactory.create()
         dataset_c = DatasetFactory.create()
 
-        dataservice_a = DataserviceFactory.create(
+        DataserviceFactory.create(
             datasets=[dataset_a.id], harvest=HarvestMetadataFactory()
         )
         dataservice_b = DataserviceFactory.create(datasets=[dataset_b.id])

--- a/udata/tests/test_cors.py
+++ b/udata/tests/test_cors.py
@@ -1,11 +1,8 @@
 from datetime import datetime
 
-import pytest
 from flask import url_for
 
 from udata.core.dataset.factories import DatasetFactory
-from udata.core.topic.factories import TopicFactory
-from udata.search import reindex
 from udata.tests.api import APITestCase
 from udata.tests.helpers import assert_status
 

--- a/udata/tests/test_owned.py
+++ b/udata/tests/test_owned.py
@@ -161,8 +161,8 @@ class OwnedQuerysetTest(DBTestMixin, TestCase):
         result = Owned.objects.owned_by(org, user)
 
         self.assertEqual(len(result), 2)
-        for owned in result:
-            self.assertIn(owned, owneds)
+        for owned_ in result:
+            self.assertIn(owned_, owneds)
 
-        for owned in excluded:
-            self.assertNotIn(owned, result)
+        for owned_ in excluded:
+            self.assertNotIn(owned_, result)

--- a/udata/tests/test_routing.py
+++ b/udata/tests/test_routing.py
@@ -273,7 +273,7 @@ class SlugAsSLugFieldWithFollowTest(AsSlugMixin):
         assert404(client.get(second_url))
         assert404(client.get(last_url))
 
-        assert SlugFollow.objects.count() is 0
+        assert SlugFollow.objects.count() == 0
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -38,7 +38,7 @@ class TagsTests:
         rows = list(reader)
 
         assert header == ["name", "datasets", "reuses", "total"]
-        assert len(rows) is 3
+        assert len(rows) == 3
         assert rows[0] == ["both", "15", "10", "25"]
         assert rows[1] == ["datasets-only", "15", "0", "15"]
         assert rows[2] == ["reuses-only", "0", "10", "10"]

--- a/udata/tests/test_transfer.py
+++ b/udata/tests/test_transfer.py
@@ -13,8 +13,7 @@ from udata.core.user.metrics import (
 from udata.features.transfer.actions import accept_transfer, request_transfer
 from udata.features.transfer.factories import TransferFactory
 from udata.features.transfer.notifications import transfer_request_notifications
-from udata.models import Dataset, Member
-from udata.tests.helpers import assert_emit
+from udata.models import Member
 from udata.utils import faker
 
 pytestmark = pytest.mark.usefixtures("clean_db")

--- a/udata/tests/workers/test_jobs_commands.py
+++ b/udata/tests/workers/test_jobs_commands.py
@@ -101,7 +101,7 @@ class JobsCommandsTest:
         ]
         result = cli("job scheduled")
 
-        filtered = [l for l in result.output.splitlines() if "Tip" not in l]
+        filtered = [line for line in result.output.splitlines() if "Tip" not in line]
         assert len(filtered) == len(tasks)
 
         assert "not-scheduled" not in result.output


### PR DESCRIPTION
My comprehension from https://docs.astral.sh/ruff/settings/#lint_select is that it defines the rules ruff should care about.

We do want all the default rules that ruff cares about, and add the https://docs.astral.sh/ruff/rules/#isort-i ones (missing required imports, and unsorted imports), and thus
https://docs.astral.sh/ruff/settings/#lint_extend-select should be used instead.