### PR TITLE
feat: Add remote URL prefix option to csw-dcat harvester

### DIFF
--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -258,6 +258,15 @@ class CswDcatBackend(DcatBackend):
 
     display_name = "CSW-DCAT"
 
+    extra_configs = (
+        HarvestExtraConfig(
+            _("Remote URL prefix"),
+            "remote_url_prefix",
+            str,
+            _("A prefix used to build the remote URL of the harvested items."),
+        ),
+    )
+
     # CSW_REQUEST is based on:
     # - Request syntax from spec [1] and example requests [1] [2].
     # - Sort settings to ensure stable paging [3].
@@ -425,15 +434,6 @@ class CswIso19139DcatBackend(CswDcatBackend):
     """
 
     display_name = "CSW-ISO-19139"
-
-    extra_configs = (
-        HarvestExtraConfig(
-            _("Remote URL prefix"),
-            "remote_url_prefix",
-            str,
-            _("A prefix used to build the remote URL of the harvested items."),
-        ),
-    )
 
     CSW_OUTPUT_SCHEMA = "http://www.isotc211.org/2005/gmd"
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/udata/tree/feat/csw-harvester-remote-url-prefix

Draft because of https://github.com/ecolabdata/ecospheres/issues/733#issuecomment-3376565668.