### PR TITLE
Exclude deleted dataservices in csv queryset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Exclude deleted dataservices in csv queryset [#3297](https://github.com/opendatateam/udata/pull/3297)
 
 ## 10.3.0 (2025-04-11)
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -140,7 +140,7 @@ def get_queryset(model_cls):
     if model_cls.__name__ == "Resource":
         model_cls = getattr(udata_models, "Dataset")
     params = {}
-    attrs = ("private", "deleted")
+    attrs = ("private", "deleted", "deleted_at")
     for attr in attrs:
         if getattr(model_cls, attr, None):
             params[attr] = False


### PR DESCRIPTION
Dataservice has [a `deleted_at` property](https://github.com/opendatateam/udata/blob/9d2d993537061b6e57a142d4a5fb70e985183d5f/udata/core/dataservices/models.py#L205).