### PR TITLE
ci: fix deprecated CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - image: mongo:6.0.4
       - image: redis:alpine
     environment:
-       BASH_ENV: /root/.bashrc
+      BASH_ENV: /root/.bashrc
     steps:
       - checkout
       - run:
@@ -68,7 +68,7 @@ jobs:
       # TODO make an image based on 2-alpine w/ nvm and phantom deps
       - image: udata/circleci:py3.11
     environment:
-       BASH_ENV: /root/.bashrc
+      BASH_ENV: /root/.bashrc
     steps:
       - checkout
       - run:
@@ -112,7 +112,7 @@ jobs:
     docker:
       - image: udata/circleci:py3.11
     environment:
-       BASH_ENV: /root/.bashrc
+      BASH_ENV: /root/.bashrc
     steps:
       - checkout
       - attach_workspace:
@@ -145,7 +145,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - deploy:
+      - run:
           name: Publish on PyPI
           command: |
             source venv/bin/activate
@@ -153,7 +153,6 @@ jobs:
             twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
 
 workflows:
-  version: 2
   build:
     jobs:
       - python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ jobs:
             twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
 
 workflows:
+  version: 2
   build:
     jobs:
       - python:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use trailing slashes for the upload files URLs [#3177](https://github.com/opendatateam/udata/pull/3177)
 - Use hydra's RESTful endpoint URLs [#3146](https://github.com/opendatateam/udata/pull/3146)
 - Fix flaky "duplicated email" importing fixtures tests [#3176](https://github.com/opendatateam/udata/pull/3176)
+- Fix deprecated CircleCI config [#3181](https://github.com/opendatateam/udata/pull/3181)
 
 ## 9.2.4 (2024-10-22)
 
@@ -41,7 +42,6 @@
 - Fix the boolean filters in the API for the "new system" endpoints [#3139](https://github.com/opendatateam/udata/pull/3139)
 - Update authlib dependency from 0.14.3 to 1.3.1 [#3135](https://github.com/opendatateam/udata/pull/3135)
 - Add CORS on resource redirect [#3145](https://github.com/opendatateam/udata/pull/3145)
-- Fix deprecated CircleCI step name [#3181](https://github.com/opendatateam/udata/pull/3181)
 
 ## 9.1.4 (2024-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix the boolean filters in the API for the "new system" endpoints [#3139](https://github.com/opendatateam/udata/pull/3139)
 - Update authlib dependency from 0.14.3 to 1.3.1 [#3135](https://github.com/opendatateam/udata/pull/3135)
 - Add CORS on resource redirect [#3145](https://github.com/opendatateam/udata/pull/3145)
+- Fix deprecated CircleCI step name [#3181](https://github.com/opendatateam/udata/pull/3181)
 
 ## 9.1.4 (2024-08-26)
 


### PR DESCRIPTION
- Change deprecated Circle step name from `deploy`to `run`(see https://circleci.com/docs/migrate-from-deploy-to-run/)
- Fix a few wrong indents in CircleCI config file