### PR TITLE
Return dataservices visible to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add contact_form in ContactPoint api fields [#3175](https://github.com/opendatateam/udata/pull/3175)
 - Use trailing slashes for the upload files URLs [#3177](https://github.com/opendatateam/udata/pull/3177)
 - Use hydra's RESTful endpoint URLs [#3146](https://github.com/opendatateam/udata/pull/3146)
+- Return dataservices visible to the user [#3180](https://github.com/opendatateam/udata/pull/3180)
 
 ## 9.2.4 (2024-10-22)
 

--- a/udata/core/dataservices/api.py
+++ b/udata/core/dataservices/api.py
@@ -30,7 +30,9 @@ class DataservicesAPI(API):
     @api.marshal_with(Dataservice.__page_fields__)
     def get(self):
         """List or search all dataservices"""
-        query = Dataservice.objects.visible()
+        query = Dataservice.objects.visible_by_user(
+            current_user, mongoengine.Q(private__ne=True, archived_at=None, deleted_at=None)
+        )
 
         return Dataservice.apply_sort_filters_and_pagination(query)
 

--- a/udata/tests/api/test_dataservices_api.py
+++ b/udata/tests/api/test_dataservices_api.py
@@ -158,7 +158,7 @@ class DataserviceAPITest(APITestCase):
         self.assertIsNone(dataservice.deleted_at)
 
     def test_dataservice_api_list_owned(self) -> None:
-        """Should filters out private dataservices if not owner"""
+        """Should filter out private dataservices if not owner"""
         owner = UserFactory()
         org = OrganizationFactory()
         public_dataservice = DataserviceFactory()
@@ -244,7 +244,7 @@ class DataserviceAPITest(APITestCase):
 
         self.assertEqual(Dataservice.objects.count(), 4)
 
-        # Login with a distinct user
+        # Login with a distinct user, without visibility on the private dataservice
         self.login(UserFactory())
 
         response = self.get(url_for("api.dataservices"))


### PR DESCRIPTION
Close https://github.com/datagouv/data.gouv.fr/issues/1549

Apply a similar logic as [for reuses](https://github.com/opendatateam/udata/pull/3140) without the private param.