### PR TITLE
Add sort and pagination to the organization's discussions route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Convert reuse to new API system [#3066](https://github.com/opendatateam/udata/pull/3066)
 - Fix circular import error [#3128](https://github.com/opendatateam/udata/pull/3128)
 - Add an option to specify the port when using `inv serve` [#3123](https://github.com/opendatateam/udata/pull/3123)
+- Add sort and pagination parameters to the organization discussions API [#3124](https://github.com/opendatateam/udata/pull/3124)
 
 ## 9.1.3 (2024-08-01)
 

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -15,6 +15,7 @@ from flask import (
     url_for,
 )
 from flask_restx import Api, Resource
+from flask_restx.reqparse import RequestParser
 from flask_storage import UnauthorizedFileType
 
 from udata import entrypoints, tracking
@@ -145,6 +146,20 @@ class UDataApi(Api):
             "page_size", type=int, default=20, location="args", help="The page size to fetch"
         )
         return parser
+
+
+def adminified_parser(parser: RequestParser) -> RequestParser:
+    """The admin has some constraints. Make sure the parser respects them.
+
+    This returns a new copy of the parser, leaving the original one untouched."""
+    # The admin isn't paginated, so if there's a `page_size` arg, remove its default
+    # value so the all the results are returned if no `page_size` is provided.
+    new_parser = parser.copy()
+    if [arg for arg in new_parser.args if arg.name == "page_size"]:
+        new_parser.replace_argument(
+            "page_size", type=int, location="args", help="The page size to fetch"
+        )
+    return new_parser
 
 
 api = UDataApi(

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -89,9 +89,9 @@ parser.add_argument(
 )
 parser.add_argument("user", type=str, location="args", help="Filter discussions created by a user")
 parser.add_argument("page", type=int, default=1, location="args", help="The page to fetch")
-# The admin isn't paginated, so if there's no `page_size` parameter, don't set a default, and return
-# all the discussions. If there's a need for a default value, set it after the `parse_args()`.
-parser.add_argument("page_size", type=int, location="args", help="The page size to fetch")
+parser.add_argument(
+    "page_size", type=int, default=20, location="args", help="The page size to fetch"
+)
 parser.add_argument(
     "org", type=str, location="args", help="Filter discussions created for an organization"
 )
@@ -221,8 +221,7 @@ class DiscussionsAPI(API):
     def get(self):
         """List all Discussions"""
         args = parser.parse_args()
-        page_size = args.get("page_size") or 20
-        return get_discussion_list(args).paginate(args["page"], page_size)
+        return get_discussion_list(args).paginate(args["page"], args["page_size"])
 
     @api.secure
     @api.doc("create_discussion")

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from flask import make_response, redirect, request, url_for
 from mongoengine.queryset.visitor import Q
 
-from udata.api import API, api, errors
+from udata.api import API, adminified_parser, api, errors
 from udata.api.parsers import ModelApiParser
 from udata.auth import admin_permission, current_user
 from udata.core.badges import api as badges_api
@@ -476,7 +476,8 @@ class OrgDiscussionsAPI(API):
     @api.marshal_list_with(discussion_fields)
     def get(self, org):
         """List organization discussions"""
-        args = discussion_parser.parse_args()
+        parser = adminified_parser(discussion_parser)
+        args = parser.parse_args()
         args["org"] = org
         qs = get_discussion_list(args)
         if args["page_size"]:

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -491,8 +491,8 @@ class OrgDiscussionsAPI(API):
     def get(self, org):
         """List organization discussions"""
         args = discussion_parser.parse_args()
-        reuses = Reuse.objects(organization=org).only("id")
-        datasets = Dataset.objects(organization=org).only("id")
+        reuses = Reuse.objects.owned_by(org).only("id")
+        datasets = Dataset.objects.owned_by(org).only("id")
         subjects = list(reuses) + list(datasets)
         qs = Discussion.objects(subject__in=subjects).order_by(args["sort"])
         if args["page_size"]:

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -479,7 +479,7 @@ adminified_discussion_parser.remove_argument("org")
 class OrgDiscussionsAPI(API):
     @api.doc("list_organization_discussions")
     @api.expect(adminified_discussion_parser)
-    @api.marshal_list_with(discussion_fields)
+    @api.marshal_list_for_old_admin_with(discussion_fields)
     def get(self, org):
         """List organization discussions"""
         args = adminified_discussion_parser.parse_args()
@@ -487,7 +487,9 @@ class OrgDiscussionsAPI(API):
         qs = get_discussion_list(args)
         if args["page_size"]:
             qs = qs.paginate(args["page"], args["page_size"])
-        return list(qs)
+            return qs
+        else:
+            return list(qs)
 
 
 @ns.route("/roles/", endpoint="org_roles")

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -470,14 +470,19 @@ class OrgReusesAPI(API):
         return list(qs)
 
 
+adminified_discussion_parser = adminified_parser(discussion_parser)
+# The `org` argument is part of the path in this API, so shouldn't be in the query parameters.
+adminified_discussion_parser.remove_argument("org")
+
+
 @ns.route("/<org:org>/discussions/", endpoint="org_discussions")
 class OrgDiscussionsAPI(API):
     @api.doc("list_organization_discussions")
+    @api.expect(adminified_discussion_parser)
     @api.marshal_list_with(discussion_fields)
     def get(self, org):
         """List organization discussions"""
-        parser = adminified_parser(discussion_parser)
-        args = parser.parse_args()
+        args = adminified_discussion_parser.parse_args()
         args["org"] = org
         qs = get_discussion_list(args)
         if args["page_size"]:

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -849,8 +849,13 @@ class OrganizationDiscussionsAPITest:
         response = api.get(url_for("api.org_discussions", org=org))
         assert len(response.json) == len(discussions)
 
+        # If there's a `page_size` parameter, paginated and return a pager
         response = api.get(url_for("api.org_discussions", org=org, page_size=1, sort="-created"))
-        assert len(response.json) == 1
+        assert "data" in response.json
+        assert "page_size" in response.json
+        assert "page" in response.json
+        assert "next_page" in response.json
+        assert len(response.json["data"]) == 1
 
 
 class OrganizationBadgeAPITest:

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -803,7 +803,7 @@ class OrganizationDiscussionsAPITest:
             Discussion.objects.create(subject=reuse, title="", user=user),
         ]
 
-        response = api.get(url_for("api.org_discussions", org=org), follow_redirects=True)
+        response = api.get(url_for("api.org_discussions", org=org))
 
         assert200(response)
         assert len(response.json) == len(discussions)
@@ -828,13 +828,11 @@ class OrganizationDiscussionsAPITest:
         ]
 
         # By default, the sort is by `-created`
-        response = api.get(url_for("api.org_discussions", org=org), follow_redirects=True)
+        response = api.get(url_for("api.org_discussions", org=org))
         # The first is the newest
         assert response.json[0]["created"] == discussions[1].created
 
-        response = api.get(
-            url_for("api.org_discussions", org=org, sort="created"), follow_redirects=True
-        )
+        response = api.get(url_for("api.org_discussions", org=org, sort="created"))
         # The first is the oldest
         assert response.json[0]["created"] == discussions[0].created
 
@@ -848,13 +846,10 @@ class OrganizationDiscussionsAPITest:
         ]
 
         # By default, there is no pagination so all the discussions are listed
