### PR TITLE
Show user domain in suggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Show user domain in suggest [#3324](https://github.com/opendatateam/udata/pull/3324)
 
 ## 10.4.1 (2025-05-20)
 

--- a/udata/core/organization/api_fields.py
+++ b/udata/core/organization/api_fields.py
@@ -42,9 +42,6 @@ org_ref_fields = api.inherit(
     },
 )
 
-# This import is not at the top of the file to avoid circular imports
-from udata.core.user.api_fields import user_ref_fields  # noqa
-
 
 def check_can_access_user_private_info():
     # This endpoint is secure, only organization member has access.
@@ -64,13 +61,17 @@ def check_can_access_user_private_info():
 def member_email_with_visibility_check(email):
     if current_user_is_admin_or_self():
         return email
+    name, domain = email.split("@")
     if check_can_access_user_private_info():
         # Obfuscate email partially for other members
-        name, domain = email.split("@")
         name = name[:2] + "*" * (len(name) - 2)
         return f"{name}@{domain}"
-    return None
+    # Return only domain for other users
+    return f"***@{domain}"
 
+
+# This import is not at the top of the file to avoid circular imports
+from udata.core.user.api_fields import user_ref_fields  # noqa
 
 member_user_with_email_fields = api.inherit(
     "MemberUserWithEmail",

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -10,7 +10,6 @@ from udata.core.dataset.api_fields import community_resource_fields, dataset_fie
 from udata.core.discussions.actions import discussions_for
 from udata.core.discussions.api import discussion_fields
 from udata.core.followers.api import FollowAPI
-from udata.core.organization.api_fields import member_email_with_visibility_check
 from udata.core.storages.api import (
     image_parser,
     parse_uploaded_image,

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -10,6 +10,7 @@ from udata.core.dataset.api_fields import community_resource_fields, dataset_fie
 from udata.core.discussions.actions import discussions_for
 from udata.core.discussions.api import discussion_fields
 from udata.core.followers.api import FollowAPI
+from udata.core.organization.api_fields import member_email_with_visibility_check
 from udata.core.storages.api import (
     image_parser,
     parse_uploaded_image,
@@ -409,6 +410,7 @@ class SuggestUsersAPI(API):
                 "first_name": user.first_name,
                 "last_name": user.last_name,
                 "avatar_url": user.avatar,
+                "email": user.email,
                 "slug": user.slug,
             }
             for user in users.order_by(DEFAULT_SORTING).limit(args["size"])

--- a/udata/core/user/api_fields.py
+++ b/udata/core/user/api_fields.py
@@ -127,7 +127,7 @@ user_suggestion_fields = api.model(
             size=BIGGEST_AVATAR_SIZE, description="The user avatar URL", readonly=True
         ),
         "email": fields.Raw(
-            attribute=lambda o: member_email_with_visibility_check(o['email']),
+            attribute=lambda o: member_email_with_visibility_check(o["email"]),
             description="The user email (only the domain for non-admin user)",
             readonly=True,
         ),

--- a/udata/core/user/api_fields.py
+++ b/udata/core/user/api_fields.py
@@ -30,7 +30,7 @@ user_ref_fields = api.inherit(
     },
 )
 
-from udata.core.organization.api_fields import org_ref_fields  # noqa
+from udata.core.organization.api_fields import member_email_with_visibility_check, org_ref_fields  # noqa
 
 user_fields = api.model(
     "User",
@@ -125,6 +125,11 @@ user_suggestion_fields = api.model(
         "last_name": fields.String(description="The user last name", readonly=True),
         "avatar_url": fields.ImageField(
             size=BIGGEST_AVATAR_SIZE, description="The user avatar URL", readonly=True
+        ),
+        "email": fields.Raw(
+            attribute=lambda o: member_email_with_visibility_check(o['email']),
+            description="The user email (only the domain for non-admin user)",
+            readonly=True,
         ),
         "slug": fields.String(description="The user permalink string", readonly=True),
     },

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -362,10 +362,10 @@ class MembershipAPITest:
         assert len(members) == 2
         assert members[0]["role"] == "admin"
         assert members[0]["since"] == "2024-04-14T00:00:00+00:00"
-        assert members[0]["user"]["email"] is None
+        assert members[0]["user"]["email"] == "***@example.org"
 
         assert members[1]["role"] == "editor"
-        assert members[1]["user"]["email"] is None
+        assert members[1]["user"]["email"] == "***@example.org"
 
         # Super admin of udata can see emails
         api.login(AdminFactory())


### PR DESCRIPTION
This PR adds email domains to user suggest.

It uses the existing `member_email_with_visibility_check` to do so.

We can remove the member for the function name to improve readability.