### PR TITLE
Don’t duplicate datasets with a `harvest.remote_id` URI when harvesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix the `parse-url` command [#3225](https://github.com/opendatateam/udata/pull/3225)
+- Don’t duplicated datasets with a harvest.remote_id URI when harvesting [#3219](https://github.com/opendatateam/udata/pull/3219)
 
 ## 10.0.5 (2024-12-09)
 

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -88,7 +88,7 @@ optional arguments:
 
 ## Backends
 
-`udata` comes with 3 harvest backends but you can implement your own backend.
+`udata` comes with 3 harvest backends (listed below) but you can implement your own backend.
 In order for `udata` to be able to use any of those backends, they first need to be enabled
 in the `udata.cfg` `PLUGINS` section, like so:
 
@@ -262,15 +262,14 @@ You may take a look at the [existing backends][backends-repository] to see exiti
 Debugging the harvesting code may be difficult as it's run in Celery, asynchronously, and using a `breakpoint` (to drop into a pdb)
 is [kind of a pain](https://docs.celeryq.dev/en/stable/userguide/debugging.html).
 
-Another trick could be calling the `udata.harvest.task.harvest` function straight from a `udata shell`.
-To do that:
+Another trick could be calling the synchronous version of the harvesting command:
 
-```python
+```shell
 # Drop a `breakpoint()` somewhere in your harvesting code, then:
-$ udata shell
->>> from udata.harvest.tasks import harvest
->>> harvest("<id of your job here, taken from the (old) admin at http://dev.local:7000/fr/admin/system/>")
+$ udata harvest run <source_id>
 ```
+
+`source_id` is the id of your job, taken from the (old) admin at http://dev.local:7000/fr/admin/system/.
 
 
 [DCAT]: https://www.w3.org/TR/vocab-dcat/

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -89,6 +89,12 @@ optional arguments:
 ## Backends
 
 `udata` comes with 3 harvest backends but you can implement your own backend.
+In order for `udata` to be able to use any of those backends, they first need to be enabled
+in the `udata.cfg` `PLUGINS` section, like so:
+
+```cfg
+PLUGINS = ['dcat']
+```
 
 ### DCAT
 
@@ -249,6 +255,22 @@ cookiecutter gh:opendatateam/cookiecutter-udata-harvester
 This will create a new package with a harvester skeleton on which you can start hacking.
 
 You may take a look at the [existing backends][backends-repository] to see exiting implementations.
+
+
+## Debugging
+
+Debugging the harvesting code may be difficult as it's run in Celery, asynchronously, and using a `breakpoint` (to drop into a pdb)
+is [kind of a pain](https://docs.celeryq.dev/en/stable/userguide/debugging.html).
+
+Another trick could be calling the `udata.harvest.task.harvest` function straight from a `udata shell`.
+To do that:
+
+```python
+# Drop a `breakpoint()` somewhere in your harvesting code, then:
+$ udata shell
+>>> from udata.harvest.tasks import harvest
+>>> harvest("<id of your job here, taken from the (old) admin at http://dev.local:7000/fr/admin/system/>")
+```
 
 
 [DCAT]: https://www.w3.org/TR/vocab-dcat/

--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -7,6 +7,7 @@ import requests
 from flask import current_app
 from voluptuous import MultipleInvalid, RequiredFieldInvalid
 
+import udata.uris as uris
 from udata.core.dataservices.models import Dataservice
 from udata.core.dataservices.models import HarvestMetadata as HarvestDataserviceMetadata
 from udata.core.dataset.models import HarvestDatasetMetadata
@@ -388,15 +389,19 @@ class BaseBackend(object):
         """Get or create a dataset given its remote ID (and its source)
         We first try to match `source_id` to be source domain independent
         """
-        dataset = Dataset.objects(
-            __raw__={
-                "harvest.remote_id": remote_id,
-                "$or": [
-                    {"harvest.domain": self.source.domain},
-                    {"harvest.source_id": str(self.source.id)},
-                ],
-            }
-        ).first()
+        try:
+            uris.validate(remote_id)
+            dataset = Dataset.objects(harvest__remote_id=remote_id).first()
+        except uris.ValidationError:
+            dataset = Dataset.objects(
+                __raw__={
+                    "harvest.remote_id": remote_id,
+                    "$or": [
+                        {"harvest.domain": self.source.domain},
+                        {"harvest.source_id": str(self.source.id)},
+                    ],
+                }
+            ).first()
 
         if dataset:
             return dataset

--- a/udata/harvest/tests/test_base_backend.py
+++ b/udata/harvest/tests/test_base_backend.py
@@ -35,6 +35,11 @@ class FakeBackend(BaseBackend):
     )
 
     def inner_harvest(self):
+        for remote_id in self.source.config.get("dataset_remote_ids", []):
+            self.process_dataset(remote_id)
+            if self.is_done():
+                return
+
         for i in range(self.source.config.get("nb_datasets", 3)):
             remote_id = f"fake-{i}"
             self.process_dataset(remote_id)
@@ -45,7 +50,8 @@ class FakeBackend(BaseBackend):
         dataset = self.get_dataset(item.remote_id)
 
         for key, value in DatasetFactory.as_dict(visible=True).items():
-            setattr(dataset, key, value)
+            if getattr(dataset, key) is None:
+                setattr(dataset, key, value)
         if self.source.config.get("last_modified"):
             dataset.last_modified_internal = self.source.config["last_modified"]
         return dataset
@@ -280,6 +286,78 @@ class BaseBackendTest:
         job.reload()
         for item in job.items:
             assert item.dataset is None
+
+    def test_no_datasets_duplication(self, app):
+        limit = app.config["HARVEST_AUTOARCHIVE_GRACE_DAYS"]
+        last_update = datetime.utcnow() - timedelta(days=limit - 1)
+        reuse_remote_id_uri = "http://example.com/reuse-this-uri"
+        nb_datasets = 3
+        source = HarvestSourceFactory(
+            config={
+                "nb_datasets": nb_datasets,
+                "dataset_remote_ids": [reuse_remote_id_uri],
+            }
+        )
+        backend = FakeBackend(source)
+
+        # Create a dataset that should be reused by the harvest, which will update it
+        # instead of creating a new one, as it has the same remote_id, domain and source_id.
+        dataset_reused = DatasetFactory(
+            title="Reused Dataset",
+            harvest={
+                "domain": source.domain,
+                "remote_id": "fake-0",  # the FakeBackend harvest should reuse this dataset
+                "source_id": str(source.id),
+                "last_update": last_update,
+            },
+        )
+
+        # Create a dataset that should be reused even though it's a different `remote_id` and `domain,
+        # because it's an URI.
+        dataset_reused_uri = DatasetFactory(
+            title="Reused Dataset with URI",
+            harvest={
+                "domain": "some-other-domain",
+                # the FakeBackend harvest above should reuse this dataset with the same remote_id URI
+                "remote_id": reuse_remote_id_uri,
+                "source_id": "some-other-source-id",
+                "last_update": last_update,
+            },
+        )
+
+        # Create a dataset that should not be reused even though it's the same `remote_id`,
+        # as it's not an URI, and has a different domain and source id.
+        dataset_not_reused = DatasetFactory(
+            title="Duplicated Dataset",
+            harvest={
+                "domain": "some-other-domain",
+                "remote_id": "fake-0",  # the "source" harvest above should create another dataset with the same remote_id
+                "source_id": "some-other-source-id",
+                "last_update": last_update,
+            },
+        )
+
+        job = backend.harvest()
+
+        # 3 (nb_datasets) + 1 (dataset_remote_ids) created by the HarvestSourceFactory
+        assert len(job.items) == nb_datasets + 1
+        # all datasets : 4 mocks (3 nb_datasets + 1 dataset_remote_ids) + 3 created with DatasetFactory - 2 reused
+        assert Dataset.objects.count() == nb_datasets + 1 + 3 - 2
+        assert (
+            # and not 3, data_reused was not duplicated
+            Dataset.objects(harvest__remote_id="fake-0").count() == 2
+        )
+        # The dataset not reused wasn't overwritten nor updated by the harvest.
+        dataset_not_reused.reload()
+        assert dataset_not_reused.harvest.domain == "some-other-domain"
+        assert dataset_not_reused.harvest.source_id == "some-other-source-id"
+        # The "reused dataset" was overwritten and updated by the harvest.
+        dataset_reused.reload()
+        assert dataset_reused.harvest.last_update != last_update
+        # The "reused dataset with uri" was overwritten and updated by the harvest.
+        dataset_reused_uri.reload()
+        assert dataset_reused_uri.harvest.domain == source.domain
+        assert dataset_reused_uri.harvest.source_id == str(source.id)
 
 
 @pytest.mark.usefixtures("clean_db")


### PR DESCRIPTION
Fixes [#1587](https://github.com/datagouv/data.gouv.fr/issues/1587)