### PR TITLE
Add link to new admin in existing udata admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add more comments and types in the `api_field.py` "lib" [#3174](https://github.com/opendatateam/udata/pull/3174)
 - Allow overriding of badges (for example in plugins like udata-front) [#3191](https://github.com/opendatateam/udata/pull/3191)
+- Add link to new admin in existing udata admin based on `NEW_ADMIN_URL` setting [#3194](https://github.com/opendatateam/udata/pull/3194)
 
 ## 10.0.0 (2024-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allow overriding of badges (for example in plugins like udata-front) [#3191](https://github.com/opendatateam/udata/pull/3191)
 - Add link to new admin in existing udata admin based on `NEW_ADMIN_URL` setting [#3194](https://github.com/opendatateam/udata/pull/3194)
 - Add business documentation url property on dataservice [#3193](https://github.com/opendatateam/udata/pull/3193)
+- Expose the dataset's alternate identifier in RDF [#3186](https://github.com/opendatateam/udata/pull/3186)
 
 ## 10.0.0 (2024-11-07)
 
@@ -24,7 +25,6 @@
     * you will need https://github.com/opendatateam/udata-search-service/pull/48
 - Expose the "landingPage" in DCAT RDF [#3183](https://github.com/opendatateam/udata/pull/3183)
 - Licence.guess: extract first URL for better matching [#3185](https://github.com/opendatateam/udata/pull/3185)
-- Expose the dataset's alternate identifier in RDF [#3186](https://github.com/opendatateam/udata/pull/3186)
 
 ## 9.2.4 (2024-10-22)
 

--- a/js/admin.vue
+++ b/js/admin.vue
@@ -2,7 +2,7 @@
 <div>
     <!-- Placeholder for non-routable modals -->
     <div v-el:modal></div>
-    <app-header></app-header>
+    <app-header :new-admin-url="newAdminUrl"></app-header>
     <sidebar></sidebar>
     <router-view></router-view>
 </div>
@@ -27,6 +27,7 @@ export default {
             notifications: [],
             site, me, config,
             readOnlyEnabled: config.read_only_enabled,
+            newAdminUrl: config.new_admin_url,
         };
     },
     components: {AppHeader, Sidebar},

--- a/js/components/header.vue
+++ b/js/components/header.vue
@@ -25,6 +25,12 @@
             <span class="sr-only">Toggle navigation</span>
             <span :class="['fa', $root.toggled ? 'fa-angle-double-left' : 'fa-angle-double-right']"></span>
         </a>
+        <span class="navbar-banner" v-if="newAdminUrl">
+            <a :href="newAdminUrl" target="_blank">
+                {{ _("✨ Come and discover the new version of the back office") }}
+                <span class="fa fa-external-link"></span>
+            </a>
+        </span>
       <div class="navbar-custom-menu">
           <ul class="nav navbar-nav">
             <notification-menu></notification-menu>
@@ -41,6 +47,9 @@
 'use strict';
 
 module.exports = {
+    props: {
+        newAdminUrl: String,
+    },
     components: {
         'user-menu': require('components/user-menu.vue'),
         'notification-menu': require('components/notification-menu.vue'),

--- a/js/config.js
+++ b/js/config.js
@@ -180,6 +180,11 @@ export const search_autocomplete_debounce = _jsonMeta('search-autocomplete-debou
  */
 export const read_only_enabled = _jsonMeta('read-only-enabled');
 
+/**
+ * Whether to add a banner towards a new admin
+ */
+export const new_admin_url = _meta('new-admin-url');
+
 
 export default {
     user,
@@ -207,4 +212,5 @@ export default {
     search_autocomplete_debounce,
     markdown,
     read_only_enabled,
+    new_admin_url,
 };

--- a/js/locales/udata.en.json
+++ b/js/locales/udata.en.json
@@ -520,5 +520,6 @@
     "{name} has been unscheduled": "{name} has been unscheduled",
     "{start} to {end}": "{start} to {end}",
     "{user} is not a member of this organization anymore": "{user} is not a member of this organization anymore",
-    "{user} is now {role} of this organization": "{user} is now {role} of this organization"
+    "{user} is now {role} of this organization": "{user} is now {role} of this organization",
+    "✨ Come and discover the new version of the back office": "✨ Come and discover the new version of the back office"
 }

--- a/less/admin/skin.less
+++ b/less/admin/skin.less
@@ -34,6 +34,11 @@
         }
       }
       .navbar-banner{
+
+        @media (max-width: @screen-header-collapse) {
+          display: none;
+        }
+
         line-height: 50px;
         > a, > a:hover, > a:focus {
           color: #fff;

--- a/less/admin/skin.less
+++ b/less/admin/skin.less
@@ -34,11 +34,7 @@
         }
       }
       .navbar-banner{
-        float: left;
-        // background-color: #605ca8; // #00a65a;
-        border-radius: 5px;
-        padding: 6px;
-        margin: 8px;
+        line-height: 50px;
         > a, > a:hover, > a:focus {
           color: #fff;
           text-decoration: underline white;

--- a/less/admin/skin.less
+++ b/less/admin/skin.less
@@ -33,6 +33,21 @@
           }
         }
       }
+      .navbar-banner{
+        float: left;
+        // background-color: #605ca8; // #00a65a;
+        border-radius: 5px;
+        padding: 6px;
+        margin: 8px;
+        > a, > a:hover, > a:focus {
+          color: #fff;
+          text-decoration: underline white;
+
+          > .fa-external-link {
+            padding-left: 5px;
+          }
+        }
+      }
     }
     //Logo
     .logo {

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -519,6 +519,11 @@ class Defaults(object):
         "FollowAPI.post",
     ]
 
+    # New admin URL
+    ####################
+    # This setting will add a banner on the old udata admin with a link to a new admin
+    NEW_ADMIN_URL = None
+
     FIXTURE_DATASET_SLUGS = []
     PUBLISH_ON_RESOURCE_EVENTS = False
     RESOURCES_ANALYSER_URI = "http://localhost:8000"

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -64,6 +64,7 @@
     config.LICENSE_GROUPS|tojson|urlencode
 }} />
 <meta name="read-only-enabled" content="{{ 'true' if config.READ_ONLY_MODE else 'false' }}">
+<meta name="new-admin-url" content="{{ config.NEW_ADMIN_URL or '' }}">
 <meta name="harvest-enable-manual-run" content="{{ 'true' if config.HARVEST_ENABLE_MANUAL_RUN else 'false' }}">
 {% if config.HARVEST_VALIDATION_CONTACT_FORM %}
 <meta name="harvest-validation-contact-form" content="{{config.HARVEST_VALIDATION_CONTACT_FORM}}">

--- a/udata/translations/udata.pot
+++ b/udata/translations/udata.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata 9.2.4.dev0\n"
+"Project-Id-Version: udata 10.0.1.dev0\n"
 "Report-Msgid-Bugs-To: i18n@opendata.team\n"
-"POT-Creation-Date: 2024-10-14 16:52+0200\n"
-"PO-Revision-Date: 2024-10-14 16:52+0200\n"
+"POT-Creation-Date: 2024-11-15 10:00+0100\n"
+"PO-Revision-Date: 2024-11-15 10:00+0100\n"
 "Last-Translator: Open Data Team <i18n@opendata.team>\n"
 "Language: en\n"
 "Language-Team: Open Data Team <i18n@opendata.team>\n"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Invalid URL \"{url}\": {reason}"
 msgstr ""
 
-#: udata/tests/api/test_datasets_api.py:795 udata/tests/test_model.py:367
+#: udata/tests/api/test_datasets_api.py:810 udata/tests/test_model.py:367
 #: udata/uris.py:55
 msgid "Invalid URL \"{url}\""
 msgstr ""
@@ -206,7 +206,7 @@ msgid "Your udata instance is ready!"
 msgstr ""
 
 #: udata/core/owned.py:53 udata/forms/fields.py:735
-#: udata/tests/api/test_dataservices_api.py:297
+#: udata/tests/api/test_dataservices_api.py:407
 msgid "You can only set yourself as owner"
 msgstr ""
 
@@ -215,15 +215,15 @@ msgid "Unknown organization"
 msgstr ""
 
 #: udata/core/owned.py:66 udata/forms/fields.py:756
-#: udata/tests/api/test_dataservices_api.py:311
+#: udata/tests/api/test_dataservices_api.py:421
 msgid "Permission denied for this organization"
 msgstr ""
 
-#: udata/core/badges/forms.py:15
+#: udata/core/badges/forms.py:12
 msgid "Kind"
 msgstr ""
 
-#: udata/core/badges/forms.py:18
+#: udata/core/badges/forms.py:15
 msgid "Kind of badge (certified, etc)"
 msgstr ""
 
@@ -256,12 +256,12 @@ msgstr ""
 msgid "At least an email or a contact form is required for a contact point"
 msgstr ""
 
-#: udata/core/dataservices/models.py:159 udata/core/dataset/models.py:531
+#: udata/core/dataservices/models.py:163 udata/core/dataset/models.py:568
 #: udata/mongo/datetime_fields.py:60
 msgid "Creation date"
 msgstr ""
 
-#: udata/core/dataservices/models.py:164 udata/core/dataset/models.py:534
+#: udata/core/dataservices/models.py:168 udata/core/dataset/models.py:571
 #: udata/mongo/datetime_fields.py:66
 msgid "Last modification date"
 msgstr ""
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Related dataset"
 msgstr ""
 
-#: udata/core/dataset/forms.py:134 udata/tests/api/test_datasets_api.py:710
+#: udata/core/dataset/forms.py:134 udata/tests/api/test_datasets_api.py:725
 msgid "Wrong contact point id or contact point ownership mismatch"
 msgstr ""
 
@@ -550,44 +550,44 @@ msgstr ""
 msgid "Restrict the dataset visibility to you or your organization only."
 msgstr ""
 
-#: udata/core/dataset/models.py:129
+#: udata/core/dataset/models.py:59
+msgid "Pivotal data"
+msgstr ""
+
+#: udata/core/dataset/models.py:135
 msgid "A schema must contains a name or an URL when a version is provided."
 msgstr ""
 
-#: udata/core/dataset/models.py:160 udata/tests/api/test_datasets_api.py:803
-#: udata/tests/api/test_datasets_api.py:814
+#: udata/core/dataset/models.py:166 udata/tests/api/test_datasets_api.py:818
+#: udata/tests/api/test_datasets_api.py:829
 msgid "Schema name \"{schema}\" is not an allowed value. Allowed values: {values}"
 msgstr ""
 
-#: udata/core/dataset/models.py:179 udata/tests/api/test_datasets_api.py:825
+#: udata/core/dataset/models.py:185 udata/tests/api/test_datasets_api.py:840
 msgid ""
 "Version \"{version}\" is not an allowed value for the schema \"{name}\". "
 "Allowed versions: {values}"
 msgstr ""
 
-#: udata/core/dataset/models.py:439 udata/core/dataset/rdf.py:468
-#: udata/tests/dataset/test_dataset_rdf.py:529
-#: udata/tests/dataset/test_dataset_rdf.py:542
+#: udata/core/dataset/models.py:462 udata/core/dataset/rdf.py:503
+#: udata/tests/dataset/test_dataset_rdf.py:556
+#: udata/tests/dataset/test_dataset_rdf.py:569
 msgid "Nameless resource"
 msgstr ""
 
-#: udata/core/dataset/models.py:517
+#: udata/core/dataset/models.py:554
 msgid "Future date of update"
 msgstr ""
 
-#: udata/core/dataset/models.py:543
-msgid "Pivotal data"
-msgstr ""
-
-#: udata/core/dataset/models.py:584
+#: udata/core/dataset/models.py:617
 msgid "dataset"
 msgstr ""
 
-#: udata/core/dataset/rdf.py:466 udata/tests/dataset/test_dataset_rdf.py:516
+#: udata/core/dataset/rdf.py:501 udata/tests/dataset/test_dataset_rdf.py:543
 msgid "{format} resource"
 msgstr ""
 
-#: udata/core/dataset/tasks.py:106
+#: udata/core/dataset/tasks.py:108
 msgid "You need to update some frequency-based datasets"
 msgstr ""
 
@@ -663,17 +663,17 @@ msgid "Refused"
 msgstr ""
 
 #: udata/core/organization/forms.py:25
-#: udata/tests/api/test_organizations_api.py:116
+#: udata/tests/api/test_organizations_api.py:131
 msgid "A siret number is made of 14 digits"
 msgstr ""
 
 #: udata/core/organization/forms.py:36
-#: udata/tests/api/test_organizations_api.py:128
+#: udata/tests/api/test_organizations_api.py:143
 msgid "A siret number is only made of digits"
 msgstr ""
 
 #: udata/core/organization/forms.py:39
-#: udata/tests/api/test_organizations_api.py:123
+#: udata/tests/api/test_organizations_api.py:138
 msgid "Invalid Siret number"
 msgstr ""
 
@@ -709,23 +709,23 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: udata/core/organization/models.py:130
+#: udata/core/organization/models.py:34
 msgid "Public Service"
 msgstr ""
 
-#: udata/core/organization/models.py:131
+#: udata/core/organization/models.py:35
 msgid "Certified"
 msgstr ""
 
-#: udata/core/organization/models.py:132
+#: udata/core/organization/models.py:36
 msgid "Association"
 msgstr ""
 
-#: udata/core/organization/models.py:133
+#: udata/core/organization/models.py:37
 msgid "Company"
 msgstr ""
 
-#: udata/core/organization/models.py:134
+#: udata/core/organization/models.py:38
 msgid "Local authority"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Connected device"
 msgstr ""
 
-#: udata/core/reuse/constants.py:15 udata/tests/reuse/test_reuse_model.py:105
+#: udata/core/reuse/constants.py:15 udata/tests/reuse/test_reuse_model.py:106
 msgid "Health"
 msgstr ""
 
@@ -935,11 +935,11 @@ msgstr ""
 msgid "Open data tools"
 msgstr ""
 
-#: udata/core/reuse/models.py:33
+#: udata/core/reuse/models.py:35
 msgid "This URL is already registered"
 msgstr ""
 
-#: udata/core/reuse/models.py:160
+#: udata/core/reuse/models.py:175
 msgid "reuse"
 msgstr ""
 


### PR DESCRIPTION
Add a `NEW_ADMIN_URL` config.
Display a link to it in udata admin if this setting is set.

Current rendering:
![image](https://github.com/user-attachments/assets/39efa1ce-be60-4867-9cdd-1cb36c860204)
