### PR TITLE
ci: do not publish on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,8 @@ jobs:
 workflows:
   build-publish-deploy:
     jobs:
+      - python
+      - assets
       - dist:
           requires:
             - python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,11 @@ jobs:
       - save_cache:
           key: py3-cache-v12-{{ arch }}-{{ checksum "pyproject.toml" }}
           paths:
-          - venv
+            - venv
       - save_cache:
           key: py3-cache-v12-{{ arch }}-{{ .Branch }}
           paths:
-          - venv
+            - venv
       - run:
           name: Lint and format code and sort imports
           # ruff check --extend-select I . : check linting and imports sorting without fixing (to fix, use --fix)
@@ -75,7 +75,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-          - venv
+            - venv
 
   assets:
     docker:
@@ -110,11 +110,11 @@ jobs:
       - save_cache:
           key: js-cache-{{ arch }}-{{ checksum "js.deps" }}
           paths:
-          - node_modules
+            - node_modules
       - save_cache:
           key: js-cache-{{ arch }}-{{ .Branch }}
           paths:
-          - node_modules
+            - node_modules
       - run:
           name: Compile assets
           command: |
@@ -236,21 +236,10 @@ jobs:
 workflows:
   build-publish-deploy:
     jobs:
-      - python:
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-      - assets:
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
       - dist:
           requires:
             - python
             - assets
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
       - publish:
           requires:
             - dist
@@ -258,9 +247,6 @@ workflows:
             branches:
               only:
                 - << pipeline.parameters.publish-branch >>
-                - /[0-9]+(\.[0-9]+)+/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
           context: org-global
       - trigger-gitlab-pipeline:
           requires:
@@ -279,7 +265,5 @@ workflows:
             branches:
               only:
                 - << pipeline.parameters.publish-branch >>
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
           context:
             - org-global


### PR DESCRIPTION
With `setuptools_scm` (introduced in https://github.com/opendatateam/udata/pull/3434), the Pypi CI from the `master` branch publish with the tag on the current commit (before it always published with a suffix `.devx`).

Since the `11.1.1` and `11.1.1.dev0` are the same we don't need to publish from `master` and from the tag. And since publishing from `master` do the correct thing, we removed the CI on tags. 