### PR TITLE
Add cors on resource redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a minimal publiccode.yml [#3144](https://github.com/opendatateam/udata/pull/3144)
 - Fix the boolean filters in the API for the "new system" endpoints [#3139](https://github.com/opendatateam/udata/pull/3139)
 - Update authlib dependency from 0.14.3 to 1.3.1 [#3135](https://github.com/opendatateam/udata/pull/3135)
+- Add CORS on resource redirect [#3145](https://github.com/opendatateam/udata/pull/3145)
 
 ## 9.1.4 (2024-08-26)
 

--- a/udata/cors.py
+++ b/udata/cors.py
@@ -33,9 +33,9 @@ def is_preflight_request() -> bool:
 
 def is_allowed_cors_route():
     if g and hasattr(g, "lang_code"):
-        path = request.path.replace(f"/{g.lang_code}", "")
+        path: str = request.path.removeprefix(f"/{g.lang_code}")
     else:
-        path = request.path
+        path: str = request.path
     return (
         path.endswith((".js", ".css", ".woff", ".woff2", ".png", ".jpg", ".jpeg", ".svg"))
         or path.startswith("/api")

--- a/udata/cors.py
+++ b/udata/cors.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import request
+from flask import g, request
 from werkzeug.datastructures import Headers
 
 log = logging.getLogger(__name__)
@@ -32,10 +32,15 @@ def is_preflight_request() -> bool:
 
 
 def is_allowed_cors_route():
+    if g and hasattr(g, "lang_code"):
+        path = request.path.replace(f"/{g.lang_code}", "")
+    else:
+        path = request.path
     return (
-        request.path.endswith((".js", ".css", ".woff", ".woff2", ".png", ".jpg", ".jpeg", ".svg"))
-        or request.path.startswith("/api")
-        or request.path.startswith("/oauth")
+        path.endswith((".js", ".css", ".woff", ".woff2", ".png", ".jpg", ".jpeg", ".svg"))
+        or path.startswith("/api")
+        or path.startswith("/oauth")
+        or path.startswith("/datasets/r/")
     )
 
 


### PR DESCRIPTION
Fix CORS missing on stable resource permalink, ex : `https://www.data.gouv.fr/fr/datasets/r/503c39b0-58d8-45fe-ace0-55795bb0a6b7`.

Indeed, the resource permalink may be used directly in Observable for example for a parquet file.

TODO:
- [X] find a better way to trim lang code
    - could not find a perfect solution but used the optionnal lang code with `g.lang_code` and trim it with `removeprefix`
- [X] check CORS on static resources
    - correctly served by nginx