### PR TITLE
Add matomo campaign parameters on links in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add more comments and types in the `api_field.py` "lib" [#3174](https://github.com/opendatateam/udata/pull/3174)
+- Add a matomo "campaign" parameter on links in emails if `MAIL_CAMPAIGN` is configured [#3190](https://github.com/opendatateam/udata/pull/3190)
 
 ## 10.0.0 (2024-11-07)
 

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -21,6 +21,7 @@ from udata.core import storages
 from udata.core.owned import Owned, OwnedQuerySet
 from udata.frontend.markdown import mdstrip
 from udata.i18n import lazy_gettext as _
+from udata.mail import get_mail_campaign_dict
 from udata.models import Badge, BadgeMixin, BadgesList, SpatialCoverage, WithMetrics, db
 from udata.mongo.errors import FieldValidationError
 from udata.uris import ValidationError, endpoint_for
@@ -683,6 +684,11 @@ class Dataset(WithMetrics, DatasetBadgeMixin, Owned, db.Document):
     @property
     def external_url(self):
         return self.url_for(_external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.url_for(_external=True, **extras)
 
     @property
     def image_url(self):

--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from flask_login import current_user
 
 from udata.core.spam.models import SpamMixin, spam_protected
+from udata.mail import get_mail_campaign_dict
 from udata.mongo import db
 
 from .signals import on_discussion_closed, on_new_discussion, on_new_discussion_comment
@@ -93,6 +94,13 @@ class Discussion(SpamMixin, db.Document):
     @property
     def external_url(self):
         return self.subject.url_for(_anchor="discussion-{id}".format(id=self.id), _external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.subject.url_for(
+            _anchor="discussion-{id}".format(id=self.id), _external=True, **extras
+        )
 
     def spam_report_message(self, breadcrumb):
         message = f"Spam potentiel sur la discussion « [{self.title}]({self.external_url}) »"

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -11,6 +11,7 @@ from udata.core.metrics.models import WithMetrics
 from udata.core.storages import avatars, default_image_basename
 from udata.frontend.markdown import mdstrip
 from udata.i18n import lazy_gettext as _
+from udata.mail import get_mail_campaign_dict
 from udata.mongo import db
 from udata.uris import endpoint_for
 
@@ -182,6 +183,11 @@ class Organization(WithMetrics, OrganizationBadgeMixin, db.Datetimed, db.Documen
     @property
     def external_url(self):
         return self.url_for(_external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.url_for(_external=True, **extras)
 
     @property
     def pending_requests(self):

--- a/udata/core/post/models.py
+++ b/udata/core/post/models.py
@@ -2,6 +2,7 @@ from flask import url_for
 
 from udata.core.storages import default_image_basename, images
 from udata.i18n import lazy_gettext as _
+from udata.mail import get_mail_campaign_dict
 from udata.mongo import db
 
 from .constants import BODY_TYPES, IMAGE_SIZES
@@ -60,6 +61,11 @@ class Post(db.Datetimed, db.Document):
     @property
     def external_url(self):
         return self.url_for(_external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.url_for(_external=True, **extras)
 
     def count_discussions(self):
         # There are no metrics on Post to store discussions count

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -9,6 +9,7 @@ from udata.core.reuse.api_fields import BIGGEST_IMAGE_SIZE
 from udata.core.storages import default_image_basename, images
 from udata.frontend.markdown import mdstrip
 from udata.i18n import lazy_gettext as _
+from udata.mail import get_mail_campaign_dict
 from udata.models import Badge, BadgeMixin, BadgesList, WithMetrics, db
 from udata.mongo.errors import FieldValidationError
 from udata.uris import endpoint_for
@@ -212,6 +213,11 @@ class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
     @property
     def external_url(self):
         return self.url_for(_external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.url_for(_external=True, **extras)
 
     @property
     def type_label(self):

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -5,6 +5,7 @@ from werkzeug.utils import cached_property
 from udata.app import cache
 from udata.core.metrics.models import WithMetrics
 from udata.i18n import _, get_locale, language
+from udata.mail import get_mail_campaign_dict
 from udata.mongo import db
 from udata.uris import endpoint_for
 
@@ -96,6 +97,11 @@ class GeoZone(WithMetrics, db.Document):
     @property
     def external_url(self):
         return endpoint_for("territories.territory", territory=self, _external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return endpoint_for("territories.territory", territory=self, _external=True, **extras)
 
     def count_datasets(self):
         from udata.models import Dataset

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -17,6 +17,7 @@ from udata.core.discussions.models import Discussion
 from udata.core.storages import avatars, default_image_basename
 from udata.frontend.markdown import mdstrip
 from udata.i18n import lazy_gettext as _
+from udata.mail import get_mail_campaign_dict
 from udata.models import Follow, WithMetrics, db
 from udata.uris import endpoint_for
 
@@ -127,6 +128,11 @@ class User(WithMetrics, UserMixin, db.Document):
     @property
     def external_url(self):
         return self.url_for(_external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.url_for(_external=True, **extras)
 
     @property
     def visible(self):

--- a/udata/features/territories/models.py
+++ b/udata/features/territories/models.py
@@ -1,5 +1,6 @@
 from flask import url_for
 
+from udata.mail import get_mail_campaign_dict
 from udata.models import License, Organization
 
 __all__ = ("TerritoryDataset", "ResourceBasedTerritoryDataset", "TERRITORY_DATASETS")
@@ -59,3 +60,8 @@ class ResourceBasedTerritoryDataset(TerritoryDataset):
     @property
     def external_url(self):
         return self.url_for(external=True)
+
+    @property
+    def external_url_with_campaign(self):
+        extras = get_mail_campaign_dict()
+        return self.url_for(_external=True, **extras)

--- a/udata/mail.py
+++ b/udata/mail.py
@@ -50,10 +50,7 @@ def send(subject, recipients, template_base, **kwargs):
     debug = current_app.config.get("DEBUG", False)
     send_mail = current_app.config.get("SEND_MAIL", not debug)
     connection = send_mail and mail.connect or dummyconnection
-    extras = {}
-    mail_campaign = current_app.config.get("MAIL_CAMPAIGN")
-    if mail_campaign:
-        extras["mtm_campaign"] = mail_campaign
+    extras = get_mail_campaign_dict()
 
     with connection() as conn:
         for recipient in recipients:
@@ -81,3 +78,12 @@ def send(subject, recipients, template_base, **kwargs):
                     conn.send(msg)
                 except SMTPException as e:
                     log.error(f"Error sending mail {e}")
+
+
+def get_mail_campaign_dict() -> dict:
+    """Return a dict with the `mtm_campaign` key set if there is a `MAIL_CAMPAIGN` configured in udata.cfg."""
+    extras = {}
+    mail_campaign = current_app.config.get("MAIL_CAMPAIGN")
+    if mail_campaign:
+        extras["mtm_campaign"] = mail_campaign
+    return extras

--- a/udata/mail.py
+++ b/udata/mail.py
@@ -50,6 +50,10 @@ def send(subject, recipients, template_base, **kwargs):
     debug = current_app.config.get("DEBUG", False)
     send_mail = current_app.config.get("SEND_MAIL", not debug)
     connection = send_mail and mail.connect or dummyconnection
+    extras = {}
+    mail_campaign = current_app.config.get("MAIL_CAMPAIGN")
+    if mail_campaign:
+        extras["mtm_campaign"] = mail_campaign
 
     with connection() as conn:
         for recipient in recipients:
@@ -58,13 +62,19 @@ def send(subject, recipients, template_base, **kwargs):
                 log.debug('Sending mail "%s" to recipient "%s"', subject, recipient)
                 msg = Message(subject, sender=sender, recipients=[recipient.email])
                 msg.body = render_template(
-                    f"{tpl_path}.txt", subject=subject, sender=sender, recipient=recipient, **kwargs
+                    f"{tpl_path}.txt",
+                    subject=subject,
+                    sender=sender,
+                    recipient=recipient,
+                    extras=extras,
+                    **kwargs,
                 )
                 msg.html = render_template(
                     f"{tpl_path}.html",
                     subject=subject,
                     sender=sender,
                     recipient=recipient,
+                    extras=extras,
                     **kwargs,
                 )
                 try:

--- a/udata/templates/mail/badge_added_association.html
+++ b/udata/templates/mail/badge_added_association.html
@@ -6,15 +6,14 @@
     _('%(user)s has identified your organization "%(name)s" as an association',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True, **extras)
+        + badge.created_by.external_url_with_campaign
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
     ),
     name=(
         '<a href="'|safe
-        + organization.external_url
-        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+        + organization.external_url_with_campaign
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,8 +25,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the badge'),
-                organization.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                organization.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_association.html
+++ b/udata/templates/mail/badge_added_association.html
@@ -6,7 +6,7 @@
     _('%(user)s has identified your organization "%(name)s" as an association',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True)
+        + url_for('api.user', user=badge.created_by, _external=True, **extras)
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
@@ -14,6 +14,7 @@
     name=(
         '<a href="'|safe
         + organization.external_url
+        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,6 +27,7 @@
             {{ mail_button(
                 _('See the badge'),
                 organization.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_association.txt
+++ b/udata/templates/mail/badge_added_association.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ organization.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/badge_added_association.txt
+++ b/udata/templates/mail/badge_added_association.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}
+{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/badge_added_certified.html
+++ b/udata/templates/mail/badge_added_certified.html
@@ -6,15 +6,14 @@
     _('%(user)s has certified your organization "%(name)s"',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True, **extras)
+        + badge.created_by.external_url_with_campaign
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
     ),
     name=(
         '<a href="'|safe
-        + organization.external_url
-        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+        + organization.external_url_with_campaign
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,8 +25,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the badge'),
-                organization.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                organization.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_certified.html
+++ b/udata/templates/mail/badge_added_certified.html
@@ -6,7 +6,7 @@
     _('%(user)s has certified your organization "%(name)s"',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True)
+        + url_for('api.user', user=badge.created_by, _external=True, **extras)
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
@@ -14,6 +14,7 @@
     name=(
         '<a href="'|safe
         + organization.external_url
+        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,6 +27,7 @@
             {{ mail_button(
                 _('See the badge'),
                 organization.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_certified.txt
+++ b/udata/templates/mail/badge_added_certified.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ organization.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/badge_added_certified.txt
+++ b/udata/templates/mail/badge_added_certified.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}
+{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/badge_added_company.html
+++ b/udata/templates/mail/badge_added_company.html
@@ -6,15 +6,14 @@
     _('%(user)s has identified your organization "%(name)s" as a company',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True, **extras)
+        + badge.created_by.external_url_with_campaign
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
     ),
     name=(
         '<a href="'|safe
-        + organization.external_url
-        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+        + organization.external_url_with_campaign
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,8 +25,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the badge'),
-                organization.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                organization.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_company.html
+++ b/udata/templates/mail/badge_added_company.html
@@ -6,7 +6,7 @@
     _('%(user)s has identified your organization "%(name)s" as a company',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True)
+        + url_for('api.user', user=badge.created_by, _external=True, **extras)
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
@@ -14,6 +14,7 @@
     name=(
         '<a href="'|safe
         + organization.external_url
+        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,6 +27,7 @@
             {{ mail_button(
                 _('See the badge'),
                 organization.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_company.txt
+++ b/udata/templates/mail/badge_added_company.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ organization.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/badge_added_company.txt
+++ b/udata/templates/mail/badge_added_company.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}
+{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/badge_added_local_authority.html
+++ b/udata/templates/mail/badge_added_local_authority.html
@@ -6,7 +6,7 @@
     _('%(user)s has identified your organization "%(name)s" as a local authority',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True)
+        + url_for('api.user', user=badge.created_by, _external=True, **extras)
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
@@ -14,6 +14,7 @@
     name=(
         '<a href="'|safe
         + organization.external_url
+        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,6 +27,7 @@
             {{ mail_button(
                 _('See the badge'),
                 organization.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_local_authority.html
+++ b/udata/templates/mail/badge_added_local_authority.html
@@ -6,15 +6,14 @@
     _('%(user)s has identified your organization "%(name)s" as a local authority',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True, **extras)
+        + badge.created_by.external_url_with_campaign
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
     ),
     name=(
         '<a href="'|safe
-        + organization.external_url
-        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+        + organization.external_url_with_campaign
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,8 +25,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the badge'),
-                organization.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                organization.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_local_authority.txt
+++ b/udata/templates/mail/badge_added_local_authority.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ organization.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/badge_added_local_authority.txt
+++ b/udata/templates/mail/badge_added_local_authority.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}
+{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/badge_added_public_service.html
+++ b/udata/templates/mail/badge_added_public_service.html
@@ -6,7 +6,7 @@
     _('%(user)s has identified your organization "%(name)s" as public service',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True)
+        + url_for('api.user', user=badge.created_by, _external=True, **extras)
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
@@ -14,6 +14,7 @@
     name=(
         '<a href="'|safe
         + organization.external_url
+        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,6 +27,7 @@
             {{ mail_button(
                 _('See the badge'),
                 organization.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_public_service.html
+++ b/udata/templates/mail/badge_added_public_service.html
@@ -6,15 +6,14 @@
     _('%(user)s has identified your organization "%(name)s" as public service',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=badge.created_by, _external=True, **extras)
+        + badge.created_by.external_url_with_campaign
         + '">'|safe
         + badge.created_by.fullname
         + '</a>'|safe
     ),
     name=(
         '<a href="'|safe
-        + organization.external_url
-        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+        + organization.external_url_with_campaign
         + '">'|safe
         + organization.name|string
         + '</a>'|safe
@@ -26,8 +25,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the badge'),
-                organization.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                organization.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/badge_added_public_service.txt
+++ b/udata/templates/mail/badge_added_public_service.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ organization.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/badge_added_public_service.txt
+++ b/udata/templates/mail/badge_added_public_service.txt
@@ -7,5 +7,5 @@
 ) }}.
 
 {{ _('You can see the badge on this page:') }}
-{{ organization.external_url }}
+{{ organization.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/base.html
+++ b/udata/templates/mail/base.html
@@ -41,6 +41,7 @@
                                 {% set link =
                                     '<a href="'|safe
                                      + browser_link
+                                     + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
                                      + '&quot;Helvetica Neue&quot;, &quot;Helvetica&quot;, Helvetica, Arial, sans-serif;color: #2081c5;text-decoration: none;"> '|safe
                                      + _('on your browser.')
                                      + '</a>'|safe

--- a/udata/templates/mail/base.html
+++ b/udata/templates/mail/base.html
@@ -41,7 +41,6 @@
                                 {% set link =
                                     '<a href="'|safe
                                      + browser_link
-                                     + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
                                      + '&quot;Helvetica Neue&quot;, &quot;Helvetica&quot;, Helvetica, Arial, sans-serif;color: #2081c5;text-decoration: none;"> '|safe
                                      + _('on your browser.')
                                      + '</a>'|safe

--- a/udata/templates/mail/discussion_closed.html
+++ b/udata/templates/mail/discussion_closed.html
@@ -7,15 +7,14 @@
         type=discussion.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('api.user', user=message.posted_by, _external=True, **extras)
+            + message.posted_by.external_url_with_campaign
             + '">'|safe
             + message.posted_by.fullname
             + '</a>'|safe
         ),
         subject=(
             '<a href="'|safe
-            + discussion.external_url
-            + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+            + discussion.external_url_with_campaign
             + '">'|safe
             + discussion.subject|string
             + '</a>'|safe
@@ -39,8 +38,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the discussion'),
-                discussion.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                discussion.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/discussion_closed.html
+++ b/udata/templates/mail/discussion_closed.html
@@ -7,7 +7,7 @@
         type=discussion.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('api.user', user=message.posted_by, _external=True)
+            + url_for('api.user', user=message.posted_by, _external=True, **extras)
             + '">'|safe
             + message.posted_by.fullname
             + '</a>'|safe
@@ -15,6 +15,7 @@
         subject=(
             '<a href="'|safe
             + discussion.external_url
+            + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             + '">'|safe
             + discussion.subject|string
             + '</a>'|safe
@@ -39,6 +40,7 @@
             {{ mail_button(
                 _('See the discussion'),
                 discussion.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/discussion_closed.txt
+++ b/udata/templates/mail/discussion_closed.txt
@@ -12,5 +12,5 @@
 
 
 {{ _('You can see the discussion on this page:') }}
-{{ discussion.external_url }}
+{{ discussion.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/discussion_closed.txt
+++ b/udata/templates/mail/discussion_closed.txt
@@ -12,5 +12,5 @@
 
 
 {{ _('You can see the discussion on this page:') }}
-{{ discussion.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ discussion.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/frequency_reminder.html
+++ b/udata/templates/mail/frequency_reminder.html
@@ -23,7 +23,7 @@
             <td align="center">
                 {{ mail_button(
                     _('Update the dataset and associated resources'),
-                    url_for('admin.index', path='dataset/{id}/'.format(id=dataset.id), _external=True)
+                    url_for('admin.index', path='dataset/{id}/'.format(id=dataset.id), _external=True, **extras)
                 ) }}
             </td>
         </tr>

--- a/udata/templates/mail/frequency_reminder.txt
+++ b/udata/templates/mail/frequency_reminder.txt
@@ -11,7 +11,7 @@
     dataset_frequency=dataset.frequency_str,
     due_update_days=dataset.outdated.days) }}
   {{ _('You can update the dataset and associated resources at:') }}
-  {{ url_for('admin.index', path='dataset/{id}/'.format(id=dataset.id), _external=True) }}
+  {{ url_for('admin.index', path='dataset/{id}/'.format(id=dataset.id), _external=True, **extras) }}
 
 {% endfor %}
 

--- a/udata/templates/mail/membership_refused.html
+++ b/udata/templates/mail/membership_refused.html
@@ -7,7 +7,7 @@
 {{ _('Your membership for the organization "%(org)s" has been refused',
     org=(
         '<a href="'|safe
-        + org.url_for(_external=True, **extras)
+        + org.external_url_with_campaign
         + '">'|safe
         + org.name
         + '</a>'|safe

--- a/udata/templates/mail/membership_refused.html
+++ b/udata/templates/mail/membership_refused.html
@@ -7,7 +7,7 @@
 {{ _('Your membership for the organization "%(org)s" has been refused',
     org=(
         '<a href="'|safe
-        + org.url_for(_external=True)
+        + org.url_for(_external=True, **extras)
         + '">'|safe
         + org.name
         + '</a>'|safe

--- a/udata/templates/mail/membership_request.html
+++ b/udata/templates/mail/membership_request.html
@@ -8,14 +8,14 @@
 {{ _('As an administrator of "%(org)s" you are being informed than a new membership request from %(user)s is pending for validation',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=request.user, _external=True, **extras)
+        + request.user.external_url_with_campaign
         + '">'|safe
         + request.user.fullname
         + '</a>'|safe
     ),
     org=(
         '<a href="'|safe
-        + org.url_for(_external=True, **extras)
+        + org.external_url_with_campaign
         + '">'|safe
         + org.name
         + '</a>'|safe

--- a/udata/templates/mail/membership_request.html
+++ b/udata/templates/mail/membership_request.html
@@ -8,14 +8,14 @@
 {{ _('As an administrator of "%(org)s" you are being informed than a new membership request from %(user)s is pending for validation',
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=request.user, _external=True)
+        + url_for('api.user', user=request.user, _external=True, **extras)
         + '">'|safe
         + request.user.fullname
         + '</a>'|safe
     ),
     org=(
         '<a href="'|safe
-        + org.url_for(_external=True)
+        + org.url_for(_external=True, **extras)
         + '">'|safe
         + org.name
         + '</a>'|safe
@@ -38,7 +38,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the request'),
-                url_for('admin.index', path='organization/{id}/'.format(id=org.id), _anchor='membership-requests', _external=True)
+                url_for('admin.index', path='organization/{id}/'.format(id=org.id), _anchor='membership-requests', _external=True, **extras)
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/membership_request.txt
+++ b/udata/templates/mail/membership_request.txt
@@ -8,5 +8,5 @@
 
 
 {{ _('You can go on your organization backoffice to accept or refuse the request') }}:
-{{ url_for('admin.index', path='organization/{id}/'.format(id=org.id), _anchor='membership-requests', _external=True) }}
+{{ url_for('admin.index', path='organization/{id}/'.format(id=org.id), _anchor='membership-requests', _external=True, **extras) }}
 {% endblock %}

--- a/udata/templates/mail/new_discussion.html
+++ b/udata/templates/mail/new_discussion.html
@@ -7,7 +7,7 @@
     type=discussion.subject.verbose_name,
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=discussion.user, _external=True)
+        + url_for('api.user', user=discussion.user, _external=True, **extras)
         + '">'|safe
         + discussion.user.fullname
         + '</a>'|safe
@@ -15,6 +15,7 @@
     subject=(
         '<a href="'|safe
         + discussion.external_url
+        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
         + '">'|safe
         + discussion.subject|string
         + '</a>'|safe
@@ -37,6 +38,7 @@
             {{ mail_button(
                 _('See the discussion'),
                 discussion.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/new_discussion.html
+++ b/udata/templates/mail/new_discussion.html
@@ -7,15 +7,14 @@
     type=discussion.subject.verbose_name,
     user=(
         '<a href="'|safe
-        + url_for('api.user', user=discussion.user, _external=True, **extras)
+        + discussion.user.external_url_with_campaign
         + '">'|safe
         + discussion.user.fullname
         + '</a>'|safe
     ),
     subject=(
         '<a href="'|safe
-        + discussion.external_url
-        + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+        + discussion.external_url_with_campaign
         + '">'|safe
         + discussion.subject|string
         + '</a>'|safe
@@ -37,8 +36,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the discussion'),
-                discussion.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                discussion.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/new_discussion.txt
+++ b/udata/templates/mail/new_discussion.txt
@@ -11,5 +11,5 @@
 {{ _('Title') }}: {{ discussion.title }}
 
 {{ _('You can see the discussion on this page:') }}
-{{ discussion.subject.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ discussion.subject.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/new_discussion.txt
+++ b/udata/templates/mail/new_discussion.txt
@@ -11,5 +11,5 @@
 {{ _('Title') }}: {{ discussion.title }}
 
 {{ _('You can see the discussion on this page:') }}
-{{ discussion.subject.external_url }}
+{{ discussion.subject.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/new_discussion_comment.html
+++ b/udata/templates/mail/new_discussion_comment.html
@@ -7,7 +7,7 @@
         type=discussion.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('api.user', user=message.posted_by, _external=True)
+            + url_for('api.user', user=message.posted_by, _external=True, **extras)
             + '">'|safe
             + message.posted_by.fullname
             + '</a>'|safe
@@ -15,6 +15,7 @@
         subject=(
             '<a href="'|safe
             + discussion.external_url
+            + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             + '">'|safe
             + discussion.subject|string
             + '</a>'|safe
@@ -38,6 +39,7 @@
             {{ mail_button(
                 _('See the discussion'),
                 discussion.external_url
+                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/new_discussion_comment.html
+++ b/udata/templates/mail/new_discussion_comment.html
@@ -7,15 +7,14 @@
         type=discussion.subject.verbose_name,
         user=(
             '<a href="'|safe
-            + url_for('api.user', user=message.posted_by, _external=True, **extras)
+            + message.posted_by.external_url_with_campaign
             + '">'|safe
             + message.posted_by.fullname
             + '</a>'|safe
         ),
         subject=(
             '<a href="'|safe
-            + discussion.external_url
-            + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+            + discussion.external_url_with_campaign
             + '">'|safe
             + discussion.subject|string
             + '</a>'|safe
@@ -38,8 +37,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the discussion'),
-                discussion.external_url
-                + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+                discussion.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/new_discussion_comment.txt
+++ b/udata/templates/mail/new_discussion_comment.txt
@@ -12,5 +12,5 @@
 
 
 {{ _('You can see the discussion on this page:') }}
-{{ discussion.external_url }}
+{{ discussion.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
 {% endblock %}

--- a/udata/templates/mail/new_discussion_comment.txt
+++ b/udata/templates/mail/new_discussion_comment.txt
@@ -12,5 +12,5 @@
 
 
 {{ _('You can see the discussion on this page:') }}
-{{ discussion.external_url }}{% if extras.get('mtm_campaign') %}?mtm_campaign={{ extras.get('mtm_campaign') }}{% endif %}
+{{ discussion.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/new_member.html
+++ b/udata/templates/mail/new_member.html
@@ -7,7 +7,7 @@
 {{ _('Congratulations, you are now a member of the organization "%(org)s"',
     org=(
         '<a href="'|safe
-        + org.url_for(_external=True)
+        + org.url_for(_external=True, **extras)
         + '">'|safe
         + org.name
         + '</a>'|safe
@@ -19,7 +19,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the organization page'),
-                org.url_for(_external=True)
+                org.url_for(_external=True, **extras)
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/new_member.html
+++ b/udata/templates/mail/new_member.html
@@ -7,7 +7,7 @@
 {{ _('Congratulations, you are now a member of the organization "%(org)s"',
     org=(
         '<a href="'|safe
-        + org.url_for(_external=True, **extras)
+        + org.external_url_with_campaign
         + '">'|safe
         + org.name
         + '</a>'|safe
@@ -19,7 +19,7 @@
         <td align="center">
             {{ mail_button(
                 _('See the organization page'),
-                org.url_for(_external=True, **extras)
+                org.external_url_with_campaign
             ) }}
         </td>
     </tr>

--- a/udata/templates/mail/new_member.txt
+++ b/udata/templates/mail/new_member.txt
@@ -7,5 +7,5 @@
 
 
 {{ _('You can go on your organization page') }}:
-{{ org.url_for(_external=True) }}
+{{ org.url_for(_external=True, **extras) }}
 {% endblock %}

--- a/udata/templates/mail/new_member.txt
+++ b/udata/templates/mail/new_member.txt
@@ -7,5 +7,5 @@
 
 
 {{ _('You can go on your organization page') }}:
-{{ org.url_for(_external=True, **extras) }}
+{{ org.external_url_with_campaign }}
 {% endblock %}

--- a/udata/templates/mail/new_reuse.html
+++ b/udata/templates/mail/new_reuse.html
@@ -8,6 +8,7 @@
         dataset=(
             '<a href="'|safe
             + dataset.external_url
+            + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
             + '" style="text-decoration: none;">'|safe
             + dataset.title
             + '</a>'|safe
@@ -29,14 +30,14 @@
         <td align="center">
             {{ mail_button(
                 _('See the reuse'),
-                url_for('reuses.show', reuse=reuse.id, _external=True)
+                url_for('reuses.show', reuse=reuse.id, _external=True, **extras)
             ) }}
         </td>
         <td align="center">
             {{ mail_button(
                 _('See on the dataset page'),
                 (
-                    url_for('datasets.show', dataset=dataset.id, _external=True)
+                    url_for('datasets.show', dataset=dataset.id, _external=True, **extras)
                     + '#reuse-'|safe
                     + reuse.id|string
                 )

--- a/udata/templates/mail/new_reuse.html
+++ b/udata/templates/mail/new_reuse.html
@@ -7,8 +7,7 @@
     _('A new reuse of your dataset %(dataset)s has been published',
         dataset=(
             '<a href="'|safe
-            + dataset.external_url
-            + ('?mtm_campaign=' + extras.get('mtm_campaign')) if extras.get('mtm_campaign') else ''
+            + dataset.external_url_with_campaign
             + '" style="text-decoration: none;">'|safe
             + dataset.title
             + '</a>'|safe

--- a/udata/templates/mail/new_reuse.txt
+++ b/udata/templates/mail/new_reuse.txt
@@ -5,7 +5,7 @@
     reuse=reuse.title, dataset=dataset.name
 ) }}.
 {{ _('You can see this new reuse on its own page:') }}
-{{ url_for('reuses.show', reuse=reuse.id, _external=True) }}
+{{ url_for('reuses.show', reuse=reuse.id, _external=True, **extras) }}
 {{ _('Or in the reuse list on you dataset page:')}}
-{{ url_for('datasets.show', dataset=dataset.id, _external=True) }}#reuse-{{reuse.id}}
+{{ url_for('datasets.show', dataset=dataset.id, _external=True, **extras) }}#reuse-{{reuse.id}}
 {% endblock %}

--- a/udata/templates/mail/user_mail_card.html
+++ b/udata/templates/mail/user_mail_card.html
@@ -1,5 +1,5 @@
 {% macro user_mail_card(user, msg=None) %}
-<a href="{{ url_for('api.user', user=user.id, _external=True, **extras) }}"
+<a href="{{ user.external_url_with_campaign }}"
      style="margin: 0;padding: 0;width:100%;">
     <table height="60" cellpadding="0" cellspacing="0" style="margin: 0;padding: 0;border:1px solid #eee;width:100%;">
         <tr style="margin: 0;padding: 0;">

--- a/udata/templates/mail/user_mail_card.html
+++ b/udata/templates/mail/user_mail_card.html
@@ -1,5 +1,5 @@
 {% macro user_mail_card(user, msg=None) %}
-<a href="{{ url_for('api.user', user=user.id, _external=True) }}"
+<a href="{{ url_for('api.user', user=user.id, _external=True, **extras) }}"
      style="margin: 0;padding: 0;width:100%;">
     <table height="60" cellpadding="0" cellspacing="0" style="margin: 0;padding: 0;border:1px solid #eee;width:100%;">
         <tr style="margin: 0;padding: 0;">

--- a/udata/tests/test_mail.py
+++ b/udata/tests/test_mail.py
@@ -102,7 +102,6 @@ class MailCampaignTest:
         message = outbox[0]
         assert "mtm_campaign" not in message.body
         assert "mtm_campaign" not in message.html
-        breakpoint()
 
         app.config["MAIL_CAMPAIGN"] = "data-gouv-fr"
         with mail.record_messages() as outbox:
@@ -111,4 +110,3 @@ class MailCampaignTest:
         message = outbox[0]
         assert "mtm_campaign=data-gouv-fr" in message.body
         assert "mtm_campaign=data-gouv-fr" in message.html
-        breakpoint()


### PR DESCRIPTION
Fixes [#1445](https://github.com/datagouv/data.gouv.fr/issues/1445)

To be used in production, this needs a new setting to be set:

`MAIL_CAMPAIGN = "campaign-name-for-matomo"`