### PR TITLE
ci: trigger gitlab infra deployment through simple-scaffolding script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
           command: |
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:
-          name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
+          name: Trigger Gitlab CI/CD pipeline for udata to be deployed to dev environment
           environment:
             # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
             GITLAB_API_TOKEN: ${GITLAB_API_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
             npm run assets:build
             npm run widgets:build
             npm run oembed:build
-
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,11 @@ parameters:
   publish-branch:
     type: string
     default: "master"
+    description: "Branch to publish to PyPi and trigger the Gitlab CI/CD pipeline when pushed to"
+  deploy-env:
+    type: string
+    default: "dev"
+    description: "Environment to deploy to"
 
 jobs:
   python:
@@ -219,9 +224,9 @@ jobs:
             # The script args are, in order:
             # - udata: the name of the project to deploy (APP_NAME)
             # - $RELEASE_VERSION: the version to deploy (RELEASE_VERSION)
-            # - env: the environment to deploy to (ENV)
+            # - << pipeline.parameters.deploy-env >>: the environment to deploy to (ENV)
             # - "": the deploy variables (VARS)
-            ./scripts/gitlab-ci-pipeline.sh udata $RELEASE_VERSION dev ""
+            ./scripts/gitlab-ci-pipeline.sh udata $RELEASE_VERSION << pipeline.parameters.deploy-env >> ""
 
 workflows:
   build-publish-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     description: "Environment to deploy to"
 
 jobs:
-  python-test:
+  python:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
       - image: mongo:6.0.4
@@ -81,7 +81,7 @@ jobs:
           paths:
           - venv
 
-  build-assets:
+  assets:
     docker:
       # TODO make an image based on 2-alpine w/ nvm and phantom deps
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
@@ -130,7 +130,7 @@ jobs:
           paths:
             - udata/static
 
-  build-package:
+  dist:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
     steps:
@@ -230,24 +230,24 @@ jobs:
 workflows:
   build-publish-deploy:
     jobs:
-      - python-test:
+      - python:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - build-assets:
+      - assets:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - build-package:
+      - dist:
           requires:
-            - python-test
-            - build-assets
+            - python
+            - assets
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
       - publish:
           requires:
-            - build-package
+            - dist
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,14 +213,13 @@ jobs:
           command: |
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:
-          name: Trigger Gitlab CI/CD pipeline for udata to be deployed to dev environment
-          environment:
-            # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
-            GITLAB_API_TOKEN: ${GITLAB_API_TOKEN}
+          name: Trigger GitLab CI/CD pipeline for udata to deploy to << pipeline.parameters.deploy-env >> environment
           command: |
             RELEASE_VERSION=$(cat version.txt)
             cd scaffold
             # Run the script that triggers the Gitlab CI/CD pipeline.
+            # Must have GITLAB_API_TOKEN set in the environment
+            # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
             # The script args are, in order:
             # - udata: the name of the project to deploy (APP_NAME)
             # - $RELEASE_VERSION: the version to deploy (RELEASE_VERSION)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,14 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py3-cache-v12-{{ arch }}-{{ checksum "python.deps" }}
-          - py3-cache-v12-{{ arch }}-{{ .Branch }}
-          - py3-cache-v12-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            # 1. Exact match of dependencies
+            - py3-cache-v12-{{ arch }}-{{ checksum "python.deps" }}
+            # 2. Latest cache from this branch
+            - py3-cache-v12-{{ arch }}-{{ .Branch }}
+            # 3. Latest cache from base branch (e.g., master)
+            - py3-cache-v12-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            # 4. Any latest cache for this architecture (fallback)
+            - py3-cache-v12-{{ arch }}-
       - run:
           name: Install Python dependencies
           command: |
@@ -87,9 +92,14 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
+            # 1. Exact match of dependencies
             - js-cache-{{ arch }}-{{ checksum "js.deps" }}
+            # 2. Latest cache from this branch
             - js-cache-{{ arch }}-{{ .Branch }}
+            # 3. Latest cache from base branch (e.g., master)
             - js-cache-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            # 4. Any latest cache for this architecture (fallback)
+            - js-cache-{{ arch }}-
       - run:
           name: Install NodeJS and dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ jobs:
           name: Build a distributable package as a wheel release
           command: |
             source venv/bin/activate
+            RELEASE_VERSION=$(cat version.txt)
             inv pydist -b $RELEASE_VERSION
       - store_artifacts:
           path: dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
             echo "Git tag: $CIRCLE_TAG"
       - run:
-          name: Build a distributable package
+          name: Build a distributable package as a wheel release
           command: |
             source venv/bin/activate
             inv pydist -b $RELEASE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,6 @@ jobs:
   build:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
-    environment:
-      BASH_ENV: /root/.bashrc
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     description: "Environment to deploy to"
 
 jobs:
-  python:
+  python-test:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
       - image: mongo:6.0.4
@@ -81,7 +81,7 @@ jobs:
           paths:
           - venv
 
-  assets:
+  build-assets:
     docker:
       # TODO make an image based on 2-alpine w/ nvm and phantom deps
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
@@ -130,7 +130,7 @@ jobs:
           paths:
             - udata/static
 
-  build:
+  build-package:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
     steps:
@@ -231,24 +231,24 @@ jobs:
 workflows:
   build-publish-deploy:
     jobs:
-      - python:
+      - python-test:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - assets:
+      - build-assets:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - build:
+      - build-package:
           requires:
-            - python
-            - assets
+            - python-test
+            - build-assets
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
       - publish:
           requires:
-            - build
+            - build-package
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,18 @@
 ---
-version: 2
+version: 2.1
+
+parameters:
+  python-version:
+    type: string
+    default: "3.11"
+  publish-branch:
+    type: string
+    default: "master"
 
 jobs:
   python:
     docker:
-      - image: udata/circleci:py3.11
+      - image: udata/circleci:py<< pipeline.parameters.python-version >>
       - image: mongo:6.0.4
       - image: redis:alpine
     environment:
@@ -66,7 +74,7 @@ jobs:
   assets:
     docker:
       # TODO make an image based on 2-alpine w/ nvm and phantom deps
-      - image: udata/circleci:py3.11
+      - image: udata/circleci:py<< pipeline.parameters.python-version >>
     environment:
       BASH_ENV: /root/.bashrc
     steps:
@@ -108,9 +116,9 @@ jobs:
           paths:
             - udata/static
 
-  dist:
+  build:
     docker:
-      - image: udata/circleci:py3.11
+      - image: udata/circleci:py<< pipeline.parameters.python-version >>
     environment:
       BASH_ENV: /root/.bashrc
     steps:
@@ -141,7 +149,7 @@ jobs:
 
   publish:
     docker:
-      - image: udata/circleci:py3.11
+      - image: udata/circleci:py<< pipeline.parameters.python-version >>
     steps:
       - attach_workspace:
           at: .
@@ -152,9 +160,48 @@ jobs:
             pip install twine
             twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
 
+  trigger-gitlab-pipeline:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Configure the SSH simple-scaffold repository private key
+          command: |
+            mkdir -p ~/.ssh
+            # SCAFFOLD_PRIVATE_KEY is the private key related to the "simple-scaffold" GitLab repository, so that it can be cloned
+            # CircleCI doesn't accept multiple lines in a single environment variable, so the multiline private key must be base64 encoded, and then decoded here
+            echo "$SCAFFOLD_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519
+            chmod 600 ~/.ssh/id_ed25519
+            ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "root@data.gouv.fr"
+            git config --global user.name "datagouv"
+      - run:
+          name: Clone simple-scaffold repository
+          command: |
+            git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
+      - run:
+          name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
+          environment:
+            # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
+            GITLAB_API_TOKEN: ${GITLAB_API_TOKEN}
+          command: |
+            RELEASE_VERSION=$(cat version.txt)
+            cd scaffold
+            # Run the script that triggers the Gitlab CI/CD pipeline.
+            # The script args are, in order:
+            # - udata: the name of the project to deploy (APP_NAME)
+            # - $RELEASE_VERSION: the version to deploy (RELEASE_VERSION)
+            # - env: the environment to deploy to (ENV)
+            # - "": the deploy variables (VARS)
+            ./scripts/gitlab-ci-pipeline.sh udata $RELEASE_VERSION dev ""
+
 workflows:
-  version: 2
-  build:
+  build-and-publish:
     jobs:
       - python:
           filters:
@@ -164,7 +211,7 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - dist:
+      - build:
           requires:
             - python
             - assets
@@ -173,12 +220,22 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*/
       - publish:
           requires:
-            - dist
+            - build
           filters:
             branches:
               only:
-                - master
+                - << pipeline.parameters.publish-branch >>
                 - /[0-9]+(\.[0-9]+)+/
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global
+      - trigger-gitlab-pipeline:
+          requires:
+            - publish
+          filters:
+            branches:
+              only:
+                - << pipeline.parameters.publish-branch >>
+          context:
+            - org-global
+            - gitlab-trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
             ./scripts/gitlab-ci-pipeline.sh udata $RELEASE_VERSION dev ""
 
 workflows:
-  build-and-publish:
+  build-publish-deploy:
     jobs:
       - python:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,26 +126,41 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Set version
+          command: |
+            if [[ $CIRCLE_TAG ]]; then
+                # This is a tagged release, version has been handled upstream
+                export RELEASE_VERSION=$CIRCLE_TAG
+            # Otherwise, relies on a dev version like "1.2.1.dev" by default
+            elif [[ "$CIRCLE_BRANCH" == feature/* ]]; then
+                # This is a feature branch
+                export RELEASE_VERSION=$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}
+            else
+                # This is a simple development build
+                export RELEASE_VERSION=$CIRCLE_BUILD_NUM
+            fi
+            # Save version to a file that will be persisted
+            echo "$RELEASE_VERSION" > version.txt
+      - run:
+          name: Display build info for debugging
+          command: |
+            RELEASE_VERSION=$(cat version.txt)
+            echo "Building a wheel release with version $RELEASE_VERSION"
+            echo "Build number: $CIRCLE_BUILD_NUM"
+            echo "Commit hash: ${CIRCLE_SHA1:0:7}"
+            echo "Git tag: $CIRCLE_TAG"
+      - run:
           name: Build a distributable package
           command: |
             source venv/bin/activate
-            # Build a wheel release
-            if [[ $CIRCLE_TAG ]]; then
-                # This is a tagged release
-                inv pydist
-            elif [[ "$CIRCLE_BRANCH" == feature/* ]]; then
-                # This is a feature branch
-                inv pydist -b $CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}
-            else
-                # This is a simple development build
-                inv pydist -b $CIRCLE_BUILD_NUM
-            fi
+            inv pydist -b $RELEASE_VERSION
       - store_artifacts:
           path: dist
       - persist_to_workspace:
           root: .
           paths:
             - dist
+            - version.txt
 
   publish:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix failing dataset save in update reuses metrics [#3230](https://github.com/opendatateam/udata/pull/3230)
 - Fix catalog RDF by preventing memory increase on getting dataservice hvd tags [#3231](https://github.com/opendatateam/udata/pull/3231)
 - Update purge tasks [#3167](https://github.com/opendatateam/udata/pull/3167)
+- Trigger GitLab infra deployment through simple-scaffolding script [#3232](https://github.com/opendatateam/udata/pull/3232)
 
 ## 10.0.5 (2024-12-09)
 


### PR DESCRIPTION
Similar to https://github.com/datagouv/hydra/pull/186 on Hydra, this PR adds automatic deployment by triggering GitLab infra CI through the `simple-scaffolding` script.

- Add job `trigger-gitlab-pipeline` using `simple-scaffolding` deploy script
- Add CI parameters `python-version`, `publish-branch` and `deploy-env`
- Build the version number in build job and persists it in a file to be used by `trigger-gitlab-pipeline`
- Split the build job into smaller, more explicit steps for better debugging and readability
- Rename workflow to avoid confusion with building job and to be more explicit
- Rename `dist` CI job to `build` be more explicit

This CI needs:
- `SCAFFOLD_PRIVATE_KEY` to be created and added 
    [x] private one to be added as CircleCI env
    [x] public one to be added on simple-scaffold GitLab repo
- `GITLAB_API_TOKEN` to be created and added
    [] on GitLab infra API tokens
    [] on CircleCI env
