### PR TITLE
Add resources formats and harvest remote_url on dataset catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a filter on organization and document sort parameters in the `/discussions` endpoint [#3147](https://github.com/opendatateam/udata/pull/3147)
 - Move discussion catalog creation and add fields [#3152](https://github.com/opendatateam/udata/pull/3152) and [#3154](https://github.com/opendatateam/udata/pull/3154)
+- Add resources formats and harvest remote_url on dataset catalog [#3159](https://github.com/opendatateam/udata/pull/3159)
 
 ## 9.2.1 (2024-09-23)
 

--- a/udata/core/dataset/csv.py
+++ b/udata/core/dataset/csv.py
@@ -37,11 +37,13 @@ class DatasetCsvAdapter(csv.Adapter):
         ("archived", lambda o: o.archived or False),
         ("resources_count", lambda o: len(o.resources)),
         ("main_resources_count", lambda o: len([r for r in o.resources if r.type == "main"])),
+        ("format", lambda o: ",".join(set(r.format for r in o.resources))),
         "downloads",
         ("harvest.backend", lambda r: r.harvest and r.harvest.backend),
         ("harvest.domain", lambda r: r.harvest and r.harvest.domain),
         ("harvest.created_at", lambda r: r.harvest and r.harvest.created_at),
         ("harvest.modified_at", lambda r: r.harvest and r.harvest.modified_at),
+        ("harvest.remote_url", lambda r: r.harvest and r.harvest.remote_url),
         ("quality_score", lambda o: format(o.quality["score"], ".2f")),
         # schema? what is the schema of a dataset?
     )

--- a/udata/core/dataset/csv.py
+++ b/udata/core/dataset/csv.py
@@ -37,7 +37,7 @@ class DatasetCsvAdapter(csv.Adapter):
         ("archived", lambda o: o.archived or False),
         ("resources_count", lambda o: len(o.resources)),
         ("main_resources_count", lambda o: len([r for r in o.resources if r.type == "main"])),
-        ("format", lambda o: ",".join(set(r.format for r in o.resources))),
+        ("resources_formats", lambda o: ",".join(set(r.format for r in o.resources))),
         "downloads",
         ("harvest.backend", lambda r: r.harvest and r.harvest.backend),
         ("harvest.domain", lambda r: r.harvest and r.harvest.domain),


### PR DESCRIPTION
* format as a comma-separated set of resources formats
* harvest remote_url if exists

This format information is useful at the dataset level to prevent having to join with the resources catalog.