### PR TITLE
Move factory-boy to the main dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add new badges [#3415](https://github.com/opendatateam/udata/pull/3415)
 - Refactor `@function_field` and `@field` to provide better doc and type support [#3441](https://github.com/opendatateam/udata/pull/3441/)
 - feat(topic): add Dataservice to supported elements [#3444](https://github.com/opendatateam/udata/pull/3444)
+- Move factory-boy to the main dependencies [3447](https://github.com/opendatateam/udata/pull/3447)
 
 ## 11.0.1 (2025-09-15)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "cryptography==44.0.2",
     "dnspython==2.7.0",
     "email-validator==2.2.0",
+    "factory-boy==3.3.3",
     "feedgenerator==2.1.0",
     "filelock==3.18.0",
     "flask==2.1.2",
@@ -165,7 +166,6 @@ dev = [
     "wheel==0.45.1",
 ]
 test = [
-    "factory-boy==3.3.3",
     "faker==37.0.2",
     "feedparser==6.0.11",
     "httpretty==1.1.4",


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/3413, factory-boy is only in test deps.

However factories are imported when running udata serve, factory-boy is then required also at runtime.

This setup was somehow still working because factory boy is already installed in local and production environments.