### PR TITLE
Fix fake tags min length (again)

### DIFF
--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -26,7 +26,7 @@ def inner_harvest():
 def inner_process_dataset(item: HarvestItem, args1, args2, args3):
     dataset = self.get_dataset(item.remote_id)
 
-    update_dataset(dataset, args1, args2) 
+    update_dataset(dataset, args1, args2)
 
     return dataset
 ```
@@ -207,7 +207,7 @@ class RandomBackend(BaseBackend):
 
         dataset.title = faker.sentence()
         dataset.description = faker.text()
-        dataset.tags = list(set(faker.words(nb=faker.pyint())))
+        dataset.tags = list(set(faker.tags(nb=faker.pyint())))
 
         # Resources
         for i in range(faker.pyint()):

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -84,7 +84,7 @@ class DatasetToRdfTest:
         resources = ResourceFactory.build_batch(3)
         org = OrganizationFactory(name="organization")
         dataset = DatasetFactory(
-            tags=faker.words(nb=3),
+            tags=faker.tags(nb=3),
             resources=resources,
             frequency="daily",
             acronym="acro",
@@ -295,7 +295,7 @@ class RdfToDatasetTest:
         title = faker.sentence()
         acronym = faker.word()
         description = faker.paragraph()
-        tags = faker.words(nb=3)
+        tags = faker.tags(nb=3)
         start = faker.past_date(start_date="-30d")
         end = faker.future_date(end_date="+30d")
         g.set((node, RDF.type, DCAT.Dataset))
@@ -347,7 +347,7 @@ class RdfToDatasetTest:
         node = BNode()
         g = Graph()
 
-        tags = faker.words(nb=3)
+        tags = faker.tags(nb=3)
         themes = faker.words(nb=3)
         g.add((node, RDF.type, DCAT.Dataset))
         g.add((node, DCT.title, Literal(faker.sentence())))

--- a/udata/tests/frontend/test_csv.py
+++ b/udata/tests/frontend/test_csv.py
@@ -59,7 +59,7 @@ class FakeFactory(MongoEngineFactory):
 
     title = factory.LazyAttribute(lambda o: faker.sentence())
     description = factory.LazyAttribute(lambda o: faker.paragraph())
-    tags = factory.LazyAttribute(lambda o: [faker.word() for _ in range(1, randint(1, 4))])
+    tags = factory.LazyAttribute(lambda o: [faker.tag() for _ in range(1, randint(1, 4))])
     sub = factory.SubFactory(NestedFactory)
 
 

--- a/udata/tests/frontend/test_csv.py
+++ b/udata/tests/frontend/test_csv.py
@@ -59,7 +59,7 @@ class FakeFactory(MongoEngineFactory):
 
     title = factory.LazyAttribute(lambda o: faker.sentence())
     description = factory.LazyAttribute(lambda o: faker.paragraph())
-    tags = factory.LazyAttribute(lambda o: [faker.tag() for _ in range(1, randint(1, 4))])
+    tags = factory.LazyAttribute(lambda o: faker.tags(randint(1, 4)))
     sub = factory.SubFactory(NestedFactory)
 
 

--- a/udata/utils.py
+++ b/udata/utils.py
@@ -279,14 +279,19 @@ PROVIDERS.remove("faker.providers.lorem")
 faker = Faker("fr_FR")  # Use a unicode/utf-8 based locale
 
 
-def tag() -> str:
+def generate_tags(nb=3) -> [str]:
+    return [generate_tag() for _ in range(nb)]
+
+
+def generate_tag() -> str:
     fake_tag: str = faker.word()
     while len(fake_tag) < tags.MIN_TAG_LENGTH:
         fake_tag = faker.word()
     return fake_tag
 
 
-faker.tag = tag
+faker.tag = generate_tag
+faker.tags = generate_tags
 
 
 def faker_provider(provider):


### PR DESCRIPTION
This follows https://github.com/opendatateam/udata/pull/3129 which wasn't fixing all the instances of `faker.word(s)` being used instead of `faker.tag(s)`.