### PR TITLE
Add a "private" filter on the reuses endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- **breaking change** Return all the reuses available to a user, including the private, deleted and archived one they own [#3140](https://github.com/opendatateam/udata/pull/3140)
+- **breaking change** Return all the reuses available to a user, including the private, deleted and archived ones they own, and allow filtering on `private=true|false`, `deleted=true|false`and `archived=true|false` [#3140](https://github.com/opendatateam/udata/pull/3140)
 
 ## 9.1.4 (2024-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- **breaking change** Return all the reuses available to a user, including the private and deleted ones they own [#3140](https://github.com/opendatateam/udata/pull/3140). Reuses without datasets will be also now be counted in the "visible" reuses, and thus added to the metrics.
+- **breaking change** Return all the reuses available to a user on the /reuses endpoint, including the private and deleted ones they own [#3140](https://github.com/opendatateam/udata/pull/3140).
 
 ## 9.1.4 (2024-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- **breaking change** Return all the reuses available to a user, including the private, deleted and archived one they own [#3140](https://github.com/opendatateam/udata/pull/3140)
+- **breaking change** Return all the reuses available to a user, including the private and deleted ones they own [#3140](https://github.com/opendatateam/udata/pull/3140). Reuses without datasets will be also now be counted in the "visible" reuses, and thus added to the metrics.
 
 ## 9.1.4 (2024-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- **breaking change** Return all the reuses available to a user, including the private, deleted and archived ones they own, and allow filtering on `private=true|false`, `deleted=true|false`and `archived=true|false` [#3140](https://github.com/opendatateam/udata/pull/3140)
+- **breaking change** Return all the reuses available to a user, including the private, deleted and archived one they own [#3140](https://github.com/opendatateam/udata/pull/3140)
 
 ## 9.1.4 (2024-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- **breaking change** Return all the reuses available to a user, including the private, deleted and archived one they own [#3140](https://github.com/opendatateam/udata/pull/3140)
 
 ## 9.1.4 (2024-08-26)
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -197,7 +197,7 @@ def qa(ctx):
 def serve(ctx, host="localhost", port="7000"):
     """Run a development server"""
     with ctx.cd(ROOT):
-        ctx.run(f"python manage.py serve -d -r -h {host} -p {port}")
+        ctx.run(f"python manage.py serve -d -r -h {host} -p {port}", pty=True)
 
 
 @task

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -305,8 +305,6 @@ def generate_fields(**kwargs):
             parser.add_argument(
                 filterable["key"],
                 type=filterable["type"],
-                default=filterable.get("default"),
-                choices=filterable.get("choices"),
                 location="args",
             )
 

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -302,7 +302,13 @@ def generate_fields(**kwargs):
             parser.add_argument("q", type=str, location="args")
 
         for filterable in filterables:
-            parser.add_argument(filterable["key"], type=filterable["type"], location="args")
+            parser.add_argument(
+                filterable["key"],
+                type=filterable["type"],
+                default=filterable.get("default"),
+                choices=filterable.get("choices"),
+                location="args",
+            )
 
         cls.__index_parser__ = parser
 

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -209,8 +209,6 @@ def generate_fields(**kwargs):
                     filterable["type"] = str
                     if isinstance(field, mongo_fields.BooleanField):
                         filterable["type"] = boolean
-                if filterable["type"] == boolean and isinstance(field, mongo_fields.DateTimeField):
-                    filterable["datetime_as_boolean"] = True
 
                 # We may add more information later here:
                 # - type of mongo query to execute (right now only simple =)
@@ -344,19 +342,11 @@ def generate_fields(**kwargs):
                         ):
                             api.abort(400, f'`{filterable["key"]}` must be an identifier')
 
-                    filter_value = args[filterable["key"]]
-                    filter_column = filterable["column"]
-
-                    if filterable.get("datetime_as_boolean"):
-                        # It's a datetime field, but we filter it as a bool, so we convert
-                        # - True -> field__ne=None (objects which have a `deleted` datetime set)
-                        # - False -> field=None (objects without a `deleted` datetime set)
-                        if filter_value:
-                            filter_column += "__ne"
-                        filter_value = None
-
-                    filter = {filter_column: filter_value}
-                    base_query = base_query.filter(**filter)
+                    base_query = base_query.filter(
+                        **{
+                            filterable["column"]: args[filterable["key"]],
+                        }
+                    )
 
             if paginable:
                 base_query = base_query.paginate(args["page"], args["page_size"])

--- a/udata/core/owned.py
+++ b/udata/core/owned.py
@@ -26,6 +26,9 @@ class OwnedQuerySet(UDataQuerySet):
 
     def visible_by_user(self, user: User, visible_query: Q):
         """Return EVERYTHING visible to the user."""
+        if user.sysadmin:
+            return self()
+
         if user.is_anonymous:
             return self(visible_query)
 

--- a/udata/core/owned.py
+++ b/udata/core/owned.py
@@ -26,11 +26,11 @@ class OwnedQuerySet(UDataQuerySet):
 
     def visible_by_user(self, user: User, visible_query: Q):
         """Return EVERYTHING visible to the user."""
-        if user.sysadmin:
-            return self()
-
         if user.is_anonymous:
             return self(visible_query)
+
+        if user.sysadmin:
+            return self()
 
         owners: list[User | Organization] = list(user.organizations) + [user.id]
         # We create a new queryset because we want a pristine self._query_obj.

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -99,9 +99,7 @@ class ReuseListAPI(API):
     @api.expect(Reuse.__index_parser__)
     @api.marshal_with(Reuse.__page_fields__)
     def get(self):
-        owners = list(current_user.organizations) + [current_user.id]
-        query = Reuse.objects(deleted=None).owned_by(*owners)
-
+        query = Reuse.objects.visible_by_user(current_user)
         return Reuse.apply_sort_filters_and_pagination(query)
 
     @api.secure

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -99,7 +99,8 @@ class ReuseListAPI(API):
     @api.expect(Reuse.__index_parser__)
     @api.marshal_with(Reuse.__page_fields__)
     def get(self):
-        query = Reuse.objects.visible_by_user(current_user)
+        visible_query = mongoengine.Q(private__ne=True, deleted=None)
+        query = Reuse.objects.visible_by_user(current_user, visible_query)
         return Reuse.apply_sort_filters_and_pagination(query)
 
     @api.secure

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -99,8 +99,7 @@ class ReuseListAPI(API):
     @api.expect(Reuse.__index_parser__)
     @api.marshal_with(Reuse.__page_fields__)
     def get(self):
-        visible_query = mongoengine.Q(private__ne=True, deleted=None)
-        query = Reuse.objects.visible_by_user(current_user, visible_query)
+        query = Reuse.objects.visible_by_user(current_user)
         return Reuse.apply_sort_filters_and_pagination(query)
 
     @api.secure

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -99,7 +99,8 @@ class ReuseListAPI(API):
     @api.expect(Reuse.__index_parser__)
     @api.marshal_with(Reuse.__page_fields__)
     def get(self):
-        query = Reuse.objects(deleted=None, private__ne=True)
+        owners = list(current_user.organizations) + [current_user.id]
+        query = Reuse.objects(deleted=None).owned_by(*owners)
 
         return Reuse.apply_sort_filters_and_pagination(query)
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -99,7 +99,9 @@ class ReuseListAPI(API):
     @api.expect(Reuse.__index_parser__)
     @api.marshal_with(Reuse.__page_fields__)
     def get(self):
-        query = Reuse.objects.visible_by_user(current_user)
+        query = Reuse.objects.visible_by_user(
+            current_user, mongoengine.Q(private__ne=True, deleted=None)
+        )
         return Reuse.apply_sort_filters_and_pagination(query)
 
     @api.secure

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -1,4 +1,5 @@
 from blinker import Signal
+from flask_restx.inputs import boolean
 from mongoengine.signals import post_save, pre_save
 from werkzeug.utils import cached_property
 
@@ -133,9 +134,11 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, Owned, db.Document):
     deleted = field(
         db.DateTimeField(),
         readonly=True,
+        filterable={"type": boolean},
     )
     archived = field(
         db.DateTimeField(),
+        filterable={"type": boolean},
     )
 
     def __str__(self):

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -21,10 +21,10 @@ __all__ = ("Reuse",)
 
 class ReuseQuerySet(OwnedQuerySet):
     def visible(self):
-        return self(private__ne=True, datasets__0__exists=True, deleted=None)
+        return self(private__ne=True, deleted=None)
 
     def hidden(self):
-        return self(db.Q(private=True) | db.Q(datasets__0__exists=False) | db.Q(deleted__ne=None))
+        return self(db.Q(private=True) | db.Q(deleted__ne=None))
 
 
 def check_url_does_not_exists(url):

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -1,5 +1,4 @@
 from blinker import Signal
-from flask_restx.inputs import boolean
 from mongoengine.signals import post_save, pre_save
 from werkzeug.utils import cached_property
 
@@ -134,11 +133,9 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, Owned, db.Document):
     deleted = field(
         db.DateTimeField(),
         readonly=True,
-        filterable={"type": boolean},
     )
     archived = field(
         db.DateTimeField(),
-        filterable={"type": boolean},
     )
 
     def __str__(self):

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -104,7 +104,7 @@ class Reuse(db.Datetimed, WithMetrics, BadgeMixin, Owned, db.Document):
     )
     # badges = db.ListField(db.EmbeddedDocumentField(ReuseBadge))
 
-    private = field(db.BooleanField(default=False))
+    private = field(db.BooleanField(default=False), filterable={})
 
     ext = db.MapField(db.GenericEmbeddedDocumentField())
     extras = field(db.ExtrasField())

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -21,10 +21,10 @@ __all__ = ("Reuse",)
 
 class ReuseQuerySet(OwnedQuerySet):
     def visible(self):
-        return self(private__ne=True, deleted=None)
+        return self(private__ne=True, datasets__0__exists=True, deleted=None)
 
     def hidden(self):
-        return self(db.Q(private=True) | db.Q(deleted__ne=None))
+        return self(db.Q(private=True) | db.Q(datasets__0__exists=False) | db.Q(deleted__ne=None))
 
 
 def check_url_does_not_exists(url):

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -27,11 +27,9 @@ class ReuseQuerySet(OwnedQuerySet):
 
     def visible_by_user(self, user: User) -> OwnedQuerySet:
         """Return EVERYTHING visible to the user."""
-        public_qs: OwnedQuerySet = db.Q(private__ne=True, deleted=None)
+        public_qs: OwnedQuerySet = db.Q(private__ne=True, deleted=None, archived=None)
         if user.is_anonymous:
             return self(public_qs)
-
-        public_qs = db.Q(private__ne=True, deleted=None)
 
         owners: list[User | Organization] = []
         owned_qs: OwnedQuerySet = db.Q()

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -161,7 +161,6 @@ class ReuseAPITest:
     def test_reuse_api_list_filter_private_only_owned_by_user(self, api) -> None:
         """Should only return private reuses that are owned."""
         user = UserFactory()
-        breakpoint()
         member = Member(user=user, role="editor")
         org = OrganizationFactory(members=[member])
         private_owned: Reuse = ReuseFactory(private=True, owner=user)

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -43,10 +43,10 @@ class ReuseAPITest:
         assert len(response.json["data"]) == len(reuses)
 
     def test_reuse_api_list_with_sorts(self, api):
-        ReuseFactory(title="A", created_at="2024-03-01", visible=True)
-        ReuseFactory(title="B", metrics={"views": 42}, created_at="2024-02-01", visible=True)
-        ReuseFactory(title="C", metrics={"views": 1337}, created_at="2024-05-01", visible=True)
-        ReuseFactory(title="D", created_at="2024-04-01", visible=True)
+        ReuseFactory(title="A", created_at="2024-03-01")
+        ReuseFactory(title="B", metrics={"views": 42}, created_at="2024-02-01")
+        ReuseFactory(title="C", metrics={"views": 1337}, created_at="2024-05-01")
+        ReuseFactory(title="D", created_at="2024-04-01")
 
         response = api.get(url_for("api.reuses", sort="views"))
         assert200(response)
@@ -70,12 +70,12 @@ class ReuseAPITest:
 
         [ReuseFactory(topic="health", type="api") for i in range(2)]
 
-        tag_reuse = ReuseFactory(tags=["my-tag", "other"], topic="health", type="api", visible=True)
-        owner_reuse = ReuseFactory(owner=owner, topic="health", type="api", visible=True)
-        org_reuse = ReuseFactory(organization=org, topic="health", type="api", visible=True)
-        featured_reuse = ReuseFactory(featured=True, topic="health", type="api", visible=True)
-        topic_reuse = ReuseFactory(topic="transport_and_mobility", type="api", visible=True)
-        type_reuse = ReuseFactory(topic="health", type="application", visible=True)
+        tag_reuse = ReuseFactory(tags=["my-tag", "other"], topic="health", type="api")
+        owner_reuse = ReuseFactory(owner=owner, topic="health", type="api")
+        org_reuse = ReuseFactory(organization=org, topic="health", type="api")
+        featured_reuse = ReuseFactory(featured=True, topic="health", type="api")
+        topic_reuse = ReuseFactory(topic="transport_and_mobility", type="api")
+        type_reuse = ReuseFactory(topic="health", type="application")
 
         # filter on tag
         response = api.get(url_for("api.reuses", tag="my-tag"))
@@ -128,8 +128,8 @@ class ReuseAPITest:
     def test_reuse_api_list_filter_private(self, api) -> None:
         """Should filters reuses results based on the `private` filter"""
         user = api.login()
-        public_reuse: Reuse = ReuseFactory(visible=True)
-        private_reuse: Reuse = ReuseFactory(private=True, owner=user, visible=True)
+        public_reuse: Reuse = ReuseFactory()
+        private_reuse: Reuse = ReuseFactory(private=True, owner=user)
 
         # all the reuses (by default)
         response: TestResponse = api.get(url_for("api.reuses"))
@@ -155,11 +155,9 @@ class ReuseAPITest:
         user = api.login()
         member = Member(user=user, role="editor")
         org = OrganizationFactory(members=[member])
-        private_owned: Reuse = ReuseFactory(private=True, owner=user, visible=True)
-        private_owned_through_org: Reuse = ReuseFactory(
-            private=True, organization=org, visible=True
-        )
-        private_not_owned: Reuse = ReuseFactory(private=True, visible=True)
+        private_owned: Reuse = ReuseFactory(private=True, owner=user)
+        private_owned_through_org: Reuse = ReuseFactory(private=True, organization=org)
+        private_not_owned: Reuse = ReuseFactory(private=True)
 
         response: TestResponse = api.get(url_for("api.reuses"))
         assert200(response)
@@ -186,13 +184,11 @@ class ReuseAPITest:
         user = UserFactory()
         member = Member(user=user, role="editor")
         org = OrganizationFactory(members=[member])
-        public_owned: Reuse = ReuseFactory(owner=user, visible=True)
-        public_not_owned: Reuse = ReuseFactory(visible=True)
-        _private_owned: Reuse = ReuseFactory(private=True, owner=user, visible=True)
-        _private_owned_through_org: Reuse = ReuseFactory(
-            private=True, organization=org, visible=True
-        )
-        _private_not_owned: Reuse = ReuseFactory(private=True, visible=True)
+        public_owned: Reuse = ReuseFactory(owner=user)
+        public_not_owned: Reuse = ReuseFactory()
+        _private_owned: Reuse = ReuseFactory(private=True, owner=user)
+        _private_owned_through_org: Reuse = ReuseFactory(private=True, organization=org)
+        _private_not_owned: Reuse = ReuseFactory(private=True)
 
         response: TestResponse = api.get(url_for("api.reuses"))
         assert200(response)

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -43,10 +43,10 @@ class ReuseAPITest:
         assert len(response.json["data"]) == len(reuses)
 
     def test_reuse_api_list_with_sorts(self, api):
-        ReuseFactory(title="A", created_at="2024-03-01")
-        ReuseFactory(title="B", metrics={"views": 42}, created_at="2024-02-01")
-        ReuseFactory(title="C", metrics={"views": 1337}, created_at="2024-05-01")
-        ReuseFactory(title="D", created_at="2024-04-01")
+        ReuseFactory(title="A", created_at="2024-03-01", visible=True)
+        ReuseFactory(title="B", metrics={"views": 42}, created_at="2024-02-01", visible=True)
+        ReuseFactory(title="C", metrics={"views": 1337}, created_at="2024-05-01", visible=True)
+        ReuseFactory(title="D", created_at="2024-04-01", visible=True)
 
         response = api.get(url_for("api.reuses", sort="views"))
         assert200(response)
@@ -70,12 +70,12 @@ class ReuseAPITest:
 
         [ReuseFactory(topic="health", type="api") for i in range(2)]
 
-        tag_reuse = ReuseFactory(tags=["my-tag", "other"], topic="health", type="api")
-        owner_reuse = ReuseFactory(owner=owner, topic="health", type="api")
-        org_reuse = ReuseFactory(organization=org, topic="health", type="api")
-        featured_reuse = ReuseFactory(featured=True, topic="health", type="api")
-        topic_reuse = ReuseFactory(topic="transport_and_mobility", type="api")
-        type_reuse = ReuseFactory(topic="health", type="application")
+        tag_reuse = ReuseFactory(tags=["my-tag", "other"], topic="health", type="api", visible=True)
+        owner_reuse = ReuseFactory(owner=owner, topic="health", type="api", visible=True)
+        org_reuse = ReuseFactory(organization=org, topic="health", type="api", visible=True)
+        featured_reuse = ReuseFactory(featured=True, topic="health", type="api", visible=True)
+        topic_reuse = ReuseFactory(topic="transport_and_mobility", type="api", visible=True)
+        type_reuse = ReuseFactory(topic="health", type="application", visible=True)
 
         # filter on tag
         response = api.get(url_for("api.reuses", tag="my-tag"))
@@ -128,8 +128,8 @@ class ReuseAPITest:
     def test_reuse_api_list_filter_private(self, api) -> None:
         """Should filters reuses results based on the `private` filter"""
         user = api.login()
-        public_reuse: Reuse = ReuseFactory()
-        private_reuse: Reuse = ReuseFactory(private=True, owner=user)
+        public_reuse: Reuse = ReuseFactory(visible=True)
+        private_reuse: Reuse = ReuseFactory(private=True, owner=user, visible=True)
 
         # all the reuses (by default)
         response: TestResponse = api.get(url_for("api.reuses"))
@@ -155,9 +155,11 @@ class ReuseAPITest:
         user = api.login()
         member = Member(user=user, role="editor")
         org = OrganizationFactory(members=[member])
-        private_owned: Reuse = ReuseFactory(private=True, owner=user)
-        private_owned_through_org: Reuse = ReuseFactory(private=True, organization=org)
-        private_not_owned: Reuse = ReuseFactory(private=True)
+        private_owned: Reuse = ReuseFactory(private=True, owner=user, visible=True)
+        private_owned_through_org: Reuse = ReuseFactory(
+            private=True, organization=org, visible=True
+        )
+        private_not_owned: Reuse = ReuseFactory(private=True, visible=True)
 
         response: TestResponse = api.get(url_for("api.reuses"))
         assert200(response)
@@ -184,11 +186,13 @@ class ReuseAPITest:
         user = UserFactory()
         member = Member(user=user, role="editor")
         org = OrganizationFactory(members=[member])
-        public_owned: Reuse = ReuseFactory(owner=user)
-        public_not_owned: Reuse = ReuseFactory()
-        _private_owned: Reuse = ReuseFactory(private=True, owner=user)
-        _private_owned_through_org: Reuse = ReuseFactory(private=True, organization=org)
-        _private_not_owned: Reuse = ReuseFactory(private=True)
+        public_owned: Reuse = ReuseFactory(owner=user, visible=True)
+        public_not_owned: Reuse = ReuseFactory(visible=True)
+        _private_owned: Reuse = ReuseFactory(private=True, owner=user, visible=True)
+        _private_owned_through_org: Reuse = ReuseFactory(
+            private=True, organization=org, visible=True
+        )
+        _private_not_owned: Reuse = ReuseFactory(private=True, visible=True)
 
         response: TestResponse = api.get(url_for("api.reuses"))
         assert200(response)

--- a/udata/tests/organization/test_organization_model.py
+++ b/udata/tests/organization/test_organization_model.py
@@ -34,7 +34,7 @@ class OrganizationModelTest(TestCase, DBTestMixin):
             )
 
         assert org.get_metrics()["datasets"] == 1
