### PR TITLE
feat(topic): add datasets clear API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix the `parse-url` command [#3225](https://github.com/opendatateam/udata/pull/3225)
+- feat(topic): add datasets clear API [#3228](https://github.com/opendatateam/udata/pull/3228)
 
 ## 10.0.5 (2024-12-09)
 

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -188,6 +188,22 @@ class TopicDatasetsAPI(API):
         return topic, 201
 
 
+@ns.route("/<topic:topic>/datasets/clear/", endpoint="topic_datasets_clear", doc=common_doc)
+class TopicDatasetsClearAPI(API):
+    @apiv2.secure
+    @apiv2.doc("topic_datasets_clear")
+    @apiv2.response(403, "Forbidden")
+    @apiv2.response(404, "Topic not found")
+    def post(self, topic):
+        """Clear all datasets from a topic"""
+        if not TopicEditPermission(topic).can():
+            apiv2.abort(403, "Forbidden")
+
+        topic.datasets = []
+        topic.save()
+        return "", 204
+
+
 @ns.route(
     "/<topic:topic>/datasets/<dataset:dataset>/",
     endpoint="topic_dataset",

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -4,7 +4,6 @@ from mongoengine.signals import pre_save
 from udata.core.owned import Owned, OwnedQuerySet
 from udata.models import SpatialCoverage, db
 from udata.search import reindex
-from udata.tasks import as_task_param
 
 __all__ = ("Topic",)
 
@@ -49,7 +48,7 @@ class Topic(db.Document, Owned, db.Datetimed):
         except cls.DoesNotExist:
             datasets_list_dif = document.datasets
         for dataset in datasets_list_dif:
-            reindex.delay(*as_task_param(dataset.fetch()))
+            reindex.delay("Dataset", str(dataset.pk))
 
     @property
     def display_url(self):

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -154,6 +154,24 @@ class TopicDatasetsAPITest(APITestCase):
         assert response.status_code == 400
 
 
+class TopicDatasetsClearAPI(APITestCase):
+    def test_clear_datasets(self):
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        assert len(topic.datasets) > 0
+        response = self.post(url_for("apiv2.topic_datasets_clear", topic=topic))
+        assert response.status_code == 204
+        topic.reload()
+        assert len(topic.datasets) == 0
+
+    def test_clear_datasets_perm(self):
+        user = UserFactory()
+        topic = TopicFactory(owner=user)
+        self.login()
+        response = self.post(url_for("apiv2.topic_datasets_clear", topic=topic))
+        assert response.status_code == 403
+
+
 class TopicDatasetAPITest(APITestCase):
     def test_delete_dataset(self):
         owner = self.login()


### PR DESCRIPTION
This adds a `POST /api/2/topics/{id}/datasets/clear/` route which empties the datasets list of the given topic.

This is useful to sync a huge topic against a list of datasets, instead of relying on [ugly hacks](https://github.com/ecolabdata/ecospheres-universe/blob/31af696b47f71fa2e154ab6c38b55cc4a4f64233/feed-universe.py#L185) or [a very slow process](https://github.com/ecolabdata/ecospheres-universe/blob/31af696b47f71fa2e154ab6c38b55cc4a4f64233/feed-universe.py#L213). 

This also optimizes the datasets reindexation of a topic, by not calling `Dataset.fetch()` when triggering the reindex (I don't know why I did not do this before 🤔). This a performance gain on all topics write operations involving datasets.

Tested locally on a 66k datasets topic (no search service).

With optim:
```
❯ time curl -X POST -H "x-api-key: xxx"  http://dev.local:7000/api/2/topics/change-title/datasets/clear/

________________________________________________________
Executed in    9.14 secs      fish           external
   usr time    5.98 millis    0.11 millis    5.87 millis
   sys time   12.40 millis    1.07 millis   11.32 millis
```

Without optim:
```
❯ time curl -X POST -H "x-api-key: xxx"  http://dev.local:7000/api/2/topics/change-title/datasets/clear/

________________________________________________________
Executed in  133.37 secs      fish           external
   usr time    7.22 millis    0.10 millis    7.12 millis
   sys time   14.90 millis    1.16 millis   13.74 millis
```

Fix https://github.com/ecolabdata/ecospheres/issues/510