### PR TITLE
Filter by org badge complex

### DIFF
--- a/udata/core/badges/models.py
+++ b/udata/core/badges/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from mongoengine.signals import post_save
 
-from udata.api_fields import field
+from udata.api_fields import field, generate_fields
 from udata.auth import current_user
 from udata.core.badges.fields import badge_fields
 from udata.mongo import db
@@ -12,27 +12,23 @@ from .signals import on_badge_added, on_badge_removed
 
 log = logging.getLogger(__name__)
 
-__all__ = ("Badge", "BadgeMixin")
 
+def new_badge_type(choices):
+    @generate_fields(default_filterable_field="kind")
+    class Badge(db.EmbeddedDocument):
+        kind = db.StringField(required=True, choices=choices)
+        created = db.DateTimeField(default=datetime.utcnow, required=True)
+        created_by = db.ReferenceField("User")
 
-class Badge(db.EmbeddedDocument):
-    kind = db.StringField(required=True)
-    created = db.DateTimeField(default=datetime.utcnow, required=True)
-    created_by = db.ReferenceField("User")
+        def __str__(self):
+            return self.kind
 
-    def __str__(self):
-        return self.kind
-
-    def validate(self, clean=True):
-        badges = getattr(self._instance, "__badges__", {})
-        if self.kind not in badges.keys():
-            raise db.ValidationError("Unknown badge type %s" % self.kind)
-        return super(Badge, self).validate(clean=clean)
+    return Badge
 
 
 class BadgesList(db.EmbeddedDocumentListField):
-    def __init__(self, *args, **kwargs):
-        return super(BadgesList, self).__init__(Badge, *args, **kwargs)
+    def __init__(self, badge_type, *args, **kwargs):
+        return super(BadgesList, self).__init__(badge_type, *args, **kwargs)
 
     def validate(self, value):
         kinds = [b.kind for b in value]
@@ -41,52 +37,66 @@ class BadgesList(db.EmbeddedDocumentListField):
         return super(BadgesList, self).validate(value)
 
 
-class BadgeMixin(object):
-    badges = field(
-        BadgesList(),
-        readonly=True,
-        inner_field_info={"nested_fields": badge_fields},
-    )
+def badge_mixin(choices):
+    badge_type = new_badge_type(choices)
 
-    def get_badge(self, kind):
-        """Get a badge given its kind if present"""
-        candidates = [b for b in self.badges if b.kind == kind]
-        return candidates[0] if candidates else None
+    class BadgeMixin(object):
+        badges = field(
+            BadgesList(badge_type),
+            readonly=True,
+            inner_field_info={"nested_fields": badge_fields},
+        )
 
-    def add_badge(self, kind):
-        """Perform an atomic prepend for a new badge"""
-        badge = self.get_badge(kind)
-        if badge:
-            return badge
-        if kind not in getattr(self, "__badges__", {}):
-            msg = "Unknown badge type for {model}: {kind}"
-            raise db.ValidationError(msg.format(model=self.__class__.__name__, kind=kind))
-        badge = Badge(kind=kind)
-        if current_user.is_authenticated:
-            badge.created_by = current_user.id
+        def get_badge(self, kind):
+            """Get a badge given its kind if present"""
+            candidates = [b for b in self.badges if b.kind == kind]
+            return candidates[0] if candidates else None
 
-        self.update(__raw__={"$push": {"badges": {"$each": [badge.to_mongo()], "$position": 0}}})
-        self.reload()
-        post_save.send(self.__class__, document=self)
-        on_badge_added.send(self, kind=kind)
-        return self.get_badge(kind)
+        def add_badge(self, kind):
+            """Perform an atomic prepend for a new badge"""
+            badge = self.get_badge(kind)
+            if badge:
+                return badge
+            if kind not in getattr(self, "__badges__", {}):
+                msg = "Unknown badge type for {model}: {kind}"
+                raise db.ValidationError(msg.format(model=self.__class__.__name__, kind=kind))
+            badge = self.badge_type(kind=kind)
+            if current_user.is_authenticated:
+                badge.created_by = current_user.id
 
-    def remove_badge(self, kind):
-        """Perform an atomic removal for a given badge"""
-        self.update(__raw__={"$pull": {"badges": {"kind": kind}}})
-        self.reload()
-        on_badge_removed.send(self, kind=kind)
-        post_save.send(self.__class__, document=self)
+            self.update(
+                __raw__={"$push": {"badges": {"$each": [badge.to_mongo()], "$position": 0}}}
+            )
+            self.reload()
+            post_save.send(self.__class__, document=self)
+            on_badge_added.send(self, kind=kind)
+            return self.get_badge(kind)
 
-    def toggle_badge(self, kind):
-        """Toggle a bdage given its kind"""
-        badge = self.get_badge(kind)
-        if badge:
-            return self.remove_badge(kind)
-        else:
-            return self.add_badge(kind)
+        def remove_badge(self, kind):
+            """Perform an atomic removal for a given badge"""
+            self.update(__raw__={"$pull": {"badges": {"kind": kind}}})
+            self.reload()
+            on_badge_removed.send(self, kind=kind)
+            post_save.send(self.__class__, document=self)
 
