### PR TITLE
Remove `downloads` in dataset csv adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Remove duplicate `downloads` in dataset csv adapter [#3319](https://github.com/opendatateam/udata/pull/3319)
 
 ## 10.4.0 (2025-05-15)
 

--- a/udata/core/dataset/csv.py
+++ b/udata/core/dataset/csv.py
@@ -40,7 +40,6 @@ class DatasetCsvAdapter(csv.Adapter):
         ("resources_count", lambda o: len(o.resources)),
         ("main_resources_count", lambda o: len([r for r in o.resources if r.type == "main"])),
         ("resources_formats", lambda o: ",".join(set(r.format for r in o.resources if r.format))),
-        "downloads",
         ("harvest.backend", lambda r: r.harvest and r.harvest.backend),
         ("harvest.domain", lambda r: r.harvest and r.harvest.domain),
         ("harvest.created_at", lambda r: r.harvest and r.harvest.created_at),

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -897,10 +897,6 @@ class Dataset(WithMetrics, DatasetBadgeMixin, Owned, db.Document):
 
         return result
 
-    @property
-    def downloads(self):
-        return sum(resource.metrics.get("views", 0) for resource in self.resources)
-
     @staticmethod
     def normalize_score(score):
         """

--- a/udata/tests/dataset/test_csv_adapter.py
+++ b/udata/tests/dataset/test_csv_adapter.py
@@ -21,7 +21,10 @@ class DatasetCSVAdapterTest:
                         "created_at": date_created,
                         "modified_at": date_modified,
                         "uri": "http://domain.gouv.fr/dataset/uri",
-                    }
+                    },
+                    metrics={
+                        "views": 42,
+                    },
                 )
             ],
             harvest={
@@ -41,6 +44,8 @@ class DatasetCSVAdapterTest:
         assert date_modified.isoformat() in d_row
         # dataset harvest dates should not be here
         assert another_date.isoformat() not in d_row
+        # assert resource metrics downloads
+        assert 42 in d_row
 
     def test_datasets_csv_adapter(self):
         date_created = datetime(2022, 12, 31)
@@ -92,4 +97,3 @@ class DatasetCSVAdapterTest:
         assert resources_dataset_values["resources_count"] == 3
         assert resources_dataset_values["main_resources_count"] == 1
         assert set(resources_dataset_values["resources_formats"].split(",")) == set(["csv", "json"])
-        assert resources_dataset_values["downloads"] == 1337 + 42

--- a/udata/tests/dataset/test_csv_adapter.py
+++ b/udata/tests/dataset/test_csv_adapter.py
@@ -87,7 +87,6 @@ class DatasetCSVAdapterTest:
         assert harvest_dataset_values["harvest.domain"] == "example.com"
         assert harvest_dataset_values["harvest.remote_url"] == "https://www.example.com/"
         assert harvest_dataset_values["resources_count"] == 0
-        assert harvest_dataset_values["downloads"] == 0
 
         resources_dataset_values = csv[str(resources_dataset.id)]
         assert resources_dataset_values["resources_count"] == 3


### PR DESCRIPTION
It was a duplicate of `metric.resources_downloads`, added in https://github.com/opendatateam/udata-metrics/pull/15