### PR TITLE
Fix release version without hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,18 @@ jobs:
             - dist
             - release.env
 
+  debug:
+    docker:
+      - image: udata/circleci:py<< pipeline.parameters.python-version >>
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Debug release version
+          command: |
+            source release.env
+            echo $RELEASE_VERSION
+
   publish:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
@@ -251,6 +263,9 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+      - debug:
+          requires:
+            - dist
       - publish:
           requires:
             - dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           name: Save and show RELEASE_VERSION
           command: |
             # derive from setuptools_scm or base version + build number
-            RELEASE_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version())")
+            RELEASE_VERSION=$(python -m setuptools_scm)
 
             echo "export RELEASE_VERSION=$RELEASE_VERSION" >> $BASH_ENV
             echo "RELEASE_VERSION is $RELEASE_VERSION"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,18 +158,6 @@ jobs:
             - dist
             - release.env
 
-  debug:
-    docker:
-      - image: udata/circleci:py<< pipeline.parameters.python-version >>
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Debug release version
-          command: |
-            source release.env
-            echo $RELEASE_VERSION
-
   publish:
     docker:
       - image: udata/circleci:py<< pipeline.parameters.python-version >>
@@ -263,9 +251,6 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - debug:
-          requires:
-            - dist
       - publish:
           requires:
             - dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Emit harvest activities. Set `HARVEST_ACTIVITY_USER_ID` to an existing user account to activate it [#3412](https://github.com/opendatateam/udata/pull/3412)
 - fix(harvest): refactor dates handling [#3352](https://github.com/opendatateam/udata/pull/3352)
 - Remove unused BadgesField [#3420](https://github.com/opendatateam/udata/pull/3420)
-- migrate to pyproject.toml, replace `CIRCLE_TAG` by `setuptools_scm` to compute the correct version automatically [#3413](https://github.com/opendatateam/udata/pull/3413) [#3434](https://github.com/opendatateam/udata/pull/3434) [#3435](https://github.com/opendatateam/udata/pull/3435) [#3437](https://github.com/opendatateam/udata/pull/3437)
+- migrate to pyproject.toml, replace `CIRCLE_TAG` by `setuptools_scm` to compute the correct version automatically [#3413](https://github.com/opendatateam/udata/pull/3413) [#3434](https://github.com/opendatateam/udata/pull/3434) [#3435](https://github.com/opendatateam/udata/pull/3435) [#3437](https://github.com/opendatateam/udata/pull/3437) [#3438](https://github.com/opendatateam/udata/pull/3438/)
 
 ## 11.0.1 (2025-09-15)
 


### PR DESCRIPTION
Calling setuptools_scm from Python it doesn't respect the `pyproject.toml` config that specify no hash. So we try to deploy the version without hash but we have published the version without hash.