### PR TITLE
fix: do not send security mail in demo

### DIFF
--- a/udata/auth/__init__.py
+++ b/udata/auth/__init__.py
@@ -81,7 +81,7 @@ def init_app(app):
     # Same logic as in our own mail system :DisableMail
     debug = app.config.get("DEBUG", False)
     send_mail = app.config.get("SEND_MAIL", not debug)
-    mail_util_cls = None if send_mail else NoopMailUtil
+    mail_util_cls = mail_util.MailUtil if send_mail else NoopMailUtil
 
     security = Security(
         datastore,


### PR DESCRIPTION
`init_app` support overriding most of the config except `mail_util_cls`. We should set it in `__init__()`.  So we cannot expose a global security variable (because we don't have the app context) but I'm not sure it's useful.