### PR TITLE
Expose contact point in DCAT RDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add contact_form in ContactPoint api fields [#3175](https://github.com/opendatateam/udata/pull/3175)
+- Expose contact point in DCAT RDF [#3179](https://github.com/opendatateam/udata/pull/3179)
 
 ## 9.2.4 (2024-10-22)
 

--- a/udata/core/contact_point/factories.py
+++ b/udata/core/contact_point/factories.py
@@ -11,3 +11,4 @@ class ContactPointFactory(ModelFactory):
 
     name = factory.Faker("name")
     email = factory.Faker("email")
+    contact_form = factory.Faker("url")

--- a/udata/core/dataservices/rdf.py
+++ b/udata/core/dataservices/rdf.py
@@ -8,6 +8,7 @@ from udata.rdf import (
     DCAT,
     DCT,
     contact_point_from_rdf,
+    contact_point_to_rdf,
     namespace_manager,
     rdf_value,
     remote_url_from_rdf,
@@ -116,10 +117,10 @@ def dataservice_to_rdf(dataservice: Dataservice, graph=None):
     d.set(DCT.issued, Literal(dataservice.created_at))
 
     if dataservice.base_api_url:
-        d.set(DCAT.endpointURL, Literal(dataservice.base_api_url))
+        d.set(DCAT.endpointURL, URIRef(dataservice.base_api_url))
 
     if dataservice.endpoint_description_url:
-        d.set(DCAT.endpointDescription, Literal(dataservice.endpoint_description_url))
+        d.set(DCAT.endpointDescription, URIRef(dataservice.endpoint_description_url))
 
     for tag in dataservice.tags:
         d.add(DCAT.keyword, Literal(tag))
@@ -131,5 +132,9 @@ def dataservice_to_rdf(dataservice: Dataservice, graph=None):
     # correct Node with all the information in a future page)
     for dataset in dataservice.datasets:
         d.add(DCAT.servesDataset, dataset_to_graph_id(dataset))
+
+    contact_point = contact_point_to_rdf(dataservice.contact_point, graph)
+    if contact_point:
+        d.set(DCAT.contactPoint, contact_point)
 
     return d

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -35,6 +35,7 @@ from udata.rdf import (
     SPDX,
     TAG_TO_EU_HVD_CATEGORIES,
     contact_point_from_rdf,
+    contact_point_to_rdf,
     namespace_manager,
     rdf_unique_values,
     rdf_value,
@@ -242,6 +243,10 @@ def dataset_to_rdf(dataset, graph=None):
     publisher = owner_to_rdf(dataset, graph)
     if publisher:
         d.set(DCT.publisher, publisher)
+
+    contact_point = contact_point_to_rdf(dataset.contact_point, graph)
+    if contact_point:
+        d.set(DCAT.contactPoint, contact_point)
 
     return d
 

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -115,6 +115,7 @@
   <vcard:Organization rdf:about="http://data.test.org/contacts/1">
     <vcard:fn>Organization contact</vcard:fn>
     <vcard:hasEmail>mailto: hello@its.me</vcard:hasEmail>
+    <vcard:hasUrl>https://data.support.com</vcard:hasUrl>
   </vcard:Organization>
   <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-1">
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-05T00:00:00</schema:startDate>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -517,8 +517,9 @@ class DcatBackendTest:
         assert dataset.temporal_coverage is not None
         assert dataset.temporal_coverage.start == date(2016, 1, 1)
         assert dataset.temporal_coverage.end == date(2016, 12, 5)
-        assert dataset.contact_point["email"] == "hello@its.me"
-        assert dataset.contact_point["name"] == "Organization contact"
+        assert dataset.contact_point.email == "hello@its.me"
+        assert dataset.contact_point.name == "Organization contact"
+        assert dataset.contact_point.contact_form == "https://data.support.com"
         assert dataset.frequency is None
         # test dct:license nested in distribution
         assert dataset.license.id == "lov1"

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -356,7 +356,7 @@ def contact_point_to_rdf(contact, graph=None):
     if contact.name:
         node.set(VCARD.fn, Literal(contact.name))
     if contact.email:
-        node.set(VCARD.hasEmail, Literal(contact.email))
+        node.set(VCARD.hasEmail, URIRef(f"mailto:{contact.email}"))
     if contact.contact_form:
         node.set(VCARD.hasUrl, URIRef(contact.contact_form))
     return node

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -308,7 +308,7 @@ def contact_point_from_rdf(rdf, dataset):
             return
         if dataset.organization:
             contact_point = ContactPoint.objects(
-                name=name, email=email, organization=dataset.organization
+                name=name, email=email, contact_form=contact_form, organization=dataset.organization
             ).first()
             return (
                 contact_point
@@ -321,7 +321,7 @@ def contact_point_from_rdf(rdf, dataset):
             )
         elif dataset.owner:
             contact_point = ContactPoint.objects(
-                name=name, email=email, owner=dataset.owner
+                name=name, email=email, contact_form=contact_form, owner=dataset.owner
             ).first()
             return (
                 contact_point

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -302,10 +302,10 @@ def contact_point_from_rdf(rdf, dataset):
             or rdf_value(contact_point, VCARD.email)
             or rdf_value(contact_point, DCAT.email)
         )
-        if not email:
-            return
         email = email.replace("mailto:", "").strip()
         contact_form = rdf_value(contact_point, VCARD.hasUrl)
+        if not email and not contact_form:
+            return
         if dataset.organization:
             contact_point = ContactPoint.objects(
                 name=name, email=email, organization=dataset.organization

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -302,7 +302,7 @@ def contact_point_from_rdf(rdf, dataset):
             or rdf_value(contact_point, VCARD.email)
             or rdf_value(contact_point, DCAT.email)
         )
-        email = email.replace("mailto:", "").strip()
+        email = email.replace("mailto:", "").strip() if email else None
         contact_form = rdf_value(contact_point, VCARD.hasUrl)
         if not email and not contact_form:
             return

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -358,7 +358,7 @@ def contact_point_to_rdf(contact, graph=None):
     if contact.email:
         node.set(VCARD.hasEmail, Literal(contact.email))
     if contact.contact_form:
-        node.set(VCARD.hasUrl, Literal(contact.contact_form))
+        node.set(VCARD.hasUrl, URIRef(contact.contact_form))
     return node
 
 

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -304,19 +304,30 @@ def contact_point_from_rdf(rdf, dataset):
         if not email:
             return
         email = email.replace("mailto:", "").strip()
+        contact_form = rdf_value(contact_point, VCARD.hasUrl)
         if dataset.organization:
             contact_point = ContactPoint.objects(
                 name=name, email=email, organization=dataset.organization
             ).first()
             return (
                 contact_point
-                or ContactPoint(name=name, email=email, organization=dataset.organization).save()
+                or ContactPoint(
+                    name=name,
+                    email=email,
+                    contact_form=contact_form,
+                    organization=dataset.organization,
+                ).save()
             )
         elif dataset.owner:
             contact_point = ContactPoint.objects(
                 name=name, email=email, owner=dataset.owner
             ).first()
-            return contact_point or ContactPoint(name=name, email=email, owner=dataset.owner).save()
+            return (
+                contact_point
+                or ContactPoint(
+                    name=name, email=email, contact_form=contact_form, owner=dataset.owner
+                ).save()
+            )
 
 
 def primary_topic_identifier_from_rdf(graph: Graph, resource: RdfResource):

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -307,28 +307,16 @@ def contact_point_from_rdf(rdf, dataset):
         if not email and not contact_form:
             return
         if dataset.organization:
-            contact_point = ContactPoint.objects(
+            contact, _ = ContactPoint.objects.get_or_create(
                 name=name, email=email, contact_form=contact_form, organization=dataset.organization
-            ).first()
-            return (
-                contact_point
-                or ContactPoint(
-                    name=name,
-                    email=email,
-                    contact_form=contact_form,
-                    organization=dataset.organization,
-                ).save()
             )
         elif dataset.owner:
-            contact_point = ContactPoint.objects(
+            contact, _ = ContactPoint.objects.get_or_create(
                 name=name, email=email, contact_form=contact_form, owner=dataset.owner
-            ).first()
-            return (
-                contact_point
-                or ContactPoint(
-                    name=name, email=email, contact_form=contact_form, owner=dataset.owner
-                ).save()
             )
+        else:
+            contact = None
+        return contact
 
 
 def contact_point_to_rdf(contact, graph=None):

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -127,7 +127,7 @@ class DatasetToRdfTest:
         c = d.value(DCAT.contactPoint)
         assert c.value(RDF.type).identifier == VCARD.Kind
         assert c.value(VCARD.fn) == Literal("Organization contact")
-        assert c.value(VCARD.hasEmail) == Literal("hello@its.me")
+        assert c.value(VCARD.hasEmail).identifier == URIRef("mailto:hello@its.me")
         assert c.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")
 
     def test_map_unkownn_frequencies(self):

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -124,11 +124,11 @@ class DatasetToRdfTest:
         org = d.value(DCT.publisher)
         assert org.value(RDF.type).identifier == FOAF.Organization
         assert org.value(FOAF.name) == Literal("organization")
-        c = d.value(DCAT.contactPoint)
-        assert c.value(RDF.type).identifier == VCARD.Kind
-        assert c.value(VCARD.fn) == Literal("Organization contact")
-        assert c.value(VCARD.hasEmail).identifier == URIRef("mailto:hello@its.me")
-        assert c.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")
+        contact_rdf = d.value(DCAT.contactPoint)
+        assert contact_rdf.value(RDF.type).identifier == VCARD.Kind
+        assert contact_rdf.value(VCARD.fn) == Literal("Organization contact")
+        assert contact_rdf.value(VCARD.hasEmail).identifier == URIRef("mailto:hello@its.me")
+        assert contact_rdf.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")
 
     def test_map_unkownn_frequencies(self):
         assert frequency_to_rdf("hourly") == FREQ.continuous

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -1,8 +1,16 @@
 import pytest
+from rdflib import (
+    Literal,
+    URIRef,
+)
 
+from udata.models import ContactPoint
 from udata.rdf import (
     ACCEPTED_MIME_TYPES,
     FORMAT_MAP,
+    RDF,
+    VCARD,
+    contact_point_to_rdf,
     guess_format,
     negociate_content,
     want_rdf,
@@ -71,3 +79,19 @@ class GuessFormatTest(object):
 
     def test_unkown_mime(self):
         assert guess_format("unknown/mime") is None
+
+
+class ContactToRdfTest:
+    def test_contact_point_to_rdf(self):
+        contact = ContactPoint(
+            name="Organization contact",
+            email="hello@its.me",
+            contact_form="https://data.support.com",
+        )
+
+        c = contact_point_to_rdf(contact, None)
+
+        assert c.value(RDF.type).identifier == VCARD.Kind
+        assert c.value(VCARD.fn) == Literal("Organization contact")
+        assert c.value(VCARD.hasEmail) == Literal("hello@its.me")
+        assert c.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -93,5 +93,5 @@ class ContactToRdfTest:
 
         assert c.value(RDF.type).identifier == VCARD.Kind
         assert c.value(VCARD.fn) == Literal("Organization contact")
-        assert c.value(VCARD.hasEmail) == Literal("hello@its.me")
+        assert c.value(VCARD.hasEmail).identifier == URIRef("mailto:hello@its.me")
         assert c.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -89,9 +89,9 @@ class ContactToRdfTest:
             contact_form="https://data.support.com",
         )
 
-        c = contact_point_to_rdf(contact, None)
+        contact_rdf = contact_point_to_rdf(contact, None)
 
-        assert c.value(RDF.type).identifier == VCARD.Kind
-        assert c.value(VCARD.fn) == Literal("Organization contact")
-        assert c.value(VCARD.hasEmail).identifier == URIRef("mailto:hello@its.me")
-        assert c.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")
+        assert contact_rdf.value(RDF.type).identifier == VCARD.Kind
+        assert contact_rdf.value(VCARD.fn) == Literal("Organization contact")
+        assert contact_rdf.value(VCARD.hasEmail).identifier == URIRef("mailto:hello@its.me")
+        assert contact_rdf.value(VCARD.hasUrl).identifier == URIRef("https://data.support.com")


### PR DESCRIPTION
Close https://github.com/datagouv/data.gouv.fr/issues/1520
Close https://github.com/datagouv/data.gouv.fr/issues/1519

Example:
```
  <rdf:Description rdf:about="http://dev.local:7000/dataservices/6661e3b3ac0706063080aa40/">
    <rdf:type rdf:resource="http://www.w3.org/ns/dcat#DataService"/>
    <dcat:contactPoint rdf:resource="http://dev.local:7000/api/1/contacts/6661de3080af2e6f478a53f7/"/>
  </rdf:Description>
  <rdf:Description rdf:about="http://dev.local:7000/api/1/contacts/6661de3080af2e6f478a53f7/">
    <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
    <vcard:fn>Support API Météo-France</vcard:fn>
    <vcard:hasEmail rdf:resource="mailto:contact.api@meteo.fr"/>
    <vcard:hasUrl rdf:resource="https://ceci.est.un.test.com/"/>
  </rdf:Description>
```