### PR TITLE
Convert bool filters to 0 or 1 when querying the search service

### DIFF
--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -41,7 +41,12 @@ class SearchQuery:
             if self.sort:
                 url = url + f"&sort={self.sort}"
             for name, value in self._filters.items():
-                url = url + f"&{name}={value}"
+                param_value = value
+                # HACK: use the `.__class__.__name__` to avoid having to import `BoolFilter` here, as importing it at the top would make a import loop.
+                if self.adapter.filters[name].__class__.__name__ == "BoolFilter":
+                    # The search service uses 1 and 0 for booleans.
+                    param_value = 1 if value == "true" else 0
+                url = url + f"&{name}={param_value}"
             r = requests.get(url, timeout=current_app.config["SEARCH_SERVICE_REQUEST_TIMEOUT"])
             r.raise_for_status()
             result = r.json()

--- a/udata/tests/search/test_query.py
+++ b/udata/tests/search/test_query.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch
+
+from flask import current_app
+
+from udata.core.dataset.search import DatasetSearch
 from udata.search.query import DEFAULT_PAGE_SIZE, SearchQuery
 from udata.tests.api import APITestCase
 
@@ -37,3 +42,29 @@ class QueryTest(APITestCase):
         search_query = SearchQuery(params=query)
         url = search_query.to_url()
         assert "organization=534fff81a3a7292c64a77e5c&q=insee&sort=-created&page=1" in url
+
+    @patch("requests.get")
+    # Mock udata.search.result.SearchResult, used in SearchQuery.execute_search.
+    @patch("udata.search.query.SearchResult")
+    def test_search_query_for_search_service(self, search_result_req, mock_req):
+        """When using the search service, boolean filters need to be converted to 0 or 1."""
+        current_app.config["SEARCH_SERVICE_API_URL"] = "http://example.com/"
+        query = {
+            "featured": "true",
+            "page": 1,
+            "page_size": 20,
+        }
+        search_query = SearchQuery(query)
+        search_query.adapter = DatasetSearch
+        search_query.execute_search()
+        mock_req.assert_called_with(
+            "http://example.com/datasets/?q=&page=1&page_size=20&featured=1", timeout=20
+        )
+
+        query["featured"] = "false"
+        search_query = SearchQuery(query)
+        search_query.adapter = DatasetSearch
+        search_query.execute_search()
+        mock_req.assert_called_with(
+            "http://example.com/datasets/?q=&page=1&page_size=20&featured=0", timeout=20
+        )


### PR DESCRIPTION
Fixes [#1456](https://github.com/datagouv/data.gouv.fr/issues/1456)