### PR TITLE
Count dataservices for datasets

### DIFF
--- a/udata/core/dataset/metrics.py
+++ b/udata/core/dataset/metrics.py
@@ -1,0 +1,12 @@
+from udata.core.dataservices.models import Dataservice
+
+from .models import Dataset
+
+
+@Dataservice.on_create.connect
+@Dataservice.on_update.connect
+@Dataservice.on_delete.connect
+def update_dataset_dataservices_metric(dataservice, **kwargs):
+    for dataset in dataservice.datasets:
+        # dataset is a LazyReferenceField
+        Dataset.get(dataset.pk).count_dataservices()

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -599,6 +599,7 @@ class Dataset(Auditable, WithMetrics, DatasetBadgeMixin, Owned, db.Document):
     __metrics_keys__ = [
         "discussions",
         "reuses",
+        "dataservices",
         "followers",
         "views",
         "resources_downloads",
@@ -610,6 +611,7 @@ class Dataset(Auditable, WithMetrics, DatasetBadgeMixin, Owned, db.Document):
             "created_at_internal",
             "last_modified_internal",
             "metrics.reuses",
+            "metrics.dataservices",
             "metrics.followers",
             "metrics.views",
             "slug",
@@ -1053,6 +1055,12 @@ class Dataset(Auditable, WithMetrics, DatasetBadgeMixin, Owned, db.Document):
         from udata.models import Reuse
 
         self.metrics["reuses"] = Reuse.objects(datasets=self).visible().count()
+        self.save(signal_kwargs={"ignores": ["post_save"]})
+
+    def count_dataservices(self):
+        from udata.core.dataservices.models import Dataservice
+
+        self.metrics["dataservices"] = Dataservice.objects(datasets=self).visible().count()
         self.save(signal_kwargs={"ignores": ["post_save"]})
 
     def count_followers(self):

--- a/udata/core/metrics/__init__.py
+++ b/udata/core/metrics/__init__.py
@@ -6,6 +6,7 @@ def init_app(app):
     import udata.core.user.metrics  # noqa
     import udata.core.organization.metrics  # noqa
     import udata.core.discussions.metrics  # noqa
+    import udata.core.dataset.metrics  # noqa
     import udata.core.reuse.metrics  # noqa
     import udata.core.followers.metrics  # noqa
 

--- a/udata/core/metrics/commands.py
+++ b/udata/core/metrics/commands.py
@@ -74,6 +74,7 @@ def update(
                         dataset.metrics.clear()
                     dataset.count_discussions()
                     dataset.count_reuses()
+                    dataset.count_dataservices()
                     dataset.count_followers()
                 except Exception as e:
                     log.info(f"Error during update: {e}")
@@ -119,6 +120,7 @@ def update(
                         organization.metrics.clear()
                     organization.count_datasets()
                     organization.count_reuses()
+                    organization.count_dataservices()
                     organization.count_followers()
                     organization.count_members()
                 except Exception as e:
@@ -135,6 +137,7 @@ def update(
                         user.metrics.clear()
                     user.count_datasets()
                     user.count_reuses()
+                    user.count_dataservices()
                     user.count_followers()
                     user.count_following()
                 except Exception as e:

--- a/udata/core/organization/metrics.py
+++ b/udata/core/organization/metrics.py
@@ -35,3 +35,5 @@ def update_org_metrics(document, previous):
         previous.count_datasets()
     elif isinstance(document, Reuse):
         previous.count_reuses()
+    elif isinstance(document, Dataservice):
+        previous.count_dataservices()

--- a/udata/core/user/metrics.py
+++ b/udata/core/user/metrics.py
@@ -42,3 +42,5 @@ def update_owner_metrics(document, previous):
         previous.count_datasets()
     elif isinstance(document, Reuse):
         previous.count_reuses()
+    elif isinstance(document, Dataservice):
+        previous.count_dataservices()

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -9,6 +9,9 @@ from mongoengine import ValidationError as MongoEngineValidationError
 from mongoengine import post_save
 
 from udata.app import cache
+from udata.core import metrics
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataservices.models import Dataservice
 from udata.core.dataset.activities import (
     UserAddedResourceToDataset,
     UserCreatedDataset,
@@ -30,8 +33,10 @@ from udata.core.dataset.factories import (
     ResourceSchemaMockData,
 )
 from udata.core.dataset.models import HarvestDatasetMetadata, HarvestResourceMetadata
+from udata.core.followers.signals import on_follow, on_unfollow
+from udata.core.reuse.factories import ReuseFactory, VisibleReuseFactory
 from udata.core.user.factories import UserFactory
-from udata.models import Dataset, License, ResourceSchema, Schema, db
+from udata.models import Dataset, Follow, License, ResourceSchema, Reuse, Schema, db
 from udata.tests.helpers import assert_emit, assert_equal_dates, assert_not_emit
 from udata.utils import faker
 
@@ -398,6 +403,69 @@ class DatasetModelTest:
             dataset.deleted = datetime.utcnow()
             dataset.save()
             mock_deleted.assert_called()
+
+    def test_dataset_metrics(self):
+        # We need to init metrics module
+        metrics.init_app(current_app)
+
+        dataset = DatasetFactory()
+
+        # Add related elements
+        with assert_emit(Reuse.on_create):
+            reuse = VisibleReuseFactory(datasets=[dataset])
+            ReuseFactory()
+        with assert_emit(Dataservice.on_create):
+            dataservice = DataserviceFactory(datasets=[dataset])
+        with assert_emit(on_follow):
+            follow = Follow.objects.create(
+                following=dataset, follower=UserFactory(), since=datetime.utcnow()
+            )
+
+        dataset.reload()
+        # Reuse metrics are updated with a job following https://github.com/opendatateam/udata/pull/2531
+        # Thus, metrics are not updated real time here
+        # TODO: could we revert to using signals for reuse metrics?
+        # assert dataset.get_metrics()["reuses"] == 1
+        assert dataset.get_metrics()["dataservices"] == 1
+        assert dataset.get_metrics()["followers"] == 1
+
+        # Delete related elements
+        with assert_emit(Reuse.on_delete):
+            reuse.deleted = datetime.utcnow()
+            reuse.save()
+        with assert_emit(Dataservice.on_delete):
+            dataservice.deleted_at = datetime.utcnow()
+            dataservice.save()
+        with assert_emit(on_unfollow):
+            follow.until = datetime.utcnow()
+            follow.save()
+
+        dataset.reload()
+        # assert dataset.get_metrics()["reuses"] == 0
+        assert dataset.get_metrics()["dataservices"] == 0
+        assert dataset.get_metrics()["followers"] == 0
+
+        # Attach and then detach related elements
+        reuse = VisibleReuseFactory(datasets=[dataset])
+        dataservice = DataserviceFactory(datasets=[dataset])
+
+        dataset.reload()
+        # assert dataset.get_metrics()["reuses"] == 1
+        assert dataset.get_metrics()["dataservices"] == 1
+
+        with assert_emit(Reuse.on_update):
+            reuse.datasets = []
+            reuse.save()
+        with assert_emit(Dataservice.on_update):
+            dataservice.datasets = []
+            dataservice.save()
+
+        dataset.reload()
+        # assert dataset.get_metrics()["reuses"] == 0
+        assert dataset.get_metrics()["dataservices"] == 0
+        # TODO: the assertion above doesn't work since we don't compute
+        # count_dataservices on datasets that are no longer in the dataservices
+        # since we iterate on dataservice.datasets
 
 
 class ResourceModelTest:


### PR DESCRIPTION
This adds a `dataservices` metrics in dataset objects, displayed in cdata in the reuses and API tabs.