-        assert org.get_metrics()["reuses"] == 1
+        assert org.get_metrics()["reuses"] == 2
         assert org.get_metrics()["followers"] == 1
 
         with assert_emit(Reuse.on_delete):

--- a/udata/tests/organization/test_organization_model.py
+++ b/udata/tests/organization/test_organization_model.py
@@ -34,7 +34,7 @@ class OrganizationModelTest(TestCase, DBTestMixin):
             )
 
         assert org.get_metrics()["datasets"] == 1
-        assert org.get_metrics()["reuses"] == 2
+        assert org.get_metrics()["reuses"] == 1
         assert org.get_metrics()["followers"] == 1
 
         with assert_emit(Reuse.on_delete):

--- a/udata/tests/test_owned.py
+++ b/udata/tests/test_owned.py
@@ -214,28 +214,42 @@ class OwnedQuerysetTest(DBTestMixin, TestCase):
             private_owned_by_org,
         ]
 
-        result: owned.OwnedQuerySet = Owned.objects.visible_by_user(user)
+        result: owned.OwnedQuerySet = Owned.objects.visible_by_user(
+            user, Owned.objects.visible()._query_obj
+        )
         # 4 public + 1 private owned by user + 1 private owned by the user's org.
         self.assertEqual(len(result), 6)
         for owned_ in visible_by_user:
             self.assertIn(owned_, result)
 
         # `.visible_by_user` does not reset other queries.
