### PR TITLE
Fix dataset schemas endpoint when no resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Do not crash on invalid schemas API JSON [#3363](https://github.com/opendatateam/udata/pull/3363/)
 - Fix flaky test on timed recent Atom feeds [#3365](https://github.com/opendatateam/udata/pull/3365)
 - Allow to remove checksum from resource [#3369](https://github.com/opendatateam/udata/pull/3369)
+- Fix dataset schemas endpoint when no resource [#3373](https://github.com/opendatateam/udata/pull/3373)
 
 ## 10.6.0 (2025-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix dataset schemas endpoint when no resource [#3373](https://github.com/opendatateam/udata/pull/3373)
 
 ## 10.7.0 (2025-07-17)
 
@@ -12,7 +12,6 @@
 - Do not crash on invalid schemas API JSON [#3363](https://github.com/opendatateam/udata/pull/3363/)
 - Fix flaky test on timed recent Atom feeds [#3365](https://github.com/opendatateam/udata/pull/3365)
 - Allow to remove checksum from resource [#3369](https://github.com/opendatateam/udata/pull/3369)
-- Fix dataset schemas endpoint when no resource [#3373](https://github.com/opendatateam/udata/pull/3373)
 
 ## 10.6.0 (2025-07-08)
 

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -465,7 +465,7 @@ class DatasetSchemasAPI(API):
                     r.get("schema").get("name"),
                     r.get("schema").get("version"),
                 ): r.get("schema")
-                for r in dataset.get("resources", [])
+                for r in dataset.get("resources", []) or []
                 if r.get("schema")
             }.values()
         )

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -1250,6 +1250,11 @@ class DatasetAPITest(APITestCase):
             "version": None,
         }
 
+        # Empty dataset (no resources)
+        empty_dataset = Dataset.objects.create(title="test", resources=None)
+        response = self.get(url_for("apiv2.dataset_schemas", dataset=empty_dataset))
+        assert len(response.json) == 0
+
     def test_remove_schema(self):
         self.login(AdminFactory())
         resource = ResourceFactory(schema={"name": "etalab/schema-irve-statique"})


### PR DESCRIPTION
Fix [this error](https://errors.data.gouv.fr/organizations/sentry/issues/257740/?environment=data.gouv.fr&project=12&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=7&utc=true) ([example dataset](https://www.data.gouv.fr/api/2/datasets/680211157129d4a8826cba8c/schemas/)) when `dataset.resources` is `None` (and not missing)