### PR TITLE
feat(site): add version to response

### DIFF
--- a/udata/core/site/models.py
+++ b/udata/core/site/models.py
@@ -64,6 +64,15 @@ class Site(WithMetrics, db.Document):
     def __str__(self):
         return self.title or ""
 
+    @field(description="The current version of udata")
+    def version(self):
+        try:
+            from importlib.metadata import version
+
+            return version("udata")
+        except Exception:
+            return None
+
     def count_users(self):
         from udata.models import User
 

--- a/udata/tests/site/test_site_api.py
+++ b/udata/tests/site/test_site_api.py
@@ -16,6 +16,7 @@ class SiteAPITest(APITestCase):
         site = Site.objects.get(id=self.app.config["SITE_ID"])
 
         self.assertEqual(site.title, response.json["title"])
+        self.assertIsNotNone(response.json["version"])
 
     def test_set_site(self):
         response = self.get(url_for("api.site"))


### PR DESCRIPTION
Useful to show the version of udata in the footer of cdata