### PR TITLE
Improve reuse api perfs by adding a mask on datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Improve reuse api perfs by adding a mask on datasets [#3309](https://github.com/opendatateam/udata/pull/3309)
 
 ## 10.3.2 (2025-05-06)
 

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -58,6 +58,7 @@ class ReuseBadgeMixin(BadgeMixin):
         {"key": "views", "value": "metrics.views"},
     ],
     additional_filters={"organization_badge": "organization.badges"},
+    mask="*,datasets{title,uri,page}",
 )
 class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
     title = field(


### PR DESCRIPTION
This mask used to exist in old reuse api fields, before refacto in https://github.com/opendatateam/udata/pull/3066

It applies to all reuse endpoint by default (v1 & v2).

On reuses referencing big datasets (ex [this one](https://www.data.gouv.fr/api/1/reuses/wedof/)), it would take 2 min 40 secs locally vs 2 secs with the mask.
We can compare perfs on dev once this PR is deployed there. Currently
```
In [8]: %timeit requests.get("https://dev.data.gouv.fr/api/1/reuses/meteo-squad/")
6.09 s ± 499 ms per loop (mean ± std. dev. of 7 runs, 1 loop each
```
# Test
Locally, the diff is huge on reuses with big datasets
```
## With the fix
In [3]: %timeit requests.get("http://dev.local:7000/api/1/reuses/wedof/")
1.49 s ± 65.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

## Without the fix
In [4]: %timeit requests.get("http://dev.local:7000/api/1/reuses/wedof/")
2min 10s ± 14.2 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```