### PR TITLE
Keep existing attached datasets to a dataservice at harvest time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Simplify getting mail connection (dummy or real) condition [#3410](https://github.com/opendatateam/udata/pull/3410)
 - Emit harvest activities. Set `HARVEST_ACTIVITY_USER_ID` to an existing user account to activate it [#3412](https://github.com/opendatateam/udata/pull/3412)
+- Ignore list reordering in changed fields detection [#3448](https://github.com/opendatateam/udata/pull/3448)
+- Keep existing attached datasets to a dataservice at harvest time [#3449](https://github.com/opendatateam/udata/pull/3449)
 - fix(harvest): refactor dates handling [#3352](https://github.com/opendatateam/udata/pull/3352)
 - Remove unused BadgesField [#3420](https://github.com/opendatateam/udata/pull/3420)
 - migrate to pyproject.toml, replace `CIRCLE_TAG` by `setuptools_scm` to compute the correct version automatically [#3413](https://github.com/opendatateam/udata/pull/3413) [#3434](https://github.com/opendatateam/udata/pull/3434) [#3435](https://github.com/opendatateam/udata/pull/3435) [#3437](https://github.com/opendatateam/udata/pull/3437) [#3438](https://github.com/opendatateam/udata/pull/3438/)
@@ -14,7 +16,6 @@
 - Add new badges [#3415](https://github.com/opendatateam/udata/pull/3415)
 - Refactor `@function_field` and `@field` to provide better doc and type support [#3441](https://github.com/opendatateam/udata/pull/3441/)
 - feat(topic): add Dataservice to supported elements [#3444](https://github.com/opendatateam/udata/pull/3444)
-- Ignore list reordering in changed fields detection [#3448](https://github.com/opendatateam/udata/pull/3448)
 - Move factory-boy to the main dependencies [3447](https://github.com/opendatateam/udata/pull/3447)
 
 ## 11.0.1 (2025-09-15)

--- a/udata/core/dataservices/rdf.py
+++ b/udata/core/dataservices/rdf.py
@@ -32,7 +32,7 @@ def dataservice_from_rdf(
     remote_url_prefix: str | None = None,
 ) -> Dataservice:
     """
-    Create or update a dataset from a RDF/DCAT graph
+    Create or update a dataservice from a RDF/DCAT graph
     """
     if node is None:  # Assume first match is the only match
         node = graph.value(predicate=RDF.type, object=DCAT.DataService)
@@ -57,7 +57,6 @@ def dataservice_from_rdf(
         contact_point for role in roles for contact_point in role
     ] or dataservice.contact_points
 
-    datasets = []
     for dataset_node in d.objects(DCAT.servesDataset):
         id = dataset_node.value(DCT.identifier)
         dataset = next(
@@ -71,11 +70,9 @@ def dataservice_from_rdf(
                 None,
             )
 
-        if dataset is not None:
-            datasets.append(dataset.id)
-
-    if datasets:
-        dataservice.datasets = datasets
+        # We append the dataset to the list of the current attached ones if not already attached
+        if dataset is not None and dataset not in dataservice.datasets:
+            dataservice.datasets.append(dataset)
 
     license = rdf_value(d, DCT.license)
     if license is not None:

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -8,8 +8,9 @@ from flask import current_app
 from lxml import etree
 from rdflib import Graph
 
+from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataservices.models import Dataservice
-from udata.core.dataset.factories import LicenseFactory, ResourceSchemaMockData
+from udata.core.dataset.factories import DatasetFactory, LicenseFactory, ResourceSchemaMockData
 from udata.core.dataset.rdf import dataset_from_rdf
 from udata.core.organization.factories import OrganizationFactory
 from udata.harvest.models import HarvestJob
@@ -186,6 +187,36 @@ class DcatBackendTest:
             dataservices[0].harvest.remote_url
             == "https://data.paris2024.org/api/explore/v2.1/console"
         )
+
+    def test_harvest_dataservices_keep_attached_associated_datasets(self, rmock):
+        """It should update the existing list of dataservice.datasets and not overwrite existing ones"""
+        rmock.get("https://example.com/schemas", json=ResourceSchemaMockData.get_mock_data())
+
+        filename = "bnodes.xml"
+        url = mock_dcat(rmock, filename)
+        org = OrganizationFactory()
+        source = HarvestSourceFactory(backend="dcat", url=url, organization=org)
+
+        previously_attached_dataset = DatasetFactory()
+        existing_dataservice = DataserviceFactory(
+            datasets=[previously_attached_dataset],
+            harvest={
+                "remote_id": "https://data.paris2024.org/api/explore/v2.1/",
+                "domain": source.domain,
+                "source_id": str(source.id),
+            },
+        )
+
+        actions.run(source)
+
+        existing_dataservice.reload()
+
+        assert len(Dataservice.objects) == 1
+        assert existing_dataservice.title == "Explore API v2"
+        assert (
+            len(existing_dataservice.datasets) == 2 + 1
+        )  # The two harvested datasets and the previously attached one
+        assert previously_attached_dataset in existing_dataservice.datasets
 
     def test_harvest_dataservices_ignore_accessservices(self, rmock):
         rmock.get("https://example.com/schemas", json=ResourceSchemaMockData.get_mock_data())


### PR DESCRIPTION
Close https://github.com/datagouv/data.gouv.fr/issues/1865

Do not overwrite the list of datasets attached to a dataservice but only update it with new ones