### PR TITLE
Better organization discussion csv export perfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Prevent numerous user deleted slug duplicates [#3403](https://github.com/opendatateam/udata/pull/3403)
 - Dataservice feature [#3405](https://github.com/opendatateam/udata/pull/3405)
 - Prefer default lang for literal values with different languages [#3406](https://github.com/opendatateam/udata/pull/3406)
+- Better organization discussion csv export perfs [#3407](https://github.com/opendatateam/udata/pull/3407)
 
 ## 10.8.3 (2025-08-20)
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -1,4 +1,3 @@
-import itertools
 from datetime import datetime
 
 from flask import make_response, redirect, request, url_for
@@ -209,9 +208,9 @@ class DataservicesCsv(API):
 class DiscussionsCsvAPI(API):
     def get(self, org):
         datasets = Dataset.objects.filter(organization=str(org.id))
-        discussions = [Discussion.objects.filter(subject=dataset) for dataset in datasets]
-        # Turns a list of lists into a flat list.
-        adapter = DiscussionCsvAdapter(itertools.chain(*discussions))
+        # select_related allows us to dereference subject Referencefield  as efficiently as possible
+        discussions = Discussion.objects.filter(subject__in=datasets).select_related()
+        adapter = DiscussionCsvAdapter(discussions)
         return csv.stream(adapter, "{0}-discussions".format(org.slug))
 
 


### PR DESCRIPTION
Fix https://github.com/datagouv/data.gouv.fr/issues/1589

Prevent RAM increase and greatly improve dereferencing perfs using [mongoengine.queryset.QuerySet.select_related](https://docs.mongoengine.org/apireference.html#mongoengine.queryset.QuerySet.select_related).

Using `no_cache` would also fix the RAM usage (as is done for the [generic csv exports](https://github.com/opendatateam/udata/blob/master/udata/core/dataset/tasks.py#L135-L136)).
However `select_related`  prevents the RAM increase but also greatly improve perfs from ~35sec to ~6sec locally for http://dev.local:7000/api/1/organizations/meteo-france/discussions.csv.