### PR TITLE
fix: topic element form validation and data flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Change CSW harvesters XML processor from lxml to saxonche [#3380](https://github.com/opendatateam/udata/pull/3380)
-- **breaking change** feat: topic elements [#3318](https://github.com/opendatateam/udata/pull/3318) [#3416](https://github.com/opendatateam/udata/pull/3416) [#3417](https://github.com/opendatateam/udata/pull/3417)
+- **breaking change** feat: topic elements [#3318](https://github.com/opendatateam/udata/pull/3318) [#3416](https://github.com/opendatateam/udata/pull/3416) [#3417](https://github.com/opendatateam/udata/pull/3417) [#3418](https://github.com/opendatateam/udata/pull/3418)
 
 ## 10.9.0 (2025-08-28)
 

--- a/udata/core/topic/forms.py
+++ b/udata/core/topic/forms.py
@@ -68,7 +68,9 @@ class TopicForm(ModelForm):
 
         # Create elements and associate them with the topic
         for element_data in elements_data or []:
-            element_form = TopicElementForm(data=element_data)
+            # Create element form with only its own data, not inheriting from parent
+            element_form = TopicElementForm()
+            element_form.process(data=element_data)
             if element_form.validate():
                 element = element_form.save(commit=False)
                 element.topic = topic

--- a/udata/core/topic/forms.py
+++ b/udata/core/topic/forms.py
@@ -16,12 +16,12 @@ class TopicElementForm(ModelForm):
     extras = fields.ExtrasField()
     element = fields.ModelField(_("Element"))
 
-    def validate(self, extra_validators=None, **kwargs):
+    def validate(self, **kwargs):
         """
         Make sure that either title or element is set.
         (Empty nested element is a valid use case for "placeholder" elements)
         """
-        validation = super().validate(extra_validators, **kwargs)
+        validation = super().validate(**kwargs)
         if not self.element.data and not self.title.data:
             self.element.errors.append(_("A topic element must have a title or an element."))
             return False

--- a/udata/core/topic/forms.py
+++ b/udata/core/topic/forms.py
@@ -16,12 +16,12 @@ class TopicElementForm(ModelForm):
     extras = fields.ExtrasField()
     element = fields.ModelField(_("Element"))
 
-    def validate(self, extra_validators=None):
+    def validate(self, extra_validators=None, **kwargs):
         """
         Make sure that either title or element is set.
         (Empty nested element is a valid use case for "placeholder" elements)
         """
-        validation = super().validate(extra_validators)
+        validation = super().validate(extra_validators, **kwargs)
         if not self.element.data and not self.title.data:
             self.element.errors.append(_("A topic element must have a title or an element."))
             return False

--- a/udata/core/topic/forms.py
+++ b/udata/core/topic/forms.py
@@ -69,7 +69,7 @@ class TopicForm(ModelForm):
         # Create elements and associate them with the topic
         for element_data in elements_data or []:
             # Create element form with only its own data, not inheriting from parent
-            element_form = TopicElementForm()
+            element_form = TopicElementForm(meta={"csrf": False})
             element_form.process(data=element_data)
             if element_form.validate():
                 element = element_form.save(commit=False)


### PR DESCRIPTION
Might fix this error when using topic API v2 PUT on Topic.

```
'csrf_token' = ['The CSRF token is missing.']
```

Also fix the data flow in Element form, not inheriting from parent form.