### PR TITLE
Private objects should return 404 by api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Improve reuse api perfs by adding a mask on datasets [#3309](https://github.com/opendatateam/udata/pull/3309)
+- Private objects should return 404 by api [#3311](https://github.com/opendatateam/udata/pull/3311)
 
 ## 10.3.2 (2025-05-06)
 

--- a/udata/core/dataservices/api.py
+++ b/udata/core/dataservices/api.py
@@ -54,8 +54,11 @@ class DataserviceAPI(API):
     @api.doc("get_dataservice")
     @api.marshal_with(Dataservice.__read_fields__)
     def get(self, dataservice):
-        if dataservice.deleted_at and not OwnablePermission(dataservice).can():
-            api.abort(410, "Dataservice has been deleted")
+        if not OwnablePermission(dataservice).can():
+            if dataservice.private:
+                api.abort(404)
+            elif dataservice.deleted_at:
+                api.abort(410, "Dataservice has been deleted")
         return dataservice
 
     @api.secure

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -300,8 +300,11 @@ class DatasetAPI(API):
     @api.marshal_with(dataset_fields)
     def get(self, dataset):
         """Get a dataset given its identifier"""
-        if dataset.deleted and not DatasetEditPermission(dataset).can():
-            api.abort(410, "Dataset has been deleted")
+        if not DatasetEditPermission(dataset).can():
+            if dataset.private:
+                api.abort(404)
+            elif dataset.deleted:
+                api.abort(410, "Dataset has been deleted")
         return dataset
 
     @api.secure

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -138,8 +138,11 @@ class ReuseAPI(API):
     @api.marshal_with(Reuse.__read_fields__)
     def get(self, reuse):
         """Fetch a given reuse"""
-        if reuse.deleted and not ReuseEditPermission(reuse).can():
-            api.abort(410, "This reuse has been deleted")
+        if not ReuseEditPermission(reuse).can():
+            if reuse.private:
+                api.abort(404)
+            elif reuse.deleted:
+                api.abort(410, "This reuse has been deleted")
         return reuse
 
     @api.secure

--- a/udata/tests/api/test_dataservices_api.py
+++ b/udata/tests/api/test_dataservices_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from xml.etree.ElementTree import XML
 
 import pytest
@@ -17,7 +18,7 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Member
 from udata.core.user.factories import AdminFactory, UserFactory
 from udata.i18n import gettext as _
-from udata.tests.helpers import assert200, assert400, assert_redirects
+from udata.tests.helpers import assert200, assert400, assert410, assert_redirects
 
 from . import APITestCase
 
@@ -29,6 +30,40 @@ def dataservice_in_response(response: TestResponse, dataservice: Dataservice) ->
 
 class DataserviceAPITest(APITestCase):
     modules = []
+
+    def test_dataservice_api_get(self, api):
+        """It should fetch a dataservice from the API"""
+        dataservice = DataserviceFactory()
+        response = api.get(url_for("api.dataservice", dataservice=dataservice))
+        assert200(response)
+
+    def test_dataservice_api_get_deleted(self, api):
+        """It should not fetch a deleted dataservice from the API and raise 410"""
+        dataservice = DataserviceFactory(deleted_at=datetime.utcnow())
+        response = api.get(url_for("api.dataservice", dataservice=dataservice))
+        assert410(response)
+
+    def test_dataservice_api_get_deleted_but_authorized(self, api):
+        """It should fetch a deleted dataservice from the API if authorized"""
+        user = api.login()
+        dataservice = DataserviceFactory(deleted_at=datetime.utcnow(), owner=user)
+        response = api.get(url_for("api.dataservice", dataservice=dataservice))
+        assert200(response)
+
+    def test_dataservice_api_get_private(self):
+        """It should not fetch a private dataservice from the API and raise 404"""
+        dataservice = DataserviceFactory(private=True)
+
+        response = self.get(url_for("api.dataservice", dataservice=dataservice))
+        self.assert404(response)
+
+    def test_dataservice_api_get_private_but_authorized(self):
+        """It should fetch a private dataservice from the API if user is authorized"""
+        self.login()
+        dataservice = DataserviceFactory(owner=self.user, private=True)
+
+        response = self.get(url_for("api.dataservice", dataservice=dataservice))
+        self.assert200(response)
 
     def test_dataservices_api_list_with_filters(self):
         """Should filters dataservices results based on query filters"""
@@ -174,10 +209,10 @@ class DataserviceAPITest(APITestCase):
         response = self.get(url_for("api.dataservice", dataservice=dataservice))
         self.assert200(response)
 
-        # We cannot access deleted element as random user
+        # We cannot access private element as random user
         self.login()
         response = self.get(url_for("api.dataservice", dataservice=dataservice))
-        self.assert410(response)
+        self.assert404(response)
 
         # We can undelete with a patch
         self.login(user)

--- a/udata/tests/api/test_dataservices_api.py
+++ b/udata/tests/api/test_dataservices_api.py
@@ -31,23 +31,23 @@ def dataservice_in_response(response: TestResponse, dataservice: Dataservice) ->
 class DataserviceAPITest(APITestCase):
     modules = []
 
-    def test_dataservice_api_get(self, api):
+    def test_dataservice_api_get(self):
         """It should fetch a dataservice from the API"""
         dataservice = DataserviceFactory()
-        response = api.get(url_for("api.dataservice", dataservice=dataservice))
+        response = self.get(url_for("api.dataservice", dataservice=dataservice))
         assert200(response)
 
-    def test_dataservice_api_get_deleted(self, api):
+    def test_dataservice_api_get_deleted(self):
         """It should not fetch a deleted dataservice from the API and raise 410"""
         dataservice = DataserviceFactory(deleted_at=datetime.utcnow())
-        response = api.get(url_for("api.dataservice", dataservice=dataservice))
+        response = self.get(url_for("api.dataservice", dataservice=dataservice))
         assert410(response)
 
-    def test_dataservice_api_get_deleted_but_authorized(self, api):
+    def test_dataservice_api_get_deleted_but_authorized(self):
         """It should fetch a deleted dataservice from the API if authorized"""
-        user = api.login()
+        user = self.login()
         dataservice = DataserviceFactory(deleted_at=datetime.utcnow(), owner=user)
-        response = api.get(url_for("api.dataservice", dataservice=dataservice))
+        response = self.get(url_for("api.dataservice", dataservice=dataservice))
         assert200(response)
 
     def test_dataservice_api_get_private(self):

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -484,9 +484,24 @@ class DatasetAPITest(APITestCase):
         self.assert410(response)
 
     def test_dataset_api_get_deleted_but_authorized(self):
-        """It should a deleted dataset from the API if user is authorized"""
+        """It should fetch a deleted dataset from the API if user is authorized"""
         self.login()
         dataset = DatasetFactory(owner=self.user, deleted=datetime.utcnow())
+
+        response = self.get(url_for("api.dataset", dataset=dataset))
+        self.assert200(response)
+
+    def test_dataset_api_get_private(self):
+        """It should not fetch a private dataset from the API and raise 404"""
+        dataset = DatasetFactory(private=True)
+
+        response = self.get(url_for("api.dataset", dataset=dataset))
+        self.assert404(response)
+
+    def test_dataset_api_get_private_but_authorized(self):
+        """It should fetch a private dataset from the API if user is authorized"""
+        self.login()
+        dataset = DatasetFactory(owner=self.user, private=True)
 
         response = self.get(url_for("api.dataset", dataset=dataset))
         self.assert200(response)

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -257,6 +257,21 @@ class ReuseAPITest:
         response = api.get(url_for("api.reuse", reuse=reuse))
         assert200(response)
 
+    def test_reuse_api_get_private(self):
+        """It should not fetch a private reuse from the API and raise 404"""
+        reuse = ReuseFactory(private=True)
+
+        response = self.get(url_for("api.reuse", reuse=reuse))
+        self.assert404(response)
+
+    def test_reuse_api_get_private_but_authorized(self):
+        """It should fetch a private reuse from the API if user is authorized"""
+        self.login()
+        reuse = ReuseFactory(owner=self.user, private=True)
+
+        response = self.get(url_for("api.reuse", reuse=reuse))
+        self.assert200(response)
+
     def test_reuse_api_create(self, api):
         """It should create a reuse from the API"""
         data = ReuseFactory.as_dict()

--- a/udata/tests/api/test_reuses_api.py
+++ b/udata/tests/api/test_reuses_api.py
@@ -257,20 +257,20 @@ class ReuseAPITest:
         response = api.get(url_for("api.reuse", reuse=reuse))
         assert200(response)
 
-    def test_reuse_api_get_private(self):
+    def test_reuse_api_get_private(self, api):
         """It should not fetch a private reuse from the API and raise 404"""
         reuse = ReuseFactory(private=True)
 
-        response = self.get(url_for("api.reuse", reuse=reuse))
-        self.assert404(response)
+        response = api.get(url_for("api.reuse", reuse=reuse))
+        assert404(response)
 
-    def test_reuse_api_get_private_but_authorized(self):
+    def test_reuse_api_get_private_but_authorized(self, api):
         """It should fetch a private reuse from the API if user is authorized"""
-        self.login()
-        reuse = ReuseFactory(owner=self.user, private=True)
+        user = api.login()
+        reuse = ReuseFactory(owner=user, private=True)
 
-        response = self.get(url_for("api.reuse", reuse=reuse))
-        self.assert200(response)
+        response = api.get(url_for("api.reuse", reuse=reuse))
+        assert200(response)
 
     def test_reuse_api_create(self, api):
         """It should create a reuse from the API"""


### PR DESCRIPTION
It would prevent showing private objects on cdata for non-authorized users.

It was already the case for RDF get endpoints (on datasets and dataservices).

Do we want to apply this logic to topics? I'm unsure about the usage of `private` by ecosphere (cc @streino)