### PR TITLE
fix(test): add data to pytest norecursedirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ norecursedirs = [
     "build",
     "specs",
     ".cache",
+    "data",
     "udata/templates",
     "udata/translations",
 ]


### PR DESCRIPTION
Indeed, it makes `pytest` fail due to Permission denied ~/workspace/udata/data/db/journal/conftest.py (due to docker volumes).
Running `pytest udata` is the workaround I'm using locally.