### PR TITLE
Use another port than 7000 for MacOS users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix many linting issues reported by ruff [#3118](https://github.com/opendatateam/udata/pull/3118)
+- Add an option to specify the port when using `inv serve` [#3123](https://github.com/opendatateam/udata/pull/3123)
 
 ## 9.1.3 (2024-08-01)
 
@@ -12,6 +13,7 @@
 - Update to the version v2.0.0 of udata-fixtures (with the dataservices)
 - Add type hints [#3111](https://github.com/opendatateam/udata/pull/3111)
 - Make sure requests v2.32.3 is used everywhere consistently [#3116](https://github.com/opendatateam/udata/pull/3116)
+- Expose a dataservice in its organization's catalog, and expose a dataservice's catalog [#3122](https://github.com/opendatateam/udata/pull/3122)
 
 ## 9.1.2 (2024-07-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - Update to the version v2.0.0 of udata-fixtures (with the dataservices)
 - Add type hints [#3111](https://github.com/opendatateam/udata/pull/3111)
 - Make sure requests v2.32.3 is used everywhere consistently [#3116](https://github.com/opendatateam/udata/pull/3116)
-- Expose a dataservice in its organization's catalog, and expose a dataservice's catalog [#3122](https://github.com/opendatateam/udata/pull/3122)
 
 ## 9.1.2 (2024-07-29)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,6 +151,10 @@ This define `dev.local:7000` as the URL for your local setup. You’ll have to e
 127.0.0.1       dev.local
 ```
 
+!!! WARNING
+    For MacOS users, please note that the [control center is listening on port 7000](https://discussions.apple.com/thread/250472145?sortBy=rank),
+    so the above won't work. Instead, configure for example port `7001` in the `udata.cfg` file.
+
 ## Running the project for the first time
 
 You need to initialize some data before being able to use udata. The following command
@@ -170,6 +174,15 @@ You can then start udata server with the `serve` subcommand.
 ```bash
 inv serve
 ```
+
+!!! WARNING
+    For MacOS users, this won't work as the port `7000` is already used, as explained above. If you've changed the `udata.cfg` to
+    have a `SERVER_NAME=dev.local:7001`, use the following command instead, and make sure to use the port `7001` throughout the rest
+    of the documentation and examples.
+
+    ```bash
+    inv serve --port 7001
+    ```
 
 Now, you can use your udata api !
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -194,10 +194,10 @@ def qa(ctx):
 
 
 @task
-def serve(ctx, host="localhost"):
+def serve(ctx, host="localhost", port="7000"):
     """Run a development server"""
     with ctx.cd(ROOT):
-        ctx.run("python manage.py serve -d -r -h %s" % host)
+        ctx.run(f"python manage.py serve -d -r -h {host} -p {port}")
 
 
 @task


### PR DESCRIPTION
The port [7000 is used by the Control Center on MacOS](https://discussions.apple.com/thread/250472145?sortBy=rank), so this PR allows the specification of another port, and updates some parts of the documentation.

I would rather change everything everywhere (docs, settings, defaults, command defaults, docker-udata...) to instead use `7001` which should be available for everybody everywhere, or maybe something like `8000` which I believe is widely used in the web dev community?

What are your thoughts?