### PR TITLE
Reuse url is now a URLField and should be a valid URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - The API will now return all the datasets a user has access to, including deleted of private ones that they're the owners of [#3214](https://github.com/opendatateam/udata/pull/3214)
 - Rename administration labels from "Private" to "Draft" [#3217](https://github.com/opendatateam/udata/pull/3217)
 - Add partial obfuscation of email for members [#3220](https://github.com/opendatateam/udata/pull/3220)
+- Reuse url is now a URLField and should be a valid URL [#3222](https://github.com/opendatateam/udata/pull/3222)
 
 ## 10.0.4 (2024-11-29)
 

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -80,7 +80,7 @@ class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
         filterable={},
     )
     url = field(
-        db.StringField(required=True),
+        db.URLField(required=True),
         description="The remote URL (website)",
         check=check_url_does_not_exists,
     )

--- a/udata/tests/reuse/test_reuse_model.py
+++ b/udata/tests/reuse/test_reuse_model.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 from udata.core.dataset import tasks as dataset_tasks
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.discussions.factories import DiscussionFactory
@@ -125,6 +127,10 @@ class ReuseModelTest(TestCase, DBTestMixin):
         reuse.private = True
         reuse.save()
         self.assertEqual(reuse.private, True)
+
+    def test_reuse_url(self):
+        with pytest.raises(db.ValidationError):
+            ReuseFactory(url="not-an-url")
 
 
 class ReuseBadgeTest(DBTestMixin, TestCase):


### PR DESCRIPTION
Reuse url used to be an URLField, but has been wrongly changed to StringField in https://github.com/opendatateam/udata/pull/3066/.

A script can be applied to check for current Reuses with invalid URL and bizdev decisions to make on these.

```
from udata.uris import validate
from udata.models import Reuse

for reuse in Reuse.objects():
    if not reuse.url:
        continue
    try:
        validate(reuse.url)
    except ValueError:
        print(reuse.id, reuse.url)
```