### PR TITLE
feat(topics): serialize elements in topic_elements_create response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix(topic): absolute Topic.uri [#3436](https://github.com/opendatateam/udata/pull/3436)
 - Add new badges [#3415](https://github.com/opendatateam/udata/pull/3415)
 - feat(topic): add elements activities [#3439](https://github.com/opendatateam/udata/pull/3439)
+- feat(topics): serialize elements in topic_elements_create response [#3446](https://github.com/opendatateam/udata/pull/3446)
 
 ## 11.0.1 (2025-09-15)
 

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -108,7 +108,7 @@ class TopicElementsAPI(API):
     @apiv2.secure
     @apiv2.doc("topic_elements_create")
     @apiv2.expect([api.model_reference])
-    @apiv2.marshal_with(topic_fields)
+    @apiv2.marshal_list_with(element_fields)
     @apiv2.response(400, "Expecting a list")
     @apiv2.response(404, "Topic not found")
     @apiv2.response(403, "Forbidden")
@@ -139,7 +139,7 @@ class TopicElementsAPI(API):
 
         topic.save()
 
-        return topic, 201
+        return elements, 201
 
     @apiv2.secure
     @apiv2.doc("topic_elements_delete")

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -516,6 +516,49 @@ class TopicElementsAPITest(APITestCase):
             ],
         )
         assert response.status_code == 201
+
+        # Verify response payload contains the created elements
+        response_data = response.json
+        assert isinstance(response_data, list)
+        assert len(response_data) == 3
+
+        # Verify the dataset element in response
+        dataset_response = next(
+            elem
+            for elem in response_data
+            if elem["element"] and elem["element"]["id"] == str(dataset.id)
+        )
+        assert dataset_response["id"] is not None
+        assert dataset_response["title"] == "A dataset"
+        assert dataset_response["description"] == "A dataset description"
+        assert dataset_response["tags"] == ["tag1", "tag2"]
+        assert dataset_response["extras"] == {"extra": "value"}
+        assert dataset_response["element"]["class"] == "Dataset"
+
+        # Verify the reuse element in response
+        reuse_response = next(
+            elem
+            for elem in response_data
+            if elem["element"] and elem["element"]["id"] == str(reuse.id)
+        )
+        assert reuse_response["id"] is not None
+        assert reuse_response["title"] == "A reuse"
+        assert reuse_response["description"] == "A reuse description"
+        assert reuse_response["tags"] == ["tag1", "tag2"]
+        assert reuse_response["extras"] == {"extra": "value"}
+        assert reuse_response["element"]["class"] == "Reuse"
+
+        # Verify the element without reference in response
+        no_element_response = next(
+            elem
+            for elem in response_data
+            if elem["element"] is None and elem["title"] == "An element without element"
+        )
+        assert no_element_response["id"] is not None
+        assert no_element_response["description"] == "An element description"
+        assert no_element_response["tags"] == ["tag1", "tag2"]
+        assert no_element_response["extras"] == {"extra": "value"}
+
         topic.reload()
         assert len(topic.elements) == 6
 


### PR DESCRIPTION
Respond to `topic_elements_create` with created elements rather than the full Topic.