### PR TITLE
Deactivate cache to check for existing slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Deactivate cache to check for existing slugs [#3390](https://github.com/opendatateam/udata/pull/3390)
 
 ## 10.8.1 (2025-07-25)
 

--- a/udata/mongo/slug_fields.py
+++ b/udata/mongo/slug_fields.py
@@ -172,7 +172,7 @@ def populate_slug(instance, field):
     # Ensure uniqueness
     if field.unique:
         base_slug = slug
-        qs = instance.__class__.objects
+        qs = instance.__class__.objects.no_cache()
         if previous:
             qs = qs(id__ne=previous.id)
 


### PR DESCRIPTION
Try to [fix this error sentry](https://errors.data.gouv.fr/organizations/sentry/issues/262633/?environment=data.gouv.fr&project=12&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=1&utc=true), probably introduced following https://github.com/opendatateam/udata/pull/3388.

**Note**: It seems that [many inactive users account](https://github.com/opendatateam/udata/pull/3274) that hadn't yet been deleted (probably due to the looong time it needed before [the fix](https://github.com/opendatateam/udata/pull/3388)) are currently being deleted. It means the slugs are increasing real time, which probably causes this issue.
Stats at 7:30 on 25-07-2025:
```
# Already deleted
>>> User.objects(deleted__gte="2025-07-25").count()
7479

# Yet to delete
>>> User.objects(deleted=None, current_login_at__lte=deletion_comparison_date, inactive_deletion_notified_at__lte=notified_at).count()
39638
```