### PR TITLE
feat: add standalone 404 page

### DIFF
--- a/udata/app.py
+++ b/udata/app.py
@@ -7,7 +7,7 @@ from os.path import abspath, dirname, exists, isfile, join
 
 import bson
 from flask import Blueprint as BaseBlueprint
-from flask import Flask, abort, g, json, make_response, send_from_directory
+from flask import Flask, abort, g, json, make_response, render_template, send_from_directory
 from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 from speaklater import is_lazy_string
@@ -225,7 +225,18 @@ def register_extensions(app):
     mail.init_app(app)
     search.init_app(app)
     sentry.init_app(app)
+    register_error_handlers(app)
     return app
+
+
+def register_error_handlers(app):
+    """Register error handlers for the application"""
+
+    @app.errorhandler(404)
+    def page_not_found(e):
+        from udata.uris import homepage_url
+
+        return render_template("404.html", homepage_url=homepage_url()), 404
 
 
 def register_features(app):

--- a/udata/templates/404.html
+++ b/udata/templates/404.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - {{ _('Page not found') }}</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            margin: 0;
+            padding: 2rem;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            max-width: 600px;
+        }
+        h1 {
+            font-size: 3rem;
+            font-weight: 600;
+            margin: 0 0 0.5rem 0;
+        }
+        p {
+            color: #666;
+            line-height: 1.5;
+            margin: 0 0 1.5rem 0;
+        }
+        a {
+            color: #000;
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>404</h1>
+        <p>{{ _('The page you are looking for does not exist.') }}</p>
+        <a href="{{ homepage_url }}">{{ _('Back to home') }}</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Right row we route all URLs to udata and only some special ones to cdata. https://demo.data.gouv.fr/xxx shows us the default Flask 404.

In the near future, we want to switch the way we route the HTTP requests by defaulting to cdata and just routing /api/* to udata so a random user should never see this new 404 page (so it's not a problem to have a simpler design than the one from cdata).

- [x] Create 404 page
- [ ] Return the 404 page while `abort(404)` inside the API routes (for exemple for `/datasets/r/xxx`)
- [ ] Check if the user wants HTML or JSON to return a JSON response to the API users. (`/datasets/r/xxx` is one of the very few routes, that a user can be redirected to in a browser, maybe with the CSV downloads?)