### PR TITLE
Deactivate sitemap extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Deactivate sitemap extension [#3389](https://github.com/opendatateam/udata/pull/3389)
 
 ## 10.8.1 (2025-07-25)
 

--- a/udata/app.py
+++ b/udata/app.py
@@ -210,7 +210,6 @@ def register_extensions(app):
         routing,
         search,
         sentry,
-        sitemap,
         tasks,
     )
 
@@ -225,7 +224,6 @@ def register_extensions(app):
     csrf.init_app(app)
     mail.init_app(app)
     search.init_app(app)
-    sitemap.init_app(app)
     sentry.init_app(app)
     return app
 


### PR DESCRIPTION
It now desactives sitemap extension on udata side since it's [now supported by cdata](https://github.com/datagouv/cdata/pull/428).

Code hasn't been removed yet since some parts are imported in udata-front and I don't think it's worth making a PR there.
See dedicated issue: https://github.com/datagouv/data.gouv.fr/issues/1826.