### PR TITLE
Prevent numerous user deleted slug duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Prevent numerous user deleted slug duplicates [#3403](https://github.com/opendatateam/udata/pull/3403)
 
 ## 10.8.3 (2025-08-20)
 

--- a/udata/core/user/models.py
+++ b/udata/core/user/models.py
@@ -258,7 +258,7 @@ class User(WithMetrics, UserMixin, Linkable, db.Document):
 
         copied_user = copy(self)
         self.email = "{}@deleted".format(self.id)
-        self.slug = "deleted"
+        self.slug = "deleted-{}".format(self.id)
         self.password = None
         self.active = False
         self.first_name = "DELETED"

--- a/udata/core/user/tests/test_user_model.py
+++ b/udata/core/user/tests/test_user_model.py
@@ -42,7 +42,7 @@ class UserModelTest:
         assert Follow.objects(id=user_follow_org.id).first() is None
         assert Follow.objects(id=user_followed.id).first() is None
 
-        assert user.slug == "deleted"
+        assert user.slug == f"deleted-{user.id}"
 
     def test_mark_as_deleted_with_comments_deletion(self):
         user = UserFactory()
@@ -75,8 +75,8 @@ class UserModelTest:
         user.mark_as_deleted()
         other_user.mark_as_deleted()
 
-        assert user.slug == "deleted"
-        assert other_user.slug == "deleted-1"
+        assert user.slug == f"deleted-{user.id}"
+        assert other_user.slug == f"deleted-{other_user.id}"
 
     def test_delete_safeguard(self):
         user = UserFactory()


### PR DESCRIPTION
We still have scaling [issues](https://errors.data.gouv.fr/organizations/sentry/issues/262848/?environment=data.gouv.fr&project=12&query=duplicate&referrer=issue-stream&statsPeriod=14d&stream_index=1&utc=true) due to numerous slug duplicates in the case of deleted users, ex [deleted-75000](https://www.data.gouv.fr/users/deleted-75000).
We've tried improving perfs in https://github.com/opendatateam/udata/pull/3388 but it's not enough.

I think an alternative solution would be to prevent having so many slug duplicates since it isn't a product need to keep a minimal slug with an incremental implementation in the case of deleted users.
In our case, adding the user id seems like a safe move. We completely prevent having to look at a free spot in tens of thousands of slugs.