### PR TITLE
Optimize csv organization export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Cache dcat harvest pages to avoid two rounds of requests [#3398](https://github.com/opendatateam/udata/pull/3398)
 - Ignore Dataset.accessService when processing DataService [#3399](https://github.com/opendatateam/udata/pull/3399)
 - Add dataset field `description_short` [#3397](https://github.com/opendatateam/udata/pull/3397)
+- Optimize csv organization export [#3401](https://github.com/opendatateam/udata/pull/3401)
 
 ## 10.8.2 (2025-07-31)
 

--- a/udata/tests/organization/test_csv_adapter.py
+++ b/udata/tests/organization/test_csv_adapter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from udata.core.dataset.factories import DatasetFactory, ResourceFactory
+from udata.core.dataset.factories import DatasetFactory
 from udata.core.organization.csv import OrganizationCsvAdapter
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Organization
@@ -15,21 +15,9 @@ class OrganizationCSVAdapterTest:
 
         DatasetFactory(
             organization=org_with_dataset,
-            resources=[
-                ResourceFactory(
-                    metrics={
-                        "views": 42,
-                    }
-                ),
-                ResourceFactory(
-                    metrics={
-                        "views": 1337,
-                    }
-                ),
-                ResourceFactory(),
-            ],
+            metrics={"resources_downloads": 1337},
         )
-        DatasetFactory(organization=org_with_dataset, resources=[])
+        DatasetFactory(organization=org_with_dataset, metrics={"resources_downloads": 42})
         adapter = OrganizationCsvAdapter(Organization.objects.all())
 
         # Build a dict (Org ID to dict of header name to value) from the CSV values and headers to simplify testing below.


### PR DESCRIPTION
Prevent huge increase in memory when computing organization resources downloads following its introduction in https://github.com/opendatateam/udata/pull/2973.

This lead to workers (and celery entirely?) crashing periodically. See [the related infra ticket](https://gitlab.com/etalab/data.gouv.fr/infra/-/issues/280).

`export-csv` task for organization model also goes from ~10min to ~1min30 locally.

The expected differences are :
- the columns order change (`downloads` is now before the other metrics columns)
- we only sum download metrics for visible datasets
- we base the count on `resources_downloads`, that is fetched from metric-api (instead of iterating on every resource metrics)