-    def badge_label(self, badge):
-        """Display the badge label for a given kind"""
-        kind = badge.kind if isinstance(badge, Badge) else badge
-        return self.__badges__[kind]
+        def toggle_badge(self, kind):
+            """Toggle a bdage given its kind"""
+            badge = self.get_badge(kind)
+            if badge:
+                return self.remove_badge(kind)
+            else:
+                return self.add_badge(kind)
+
+        def badge_label(self, badge):
+            """Display the badge label for a given kind"""
+            kind = badge.kind if isinstance(badge, self.badge_type) else badge
+            return self.__badges__[kind]
+
+    setattr(BadgeMixin, "badge_type", badge_type)
+
+    return BadgeMixin
+
+
+# For backward compatibility create a badge type without any choices
+Badge = new_badge_type(None)
+BadgeMixin = badge_mixin(None)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -7,7 +7,6 @@ import udata.core.dataset.api_fields as datasets_api_fields
 from udata.api_fields import field, function_field, generate_fields
 from udata.core.dataset.models import Dataset
 from udata.core.metrics.models import WithMetrics
-from udata.core.organization.models import Organization
 from udata.core.owned import Owned, OwnedQuerySet
 from udata.i18n import lazy_gettext as _
 from udata.models import Discussion, Follow, db
@@ -97,14 +96,8 @@ class HarvestMetadata(db.EmbeddedDocument):
 
 @generate_fields(
     searchable=True,
-    related_filters=[
-        {
-            "key": "organization_badge",
-            "lookup": "organization__in",
-            "object": Organization,
-            "queryset": "with_badge",
-            "choices": list(Organization.__badges__),
-        },
+    additional_filters=[
+        "organization.badges",
     ],
 )
 class Dataservice(WithMetrics, Owned, db.Document):

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -5,7 +5,7 @@ from blinker import Signal
 from mongoengine.signals import post_save, pre_save
 from werkzeug.utils import cached_property
 
-from udata.core.badges.models import BadgeMixin
+from udata.core.badges.models import badge_mixin
 from udata.core.metrics.models import WithMetrics
 from udata.core.storages import avatars, default_image_basename
 from udata.frontend.markdown import mdstrip
@@ -86,7 +86,20 @@ class OrganizationQuerySet(db.BaseQuerySet):
         return self(badges__kind=kind)
 
 
-class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
+class Organization(
+    WithMetrics,
+    badge_mixin(
+        [
+            PUBLIC_SERVICE,
+            CERTIFIED,
+            ASSOCIATION,
+            COMPANY,
+            LOCAL_AUTHORITY,
+        ]
+    ),
+    db.Datetimed,
+    db.Document,
+):
     name = db.StringField(required=True)
     acronym = db.StringField(max_length=128)
     slug = db.SlugField(

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -4,7 +4,6 @@ from werkzeug.utils import cached_property
 
 from udata.api_fields import field, function_field, generate_fields
 from udata.core.dataset.api_fields import dataset_fields
-from udata.core.organization.models import Organization
 from udata.core.owned import Owned, OwnedQuerySet
 from udata.core.reuse.api_fields import BIGGEST_IMAGE_SIZE
 from udata.core.storages import default_image_basename, images
@@ -41,14 +40,8 @@ def check_url_does_not_exists(url):
         {"key": "followers", "value": "metrics.followers"},
         {"key": "views", "value": "metrics.views"},
     ],
-    related_filters=[
-        {
-            "key": "organization_badge",
-            "lookup": "organization__in",
-            "object": Organization,
-            "queryset": "with_badge",
-            "choices": list(Organization.__badges__),
-        },
+    additional_filters=[
+        "organization.badges",
     ],
 )
 class Reuse(db.Datetimed, WithMetrics, BadgeMixin, Owned, db.Document):

--- a/udata/tests/api/test_dataservices_api.py
+++ b/udata/tests/api/test_dataservices_api.py
@@ -29,13 +29,13 @@ class DataserviceAPITest(APITestCase):
         dataservice_public_service = DataserviceFactory(organization=org_public_service)
 
         response = self.get(
-            url_for("api.dataservices", organization_badge=org_constants.PUBLIC_SERVICE)
+            url_for("api.dataservices", organization_badges=org_constants.PUBLIC_SERVICE)
         )
         assert200(response)
         assert len(response.json["data"]) == 1
         assert response.json["data"][0]["id"] == str(dataservice_public_service.id)
 
-        response = self.get(url_for("api.dataservices", organization_badge="bad-badge"))
+        response = self.get(url_for("api.dataservices", organization_badges="bad-badge"))
         assert400(response)
 
     def test_dataservice_api_create(self):

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -132,12 +132,12 @@ class ReuseAPITest:
         assert400(response)
 
         # filter on organization badge
-        response = api.get(url_for("api.reuses", organization_badge=org_constants.PUBLIC_SERVICE))
+        response = api.get(url_for("api.reuses", organization_badges=org_constants.PUBLIC_SERVICE))
         assert200(response)
         assert len(response.json["data"]) == 1
         assert response.json["data"][0]["id"] == str(org_reuse_public_service.id)
 
-        response = api.get(url_for("api.reuses", organization_badge="bad-badge"))
+        response = api.get(url_for("api.reuses", organization_badges="bad-badge"))
         assert400(response)
 
     def test_reuse_api_list_filter_private(self, api) -> None:


### PR DESCRIPTION
Probably not worth it :-) But we tried! :-D

Modifications:
- [x] Allow to add a `default_filterable_field` on classes. For exemple if we activate the new system for the `Organization`, we could filter by `badge__kind` automatically by adding a `filterable` on the `badges` field.
- [x] Allow to use custom query for filters (instead of simple equals)
- [ ] `Badge` are now separate classes for each model (`Organization`, `Reuse`…). It enables to use the `choices` of the `StringField` instead of custom validation check