### PR TITLE
Always add Vary even for non CORS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a new `related_to` filter parameter to the activities API endpoint [#3127](https://github.com/opendatateam/udata/pull/3127)
 - Properly import the `Discussion.closed_by` from the fixtures [#3125](https://github.com/opendatateam/udata/pull/3125)
 - Send an API token to Hydra when publishing resource events [#3130](https://github.com/opendatateam/udata/pull/3130)
+- Always add Vary even for non CORS requests [#3132](https://github.com/opendatateam/udata/pull/3132)
 
 ## 9.1.3 (2024-08-01)
 

--- a/udata/cors.py
+++ b/udata/cors.py
@@ -15,10 +15,10 @@ def add_vary(headers: Headers, header: str):
 
 def add_actual_request_headers(headers: Headers) -> Headers:
     origin = request.headers.get("Origin", None)
+    add_vary(headers, "Origin")
+
     if origin:
         headers.set("Access-Control-Allow-Origin", origin)
-        add_vary(headers, "Origin")
-
         headers.set("Access-Control-Allow-Credentials", "true")
 
     return headers
@@ -41,10 +41,10 @@ def is_allowed_cors_route():
 
 def add_preflight_request_headers(headers: Headers) -> Headers:
     origin = request.headers.get("Origin", None)
+    add_vary(headers, "Origin")
+
     if origin:
         headers.set("Access-Control-Allow-Origin", origin)
-        add_vary(headers, "Origin")
-
         headers.set("Access-Control-Allow-Credentials", "true")
 
         # The API allows all methods, so just copy the browser requested methods from the request headers.


### PR DESCRIPTION
If the first request doesn't have an `Origin` we don't set the `Vary: Origin` so Nginx put the response in cache. Then if a cross origin request the same URL, Nginx returns the same response without the `Access-Control-Allow-Origin`.

The other solution could be to always return `Access-Control-Allow-Origin: *` for all API route instead of dynamic responding with the `Access-Control-Allow-Origin: doc.data.gouv.fr` for each origin.