### PR TITLE
Upgrade packaging dependency to 24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Resource catalog: fix preview_url and add extras [#3188](https://github.com/opendatateam/udata/pull/3188)
 - Add trailing slash to security routes [#3251](https://github.com/opendatateam/udata/pull/3251)
+- Upgrade packaging dependency to 24.2 [#3252](https://github.com/opendatateam/udata/pull/3252)
 
 ## 10.0.7 (2025-01-13)
 

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -154,6 +154,7 @@ cryptography==2.8
     #   -c requirements/test.pip
     #   -r requirements/install.in
     #   authlib
+    #   secretstorage
 decorator==5.1.1
     # via ipython
 distlib==0.3.8
@@ -339,6 +340,10 @@ jaraco-classes==3.3.1
     # via keyring
 jedi==0.19.1
     # via ipython
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -c requirements/install.pip
@@ -418,7 +423,7 @@ nh3==0.2.15
     # via readme-renderer
 nodeenv==1.8.0
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip
@@ -590,6 +595,8 @@ s3transfer==0.6.2
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   boto3
+secretstorage==3.3.3
+    # via keyring
 sentry-sdk[flask]==2.9.0
     # via
     #   -c requirements/install.pip

--- a/requirements/doc.pip
+++ b/requirements/doc.pip
@@ -371,7 +371,7 @@ netaddr==0.7.19
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   -r requirements/install.in
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -204,7 +204,7 @@ mongoengine==0.27.0
     #   flask-mongoengine
 netaddr==0.7.19
     # via -r requirements/install.in
-packaging==24.1
+packaging==24.2
     # via bleach
 passlib==1.7.4
     # via flask-security-too

--- a/requirements/report.pip
+++ b/requirements/report.pip
@@ -381,7 +381,7 @@ netaddr==0.7.19
     #   -c requirements/install.pip
     #   -c requirements/test.pip
     #   -r requirements/install.in
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/install.pip
     #   -c requirements/test.pip

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -307,7 +307,7 @@ netaddr==0.7.19
     # via
     #   -c requirements/install.pip
     #   -r requirements/install.in
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/install.pip
     #   bleach


### PR DESCRIPTION
Fix twine publishing failing [in CI](https://app.circleci.com/jobs/github/datagouv/udata-front/38371) with:
```
ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or    
         malformed field 'license-file'
```

Bug explanation and mitigation reference: https://github.com/pypa/twine/issues/1216#issuecomment-2609745412

Should be propagated in udata-front once merged 