-        result = Owned.objects(name="owned_by_user").visible_by_user(user)
+        result = Owned.objects(name="owned_by_user").visible_by_user(
+            user, Owned.objects.visible()._query_obj
+        )
         self.assertEqual(len(result), 1)
         self.assertIn(owned_by_user, result)
-        result = Owned.objects.visible_by_user(user).filter(name="owned_by_user")
+        result = Owned.objects.visible_by_user(user, Owned.objects.visible()._query_obj).filter(
+            name="owned_by_user"
+        )
         self.assertEqual(len(result), 1)
         self.assertIn(owned_by_user, result)
 
-        result = Owned.objects(name="private_owned_by_user").visible_by_user(user)
+        result = Owned.objects(name="private_owned_by_user").visible_by_user(
+            user, Owned.objects.visible()._query_obj
+        )
         self.assertEqual(len(result), 1)
         self.assertIn(private_owned_by_user, result)
-        result = Owned.objects.visible_by_user(user).filter(name="private_owned_by_user")
+        result = Owned.objects.visible_by_user(user, Owned.objects.visible()._query_obj).filter(
+            name="private_owned_by_user"
+        )
         self.assertEqual(len(result), 1)
         self.assertIn(private_owned_by_user, result)
 
-        result = Owned.objects(name="private_owned_by_other_user").visible_by_user(user)
+        result = Owned.objects(name="private_owned_by_other_user").visible_by_user(
+            user, Owned.objects.visible()._query_obj
+        )
         self.assertEqual(len(result), 0)
