### PR TITLE
Fix end date not defined in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix end date not defined in admin [#3281](https://github.com/opendatateam/udata/pull/3281)
 
 ## 10.1.1 (2025-03-03)
 

--- a/js/components/dataset/filters.js
+++ b/js/components/dataset/filters.js
@@ -16,7 +16,7 @@ export default {
             const end = range.end ? moment(range.end) : undefined;
             const fmt = details ? 'L' : 'YYYY';
             const start_label = start.format(fmt);
-            const end_label = end.format(fmt);
+            const end_label = end ? end.format(fmt) : undefined;
             if (details) {
                 return end_label
                     ? this._('{start} to {end}', {start: start_label, end: end_label, interpolation: { escapeValue: false }})


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/3192

It breaks our admin if the end of temporal coverage is not set