### PR TITLE
Organization url is now a URLField and should be a valid URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Organization url is now a URLField and should be a valid URL [#3227](https://github.com/opendatateam/udata/pull/3227)
 
 ## 10.0.5 (2024-12-09)
 

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -117,7 +117,7 @@ class Organization(WithMetrics, OrganizationBadgeMixin, db.Datetimed, db.Documen
         max_length=255, required=True, populate_from="name", update=True, follow=True
     )
     description = db.StringField(required=True)
-    url = db.StringField()
+    url = db.URLField()
     image_url = db.StringField()
     logo = db.ImageField(
         fs=avatars, basename=default_image_basename, max_size=LOGO_MAX_SIZE, thumbnails=LOGO_SIZES

--- a/udata/tests/organization/test_organization_model.py
+++ b/udata/tests/organization/test_organization_model.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 import udata.core.organization.constants as org_constants
 from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataservices.models import Dataservice
@@ -80,6 +82,10 @@ class OrganizationModelTest(TestCase, DBTestMixin):
         associations = list(Organization.objects.with_badge(org_constants.ASSOCIATION))
         assert len(associations) == 1
         assert org_certified_association in associations
+
+    def test_organization__url(self):
+        with pytest.raises(db.ValidationError):
+            OrganizationFactory(url="not-an-url")
 
 
 class OrganizationBadgeTest(DBTestMixin, TestCase):


### PR DESCRIPTION
Same as https://github.com/opendatateam/udata/pull/3222.

We should also apply a script to list existing invalid URL.