### PR TITLE
Improve OGC service detection to expose in RDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow Dataservice transfer [#3237](https://github.com/opendatateam/udata/pull/3237)
 - fix `function_field` wrong name [#3236](https://github.com/opendatateam/udata/pull/3236)
 - Allow dataservice archive [#3238](https://github.com/opendatateam/udata/pull/3238)
+- Improve OGC service detection to expose in RDF [#3241](https://github.com/opendatateam/udata/pull/3241)
 
 ## 10.0.6 (2024-12-19)
 

--- a/udata/core/dataset/constants.py
+++ b/udata/core/dataset/constants.py
@@ -72,7 +72,7 @@ RESOURCE_FILETYPES = OrderedDict(
     ]
 )
 
-OGC_SERVICE_FORMATS = ["ogc:wms", "ogc:wfs", "wms", "wfs"]
+OGC_SERVICE_FORMATS = ["wms", "wfs"]
 
 CHECKSUM_TYPES = ("sha1", "sha2", "sha256", "md5", "crc")
 DEFAULT_CHECKSUM_TYPE = "sha1"

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -131,7 +131,7 @@ def detect_ogc_service(resource):
     Detect if the resource points towards an OGC Service based on either
     * a known OGC Service format
     * a REQUEST=GetCapabilities param in url
-    It returns the OGC service type
+    It returns the OGC service type or None
     """
     if resource.format and resource.format.strip("ogc:") in OGC_SERVICE_FORMATS:
         return resource.format.strip("ogc:")

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -6,6 +6,7 @@ import calendar
 import json
 import logging
 from datetime import date
+from typing import Optional
 
 from dateutil.parser import parse as parse_dt
 from flask import current_app
@@ -98,7 +99,9 @@ EU_RDF_REQUENCIES = {
 }
 
 
-def temporal_to_rdf(daterange, graph=None):
+def temporal_to_rdf(
+    daterange: db.DateRange, graph: Optional[Graph] = None
+) -> Optional[RdfResource]:
     if not daterange:
         return
     graph = graph or Graph(namespace_manager=namespace_manager)
@@ -109,13 +112,13 @@ def temporal_to_rdf(daterange, graph=None):
     return pot
 
 
-def frequency_to_rdf(frequency, graph=None):
+def frequency_to_rdf(frequency: str, graph: Optional[Graph] = None) -> Optional[str]:
     if not frequency:
         return
     return RDF_FREQUENCIES.get(frequency, getattr(FREQ, frequency))
 
 
-def owner_to_rdf(dataset, graph=None):
+def owner_to_rdf(dataset: Dataset, graph: Optional[Graph] = None) -> Optional[RdfResource]:
     from udata.core.organization.rdf import organization_to_rdf
     from udata.core.user.rdf import user_to_rdf
 
@@ -126,7 +129,7 @@ def owner_to_rdf(dataset, graph=None):
     return
 
 
-def detect_ogc_service(resource):
+def detect_ogc_service(resource: Resource) -> Optional[str]:
     """
     Detect if the resource points towards an OGC Service based on either
     * a known OGC Service format
@@ -142,7 +145,13 @@ def detect_ogc_service(resource):
         return next(format for format in OGC_SERVICE_FORMATS if f"service={format}" in url)
 
 
-def ogc_service_to_rdf(dataset, resource, ogc_service_type=None, graph=None, is_hvd=False):
+def ogc_service_to_rdf(
+    dataset: Dataset,
+    resource: Resource,
+    ogc_service_type: Optional[str] = None,
+    graph: Optional[Graph] = None,
+    is_hvd: bool = False,
+) -> RdfResource:
     """
     Build a dataservice on the fly for OGC services distributions
     Inspired from https://github.com/SEMICeu/iso-19139-to-dcat-ap/blob/f61b2921dd398b90b2dd2db14085e75687f7616b/iso-19139-to-dcat-ap.xsl#L1419
@@ -181,7 +190,12 @@ def ogc_service_to_rdf(dataset, resource, ogc_service_type=None, graph=None, is_
     return service
 
 
-def resource_to_rdf(resource, dataset=None, graph=None, is_hvd=False):
+def resource_to_rdf(
+    resource: Resource,
+    dataset: Optional[Dataset] = None,
+    graph: Optional[Graph] = None,
+    is_hvd: bool = False,
+) -> RdfResource:
     """
     Map a Resource domain model to a DCAT/RDF graph
     """
@@ -256,7 +270,7 @@ def dataset_to_graph_id(dataset: Dataset) -> URIRef | BNode:
         return BNode()
 
 
-def dataset_to_rdf(dataset, graph=None):
+def dataset_to_rdf(dataset: Dataset, graph: Optional[Graph] = None) -> RdfResource:
     """
     Map a dataset domain model to a DCAT/RDF graph
     """


### PR DESCRIPTION
Follows on https://github.com/opendatateam/udata/pull/3203

Detect OGC Service on either of the following hints:
* the resource format is in the known list of OGC Service formats (already implemented in https://github.com/opendatateam/udata/pull/3203)
* the resource URL contains a REQUEST=GetCapabilities param and a corresponding SERVICE=format (new)

It used to expose an accessService on OGC distribution on [this distribution](https://www.data.gouv.fr/fr/datasets/66601a411fd7f3661df23bad/#/resources/39e6c520-48c4-43db-aac1-b8f07e44081a) (see [rdf](https://www.data.gouv.fr/api/1/datasets/66601a411fd7f3661df23bad/rdf.xml)).
We will also now exposes an accessService on [this distribution](https://www.data.gouv.fr/fr/datasets/installations-classees-pour-la-protection-de-lenvironnement-icpe-france-metropolitaine-et-drom-3/#/resources/cb550e4d-3c91-4209-b52c-b04c5cb43861) (see [rdf](https://www.data.gouv.fr/api/1/datasets/66631f6d5ff38efa62d385ac/rdf.xml)).

In an ideal world, we would like a more explicit information but the `request=getCapabilities` identification is actually the method used in the [SEMIC XLST conversion](https://github.com/SEMICeu/iso-19139-to-dcat-ap/blob/f61b2921dd398b90b2dd2db14085e75687f7616b/iso-19139-to-dcat-ap.xsl#L1419).