### PR TITLE
Add contact_form in contact point model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a filter on organization and document sort parameters in the `/discussions` endpoint [#3147](https://github.com/opendatateam/udata/pull/3147)
 - Move discussion catalog creation and add fields [#3152](https://github.com/opendatateam/udata/pull/3152) and [#3154](https://github.com/opendatateam/udata/pull/3154)
 - Add resources formats and harvest remote_url on dataset catalog [#3159](https://github.com/opendatateam/udata/pull/3159)
+- Add contact form in contact point model [#3164](https://github.com/opendatateam/udata/pull/3164)
 
 ## 9.2.1 (2024-09-23)
 

--- a/udata/core/contact_point/api.py
+++ b/udata/core/contact_point/api.py
@@ -1,3 +1,5 @@
+import mongoengine
+
 from udata.api import API, api
 from udata.api.parsers import ModelApiParser
 
@@ -29,7 +31,10 @@ class ContactPointsListAPI(API):
     def post(self):
         """Creates a contact point"""
         form = api.validate(ContactPointForm)
-        contact_point = form.save()
+        try:
+            contact_point = form.save()
+        except mongoengine.errors.ValidationError as e:
+            api.abort(400, e.message)
         return contact_point, 201
 
 

--- a/udata/core/contact_point/forms.py
+++ b/udata/core/contact_point/forms.py
@@ -12,6 +12,9 @@ class ContactPointForm(ModelForm):
         _("Name"),
         [validators.DataRequired(), validators.NoURLs(_("URLs not allowed in this field"))],
     )
-    email = fields.StringField(_("Email"), [validators.DataRequired(), validators.Email()])
+    email = fields.StringField(_("Email"), [validators.optional(), validators.Email()])
+    contact_form = fields.URLField(
+        _("Contact form"), description=_("The organization web contact form")
+    )
     owner = fields.CurrentUserField()
     organization = fields.PublishAsField(_("Publish as"))

--- a/udata/core/contact_point/models.py
+++ b/udata/core/contact_point/models.py
@@ -5,7 +5,8 @@ __all__ = ("ContactPoint",)
 
 
 class ContactPoint(db.Document, Owned):
-    email = db.StringField(max_length=255, required=True)
     name = db.StringField(max_length=255, required=True)
+    email = db.StringField(max_length=255)
+    contact_form = db.URLField()
 
     meta = {"queryset_class": OwnedQuerySet}

--- a/udata/core/contact_point/models.py
+++ b/udata/core/contact_point/models.py
@@ -10,3 +10,10 @@ class ContactPoint(db.Document, Owned):
     contact_form = db.URLField()
 
     meta = {"queryset_class": OwnedQuerySet}
+
+    def validate(self, clean=True):
+        if not self.email and not self.contact_form:
+            raise db.ValidationError(
+                "At least an email or a contact form is required for a contact point"
+            )
+        return super().validate(clean=clean)

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -3,7 +3,8 @@ from flask import url_for
 
 from udata.core.contact_point.factories import ContactPointFactory
 from udata.models import ContactPoint
-from udata.tests.helpers import assert200, assert204
+from udata.tests.helpers import assert200, assert201, assert204, assert400
+from udata.utils import faker
 
 pytestmark = [
     pytest.mark.usefixtures("clean_db"),
@@ -12,6 +13,21 @@ pytestmark = [
 
 class ContactPointAPITest:
     modules = []
+
+    def test_contact_point_api_create(self, api):
+        api.login()
+        data = {"name": faker.word(), "email": faker.email(), "contact_form": faker.url()}
+        response = api.post(url_for("api.contact_points"), data=data)
+        assert201(response)
+        assert ContactPoint.objects.count() == 1
+
+    def test_contact_point_api_invalid_email(self, api):
+        api.login()
+        data = {"name": faker.word(), "email": faker.word()}
+        response = api.post(url_for("api.contact_points"), data=data)
+        assert400(response)
+        assert "email" in response.json["errors"]
+        assert ContactPoint.objects.count() == 0
 
     def test_contact_point_api_update(self, api):
         api.login()

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -22,6 +22,18 @@ class ContactPointAPITest:
         assert201(response)
         assert ContactPoint.objects.count() == 1
 
+    def test_contact_point_api_create_email_or_contact_form(self, api):
+        api.login()
+        data = {"name": faker.word(), "contact_form": faker.url()}
+        response = api.post(url_for("api.contact_points"), data=data)
+        assert201(response)
+        assert ContactPoint.objects.count() == 1
+
+        data = {"name": faker.word(), "email": faker.email()}
+        response = api.post(url_for("api.contact_points"), data=data)
+        assert201(response)
+        assert ContactPoint.objects.count() == 2
+
     def test_contact_point_api_invalid_email(self, api):
         api.login()
         data = {"name": faker.word(), "email": faker.word()}

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -2,6 +2,7 @@ import pytest
 from flask import url_for
 
 from udata.core.contact_point.factories import ContactPointFactory
+from udata.i18n import gettext as _
 from udata.models import ContactPoint
 from udata.tests.helpers import assert200, assert201, assert204, assert400
 from udata.utils import faker
@@ -27,6 +28,16 @@ class ContactPointAPITest:
         response = api.post(url_for("api.contact_points"), data=data)
         assert400(response)
         assert "email" in response.json["errors"]
+        assert ContactPoint.objects.count() == 0
+
+    def test_contact_point_missing_contact_information(self, api):
+        api.login()
+        data = {"name": faker.word()}
+        response = api.post(url_for("api.contact_points"), data=data)
+        assert400(response)
+        assert response.json["message"] == _(
+            "At least an email or a contact form is required for a contact point"
+        )
         assert ContactPoint.objects.count() == 0
 
     def test_contact_point_api_update(self, api):


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1509.

Email is no longer required.
We're adding a validation at the form or model level to make sure we have at least an email or a contact form.
It matches with the [HVD constraint](https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/#c6).

## Notes
1. Harvesting contact form should be added in a later PR. See [dedicated issue](https://github.com/datagouv/data.gouv.fr/issues/1520).
2. Front should be updated to take the contact form and lack of email into account.