### PR TITLE
Add config entry for ISO-DCAT XSLT URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Add config entry for ISO-DCAT XSLT URL [PR TODO]
 - Fix failing to return dataservice in harvest preview because of no ID for URL [#3357](https://github.com/opendatateam/udata/pull/3357/)
 - Fix invalid resource format from harvested RDF records [#3354](https://github.com/opendatateam/udata/pull/3354)
 - Expose `dataset_id` for CommunityResource in /dataset/resource/id [#3258](https://github.com/opendatateam/udata/pull/3258)

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -344,7 +344,7 @@ class CswIso19139DcatBackend(DcatBackend):
 
     ISO_SCHEMA = "http://www.isotc211.org/2005/gmd"
 
-    XSL_URL = "https://raw.githubusercontent.com/datagouv/iso-19139-to-dcat-ap/patch-datagouv/iso-19139-to-dcat-ap.xsl"
+    DEFAULT_XSL_URL = "https://raw.githubusercontent.com/datagouv/iso-19139-to-dcat-ap/patch-datagouv/iso-19139-to-dcat-ap.xsl"
 
     def walk_graph(self, url: str, fmt: str) -> Generator[tuple[int, Graph], None, None]:
         """
@@ -355,7 +355,8 @@ class CswIso19139DcatBackend(DcatBackend):
         See https://github.com/SEMICeu/iso-19139-to-dcat-ap for more information on the XSLT.
         """
         # Load XSLT
-        xsl = ET.fromstring(self.get(self.XSL_URL).content, parser=SAFE_PARSER)
+        xsl_url = current_app.config.get("HARVEST_ISO19139_XSL_URL", self.DEFAULT_XSL_URL)
+        xsl = ET.fromstring(self.get(xsl_url).content, parser=SAFE_PARSER)
         transform = ET.XSLT(xsl)
 
         # Start querying and parsing graph


### PR DESCRIPTION
Draft PR, needs input @ThibaudDauce :
- [ ] Config param name : OK with the name, or what should I change it to?
- [ ] Default URL : Do we want 1) the patched prod branch, 2) the patched demo branch, 3) the default SEMIC branch, 4) no default, 5) something else?
- [ ] Patched demo/prod branches : How should we name them on the repo https://github.com/datagouv/iso-19139-to-dcat-ap? Is there already a convention for demo/prod branch names?