### PR TITLE
feat: handle multiple tags on datasets and topics apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use a safe XML parser that doesn't resolve entities, update lxml to 5.3.0 [#3205](https://github.com/opendatateam/udata/pull/3205)
 - Add DCAT-AP HVD properties in RDF output if the dataservice or its datasets are tagged hvd [#3187](https://github.com/opendatateam/udata/pull/3187)
 - Only keep the "local authority" org badge if it's also a "public service" [#3200](https://github.com/opendatateam/udata/pull/3200)
+- feat: handle multiple tags on datasets and topics apis [#3204](https://github.com/opendatateam/udata/pull/3204)
 
 ## 10.0.2 (2024-11-19)
 

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -90,7 +90,7 @@ class DatasetApiParser(ModelApiParser):
 
     def __init__(self):
         super().__init__()
-        self.parser.add_argument("tag", type=str, location="args")
+        self.parser.add_argument("tag", type=str, location="args", action="append")
         self.parser.add_argument("license", type=str, location="args")
         self.parser.add_argument("featured", type=bool, location="args")
         self.parser.add_argument("geozone", type=str, location="args")
@@ -120,7 +120,7 @@ class DatasetApiParser(ModelApiParser):
             phrase_query = " ".join([f'"{elem}"' for elem in args["q"].split(" ")])
             datasets = datasets.search_text(phrase_query)
         if args.get("tag"):
-            datasets = datasets.filter(tags=args["tag"])
+            datasets = datasets.filter(tags__all=args["tag"])
         if args.get("license"):
             datasets = datasets.filter(license__in=License.objects.filter(id=args["license"]))
         if args.get("geozone"):

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -267,7 +267,7 @@ class DatasetSearchAPI(API):
         """List or search all datasets"""
         args = search_parser.parse_args()
         try:
-            return search.query(Dataset, **args)
+            return search.query(Dataset, **{k: v for k, v in args.items() if v is not None})
         except NotImplementedError:
             abort(501, "Search endpoint not enabled")
         except RuntimeError:

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -9,7 +9,7 @@ from udata.api import API, apiv2, fields
 from udata.core.contact_point.api_fields import contact_point_fields
 from udata.core.organization.api_fields import member_user_with_email_fields
 from udata.core.spatial.api_fields import geojson
-from udata.utils import get_by, multi_to_dict
+from udata.utils import get_by
 
 from .api import ResourceMixin
 from .api_fields import (
@@ -265,9 +265,9 @@ class DatasetSearchAPI(API):
     @apiv2.marshal_with(dataset_page_fields)
     def get(self):
         """List or search all datasets"""
-        search_parser.parse_args()
+        args = search_parser.parse_args()
         try:
-            return search.query(Dataset, **multi_to_dict(request.args))
+            return search.query(Dataset, **args)
         except NotImplementedError:
             abort(501, "Search endpoint not enabled")
         except RuntimeError:

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -73,7 +73,7 @@ DEFAULT_MASK_APIV2 = ",".join(
 log = logging.getLogger(__name__)
 
 ns = apiv2.namespace("datasets", "Dataset related operations")
-search_parser = DatasetSearch.as_request_parser()
+search_parser = DatasetSearch.as_request_parser(store_missing=False)
 resources_parser = apiv2.parser()
 resources_parser.add_argument(
     "page", type=int, default=1, location="args", help="The page to fetch"
@@ -267,7 +267,7 @@ class DatasetSearchAPI(API):
         """List or search all datasets"""
         args = search_parser.parse_args()
         try:
-            return search.query(Dataset, **{k: v for k, v in args.items() if v is not None})
+            return search.query(Dataset, **args)
         except NotImplementedError:
             abort(501, "Search endpoint not enabled")
         except RuntimeError:

--- a/udata/core/dataset/search.py
+++ b/udata/core/dataset/search.py
@@ -7,6 +7,7 @@ from udata.models import Dataset, GeoZone, License, Organization, Topic, User
 from udata.search import (
     BoolFilter,
     Filter,
+    ListFilter,
     ModelSearchAdapter,
     ModelTermsFilter,
     TemporalCoverageFilter,
@@ -31,7 +32,7 @@ class DatasetSearch(ModelSearchAdapter):
     }
 
     filters = {
-        "tag": Filter(),
+        "tag": ListFilter(),
         "badge": Filter(choices=list(Dataset.__badges__)),
         "organization": ModelTermsFilter(model=Organization),
         "organization_badge": Filter(choices=list(Organization.__badges__)),

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -15,7 +15,7 @@ class TopicApiParser(ModelApiParser):
         super().__init__()
         if with_include_private:
             self.parser.add_argument("include_private", type=bool, location="args")
-        self.parser.add_argument("tag", type=str, location="args")
+        self.parser.add_argument("tag", type=str, location="args", action="append")
         self.parser.add_argument("geozone", type=str, location="args")
         self.parser.add_argument("granularity", type=str, location="args")
         self.parser.add_argument("organization", type=str, location="args")
@@ -31,7 +31,7 @@ class TopicApiParser(ModelApiParser):
             phrase_query = " ".join([f'"{elem}"' for elem in args["q"].split(" ")])
             topics = topics.search_text(phrase_query)
         if args.get("tag"):
-            topics = topics.filter(tags=args["tag"])
+            topics = topics.filter(tags__all=args["tag"])
         if not args.get("include_private"):
             topics = topics.filter(private=False)
         if args.get("geozone"):

--- a/udata/search/adapter.py
+++ b/udata/search/adapter.py
@@ -27,19 +27,28 @@ class ModelSearchAdapter:
         return True
 
     @classmethod
-    def as_request_parser(cls, paginate=True):
+    def as_request_parser(cls, paginate=True, store_missing: bool = True):
         parser = RequestParser()
         # q parameter
-        parser.add_argument("q", type=str, location="args", help="The search query")
+        parser.add_argument(
+            "q", type=str, location="args", help="The search query", store_missing=store_missing
+        )
         # Add filters arguments
         for name, type in cls.filters.items():
             kwargs = type.as_request_parser_kwargs()
-            parser.add_argument(name, location="args", **kwargs)
+            parser.add_argument(name, location="args", store_missing=store_missing, **kwargs)
         # Sort arguments
         keys = list(cls.sorts)
         choices = keys + ["-" + k for k in keys]
         help_msg = "The field (and direction) on which sorting apply"
-        parser.add_argument("sort", type=str, location="args", choices=choices, help=help_msg)
+        parser.add_argument(
+            "sort",
+            type=str,
+            location="args",
+            choices=choices,
+            help=help_msg,
+            store_missing=store_missing,
+        )
         if paginate:
             parser.add_argument(
                 "page", type=int, location="args", default=1, help="The page to display"

--- a/udata/search/fields.py
+++ b/udata/search/fields.py
@@ -8,7 +8,7 @@ from udata.utils import clean_string
 
 log = logging.getLogger(__name__)
 
-__all__ = ("BoolFilter", "ModelTermsFilter", "TemporalCoverageFilter", "Filter")
+__all__ = ("BoolFilter", "ModelTermsFilter", "TemporalCoverageFilter", "Filter", "ListFilter")
 
 
 ES_NUM_FAILURES = "-Infinity", "Infinity", "NaN", None
@@ -26,6 +26,12 @@ class Filter:
         if self.choices:
             return {"type": clean_string, "choices": self.choices}
         return {"type": clean_string}
+
+
+class ListFilter:
+    @classmethod
+    def as_request_parser_kwargs(self):
+        return {"action": "append"}
 
 
 class BoolFilter(Filter):

--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -37,11 +37,7 @@ class SearchQuery:
         # If SEARCH_SERVICE_API_URL is set, the remote search service will be queried.
         # Otherwise mongo search will be used instead.
         if current_app.config["SEARCH_SERVICE_API_URL"]:
-            url = f"{current_app.config['SEARCH_SERVICE_API_URL']}{self.adapter.search_url}?q={self._query}&page={self.page}&page_size={self.page_size}"
-            if self.sort:
-                url = url + f"&sort={self.sort}"
-            for name, value in self._filters.items():
-                url = url + f"&{name}={value}"
+            url = self.to_search_service_url()
             r = requests.get(url, timeout=current_app.config["SEARCH_SERVICE_REQUEST_TIMEOUT"])
             r.raise_for_status()
             result = r.json()
@@ -59,6 +55,19 @@ class SearchQuery:
                 query=self, mongo_objects=list(result), total=result.total, **query_args
             )
 
+    def to_search_service_url(self):
+        url = f"{current_app.config['SEARCH_SERVICE_API_URL']}{self.adapter.search_url}?q={self._query}&page={self.page}&page_size={self.page_size}"
+        if self.sort:
+            url = url + f"&sort={self.sort}"
+        for name, value in self._filters.items():
+            if isinstance(value, (list, tuple)):
+                for v in value:
+                    url = url + f"&{name}={v}"
+            else:
+                url = url + f"&{name}={value}"
+        return url
+
+    # FIXME: unused?
     def to_url(self, url=None, replace=False, **kwargs):
         """Serialize the query into an URL"""
         params = copy.deepcopy(self._filters)

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -154,7 +154,8 @@ class DatasetAPITest(APITestCase):
 
         [DatasetFactory() for i in range(2)]
 
-        tag_dataset = DatasetFactory(tags=["my-tag", "other"])
+        tag_dataset_1 = DatasetFactory(tags=["my-tag-shared", "my-tag-1"])
+        tag_dataset_2 = DatasetFactory(tags=["my-tag-shared", "my-tag-2"])
         license_dataset = DatasetFactory(license=LicenseFactory(id="cc-by"))
         format_dataset = DatasetFactory(resources=[ResourceFactory(format="my-format")])
         featured_dataset = DatasetFactory(featured=True)
@@ -192,10 +193,19 @@ class DatasetAPITest(APITestCase):
         )
 
         # filter on tag
-        response = self.get(url_for("api.datasets", tag="my-tag"))
+        response = self.get(url_for("api.datasets", tag="my-tag-shared"))
+        self.assert200(response)
+        self.assertEqual(len(response.json["data"]), 2)
+        self.assertEqual(
+            set([str(tag_dataset_1.id), str(tag_dataset_2.id)]),
+            set([d["id"] for d in response.json["data"]]),
+        )
+
+        # filter on multiple tags
+        response = self.get(url_for("api.datasets", tag=["my-tag-shared", "my-tag-1"]))
         self.assert200(response)
         self.assertEqual(len(response.json["data"]), 1)
-        self.assertEqual(response.json["data"][0]["id"], str(tag_dataset.id))
+        self.assertEqual(response.json["data"][0]["id"], str(tag_dataset_1.id))
 
         # filter on format
         response = self.get(url_for("api.datasets", format="my-format"))

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -22,7 +22,8 @@ class TopicsAPITest(APITestCase):
         org = OrganizationFactory()
         paca, _, _ = create_geozones_fixtures()
 
-        tag_topic = TopicFactory(tags=["energy"])
+        tag_topic_1 = TopicFactory(tags=["my-tag-shared", "my-tag-1"])
+        tag_topic_2 = TopicFactory(tags=["my-tag-shared", "my-tag-2"])
         name_topic = TopicFactory(name="topic-for-query")
         private_topic = TopicFactory(private=True)
         geozone_topic = TopicFactory(spatial=SpatialCoverageFactory(zones=[paca.id]))
@@ -32,35 +33,43 @@ class TopicsAPITest(APITestCase):
 
         response = self.get(url_for("api.topics"))
         self.assert200(response)
-        self.assertEqual(len(response.json["data"]), 6)
+        self.assertEqual(len(response.json["data"]), 7)
 
         response = self.get(url_for("api.topics", q="topic-for"))
         self.assert200(response)
         self.assertEqual(len(response.json["data"]), 1)
         self.assertEqual(response.json["data"][0]["id"], str(name_topic.id))
 
-        response = self.get(url_for("api.topics", tag="energy"))
+        response = self.get(url_for("api.topics", tag="my-tag-1"))
         self.assert200(response)
         self.assertEqual(len(response.json["data"]), 1)
-        self.assertEqual(response.json["data"][0]["id"], str(tag_topic.id))
+        self.assertEqual(response.json["data"][0]["id"], str(tag_topic_1.id))
         datasets = response.json["data"][0]["datasets"]
         self.assertEqual(len(datasets), 3)
-        for dataset, expected in zip(datasets, [d.fetch() for d in tag_topic.datasets]):
+        for dataset, expected in zip(datasets, [d.fetch() for d in tag_topic_1.datasets]):
             self.assertEqual(dataset["id"], str(expected.id))
             self.assertEqual(dataset["title"], str(expected.title))
             self.assertIsNotNone(dataset["page"])
             self.assertIsNotNone(dataset["uri"])
         reuses = response.json["data"][0]["reuses"]
-        for reuse, expected in zip(reuses, [r.fetch() for r in tag_topic.reuses]):
+        for reuse, expected in zip(reuses, [r.fetch() for r in tag_topic_1.reuses]):
             self.assertEqual(reuse["id"], str(expected.id))
             self.assertEqual(reuse["title"], str(expected.title))
             self.assertIsNotNone(reuse["page"])
             self.assertIsNotNone(reuse["uri"])
         self.assertEqual(len(reuses), 3)
 
+        response = self.get(url_for("api.topics", tag="my-tag-shared"))
+        self.assert200(response)
+        self.assertEqual(len(response.json["data"]), 2)
+        self.assertEqual(
+            set([str(tag_topic_1.id), str(tag_topic_2.id)]),
+            set([t["id"] for t in response.json["data"]]),
+        )
+
         response = self.get(url_for("api.topics", include_private="true"))
         self.assert200(response)
-        self.assertEqual(len(response.json["data"]), 7)
+        self.assertEqual(len(response.json["data"]), 8)
         self.assertIn(str(private_topic.id), [t["id"] for t in response.json["data"]])
 
         response = self.get(url_for("api.topics", geozone=paca.id))

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -40,7 +40,7 @@ class TopicsAPITest(APITestCase):
         self.assertEqual(len(response.json["data"]), 1)
         self.assertEqual(response.json["data"][0]["id"], str(name_topic.id))
 
-        response = self.get(url_for("api.topics", tag="my-tag-1"))
+        response = self.get(url_for("api.topics", tag=["my-tag-shared", "my-tag-1"]))
         self.assert200(response)
         self.assertEqual(len(response.json["data"]), 1)
         self.assertEqual(response.json["data"][0]["id"], str(tag_topic_1.id))

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -61,6 +61,21 @@ class DatasetAPIV2Test(APITestCase):
         assert len(data) == 1
         assert data[0]["id"] == str(dataset_org_public_service.id)
 
+    def test_search_dataset_tags(self):
+        tag_dataset_1 = DatasetFactory(tags=["my-tag-shared", "my-tag-1"])
+        DatasetFactory(tags=["my-tag-shared", "my-tag-2"])
+
+        response = self.get(url_for("apiv2.dataset_search", tag="my-tag-shared"))
+        self.assert200(response)
+        data = response.json["data"]
+        assert len(data) == 2
+
+        response = self.get(url_for("apiv2.dataset_search", tag=["my-tag-shared", "my-tag-1"]))
+        self.assert200(response)
+        data = response.json["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(tag_dataset_1.id)
+
 
 class DatasetResourceAPIV2Test(APITestCase):
     def test_get_specific(self):

--- a/udata/tests/search/test_query.py
+++ b/udata/tests/search/test_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from udata.search.query import DEFAULT_PAGE_SIZE, SearchQuery
 from udata.tests.api import APITestCase
 
@@ -37,3 +39,24 @@ class QueryTest(APITestCase):
         search_query = SearchQuery(params=query)
         url = search_query.to_url()
         assert "organization=534fff81a3a7292c64a77e5c&q=insee&sort=-created&page=1" in url
+
+    @pytest.mark.options(SEARCH_SERVICE_API_URL="https://example.com/")
+    def test_search_query_to_search_service_url(self):
+        class FakeAdapater:
+            search_url = "search/"
+
+        query = {
+            "organization": "534fff81a3a7292c64a77e5c",
+            "q": "insee",
+            "sort": "-created",
+            "page": 1,
+            "page_size": 20,
+            "tag": ["tag-1", "tag-2"],
+        }
+        search_query = SearchQuery(params=query)
+        search_query.adapter = FakeAdapater()
+        url = search_query.to_search_service_url()
+        assert (
+            url
+            == "https://example.com/search/?q=insee&page=1&page_size=20&sort=-created&organization=534fff81a3a7292c64a77e5c&tag=tag-1&tag=tag-2"
+        )


### PR DESCRIPTION
Multiple tags filter is now supported and datasets and topics list APIs.

The filter is a `AND`, i.e. `?tag=tag1&tag=tag2` will return objects that have both the `tag1` and `tag2` tags.

- [x] datasets api v1
- [x] datasets api v2 (`datasets/search` through MongoEngine)
- [x] topics api v1
- [x] topics api v2 
- [x] datasets api v2 w/ search service https://github.com/opendatateam/udata-search-service/pull/50