### PR TITLE
Fix release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,18 +158,6 @@ jobs:
             - dist
             - release.env
 
-  debug:
-    docker:
-      - image: udata/circleci:py<< pipeline.parameters.python-version >>
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Debug release_version
-          command: |
-            source release.env
-            echo $RELEASE_VERSION
-
   publish:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
@@ -263,9 +251,6 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - debug: 
-          requires: 
-            - dist
       - publish:
           requires:
             - dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Emit harvest activities. Set `HARVEST_ACTIVITY_USER_ID` to an existing user account to activate it [#3412](https://github.com/opendatateam/udata/pull/3412)
 - fix(harvest): refactor dates handling [#3352](https://github.com/opendatateam/udata/pull/3352)
 - Remove unused BadgesField [#3420](https://github.com/opendatateam/udata/pull/3420)
-- migrate to pyproject.toml, replace `CIRCLE_TAG` by `setuptools_scm` to compute the correct version automatically [#3413](https://github.com/opendatateam/udata/pull/3413) [#3434](https://github.com/opendatateam/udata/pull/3434) [#3435](https://github.com/opendatateam/udata/pull/3435)
+- migrate to pyproject.toml, replace `CIRCLE_TAG` by `setuptools_scm` to compute the correct version automatically [#3413](https://github.com/opendatateam/udata/pull/3413) [#3434](https://github.com/opendatateam/udata/pull/3434) [#3435](https://github.com/opendatateam/udata/pull/3435) [#3437](https://github.com/opendatateam/udata/pull/3437)
 
 ## 11.0.1 (2025-09-15)
 


### PR DESCRIPTION
`BASH_ENV` only works to share between steps in the same job, not between jobs.

Tested in https://github.com/opendatateam/udata/runs/50490579534 with a debug job: it gets the correct `RELEASE_VERSION`