### PR TITLE
Licence.guess: extract first URL for better matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix deprecated CircleCI config [#3181](https://github.com/opendatateam/udata/pull/3181)
 - Use proper RESTful Hydra API endpoints [#3178](https://github.com/opendatateam/udata/pull/3178)
 - Add a "filter by organization badge" for datasets, dataservices, reuses and organizations [#3155](https://github.com/opendatateam/udata/pull/3155]
+- Licence.guess: extract first URL for better matching [#3185](https://github.com/opendatateam/udata/pull/3185)
 
 ## 9.2.4 (2024-10-22)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -218,7 +218,7 @@ class License(db.Document):
         if text is None:
             return tuple()
         url_pattern = r"(https?://\S+)"
-        match = re.search(url_pattern, text)
+        match = re.search(url_pattern, text.rstrip("."))
         if match:
             url = match.group(1)
             remaining_text = text.replace(url, "").strip()
@@ -236,7 +236,6 @@ class License(db.Document):
         """
         license = None
         for string in strings:
-            print("input string", string)
             for prepared_string in cls.extract_first_url(string):
                 license = cls.guess_one(prepared_string)
                 if license:
@@ -253,9 +252,9 @@ class License(db.Document):
         """
         if not text:
             return
+        qs = cls.objects
         text = text.strip().lower()  # Stored identifiers are lower case
         slug = cls.slug.slugify(text)  # Use slug as it normalize string
-        qs = cls.objects
         license = qs(
             db.Q(id__iexact=text)
             | db.Q(slug=slug)

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -239,8 +239,8 @@ class License(db.Document):
             for prepared_string in cls.extract_first_url(string):
                 license = cls.guess_one(prepared_string)
                 if license:
-                    break
-        return license or kwargs.get("default")
+                    return license
+        return kwargs.get("default")
 
     @classmethod
     def guess_one(cls, text):

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -104,7 +104,7 @@
         <dcat:landingPage>http://data.test.org/datasets/2</dcat:landingPage>
         <dcat:distribution rdf:resource="http://data.test.org/datasets/4/resources/1"/>
         <dcat:distribution rdf:resource="http://data.test.org/datasets/4/resources/2"/>
-        <dcterms:title>Dataset 2</dcterms:title>
+        <dcterms:title>Dataset 4</dcterms:title>
         <dcterms:identifier>4</dcterms:identifier>
       </dcat:Dataset>
     </dcat:dataset>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -917,7 +917,7 @@ class CswIso19139DcatBackendTest:
         # this is the string used in geo-ide for now
         lov1 = LicenseFactory(
             id="lov1",
-            title="Licence Ouverte 1.0 http://www.data.gouv.fr/Licence-Ouverte-Open-Licence",
+            url="http://www.data.gouv.fr/Licence-Ouverte-Open-Licence",
         )
 
         with open(os.path.join(CSW_DCAT_FILES_DIR, "XSLT.xml"), "rb") as f:

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -384,6 +384,20 @@ class LicenseModelTest:
         assert isinstance(found, License)
         assert license.id == found.id
 
+    def test_exact_match_by_url_in_string(self):
+        license = LicenseFactory()
+        found = License.guess(f"Here is my license: {license.url}")
+        assert isinstance(found, License)
+        assert license.id == found.id
+
+    def test_exact_match_by_url_in_string_two_urls(self):
+        license = LicenseFactory()
+        found = License.guess(
+            f"Here is my license: {license.url} and another link: https://example.com/license"
+        )
+        assert isinstance(found, License)
+        assert license.id == found.id
+
     def test_match_by_url_with_final_slash(self):
         license = LicenseFactory(url="https://example.com/license")
         found = License.guess("https://example.com/license/")

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -390,10 +390,18 @@ class LicenseModelTest:
         assert isinstance(found, License)
         assert license.id == found.id
 
+    def test_exact_match_by_url_in_string_real_world(self):
+        license = LicenseFactory(url="http://www.data.gouv.fr/Licence-Ouverte-Open-Licence")
+        found = License.guess(
+            "Licence Ouverte 1.0 http://www.data.gouv.fr/Licence-Ouverte-Open-Licence."
+        )
+        assert isinstance(found, License)
+        assert license.id == found.id
+
     def test_exact_match_by_url_in_string_two_urls(self):
         license = LicenseFactory()
         found = License.guess(
-            f"Here is my license: {license.url} and another link: https://example.com/license"
+            f"Here is my license: {license.url} and another link: https://example.com/example"
         )
         assert isinstance(found, License)
         assert license.id == found.id

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -551,6 +551,12 @@ class LicenseModelTest:
         assert isinstance(found, License)
         assert license.id == found.id
 
+    def test_multiple_strings_reverse(self):
+        license = LicenseFactory()
+        found = License.guess(license.id, "should not match")
+        assert isinstance(found, License)
+        assert license.id == found.id
+
 
 class ResourceSchemaTest:
     @pytest.mark.options(SCHEMA_CATALOG_URL="https://example.com/notfound")


### PR DESCRIPTION
This improves `License` detection on strings like `Licence Ouverte 1.0 http://www.data.gouv.fr/Licence-Ouverte-Open-Licence.` by extracting the first url found (if any), and passing the url and the remaining text to the usual guessing algorithm.