### PR TITLE
Add migration to delete duplicate resources due to ODS harvesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add migration to delete duplicate resources due to ODS harvesting [#3158](https://github.com/opendatateam/udata/pull/3158)
 
 ## 9.2.2 (2024-10-08)
 

--- a/udata/migrations/2024-10-01-remove-ods-duplicates.py
+++ b/udata/migrations/2024-10-01-remove-ods-duplicates.py
@@ -1,0 +1,89 @@
+"""
+Remove duplicate OpenDataSoft resources
+The duplicate are due to ODS modifying the URL of their CSV and XLSX exports,
+the URL being the identifier of the resources in DCAT harvesting.
+The default /export/csv had been existing since harvesting ODS with DCAT.
+2024-08-07 : `use_labels=false` appended at the end of the URL -> first duplicates
+2024-08-09 : replaced by `use_labels=true` -> second set of duplicates
+"""
+
+import logging
+import traceback
+
+from mongoengine.errors import ValidationError
+
+from udata.models import Dataset
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    count = 0
+    errors = 0
+
+    # Datasets with use_labels=false are the one that were most surely impacted by the URL modifications
+    datasets = Dataset.objects(resources__url__contains="use_labels=false")
+
+    log.info("Starting")
+    log.info(f"{datasets.count()} datasets to process...")
+    for dat in datasets:
+        for res_format in ["csv", "xlsx"]:
+            resources = [res for res in dat.resources if f"/exports/{res_format}" in res.url]
+            if not resources:
+                # This dataset doesn't have csv or xlsx resources
+                continue
+            if len(resources) not in [3, 4]:
+                log.info(
+                    f"Skipping, {len(resources)} {res_format} duplicate resources found for {dat.id}. We're expecting 3 or 4"
+                )
+                continue
+            try:
+                res_original = next(
+                    res
+                    for res in resources
+                    if res.url.endswith(f"/exports/{res_format}")
+                    and res.title.endswith(f".{res_format}")
+                )
+                res_label_false = next(
+                    res for res in resources if res.url.endswith("?use_labels=false")
+                )
+                res_label_true = next(
+                    res for res in resources if res.url.endswith("?use_labels=true")
+                )
+
+                # Resource that exists prior to ODS to DCAT migration, cf https://github.com/opendatateam/udata-ods/pull/247
+                # and somehow did not get migrated properly
+                res_old_school = next(
+                    (
+                        res
+                        for res in resources
+                        if res.title == f"Export au format {res_format.upper()}"
+                    ),
+                    None,
+                )
+
+            except StopIteration:
+                log.info(
+                    f"Could not find expected params on {res_format} for {dat.id} : {set(res.url.split('/')[-1] for res in resources)}"
+                )
+                errors += 1
+                continue
+
+            # We want to keep the original resource and update its URL
+            # and remove all the other duplicates
+            res_original.url += "?use_labels=true"
+            dat.remove_resource(res_label_false)
+            dat.remove_resource(res_label_true)
+            if res_old_school:
+                dat.remove_resource(res_old_school)
+
+        try:
+            dat.save()
+            count += 1
+        except ValidationError:
+            log.info(f"Could not save dataset {dat.id}")
+            log.info(traceback.format_exc())
+            errors += 1
+
+    log.info("Done !")
+    log.info(f"Updated {count} datasets. Failed on {errors} objects.")

--- a/udata/migrations/2024-10-01-remove-ods-duplicates.py
+++ b/udata/migrations/2024-10-01-remove-ods-duplicates.py
@@ -21,14 +21,19 @@ def migrate(db):
     count = 0
     errors = 0
 
+    original = "/exports/{0}"
+    first_duplication = "?use_labels=false"
+    second_duplication = "?use_labels=true"
+
     # Datasets with use_labels=false are the one that were most surely impacted by the URL modifications
-    datasets = Dataset.objects(resources__url__contains="use_labels=false")
+    datasets = Dataset.objects(resources__url__contains=first_duplication)
 
     log.info("Starting")
     log.info(f"{datasets.count()} datasets to process...")
     for dat in datasets:
+        to_save = False
         for res_format in ["csv", "xlsx"]:
-            resources = [res for res in dat.resources if f"/exports/{res_format}" in res.url]
+            resources = [res for res in dat.resources if original.format(res_format) in res.url]
             if not resources:
                 # This dataset doesn't have csv or xlsx resources
                 continue
@@ -41,19 +46,19 @@ def migrate(db):
                 res_original = next(
                     res
                     for res in resources
-                    if res.url.endswith(f"/exports/{res_format}")
+                    if res.url.endswith(original.format(res_format))
                     and res.title.endswith(f".{res_format}")
                 )
-                res_label_false = next(
-                    res for res in resources if res.url.endswith("?use_labels=false")
+                res_first_duplication = next(
+                    res for res in resources if res.url.endswith(first_duplication)
                 )
-                res_label_true = next(
-                    res for res in resources if res.url.endswith("?use_labels=true")
+                res_second_duplication = next(
+                    res for res in resources if res.url.endswith(second_duplication)
                 )
 
-                # Resource that exists prior to ODS to DCAT migration, cf https://github.com/opendatateam/udata-ods/pull/247
-                # and somehow did not get migrated properly
-                res_old_school = next(
+                # Resource that exists prior to ODS to DCAT migration and somehow did not get migrated properly
+                # cf https://github.com/opendatateam/udata-ods/pull/247
+                res_migration_duplicate = next(
                     (
                         res
                         for res in resources
@@ -69,21 +74,24 @@ def migrate(db):
                 errors += 1
                 continue
 
-            # We want to keep the original resource and update its URL
-            # and remove all the other duplicates
-            res_original.url += "?use_labels=true"
-            dat.remove_resource(res_label_false)
-            dat.remove_resource(res_label_true)
-            if res_old_school:
-                dat.remove_resource(res_old_school)
+            # Keep the original resource and update its URL
+            res_original.url += second_duplication
+            # Remove all the other duplicates
+            dat.remove_resource(res_first_duplication)
+            dat.remove_resource(res_second_duplication)
+            if res_migration_duplicate:
+                dat.remove_resource(res_migration_duplicate)
 
-        try:
-            dat.save()
-            count += 1
-        except ValidationError:
-            log.info(f"Could not save dataset {dat.id}")
-            log.info(traceback.format_exc())
-            errors += 1
+            to_save = True
+
+        if to_save:
+            try:
+                dat.save()
+                count += 1
+            except ValidationError:
+                log.info(f"Could not save dataset {dat.id}")
+                log.info(traceback.format_exc())
+                errors += 1
 
     log.info("Done !")
     log.info(f"Updated {count} datasets. Failed on {errors} objects.")


### PR DESCRIPTION
Fix https://github.com/datagouv/data.gouv.fr/issues/1511

Remove duplicate OpenDataSoft resources.
The duplicate are due to ODS modifying the URL of their CSV and XLSX exports.
The URL being **the identifier** of the resources in our DCAT harvesting.
Timeline of duplicates:
* The default `/export/csv` had been existing since harvesting ODS with DCAT.
* 2024-08-07 : `use_labels=false` appended at the end of the URL -> first duplicates
* 2024-08-09 : replaced by `use_labels=true` -> second set of duplicates

Running the migration on a prod dump takes 6min and updates around 9,4K datasets, removing at least 2 duplicates resources per dataset.
We have around 10 datasets that have been skipped due to an unexpected number/pattern of resources.
:arrow_right: I think we should probably clean these erroneous datasets manually.

I would recommend running this migration in our preprod env and make sure that daily harvesting doesn't create new duplicates due to wrong URL modification. 