### PR TITLE
Add created and last_modified sorts on dataservice list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add a matomo "campaign" parameter on links in emails if `MAIL_CAMPAIGN` is configured [#3190](https://github.com/opendatateam/udata/pull/3190)
+- Add created and last_modified sorts on dataservice list [#3206](https://github.com/opendatateam/udata/pull/3206)
 
 ## 10.0.2 (2024-11-19)
 

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -163,12 +163,14 @@ class Dataservice(WithMetrics, Owned, db.Document):
     created_at = field(
         db.DateTimeField(verbose_name=_("Creation date"), default=datetime.utcnow, required=True),
         readonly=True,
+        sortable="created",
     )
     metadata_modified_at = field(
         db.DateTimeField(
             verbose_name=_("Last modification date"), default=datetime.utcnow, required=True
         ),
         readonly=True,
+        sortable="last_modified",
     )
     deleted_at = field(db.DateTimeField())
     archived_at = field(db.DateTimeField(), readonly=True)


### PR DESCRIPTION
Used `created` and `last_modified` wordings since they are the most commonly used on other list endpoints.