### PR TITLE
Add pyrightconfig.json

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [
+    "tasks",
+    "udata"
+  ],
+
+  "exclude": [
+    "**/__pycache__"
+  ],
+
+  "typeCheckingMode": "standard"
+}


### PR DESCRIPTION
Related to https://mattermost.incubateur.net/betagouv/pl/p7nt5zgamfn4frezgb4xb61jmw

I use the basedpyright LSP (improved pyright with some pylance features) which by default reports many more warnings/errors than pyright. This config changes the default to something more similar (equivalent?) to pyright.