### PR TITLE
Expose dataset_id for communautary resources

### DIFF
--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -391,6 +391,7 @@ class ResourceAPI(API):
             resource = get_by(dataset.resources, "id", rid)
         else:
             resource = CommunityResource.objects(id=rid).first()
+            dataset = resource.dataset
         if not resource:
             apiv2.abort(404, "Resource does not exist")
 


### PR DESCRIPTION
Fixes https://github.com/datagouv/data.gouv.fr/issues/1645

Another possibility is to allow `Dataset.objects(resources__id=rid).first()` to work for communautary resources