### PR TITLE
Improve topic api perfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Change CSW harvesters XML processor from lxml to saxonche [#3380](https://github.com/opendatateam/udata/pull/3380)
-- **breaking change** feat: topic elements [#3318](https://github.com/opendatateam/udata/pull/3318) [#3416](https://github.com/opendatateam/udata/pull/3416)
+- **breaking change** feat: topic elements [#3318](https://github.com/opendatateam/udata/pull/3318) [#3416](https://github.com/opendatateam/udata/pull/3416) [#3417](https://github.com/opendatateam/udata/pull/3417)
 
 ## 10.9.0 (2025-08-28)
 

--- a/udata/core/topic/api_fields.py
+++ b/udata/core/topic/api_fields.py
@@ -29,7 +29,7 @@ topic_fields = apiv2.model(
                     _external=True,
                 ),
                 "type": "GET",
-                "total": len(o.elements),
+                "total": o.elements.count(),
             },
             description="Link to the topic elements",
         ),


### PR DESCRIPTION
Follows https://github.com/opendatateam/udata/pull/3318

Use `count()` instead of `len()` on ElementTopic queryset total.

On a huge topic (ex http://dev.local:7000/api/2/topics/65e9aa6cb5c809c30c70ee02/), we go from ~4sec to ~0.25sec