-        response = api.get(url_for("api.org_discussions", org=org), follow_redirects=True)
+        response = api.get(url_for("api.org_discussions", org=org))
         assert len(response.json) == len(discussions)
 
-        response = api.get(
-            url_for("api.org_discussions", org=org, page_size=1, sort="-created"),
-            follow_redirects=True,
-        )
+        response = api.get(url_for("api.org_discussions", org=org, page_size=1, sort="-created"))
         assert len(response.json) == 1
 
 

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -803,7 +803,7 @@ class OrganizationDiscussionsAPITest:
             Discussion.objects.create(subject=reuse, title="", user=user),
         ]
 
-        response = api.get(url_for("api.org_discussions", org=org))
+        response = api.get(url_for("api.org_discussions", org=org), follow_redirects=True)
 
         assert200(response)
         assert len(response.json) == len(discussions)
@@ -828,11 +828,13 @@ class OrganizationDiscussionsAPITest:
         ]
 
         # By default, the sort is by `-created`
-        response = api.get(url_for("api.org_discussions", org=org))
+        response = api.get(url_for("api.org_discussions", org=org), follow_redirects=True)
         # The first is the newest
         assert response.json[0]["created"] == discussions[1].created
 
-        response = api.get(url_for("api.org_discussions", org=org, sort="created"))
+        response = api.get(
+            url_for("api.org_discussions", org=org, sort="created"), follow_redirects=True
+        )
         # The first is the oldest
         assert response.json[0]["created"] == discussions[0].created
 
@@ -841,27 +843,19 @@ class OrganizationDiscussionsAPITest:
         user = UserFactory()
         org = OrganizationFactory()
         reuse = ReuseFactory(organization=org)
-        dataset = DatasetFactory(organization=org)
         discussions = [
-            Discussion.objects.create(
-                subject=reuse, title="", user=user, created="2024-12-31T00:00:00+00:00"
-            ),
-            Discussion.objects.create(
-                subject=dataset, title="", user=user, created="2020-01-01T00:00:00+00:00"
-            ),
+            Discussion.objects.create(subject=reuse, title="", user=user) for _ in range(30)
         ]
 
         # By default, there is no pagination so all the discussions are listed
-        response = api.get(url_for("api.org_discussions", org=org))
+        response = api.get(url_for("api.org_discussions", org=org), follow_redirects=True)
         assert len(response.json) == len(discussions)
 
-        response = api.get(url_for("api.org_discussions", org=org, page_size=1))
+        response = api.get(
+            url_for("api.org_discussions", org=org, page_size=1, sort="-created"),
+            follow_redirects=True,
+        )
         assert len(response.json) == 1
-        assert response.json[0]["created"] == discussions[0].created
-
-        response = api.get(url_for("api.org_discussions", org=org, page_size=1, page=2))
-        assert len(response.json) == 1
-        assert response.json[0]["created"] == discussions[1].created
 
 
 class OrganizationBadgeAPITest:


### PR DESCRIPTION
Fixes [#1398](https://github.com/datagouv/data.gouv.fr/issues/1398)

Note: this add more than just the `sort` and `page*` parameters, it adds all the parameters available on the `/discussions/` route.
It also adds an `org` parameter on the `/discusions/` route.