### PR TITLE
feat: topics list filtered by visible_by_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix contact point permissions [#3253](https://github.com/opendatateam/udata/pull/3253)
 - Fix wrong marshal for community resource uploads [#3261](https://github.com/opendatateam/udata/pull/3261)
 - Return harvesters's errors details only for super-admins [#3264](https://github.com/opendatateam/udata/pull/3264)
+- feat: topics list filtered by visible_by_user [#3265](https://github.com/opendatateam/udata/pull/3265)
 
 ## 10.0.8 (2025-01-31)
 

--- a/udata/core/topic/api.py
+++ b/udata/core/topic/api.py
@@ -1,3 +1,6 @@
+import mongoengine
+from flask_security import current_user
+
 from udata.api import API, api, fields
 from udata.core.dataset.api_fields import dataset_fields
 from udata.core.discussions.models import Discussion
@@ -88,7 +91,7 @@ class TopicsAPI(API):
     def get(self):
         """List all topics"""
         args = topic_parser.parse()
-        topics = Topic.objects()
+        topics = Topic.objects.visible_by_user(current_user, mongoengine.Q(private__ne=True))
         topics = topic_parser.parse_filters(topics, args)
         sort = args["sort"] or ("$text_score" if args["q"] else None) or DEFAULT_SORTING
         return topics.order_by(sort).paginate(args["page"], args["page_size"])

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -3,6 +3,7 @@ import logging
 import mongoengine
 from bson import ObjectId
 from flask import request, url_for
+from flask_security import current_user
 
 from udata.api import API, apiv2, fields
 from udata.core.dataset.api import DatasetApiParser
@@ -116,7 +117,7 @@ class TopicsAPI(API):
     def get(self):
         """List all topics"""
         args = topic_parser.parse()
-        topics = Topic.objects()
+        topics = Topic.objects.visible_by_user(current_user, mongoengine.Q(private__ne=True))
         topics = topic_parser.parse_filters(topics, args)
         sort = args["sort"] or ("$text_score" if args["q"] else None) or DEFAULT_SORTING
         return topics.order_by(sort).paginate(args["page"], args["page_size"])


### PR DESCRIPTION
This filters the API `Topics` list with current owner permissions regarding `Topic.private`. Similar to what is done for datasets and other models.