### PR TITLE
Ignore inactive sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Ignore inactive sources at harvest time [#3226](https://github.com/opendatateam/udata/pull/3226)
+    - If some harvest sources were marked inactive by mistake, they won't get executed anymore
 - Organization url is now a URLField and should be a valid URL [#3227](https://github.com/opendatateam/udata/pull/3227)
 - Fix the `parse-url` command [#3225](https://github.com/opendatateam/udata/pull/3225)
 - Add `with_drafts` argument to posts API [#3229](https://github.com/opendatateam/udata/pull/3229)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Ignore inactive sources at harvest time [#3226](https://github.com/opendatateam/udata/pull/3226)
 
 ## 10.0.5 (2024-12-09)
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -13,8 +13,9 @@ def harvest(self, ident):
     log.info('Launching harvest job for source "%s"', ident)
 
     source = HarvestSource.get(ident)
-    if source.deleted:
-        return  # Ignore deleted sources
+    if source.deleted or not source.active:
+        log.info('Ignoring inactive source "%s"', ident)
+        return  # Ignore deleted and inactive sources
     Backend = backends.get(current_app, source.backend)
     backend = Backend(source)
 

--- a/udata/harvest/tasks.py
+++ b/udata/harvest/tasks.py
@@ -14,7 +14,7 @@ def harvest(self, ident):
 
     source = HarvestSource.get(ident)
     if source.deleted or not source.active:
-        log.info('Ignoring inactive source "%s"', ident)
+        log.info('Ignoring inactive or deleted source "%s"', ident)
         return  # Ignore deleted and inactive sources
     Backend = backends.get(current_app, source.backend)
     backend = Backend(source)


### PR DESCRIPTION
`active` field wasn't actually used to deactivate a source.
This field was misleading and not doing anything.

Actual sources that are marked inactive (but not actually deactivated):
```
>>> from udata.harvest.models import HarvestSource
>>> for source in HarvestSource.objects(validation__state='accepted', active=False):
...     print(source.id, source.get_last_job().status)
... 
66713b4a2063a18d4f2c77c0 done
666854d2ae020ef75f404615 done
66632580d7365f18b2c81902 done-errors
6451227e111449ae4bff5531 done-errors
641477c66237d10651e97010 done
63dd6eec5f9e9f5cf63bd631 done
633c4314a184a25b2e68b5dd done
632094a92d19bc6c4b86a351 done
62bef8cc760c4fa031fef6ae failed
621e20edf3eeb9b91b4c385c done
61c473775299bbb5dc7af685 done
619fa44bc8e802460bca2faa done
617930065fe883dc16fd36a8 done
60ba37a6657399492704cf0a done-errors
609b98f009c75b3309329255 done-errors
607e9fcbc43657eaf1b0ad93 failed
605b3b19a97b6edbad874083 done
6017a714d475bada80963806 failed
6013cb4c2eb0904b6ab34f77 failed
6013ca70c5aa11960b3e48e1 failed
600fe3a8f921a2ce63619484 done
5fa985cc221828792d64fc3b done
5f89b201fb6b903f47f98892 done
5b45c89c88ee381dc9c83574 done
```
We should set `active=True` and we may want to contact them to inform them of their active harvesters.