### PR TITLE
Remove the failing legacy frontend jstests from bumpr

### DIFF
--- a/bumpr.rc
+++ b/bumpr.rc
@@ -6,7 +6,7 @@ tag = true
 tag_format = v{version}
 push = true
 clean = inv clean
-tests = inv test jstest
+tests = inv test
 publish = inv dist
 files =
     README.md


### PR DESCRIPTION
The js tests for the legacy admin frontend have been failing for a very long time now, and probably won't ever be fixed, as the admin is being re-implemented in udata-front.

So let's remove the jstests from bumpr, our release helper.