### PR TITLE
Expose HVD dataservice as inline distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Resource catalog: fix preview_url and add extras [#3188](https://github.com/opendatateam/udata/pull/3188)
 - Add trailing slash to security routes [#3251](https://github.com/opendatateam/udata/pull/3251)
 - Upgrade packaging dependency to 24.2 [#3252](https://github.com/opendatateam/udata/pull/3252)
+- Expose HVD dataservice as inline distribution [#3256](https://github.com/opendatateam/udata/pull/3256)
 
 ## 10.0.7 (2025-01-13)
 

--- a/udata/core/dataservices/rdf.py
+++ b/udata/core/dataservices/rdf.py
@@ -181,3 +181,34 @@ def dataservice_to_rdf(dataservice: Dataservice, graph=None):
         d.set(DCAT.contactPoint, contact_point)
 
     return d
+
+
+def dataservice_as_distribution_to_rdf(
+    dataservice: Dataservice, graph: Graph = None, is_hvd: bool = True
+):
+    """
+    Create a blank distribution pointing towards a dataservice with DCAT.accessService property
+    """
+    id = BNode()
+    distribution = graph.resource(id)
+    distribution.set(RDF.type, DCAT.Distribution)
+    distribution.add(DCT.title, Literal(dataservice.title))
+    distribution.add(
+        DCAT.accessURL,
+        URIRef(
+            endpoint_for(
+                "dataservices.show_redirect",
+                "api.dataservice",
+                dataservice=dataservice.id,
+                _external=True,
+            )
+        ),
+    )
+
+    if is_hvd:
+        # DCAT-AP HVD applicable legislation is also expected at the distribution level
+        distribution.add(DCATAP.applicableLegislation, URIRef(HVD_LEGISLATION))
+
+    distribution.add(DCAT.accessService, dataservice_to_rdf(dataservice, graph))
+
+    return distribution

--- a/udata/core/dataservices/rdf.py
+++ b/udata/core/dataservices/rdf.py
@@ -193,17 +193,7 @@ def dataservice_as_distribution_to_rdf(
     distribution = graph.resource(id)
     distribution.set(RDF.type, DCAT.Distribution)
     distribution.add(DCT.title, Literal(dataservice.title))
-    distribution.add(
-        DCAT.accessURL,
-        URIRef(
-            endpoint_for(
-                "dataservices.show_redirect",
-                "api.dataservice",
-                dataservice=dataservice.id,
-                _external=True,
-            )
-        ),
-    )
+    distribution.add(DCAT.accessURL, URIRef(dataservice.base_api_url))
 
     if is_hvd:
         # DCAT-AP HVD applicable legislation is also expected at the distribution level

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -340,6 +340,20 @@ def dataset_to_rdf(dataset: Dataset, graph: Optional[Graph] = None) -> RdfResour
     for resource in dataset.resources:
         d.add(DCAT.distribution, resource_to_rdf(resource, dataset, graph, is_hvd))
 
+    if is_hvd:
+        from udata.core.dataservices.models import Dataservice
+        from udata.core.dataservices.rdf import dataservice_as_distribution_to_rdf
+
+        # Add a blank distribution pointing to a DataService using the distribution DCAT.accessService.
+        # Useful for HVD reporting since DataService are not currently harvested by
+        # data.europa.eu as first class entities.
+        # Should be removed once supported by data.europa.eu harvesting.
+        for service in Dataservice.objects.filter(datasets=dataset, tags="hvd"):
+            d.add(
+                DCAT.distribution,
+                dataservice_as_distribution_to_rdf(service, graph),
+            )
+
     if dataset.temporal_coverage:
         d.set(DCT.temporal, temporal_to_rdf(dataset.temporal_coverage, graph))
 

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -9,6 +9,7 @@ from rdflib.namespace import FOAF, RDF
 from rdflib.resource import Resource as RdfResource
 
 from udata.core.contact_point.factories import ContactPointFactory
+from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory, LicenseFactory, ResourceFactory
 from udata.core.dataset.models import (
     Checksum,
@@ -46,6 +47,7 @@ from udata.rdf import (
     primary_topic_identifier_from_rdf,
 )
 from udata.tests.helpers import assert200, assert_redirects
+from udata.uris import endpoint_for
 from udata.utils import faker
 
 pytestmark = pytest.mark.usefixtures("app")
@@ -276,6 +278,36 @@ class DatasetToRdfTest:
         )
         for distrib in d.objects(DCAT.distribution):
             assert distrib.value(DCATAP.applicableLegislation).identifier == URIRef(HVD_LEGISLATION)
+
+    def test_dataset_with_dataservice_as_distribution(self):
+        """
+        Test that a dataset tagged hvd served by an hvd dataservice has an additional distribution
+        with a DCAT.accessService and appropriate DCAT-AP HVD properties
+        """
+        dataset = DatasetFactory(
+            resources=ResourceFactory.build_batch(3), tags=["hvd", "mobilite", "test"]
+        )
+        dataservice = DataserviceFactory(datasets=[dataset], tags=["hvd"])
+        d = dataset_to_rdf(dataset)
+        g = d.graph
+
+        len(list(g.subjects(RDF.type, DCAT.Distribution))) == 4
+        len(list(g.subjects(RDF.type, DCAT.DataService))) == 1
+        dataservice_as_distribution = g.resource(next(g.subjects(DCAT.accessService)))
+        dataservice_uri = URIRef(
+            endpoint_for(
+                "dataservices.show_redirect",
+                "api.dataservice",
+                dataservice=dataservice.id,
+                _external=True,
+            )
+        )
+        assert dataservice_as_distribution.value(DCAT.accessURL).identifier == dataservice_uri
+        assert dataservice_as_distribution.value(DCT.title) == Literal(dataservice.title)
+        assert dataservice_as_distribution.value(DCATAP.applicableLegislation).identifier == URIRef(
+            HVD_LEGISLATION
+        )
+        assert dataservice_as_distribution.value(DCAT.accessService).identifier == dataservice_uri
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -302,7 +302,9 @@ class DatasetToRdfTest:
                 _external=True,
             )
         )
-        assert dataservice_as_distribution.value(DCAT.accessURL).identifier == dataservice_uri
+        assert dataservice_as_distribution.value(DCAT.accessURL).identifier == URIRef(
+            dataservice.base_api_url
+        )
         assert dataservice_as_distribution.value(DCT.title) == Literal(dataservice.title)
         assert dataservice_as_distribution.value(DCATAP.applicableLegislation).identifier == URIRef(
             HVD_LEGISLATION


### PR DESCRIPTION
Add a blank distribution pointing to a DataService using the distribution DCAT.accessService (similarly to https://github.com/opendatateam/udata/pull/3203).
Useful for HVD reporting since DataService are not currently harvested by data.europa.eu as first class entities.
*Should be removed once supported by data.europa.eu harvesting.*

These blank distributions are added on hvd datasets served by and hvd dataservice.