### PR TITLE
Add dataservice csv adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add created and last_modified sorts on dataservice list [#3206](https://github.com/opendatateam/udata/pull/3206)
 - Fix dataservice metadata_modified_at update in API [#3207](https://github.com/opendatateam/udata/pull/3207)
+- Add dataservice csv adapter [#3208](https://github.com/opendatateam/udata/pull/3208)
 
 ## 10.0.3 (2024-11-27)
 

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -251,7 +251,8 @@ def generate_fields(**kwargs) -> Callable:
 
     It will also
     - generate an API parameter parser
-    - sort and filter a list of documents with the provided params using the `apply_sort_filters_and_pagination` helper
+    - sort and filter a list of documents with the provided params using the `apply_sort_filters` helper
+    - apply a pagination with page and page size args with the `apply_pagination` helper
 
     """
 
@@ -414,7 +415,7 @@ def generate_fields(**kwargs) -> Callable:
 
         cls.__index_parser__ = parser
 
-        def apply_sort_filters_and_pagination(base_query) -> DBPaginator:
+        def apply_sort_filters(base_query) -> UDataQuerySet:
             args = cls.__index_parser__.parse_args()
 
             if sortables and args["sort"]:
@@ -457,12 +458,17 @@ def generate_fields(**kwargs) -> Callable:
                             }
                         )
 
-            if paginable:
-                base_query = base_query.paginate(args["page"], args["page_size"])
-
             return base_query
 
-        cls.apply_sort_filters_and_pagination = apply_sort_filters_and_pagination
+        def apply_pagination(base_query) -> DBPaginator:
+            args = cls.__index_parser__.parse_args()
+
+            if paginable:
+                base_query = base_query.paginate(args["page"], args["page_size"])
+            return base_query
+
+        cls.apply_sort_filters = apply_sort_filters
+        cls.apply_pagination = apply_pagination
         cls.__additional_class_info__ = kwargs
         return cls
 

--- a/udata/core/dataservices/api.py
+++ b/udata/core/dataservices/api.py
@@ -34,7 +34,7 @@ class DataservicesAPI(API):
             current_user, mongoengine.Q(private__ne=True, archived_at=None, deleted_at=None)
         )
 
-        return Dataservice.apply_sort_filters_and_pagination(query)
+        return Dataservice.apply_pagination(Dataservice.apply_sort_filters(query))
 
     @api.secure
     @api.doc("create_dataservice", responses={400: "Validation error"})

--- a/udata/core/dataservices/csv.py
+++ b/udata/core/dataservices/csv.py
@@ -1,0 +1,36 @@
+from udata.frontend import csv
+
+from .models import Dataservice
+
+
+@csv.adapter(Dataservice)
+class DataserviceCsvAdapter(csv.Adapter):
+    fields = (
+        "id",
+        "title",
+        "slug",
+        "acronym",
+        ("url", lambda d: d.self_web_url()),
+        "description",
+        "base_api_url",
+        "endpoint_description_url",
+        "business_documentation_url",
+        "authorization_request_url",
+        "availability",
+        "rate_limiting",
+        "is_restricted",
+        "has_token",
+        "license",
+        ("organization", "organization.name"),
+        ("organization_id", "organization.id"),
+        ("owner", "owner.slug"),  # in case it's owned by a user
+        ("owner_id", "owner.id"),
+        "created_at",
+        "metadata_modified_at",
+        ("archived", lambda d: d.archived_at or False),
+        ("tags", lambda d: ",".join(d.tags)),
+        ("datasets", lambda d: ",".join([str(d.id) for d in d.datasets])),
+    )
+
+    def dynamic_fields(self):
+        return csv.metric_fields(Dataservice)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -145,6 +145,9 @@ class Dataservice(WithMetrics, Owned, db.Document):
 
     tags = field(
         db.TagListField(),
+        filterable={
+            "key": "tag",
+        },
     )
 
     private = field(

--- a/udata/core/reports/api.py
+++ b/udata/core/reports/api.py
@@ -21,7 +21,7 @@ class ReportsAPI(API):
     def get(self):
         query = Report.objects
 
-        return Report.apply_sort_filters_and_pagination(query)
+        return Report.apply_pagination(Report.apply_sort_filters(query))
 
     @api.doc("create_report", responses={400: "Validation error"})
     @api.expect(Report.__write_fields__)

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -112,7 +112,7 @@ class ReuseListAPI(API):
         query = Reuse.objects.visible_by_user(
             current_user, mongoengine.Q(private__ne=True, deleted=None)
         )
-        return Reuse.apply_sort_filters_and_pagination(query)
+        return Reuse.apply_pagination(Reuse.apply_sort_filters(query))
 
     @api.secure
     @api.doc("create_reuse")

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -479,6 +479,7 @@ class Defaults(object):
         "discussion",
         "organization",
         "reuse",
+        "dataservice",
         "tag",
         "harvest",
     )

--- a/udata/tests/api/test_dataservices_api.py
+++ b/udata/tests/api/test_dataservices_api.py
@@ -44,6 +44,13 @@ class DataserviceAPITest(APITestCase):
         response = self.get(url_for("api.dataservices", organization_badge="bad-badge"))
         assert400(response)
 
+        # filter on tag
+        tag_dataservice = DataserviceFactory(tags=["my-tag", "other"])
+        response = self.get(url_for("api.dataservices", tag="my-tag"))
+        assert200(response)
+        assert len(response.json["data"]) == 1
+        assert response.json["data"][0]["id"] == str(tag_dataservice.id)
+
     def test_dataservice_api_create(self):
         user = self.login()
         datasets = DatasetFactory.create_batch(3)

--- a/udata/tests/dataservice/test_csv_adapter.py
+++ b/udata/tests/dataservice/test_csv_adapter.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+import pytest
+
+from udata.core.dataservices.csv import DataserviceCsvAdapter
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataservices.models import Dataservice
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.organization.factories import OrganizationFactory
+
+
+@pytest.mark.frontend
+@pytest.mark.usefixtures("clean_db")
+class DataserviceCSVAdapterTest:
+    def test_dataservices_csv_adapter(self):
+        dataservice = DataserviceFactory(
+            created_at=datetime(2022, 12, 31),
+            metadata_modified_at=datetime(2023, 1, 1),
+            organization=OrganizationFactory(),
+            datasets=[DatasetFactory(), DatasetFactory()],
+        )
+        [DataserviceFactory() for _ in range(10)]
+        adapter = DataserviceCsvAdapter(Dataservice.objects.all())
+
+        # Build a dict (Dataservice ID to dict of header name to value) from the CSV values and headers to simplify testing below.
+        csv = {}
+        for row in adapter.rows():
+            values = dict(zip(adapter.header(), row))
+            csv[values["id"]] = values
+
+        dataservice_values = csv[str(dataservice.id)]
+        assert dataservice_values["title"] == dataservice.title
+        assert dataservice_values["url"] == dataservice.self_web_url()
+        assert dataservice_values["organization"] == dataservice.organization.name
+        assert dataservice_values["organization_id"] == str(dataservice.organization.id)
+        assert dataservice_values["created_at"] == dataservice.created_at.isoformat()
+        assert (
+            dataservice_values["metadata_modified_at"]
+            == dataservice.metadata_modified_at.isoformat()
+        )
+        assert dataservice_values["datasets"] == ",".join(
+            str(dataset.id) for dataset in dataservice.datasets
+        )


### PR DESCRIPTION
Close https://github.com/datagouv/data.gouv.fr/issues/1556

We split apply sort & filters and apply pagination in https://github.com/opendatateam/udata/pull/3208/commits/bcde4a3bd58c2785e62dbceda215d98f550e4302.
We want to apply sort and filters but not pagination in the context of the csv adapter (see [view in udata-front](https://github.com/datagouv/udata-front/pull/612))
This may be done more elegantly perhaps? cc @ThibaudDauce 
