### PR TITLE
Fix datasets with no slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add back preview_url from tabular API (remove the PreviewPlugin system) [#3364](https://github.com/opendatateam/udata/pull/3364)
 - Do not crash on invalid schemas API JSON [#3363](https://github.com/opendatateam/udata/pull/3363/)
 - Fix flaky test on timed recent Atom feeds [#3365](https://github.com/opendatateam/udata/pull/3365)
+- Fix crashing on datasets with no slugs [#3368](https://github.com/opendatateam/udata/pull/3368/)
 
 ## 10.6.0 (2025-07-08)
 

--- a/udata/core/linkable.py
+++ b/udata/core/linkable.py
@@ -1,6 +1,10 @@
 class Linkable:
     def _link_id(self, **kwargs):
-        return self.id if kwargs.get("_useId", False) else self.slug
+        if kwargs.get("_useId", False):
+            return self.id
+
+        # Some old/special datasets don't have slug?
+        return self.slug or self.id
 
     def _self_api_url_kwargs(self, **kwargs):
         # Default to external


### PR DESCRIPTION
In local I have some datasets without slugs. I don't think it's normal but it's nice to not crash on some datasets pages?