### PR TITLE
Add contact_form in ContactPoint api fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add contact_form in ContactPoint api fields [#3175](https://github.com/opendatateam/udata/pull/3175)
 
 ## 9.2.4 (2024-10-22)
 

--- a/udata/core/contact_point/api_fields.py
+++ b/udata/core/contact_point/api_fields.py
@@ -2,7 +2,7 @@ from udata.api import api, fields
 from udata.core.organization.api_fields import org_ref_fields
 from udata.core.user.api_fields import user_ref_fields
 
-DEFAULT_MASK = ",".join(("id", "name", "email"))
+DEFAULT_MASK = ",".join(("id", "name", "email", "contact_form"))
 
 contact_point_fields = api.model(
     "ContactPoint",
@@ -10,6 +10,7 @@ contact_point_fields = api.model(
         "id": fields.String(description="The contact point's identifier", readonly=True),
         "name": fields.String(description="The contact point's name", required=True),
         "email": fields.String(description="The contact point's email", required=True),
+        "contact_form": fields.String(description="The contact point's contact form"),
         "organization": fields.Nested(
             org_ref_fields, allow_null=True, description="The producer organization"
         ),


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/3164, we now have a `contact_form` field on ContactPoint.
This PR exposes this field by API :)