### PR TITLE
Add discussion.posted_on in discussion sort choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add discussion.posted_on in discussion sort choices [3168](https://github.com/opendatateam/udata/pull/3168)
 
 ## 9.2.2 (2024-10-08)
 

--- a/udata/core/discussions/api.py
+++ b/udata/core/discussions/api.py
@@ -77,7 +77,7 @@ comment_discussion_fields = api.model(
 discussion_page_fields = api.model("DiscussionPage", fields.pager(discussion_fields))
 
 parser = api.parser()
-sorting_keys: list[str] = ["created", "title", "closed"]
+sorting_keys: list[str] = ["created", "title", "closed", "discussion.posted_on"]
 sorting_choices: list[str] = sorting_keys + ["-" + k for k in sorting_keys]
 parser.add_argument(
     "sort",


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1505

This sort is used by digest to get latest comments on data.gouv.fr. It now returns a 400 Bad Request : https://www.data.gouv.fr/api/1/discussions/?sort=-discussion.posted_on.

The sort choices had been explicitly defined in https://github.com/opendatateam/udata/pull/3147/