### PR TITLE
Allow OAuth clients without secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Allow OAuth clients without secrets [#3138](https://github.com/opendatateam/udata/pull/3138)
 
 ## 9.1.4 (2024-08-26)
 


### PR DESCRIPTION
This adds the possibility to create an `OAuth2Client` that does not have an associated secret.

This is useful when the client cannot store the secret safely (eg SPA or mobile app without backend). This way, we do not need to disclose the (not so) secret in the source code or requests of those clients, which can raise some eyebrows.

- Allow the `secret` to be `None` in MongoEngine
- Allow `none` as client authentication method for code grant and token revocation (i.e. do not require the client secret to be passed)
- Modify the oauth client creation command to create a secret by default, unless `--public` is specified

NB: this should have no impact on security, no more or no less. A traditional client with an associated secret will still require the secret to be passed in authentication requests.

Tested with https://github.com/opendatateam/udata-front-kit both with and without client secret.

References:
- https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce
- https://docs.authlib.org/en/latest/specs/rfc7636.html
- https://stackoverflow.com/questions/63057801/do-we-really-need-client-secret-to-get-access-token-on-pkce-flow