### PR TITLE
Use compose subcommand & update container name

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ You will need to install [docker][] and [docker-compose][] before getting starte
 ```bash
 git clone https://github.com/opendatateam/docker-udata
 cd docker-udata
-docker-compose up
+docker compose up
 ```
 
 The platform is available at [http://localhost:7000](http://localhost:7000).
@@ -14,7 +14,7 @@ The platform is available at [http://localhost:7000](http://localhost:7000).
 You can initialise the database with fixtures and initialize the search index with
 the `init` command. Using the udata docker container:
 ```bash
-docker exec -it docker-udata_udata_1 udata init
+docker exec -it docker-udata-udata-1 udata init
 ```
 
 You can take a look at the readme [there][docker images] for more instruction


### PR DESCRIPTION
Closes https://github.com/opendatateam/udata/issues/3150.

Containers naming depends on compose version (and whether using the docker-compose tool or compose subcommand).
Let's use the compose command and update the container name.