### PR TITLE
feat: optimize topic's datasets reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- feat: optimize topic's datasets reindex [#3234](https://github.com/opendatateam/udata/pull/3234)
 
 ## 10.0.6 (2024-12-19)
 

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -4,7 +4,6 @@ from mongoengine.signals import pre_save
 from udata.core.owned import Owned, OwnedQuerySet
 from udata.models import SpatialCoverage, db
 from udata.search import reindex
-from udata.tasks import as_task_param
 
 __all__ = ("Topic",)
 
@@ -49,7 +48,7 @@ class Topic(db.Document, Owned, db.Datetimed):
         except cls.DoesNotExist:
             datasets_list_dif = document.datasets
         for dataset in datasets_list_dif:
-            reindex.delay(*as_task_param(dataset.fetch()))
+            reindex.delay("Dataset", str(dataset.pk))
 
     @property
     def display_url(self):


### PR DESCRIPTION
Extracts the Topic's datasets reindex optimization from https://github.com/opendatateam/udata/pull/3228/.

We go from 95 seconds to 5 seconds when clearing a Topic with 60k datasets (no search service).

```
❯ time curl -X PUT -H "x-api-key: xxx" -H "Content-Type: application/json" -d '{"datasets": null, "tags": ["test"]}'  http://dev.local:7000/api/1/topics/change-title/
{"created_at": "2023-11-14T07:22:40.353000+00:00", "datasets": [], "description": "Similique\u00e9 maxime\u00e9 cum\u00e9 illo\u00e9 at\u00e9. At\u00e9 corrupti\u00e9 voluptates\u00e9 dolor\u00e9 quasi\u00e9 velit\u00e9 cum\u00e9. Ad\u00e9 dolores\u00e9 quos\u00e9 sequi\u00e9. Cum\u00e9 dicta\u00e9 eum\u00e9 odit\u00e9 eos\u00e9.", "extras": {}, "featured": false, "id": "6553204b4eed09bf62a04879", "last_modified": "2024-12-20T10:03:51.879966+00:00", "name": "change-title", "organization": null, "owner": null, "page": "http://dev.local:7000/api/1/topics/change-title/", "private": false, "reuses": [{"id": "655320404eed09bf62a04874", "image": null, "image_thumbnail": null, "page": "http://dev.local:7000/api/1/reuses/asperiorese-asperiorese-omnise-eaquee/", "title": "Asperiores\u00e9 asperiores\u00e9 omnis\u00e9 eaque\u00e9.", "uri": "http://dev.local:7000/api/1/reuses/asperiorese-asperiorese-omnise-eaquee/"}, {"id": "655320404eed09bf62a04876", "image": null, "image_thumbnail": null, "page": "http://dev.local:7000/api/1/reuses/aperiame-vitaee-distinctioe-veritatise-eae-laboree-doloribuse-aliquame/", "title": "Aperiam\u00e9 vitae\u00e9 distinctio\u00e9 veritatis\u00e9 ea\u00e9 labore\u00e9 doloribus\u00e9 aliquam\u00e9.", "uri": "http://dev.local:7000/api/1/reuses/aperiame-vitaee-distinctioe-veritatise-eae-laboree-doloribuse-aliquame/"}, {"id": "655320404eed09bf62a04878", "image": null, "image_thumbnail": null, "page": "http://dev.local:7000/api/1/reuses/aspernature-voluptatee-omnise-odite-placeate-ade-ete-nostrume/", "title": "Aspernatur\u00e9 voluptate\u00e9 omnis\u00e9 odit\u00e9 placeat\u00e9 ad\u00e9 et\u00e9 nostrum\u00e9.", "uri": "http://dev.local:7000/api/1/reuses/aspernature-voluptatee-omnise-odite-placeate-ade-ete-nostrume/"}], "slug": "change-title", "spatial": null, "tags": ["test"], "uri": "http://dev.local:7000/api/1/topics/change-title/"}
________________________________________________________
Executed in    5.77 secs      fish           external
   usr time    3.82 millis    0.08 millis    3.74 millis
   sys time   15.71 millis    1.12 millis   14.58 millis
```