### PR TITLE
Add business documentation url property on dataservice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add more comments and types in the `api_field.py` "lib" [#3174](https://github.com/opendatateam/udata/pull/3174)
 - Allow overriding of badges (for example in plugins like udata-front) [#3191](https://github.com/opendatateam/udata/pull/3191)
+- Add business documentation url property on dataservice [#3193](https://github.com/opendatateam/udata/pull/3193)
 
 ## 10.0.0 (2024-11-07)
 

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -128,6 +128,7 @@ class Dataservice(WithMetrics, Owned, db.Document):
     description = field(db.StringField(default=""), description="In markdown")
     base_api_url = field(db.URLField(), sortable=True)
     endpoint_description_url = field(db.URLField())
+    business_documentation_url = field(db.URLField())
     authorization_request_url = field(db.URLField())
     availability = field(db.FloatField(min=0, max=100), example="99.99")
     rate_limiting = field(db.StringField())


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1561

We don't harvest or expose it in DCAT yet