### PR TITLE
Add a test to clear datasets on Topics api v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add a test to clear datasets on Topics api v1 [#3233](https://github.com/opendatateam/udata/pull/3233)
 
 ## 10.0.6 (2024-12-19)
 

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -191,6 +191,18 @@ class TopicsAPITest(APITestCase):
         response = self.put(url_for("api.topic", topic=topic), data)
         self.assert403(response)
 
+    def test_topic_api_clear_datasets(self):
+        """It should remove all datasets if set to None"""
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        assert len(topic.datasets) > 0
+        data = topic.to_dict()
+        data["datasets"] = None
+        response = self.put(url_for("api.topic", topic=topic), data)
+        self.assert200(response)
+        topic.reload()
+        self.assertEqual(len(topic.datasets), 0)
+
     def test_topic_api_delete(self):
         """It should delete a topic from the API"""
         owner = self.login()

--- a/udata/tests/api/test_topics_api.py
+++ b/udata/tests/api/test_topics_api.py
@@ -195,7 +195,7 @@ class TopicsAPITest(APITestCase):
         """It should remove all datasets if set to None"""
         owner = self.login()
         topic = TopicFactory(owner=owner)
-        assert len(topic.datasets) > 0
+        self.assertGreater(len(topic.datasets), 0)
         data = topic.to_dict()
         data["datasets"] = None
         response = self.put(url_for("api.topic", topic=topic), data)


### PR DESCRIPTION
Add a test case to clear all datasets from a topic.

Alternative solution to https://github.com/opendatateam/udata/pull/3228