### PR TITLE
Escape modal title and alert details in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add created and last_modified sorts on dataservice list [#3206](https://github.com/opendatateam/udata/pull/3206)
 - Fix dataservice metadata_modified_at update in API [#3207](https://github.com/opendatateam/udata/pull/3207)
+- Escape modal title in admin [#3210](https://github.com/opendatateam/udata/pull/3210)
 
 ## 10.0.3 (2024-11-27)
 

--- a/js/components/alert.vue
+++ b/js/components/alert.vue
@@ -5,7 +5,7 @@
             <span class="icon fa fa-{{alert.icon || 'check'}}"></span>
             {{alert.title}}
         </h4>
-        {{{ details }}}
+        {{{ details | markdown }}}
     </div>
 </template>
 
@@ -37,7 +37,7 @@ export default {
         },
         details() {
             if (this.alert && this.alert.details) {
-                return this.alert.details.replace(/\n/g, '<br/>');
+                return this.alert.details;
             }
         }
     },

--- a/js/components/modal.vue
+++ b/js/components/modal.vue
@@ -9,7 +9,7 @@
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only" v-i18n="Close"></span>
                 </button>
-                <h4 class="modal-title" id="modal-title">{{{title}}}</h4>
+                <h4 class="modal-title" id="modal-title">{{title}}</h4>
             </div>
             <slot></slot>
         </div>


### PR DESCRIPTION
We don't want to interpret modal title in admin and we parse alert details as markdown