### PR TITLE
Fix missing ID in dataset reuses mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix missing ID in dataset reuses mask [#3321](https://github.com/opendatateam/udata/pull/3321)
 
 ## 10.4.0 (2025-05-15)
 

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -58,7 +58,7 @@ class ReuseBadgeMixin(BadgeMixin):
         {"key": "views", "value": "metrics.views"},
     ],
     additional_filters={"organization_badge": "organization.badges"},
-    mask="*,datasets{title,uri,page}",
+    mask="*,datasets{id,title,uri,page}",
 )
 class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
     title = field(


### PR DESCRIPTION
Broke the `DatasetSelect` for reuses http://dev.local:3000/fr/admin/reuses/680581b0d098647e7a3b088b/datasets/ or  	https://www.data.gouv.fr/fr/admin/reuses/682b44d9e4fd34d3a2ebcc5a/datasets/ in production