### PR TITLE
Fix dataservice metadata_modified_at update in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a matomo "campaign" parameter on links in emails if `MAIL_CAMPAIGN` is configured [#3190](https://github.com/opendatateam/udata/pull/3190)
 - Add DCAT-AP HVD properties in RDF output if the dataservice or its datasets are tagged hvd [#3187](https://github.com/opendatateam/udata/pull/3187)
+- Fix dataservice metadata_modified_at update in API [#3207](https://github.com/opendatateam/udata/pull/3207)
 
 ## 10.0.2 (2024-11-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add created and last_modified sorts on dataservice list [#3206](https://github.com/opendatateam/udata/pull/3206)
+- Fix dataservice metadata_modified_at update in API [#3207](https://github.com/opendatateam/udata/pull/3207)
 
 ## 10.0.3 (2024-11-27)
 
@@ -10,7 +11,6 @@
 - Add a matomo "campaign" parameter on links in emails if `MAIL_CAMPAIGN` is configured [#3190](https://github.com/opendatateam/udata/pull/3190)
 - Use a safe XML parser that doesn't resolve entities, update lxml to 5.3.0 [#3205](https://github.com/opendatateam/udata/pull/3205)
 - Add DCAT-AP HVD properties in RDF output if the dataservice or its datasets are tagged hvd [#3187](https://github.com/opendatateam/udata/pull/3187)
-- Fix dataservice metadata_modified_at update in API [#3207](https://github.com/opendatateam/udata/pull/3207)
 - Only keep the "local authority" org badge if it's also a "public service" [#3200](https://github.com/opendatateam/udata/pull/3200)
 
 ## 10.0.2 (2024-11-19)

--- a/udata/core/dataservices/api.py
+++ b/udata/core/dataservices/api.py
@@ -76,7 +76,7 @@ class DataserviceAPI(API):
         OwnablePermission(dataservice).test()
 
         patch(dataservice, request)
-        dataservice.modified_at = datetime.utcnow()
+        dataservice.metadata_modified_at = datetime.utcnow()
 
         try:
             dataservice.save()
@@ -93,7 +93,7 @@ class DataserviceAPI(API):
 
         OwnablePermission(dataservice).test()
         dataservice.deleted_at = datetime.utcnow()
-        dataservice.modified_at = datetime.utcnow()
+        dataservice.metadata_modified_at = datetime.utcnow()
         dataservice.save()
 
         return "", 204
@@ -141,6 +141,7 @@ class DataserviceDatasetsAPI(API):
 
         if diff:
             dataservice.datasets += [ObjectId(did) for did in diff]
+            dataservice.metadata_modified_at = datetime.utcnow()
             dataservice.save()
 
         return dataservice, 201
@@ -164,6 +165,7 @@ class DataserviceDatasetAPI(API):
         if dataset not in dataservice.datasets:
             api.abort(404, "Dataset not found in dataservice")
         dataservice.datasets = [d for d in dataservice.datasets if d.id != dataset.id]
+        dataservice.metadata_modified_at = datetime.utcnow()
         dataservice.save()
 
         return None, 204

--- a/udata/tests/api/test_dataservices_api.py
+++ b/udata/tests/api/test_dataservices_api.py
@@ -92,6 +92,11 @@ class DataserviceAPITest(APITestCase):
         self.assertEqual(
             response.json["self_api_url"], "http://local.test/api/1/dataservices/updated-title/"
         )
+        # metadata_modified_at should have been updated during the patch
+        self.assertNotEqual(
+            response.json["metadata_modified_at"].split("+")[0],
+            dataservice.metadata_modified_at.isoformat(),
+        )
 
         self.assertEqual(response.json["datasets"]["total"], 2)
         response_datasets = self.get(response.json["datasets"]["href"])


### PR DESCRIPTION
Use the correct wording when updating the `metadata_modified_at` field in API PATCH and DELETE calls.

This field is also used as a key in [the cache value in udata-front](https://github.com/datagouv/udata-front/blob/f22bfaf72fdb2b7b24a15a6992eaf1d15c95e585/udata_front/theme/gouvfr/templates/dataservice/display.html#L63).

Fixes https://github.com/opendatateam/udata/pull/3207