### PR TITLE
Add url_for for dataservices and mail notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add dataservice csv adapter [#3208](https://github.com/opendatateam/udata/pull/3208)
+- Add url_for for dataservices and mail notifications [#3213](https://github.com/opendatateam/udata/pull/3213)
 
 ## 10.0.4 (2024-11-29)
 

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -109,6 +109,11 @@ class Dataservice(WithMetrics, Owned, db.Document):
         "auto_create_index_on_save": True,
     }
 
+    verbose_name = _("dataservice")
+
+    def __str__(self):
+        return self.title or ""
+
     title = field(
         db.StringField(required=True),
         example="My awesome API",

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -198,6 +198,11 @@ class Dataservice(WithMetrics, Owned, db.Document):
         readonly=True,
     )
 
+    def url_for(self, *args, **kwargs):
+        return endpoint_for(
+            "dataservices.show", "api.dataservice", dataservice=self, *args, **kwargs
+        )
+
     @function_field(description="Link to the API endpoint for this dataservice")
     def self_api_url(self):
         return endpoint_for("api.dataservice", dataservice=self, _external=True)

--- a/udata/core/discussions/actions.py
+++ b/udata/core/discussions/actions.py
@@ -16,6 +16,10 @@ def discussions_for(user, only_open=True):
     datasets = Dataset.objects.owned_by(user.id, *user.organizations).only("id", "slug")
     reuses = Reuse.objects.owned_by(user.id, *user.organizations).only("id", "slug")
 
+    # TODO: add dataservices when ready. It would now break notification routing in current admin
+    # since dataservices aren't supported by the current admin.
+    # dataservices = Dataservice.objects.owned_by(user.id, *user.organizations).only("id", "slug")
+
     qs = Discussion.objects(subject__in=list(datasets) + list(reuses))
     if only_open:
         qs = qs(closed__exists=False)

--- a/udata/core/discussions/constants.py
+++ b/udata/core/discussions/constants.py
@@ -1,1 +1,8 @@
+from udata.core.dataservices.models import Dataservice
+from udata.core.dataset.models import Dataset
+from udata.core.post.models import Post
+from udata.core.reuse.models import Reuse
+
 COMMENT_SIZE_LIMIT = 50000
+
+NOTIFY_DISCUSSION_SUBJECTS = (Dataset, Reuse, Post, Dataservice)


### PR DESCRIPTION
Fix the 500 on https://www.data.gouv.fr/api/1/spam/ (see [the sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/246384/?project=12&query=is%3Aunresolved&referrer=issue-stream)).

`url_for` was actually missing for Dataservice, leading to a 500 on https://www.data.gouv.fr/api/1/spam/ trying to build a `url_for` on Dataservice.

Also add mail notification on new discussion/comment on a Dataservice.