-        result = Owned.objects.visible_by_user(user).filter(name="private_owned_by_other_user")
+        result = Owned.objects.visible_by_user(user, Owned.objects.visible()._query_obj).filter(
+            name="private_owned_by_other_user"
+        )
         self.assertEqual(len(result), 0)

--- a/udata/tests/test_owned.py
+++ b/udata/tests/test_owned.py
@@ -1,16 +1,18 @@
-from mongoengine import post_save
+from mongoengine import Q, post_save
 
 import udata.core.owned as owned
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Organization
 from udata.core.user.factories import UserFactory
 from udata.core.user.models import User
+from udata.models import Member
 from udata.mongo import db
 from udata.tests import DBTestMixin, TestCase
 
 
 class Owned(owned.Owned, db.Document):
     name = db.StringField()
+    private = db.BooleanField()
 
 
 class OwnedPostSave(owned.Owned, db.Document):
@@ -166,3 +168,75 @@ class OwnedQuerysetTest(DBTestMixin, TestCase):
 
         for owned_ in excluded:
             self.assertNotIn(owned_, result)
+
+    def test_visible_by_user(self) -> None:
+        user: User = UserFactory()
+        member = Member(user=user, role="editor")
+        other_user: User = UserFactory()
+        org: Organization = OrganizationFactory(members=[member])
+        other_org: Organization = OrganizationFactory()
+        owned_by_user: Owned = Owned.objects.create(owner=user, name="owned_by_user")
+        owned_by_org: Owned = Owned.objects.create(organization=org, name="owned_by_org")
+        owned_by_other_user: Owned = Owned.objects.create(
+            owner=other_user, name="owned_by_other_user"
+        )
+        owned_by_other_org: Owned = Owned.objects.create(
+            organization=other_org, name="owned_by_other_org"
+        )
+        private_owned_by_user: Owned = Owned.objects.create(
+            owner=user, private=True, name="private_owned_by_user"
+        )
+        private_owned_by_org: Owned = Owned.objects.create(
+            organization=org, private=True, name="private_owned_by_org"
+        )
+        _private_owned_by_other_user: Owned = Owned.objects.create(
+            owner=other_user, private=True, name="private_owned_by_other_user"
+        )
+        _private_owned_by_other_org: Owned = Owned.objects.create(
+            organization=other_org, private=True, name="private_owned_by_other_org"
+        )
+
+        visible_by_user: list[Owned] = [
+            owned_by_user,
+            owned_by_org,
+            owned_by_other_user,
+            owned_by_other_org,
+            private_owned_by_user,
+            private_owned_by_org,
+        ]
+
+        result: owned.OwnedQuerySet = Owned.objects.visible_by_user(user, Q(private__ne=True))
+        # 4 public + 1 private owned by user + 1 private owned by the user's org.
+        self.assertEqual(len(result), 6)
+        for owned_ in visible_by_user:
+            self.assertIn(owned_, result)
+
+        # `.visible_by_user` does not reset other queries.
+        result = Owned.objects(name="owned_by_user").visible_by_user(user, Q(private__ne=True))
+        self.assertEqual(len(result), 1)
+        self.assertIn(owned_by_user, result)
+        result = Owned.objects.visible_by_user(user, Q(private__ne=True)).filter(
+            name="owned_by_user"
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn(owned_by_user, result)
+
+        result = Owned.objects(name="private_owned_by_user").visible_by_user(
+            user, Q(private__ne=True)
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn(private_owned_by_user, result)
+        result = Owned.objects.visible_by_user(user, Q(private__ne=True)).filter(
+            name="private_owned_by_user"
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn(private_owned_by_user, result)
+
+        result = Owned.objects(name="private_owned_by_other_user").visible_by_user(
+            user, Q(private__ne=True)
+        )
+        self.assertEqual(len(result), 0)
+        result = Owned.objects.visible_by_user(user, Q(private__ne=True)).filter(
+            name="private_owned_by_other_user"
+        )
+        self.assertEqual(len(result), 0)


### PR DESCRIPTION
This is a new take on [#1397](https://github.com/datagouv/data.gouv.fr/issues/1397)

In this PR, we'll have the following behavior:
1. always return each and every reuse available to the logged in user (if any), including private, deleted and archived ones
2. if the filter is false, eg `private=False`, only return the reuses that don't have this filter (no private reuses)
3. if the filter is true, eg `private=True`, only return the reuses that have this filter (only private reuses)