### PR TITLE
Ensure we populate slug properly on user deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow temporal coverage with only a start date [#3192](https://github.com/opendatateam/udata/pull/3192)
 - The `extras` column in the resource catalog is now dumped as json [#3272](https://github.com/opendatateam/udata/pull/3272) and [#3273](https://github.com/opendatateam/udata/pull/3273)
+- Ensure we populate slug properly on user deletion [#3277](https://github.com/opendatateam/udata/pull/3277)
 
 ## 10.1.0 (2025-02-20)
 

--- a/udata/mongo/slug_fields.py
+++ b/udata/mongo/slug_fields.py
@@ -52,10 +52,10 @@ class SlugField(StringField):
         self.register_signals(owner)
         return super(SlugField, self).__get__(instance, owner)
 
-    def __set__(self, instance, owner):
+    def __set__(self, instance, value):
         # mongoengine calls this on document update
-        self.register_signals(owner)
-        return super(SlugField, self).__set__(instance, owner)
+        self.register_signals(instance.__class__)
+        return super(SlugField, self).__set__(instance, value)
 
     def __deepcopy__(self, memo):
         # Fixes no_dereference by avoiding deep copying instance attribute

--- a/udata/mongo/slug_fields.py
+++ b/udata/mongo/slug_fields.py
@@ -39,15 +39,23 @@ class SlugField(StringField):
         self.instance = None
         super(SlugField, self).__init__(**kwargs)
 
-    def __get__(self, instance, owner):
-        # mongoengine calls this after document initialization
+    def register_signals(self, owner):
         # We register signals handlers here to have a owner reference
         if not hasattr(self, "owner"):
             self.owner = owner
             pre_save.connect(self.populate_on_pre_save, sender=owner)
             if self.follow:
                 post_delete.connect(self.cleanup_on_delete, sender=owner)
+
+    def __get__(self, instance, owner):
+        # mongoengine calls this after document initialization
+        self.register_signals(owner)
         return super(SlugField, self).__get__(instance, owner)
+
+    def __set__(self, instance, owner):
+        # mongoengine calls this on document update
+        self.register_signals(owner)
+        return super(SlugField, self).__set__(instance, owner)
 
     def __deepcopy__(self, memo):
         # Fixes no_dereference by avoiding deep copying instance attribute

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -110,35 +110,35 @@ class SlugFieldTest:
         startup_receivers = copy(pre_save.receivers)
         assert not any(
             getattr(receiver, "__func__", None) == db.SlugField.populate_on_pre_save
-            for receiver in pre_save.receivers_for(SlugTester)
+            for receiver in pre_save.receivers_for(SlugUpdateTester)
         )
-        # Somehow SlugTester.slug already has an owner, even though it seems to be set
+        # Somehow SlugUpdateTester.slug already has an owner, even though it seems to be set
         # in `SlugField.__get__` that hasn't been called already
-        # assert not hasattr(SlugTester.slug, "owner")  # FAILS
+        # assert not hasattr(SlugUpdateTester.slug, "owner")  # FAILS
 
-        tester = SlugTester.objects.create(title="A Title")
+        tester = SlugUpdateTester.objects.create(title="A Title")
 
-        # It is registered when initializing a new SlugTester with a SlugField
+        # It is registered when initializing a new SlugUpdateTester with a SlugField
         assert any(
             getattr(receiver, "__func__", None) == db.SlugField.populate_on_pre_save
-            for receiver in pre_save.receivers_for(SlugTester)
+            for receiver in pre_save.receivers_for(SlugUpdateTester)
         )
-        assert hasattr(SlugTester.slug, "owner")
+        assert hasattr(SlugUpdateTester.slug, "owner")
         assert tester.slug == "a-title"
 
         # Clear pre_save receivers
         pre_save.receivers = startup_receivers
-        del SlugTester.slug.owner
+        del SlugUpdateTester.slug.owner
 
-        tester = SlugTester.objects(title="A Title").first()
+        tester = SlugUpdateTester.objects(title="A Title").first()
         tester.title = "Other title"
         tester.save()
 
-        # ⚠️ It is not registered when updating an existing SlugTester with a SlugField field
+        # ⚠️ It is not registered when updating an existing SlugUpdateTester with a SlugField field
         # but we want it to be registered in order to update the slug.
         assert any(
             getattr(receiver, "__func__", None) == db.SlugField.populate_on_pre_save
-            for receiver in pre_save.receivers_for(SlugTester)
+            for receiver in pre_save.receivers_for(SlugUpdateTester)
         )  # FAILS
         assert tester.slug == "other-title"  # FAILS
 

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -112,9 +112,6 @@ class SlugFieldTest:
             getattr(receiver, "__func__", None) == db.SlugField.populate_on_pre_save
             for receiver in pre_save.receivers_for(SlugUpdateTester)
         )
-        # Somehow SlugUpdateTester.slug already has an owner, even though it seems to be set
-        # in `SlugField.__get__` that hasn't been called already
-        # assert not hasattr(SlugUpdateTester.slug, "owner")  # FAILS
 
         tester = SlugUpdateTester.objects.create(title="A Title")
 
@@ -134,13 +131,12 @@ class SlugFieldTest:
         tester.title = "Other title"
         tester.save()
 
-        # ⚠️ It is not registered when updating an existing SlugUpdateTester with a SlugField field
-        # but we want it to be registered in order to update the slug.
+        # It is also registered when updating an existing SlugUpdateTester with a SlugField
         assert any(
             getattr(receiver, "__func__", None) == db.SlugField.populate_on_pre_save
             for receiver in pre_save.receivers_for(SlugUpdateTester)
-        )  # FAILS
-        assert tester.slug == "other-title"  # FAILS
+        )
+        assert tester.slug == "other-title"
 
     def test_validate(self):
         """SlugField should validate if not set"""


### PR DESCRIPTION
Fix https://github.com/datagouv/data.gouv.fr/issues/1663

The issue was that `populate_on_pre_save` was not necessarily registered on `post_save` signal.
Registration was made on documentation initialization, based on `SlugField.__get__` being called, which would not happen when updating a document.
Once the signal had been registered once in the app lifetime, we would not face the issue anymore.

[The commit](https://github.com/opendatateam/udata/commit/21d34e5dc95bda244e333fe1f22f19a790df6d0f) that introduced the signal registration on document initialization is called `Refactor SlugField population to fix a memory leak`. It seems touchy to break the logic.

We may want to refactor the signal registration better, but making sure we're registering the signal on `__set__` as well as `__get__` may be a safe move.

Looking at logs during tests, it seems that `__set__` is called twice as little as `__get__` on SlugField.