### PR TITLE
Use correct DCAT.service predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use correct DCAT.service predicate in RDF output [#3199](https://github.com/opendatateam/udata/pull/3199)
 
 ## 10.0.1 (2024-11-15)
 

--- a/udata/core/organization/rdf.py
+++ b/udata/core/organization/rdf.py
@@ -49,7 +49,7 @@ def build_org_catalog(org, datasets, dataservices, format=None):
     for dataset in datasets:
         catalog.add(DCAT.dataset, dataset_to_rdf(dataset, graph))
     for dataservice in dataservices:
-        catalog.add(DCAT.dataservice, dataservice_to_rdf(dataservice, graph))
+        catalog.add(DCAT.service, dataservice_to_rdf(dataservice, graph))
 
     values = {"org": org.id}
 

--- a/udata/core/site/rdf.py
+++ b/udata/core/site/rdf.py
@@ -43,7 +43,7 @@ def build_catalog(site, datasets, dataservices=[], format=None):
 
     for dataservice in dataservices:
         rdf_dataservice = dataservice_to_rdf(dataservice, graph)
-        catalog.add(DCAT.DataService, rdf_dataservice)
+        catalog.add(DCAT.service, rdf_dataservice)
 
     if isinstance(datasets, Paginable):
         paginate_catalog(catalog, graph, datasets, format, "api.site_rdf_catalog_format")

--- a/udata/tests/organization/test_organization_rdf.py
+++ b/udata/tests/organization/test_organization_rdf.py
@@ -72,7 +72,7 @@ class OrganizationToRdfTest(DBTestMixin, TestCase):
         self.assertEqual(str(catalog.identifier), uri)
 
         self.assertEqual(len(list(catalog.objects(DCAT.dataset))), len(datasets))
-        self.assertEqual(len(list(catalog.objects(DCAT.dataservice))), len(dataservices))
+        self.assertEqual(len(list(catalog.objects(DCAT.service))), len(dataservices))
 
         org = catalog.value(DCT.publisher)
         self.assertEqual(org.value(RDF.type).identifier, FOAF.Organization)
@@ -138,7 +138,7 @@ class OrganizationToRdfTest(DBTestMixin, TestCase):
         self.assertEqual(len(list(catalog.objects(DCAT.dataset))), page_size)
         # All dataservices that are not linked to a dataset are listed in the first page.
         # See DataserviceQuerySet.filter_by_dataset_pagination.
-        self.assertEqual(len(list(catalog.objects(DCAT.dataservice))), total)
+        self.assertEqual(len(list(catalog.objects(DCAT.service))), total)
 
         paginations = list(graph.subjects(RDF.type, HYDRA.PartialCollectionView))
         self.assertEqual(len(paginations), 1)
@@ -166,7 +166,7 @@ class OrganizationToRdfTest(DBTestMixin, TestCase):
         # 5 datasets total, 3 on the first page, 2 on the second.
         self.assertEqual(len(list(catalog.objects(DCAT.dataset))), 2)
         # 1 extra_dataservice, listed on the same page as its associated extra_dataset.
-        self.assertEqual(len(list(catalog.objects(DCAT.dataservice))), 1)
+        self.assertEqual(len(list(catalog.objects(DCAT.service))), 1)
 
         paginations = list(graph.subjects(RDF.type, HYDRA.PartialCollectionView))
         self.assertEqual(len(paginations), 1)

--- a/udata/tests/site/test_site_rdf.py
+++ b/udata/tests/site/test_site_rdf.py
@@ -270,8 +270,13 @@ class SiteRdfViewsTest:
         datasets = list(graph.subjects(RDF.type, DCAT.Dataset))
         assert len(datasets) == 3
 
+        # 4 objects of RDF.type DCAT.DataService
         dataservices = list(graph.subjects(RDF.type, DCAT.DataService))
         assert len(dataservices) == 4
+
+        # these 4 objects are also bound to catalog by DCAT.service predicate
+        catalog = graph.resource(next(graph.subjects(RDF.type, DCAT.Catalog)))
+        assert len(list(catalog.objects(DCAT.service))) == 4
 
         # Test first page contains the dataservice without dataset
         response = client.get(


### PR DESCRIPTION
Our DataServices were not harvested by data.europa.eu (cf [0 results](https://data.europa.eu/data/datasets?locale=en&minScoring=0&catalog=plateforme-ouverte-des-donnees-publiques-francaises&page=1&dataServices=true)).

The predicate to use on the catalog to link to a dataservice is `DCAT.service` (as specified in https://w3c.github.io/dxwg/dcat/#Property:catalog_service).
