### PR TITLE
chore: adapt CI and docs to main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     default: "3.11"
   publish-branch:
     type: string
-    default: "master"
+    default: "main"
     description: "Branch to publish to PyPi and trigger the Gitlab CI/CD pipeline when pushed to"
   deploy-env:
     type: string
@@ -33,7 +33,7 @@ jobs:
             - py3-cache-v13-{{ arch }}-{{ checksum "pyproject.toml" }}-{{ checksum "uv.lock" }}
             # 2. Latest cache from this branch
             - py3-cache-v13-{{ arch }}-{{ .Branch }}
-            # 3. Latest cache from base branch (e.g., master)
+            # 3. Latest cache from base branch (e.g., main)
             - py3-cache-v13-{{ arch }}-{{ .Environment.BASE_BRANCH }}
             # 4. Any latest cache for this architecture (fallback)
             - py3-cache-v13-{{ arch }}-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 - **refactor!: simplify harvesters entrypoint ([#3504](https://github.com/opendatateam/udata/pull/3504))**
   Working towards removing deprecated `pkg_resources` by removing
   `entrypoints.py`.
-  
+
   - The `udata.harvesters` entrypoints are automaticly loaded (without the
   need of `PLUGINS` settings)
   - Need to move the harvesters from `PLUGINS` to `HARVESTER_BACKENDS` to
@@ -78,9 +78,9 @@
   starting with `csw` (before it was an implicit `startswith`)
   - Need to add explicit `name` to the backends' classes (before it was
   the name of the entrypoint)
-  
+
   Example of new setting:
-  
+
   ```
   HARVESTER_BACKENDS = [
     'ckan',
@@ -90,7 +90,7 @@
     'maaf',
   ]
   ```
-  
+
   - [x] Added `name` to all internal harvesters backends
   - [x] Removed `actions.list_backends()`, use
   `backends.get_enabled_backends()` since it's not really an action.
@@ -139,18 +139,18 @@
   - [x] Tâches Python frontend : assets_build, widgets_build,
   oembed_build, *_watch, jstest
   - [x] CI/CD : Job assets et dépendances dans .circleci/config.yml
-  
+
   ---------
-  
+
   Co-authored-by: maudetes <maudet.estelle@gmail.com>
 - **refactor!: remove linkchecker ([#3483](https://github.com/opendatateam/udata/pull/3483))**
   The goal is to remove the entrypoint system. I don't think we use this
   linkchecker anymore (it's disabled in our settings), hydra is doing this
   job now? We maybe need to check the `ResourceMixin@ExtrasField` (I just
   copy/paste but it could be nice in another PR to add hydra types here?)
-  
+
   ---------
-  
+
   Co-authored-by: maudetes <maudet.estelle@gmail.com>
 - build: build with uv ([#3485](https://github.com/opendatateam/udata/pull/3485))
 - build: remove unused dependencies ([#3454](https://github.com/opendatateam/udata/pull/3454))
@@ -189,9 +189,9 @@
   - From https://www.data.gouv.fr/proconnect/logout to
   https://www.data.gouv.fr/api/1/proconnect/logout
   - Part of https://github.com/datagouv/data.gouv.fr/issues/1717
-  
+
   ---------
-  
+
   Co-authored-by: maudetes <maudet.estelle@gmail.com>
 - build: use uv ([#3459](https://github.com/opendatateam/udata/pull/3459))
 - ci: do not publish on tags ([#3455](https://github.com/opendatateam/udata/pull/3455))
@@ -1065,7 +1065,7 @@ Search refactor [#2680](https://github.com/opendatateam/udata/pull/2680)
 
 ## 3.1.0 (2021-08-31)
 
-- :warning: Use pip-tools for requirements management [#2642](https://github.com/opendatateam/udata/pull/2642)[#2650](https://github.com/opendatateam/udata/pull/2650)[#2651](https://github.com/opendatateam/udata/pull/2651). Please [read the doc](https://github.com/opendatateam/udata/blob/master/docs/development-environment.md#python-and-virtual-environment) if you are a udata developer.
+- :warning: Use pip-tools for requirements management [#2642](https://github.com/opendatateam/udata/pull/2642)[#2650](https://github.com/opendatateam/udata/pull/2650)[#2651](https://github.com/opendatateam/udata/pull/2651). Please [read the doc](https://github.com/opendatateam/udata/blob/main/docs/development-environment.md#python-and-virtual-environment) if you are a udata developer.
 - :warning: Check db integrity and apply temporary and permanent fixes [#2644](https://github.com/opendatateam/udata/pull/2644) :warning: the associated migrations can take a long time to run.
 - :warning: Upgrade to Flask-1.1.4 [#2639](https://github.com/opendatateam/udata/pull/2639)
 - Safeguard `User.delete()` [#2646](https://github.com/opendatateam/udata/pull/2646)
@@ -1099,7 +1099,7 @@ Search refactor [#2680](https://github.com/opendatateam/udata/pull/2680)
 
 ## 3.0.0 (2021-07-07)
 
-- :warning: **breaking change**: most of the theme/templates logic has been moved to https://github.com/etalab/udata-gouvfr. `udata` no longer contains a default theme. In the 3.x series, we hope it will be usable as a "headless" open data platform, but for now you probably need to plug your own theme or use udata-gouvfr. [More info about this change here](https://github.com/opendatateam/udata/blob/master/docs/roadmap/udata-3.md#the-road-to-udata3). [#2522](https://github.com/opendatateam/udata/pull/2522)
+- :warning: **breaking change**: most of the theme/templates logic has been moved to https://github.com/etalab/udata-gouvfr. `udata` no longer contains a default theme. In the 3.x series, we hope it will be usable as a "headless" open data platform, but for now you probably need to plug your own theme or use udata-gouvfr. [More info about this change here](https://github.com/opendatateam/udata/blob/main/docs/roadmap/udata-3.md#the-road-to-udata3). [#2522](https://github.com/opendatateam/udata/pull/2522)
 - Migrate from raven to sentry-sdk [#2620](https://github.com/opendatateam/udata/pull/2620)
 - Add a UdataCleaner class to use udata's markdown configuration on SafeMarkup as well [#2619](https://github.com/opendatateam/udata/pull/2619)
 - Fix schema name display in resource modal [#2617](https://github.com/opendatateam/udata/pull/2617)
@@ -1391,7 +1391,7 @@ Search refactor [#2680](https://github.com/opendatateam/udata/pull/2680)
 - Reduce following to staring [#2192](https://github.com/opendatateam/udata/pull/2192/files)
 - Simplify display of spatial coverage in search results [#2192](https://github.com/opendatateam/udata/pull/2192/files)
 - Add cache for organization and topic display pages [#2194](https://github.com/opendatateam/udata/pull/2194)
-- Dataset of datasets: id as ref instead of slug [#2195](https://github.com/opendatateam/udata/pull/2195) :warning: this introduces some settings changes, cf [documentation for EXPORT_CSV](https://github.com/opendatateam/udata/blob/master/docs/adapting-settings.md).
+- Dataset of datasets: id as ref instead of slug [#2195](https://github.com/opendatateam/udata/pull/2195) :warning: this introduces some settings changes, cf [documentation for EXPORT_CSV](https://github.com/opendatateam/udata/blob/main/docs/adapting-settings.md).
 - Add meta og:type: make twitter cards work [#2196](https://github.com/opendatateam/udata/pull/2196)
 - Fix UI responsiveness [#2199](https://github.com/opendatateam/udata/pull/2199)
 - Remove social media sharing feature [#2200](https://github.com/opendatateam/udata/pull/2200)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ basically you’ll have to:
 * commit incrementally with readable and detailed commit messages
 * add the change to the `CHANGELOG.md` file if appropriated
 * submit a pull-request against the right branch of this repository:
-    * `master` for new features or bug fixes for the current state
+    * `main` for new features or bug fixes for the current state
     * `vX.Y` for bugfixes or backports on previous versions
 
 We’ll take care of tagging your issue with the appropriated labels and answer within a week (hopefully less!) to the problem you encounter.
@@ -65,7 +65,7 @@ and will magicaly close the issue as soon as the commit is merged.
 ### Merging
 
 When the PR has been approved (at least once), you are free to merge it
-in master. We have a squash & merge strategy and pay attention to having
+in main. We have a squash & merge strategy and pay attention to having
 a clean commit message. You can then delete the branch. If linked with
 an issue, the issue should be closed automatically.
 

--- a/docs/adding-translations.md
+++ b/docs/adding-translations.md
@@ -10,7 +10,7 @@ After that you'll be able to reach the crowding pages for the project and intera
 - [udata-front crowdin page][crowdin-udata-front]
 
 !!! warning
-    We only translate strings from the `master` and maintenance branches of the repository.
+    We only translate strings from the `main` and maintenance branches of the repository.
     Do not push languages on any other branch because merging translations is incredibly painful.
 
 

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -270,6 +270,6 @@ $ udata harvest run <source_id>
 ```
 
 [DCAT]: https://www.w3.org/TR/vocab-dcat/
-[backends-repository]: https://github.com/opendatateam/udata/tree/master/udata/harvest/backends
+[backends-repository]: https://github.com/opendatateam/udata/tree/main/udata/harvest/backends
 [gov-uk-references]: http://reference.data.gov.uk/
 [cookiecutter-template]: https://github.com/opendatateam/cookiecutter-udata-harvester

--- a/docs/roadmap/udata-3.md
+++ b/docs/roadmap/udata-3.md
@@ -1,13 +1,13 @@
 # The Road to udata 3
 
-### *What is udata?* 
+### *What is udata?*
 
 [udata](https://github.com/opendatateam/udata) is the free software that provides the core features of [data.gouv.fr, the French government open data portal](https://www.data.gouv.fr/). It has been developed in the open since 2013 and is freely reused and customized by a few countries (Luxembourg, Serbia, Portugal), some government agencies and at least one NGO.
 
-That latest major breaking release, [udata 2](https://github.com/opendatateam/udata/blob/master/CHANGELOG.md#200-2020-03-11), focused mainly on the migration to python 3, right before the deadline of python 2 support being dropped. Since then, we shipped six minor releases and more patches.
+That latest major breaking release, [udata 2](https://github.com/opendatateam/udata/blob/main/CHANGELOG.md#200-2020-03-11), focused mainly on the migration to python 3, right before the deadline of python 2 support being dropped. Since then, we shipped six minor releases and more patches.
 
 ### *Who’s behind udata?*
-An [overwhelming majority of commits](https://github.com/opendatateam/udata/graphs/contributors) on udata have been made by members of [Etalab](https://www.etalab.gouv.fr), the French government agency responsible for data.gouv.fr. 
+An [overwhelming majority of commits](https://github.com/opendatateam/udata/graphs/contributors) on udata have been made by members of [Etalab](https://www.etalab.gouv.fr), the French government agency responsible for data.gouv.fr.
 
 The technical team dedicated at Etalab responsible not only for development but also for operating the platform and handling user support has always been relatively small: between one and three people.
 
@@ -25,16 +25,16 @@ Regarding udata directly, one of the heaviest burdens we face is to maintain two
 
 ### *Graphical redesign as an opportunity to reduce technical debt*
 
-In this context, we recently started a project of total graphical overhaul of data.gouv.fr. 
+In this context, we recently started a project of total graphical overhaul of data.gouv.fr.
 
 This was the perfect opportunity to reflect upon our choices regarding the legacy theme mechanism. **We concluded that with our limited resources, the minimalist default theme had to go**. We couldn’t possibly continue to maintain both versions with a complex inheritance mechanism while going through the process of rewriting data.gouv.fr’s theme completely. This already being quite a daunting task for us while continuing to operate the platform and shipping new features.
 
-This also led us to reflect more profoundly upon “separation of concerns” in our product. As stated previously, we believe in interconnected services more than in a one-size-fits-all monolith. Once again, the graphical redesign and the decision to get rid of the legacy theme provided an opportunity to move toward that goal. **We can now separate the core logic (i.e., the open data catalog, user, discussions, reuses, APIs, etc.) from the presentation logic (i.e., the views) which will now live within the theme**. 
+This also led us to reflect more profoundly upon “separation of concerns” in our product. As stated previously, we believe in interconnected services more than in a one-size-fits-all monolith. Once again, the graphical redesign and the decision to get rid of the legacy theme provided an opportunity to move toward that goal. **We can now separate the core logic (i.e., the open data catalog, user, discussions, reuses, APIs, etc.) from the presentation logic (i.e., the views) which will now live within the theme**.
 
 We believe this will ultimately lead to an easier way to maintain product, allowing use to iterate more rapidly on the API for example, without breaking the presentation logic. As a side note, we could have gone to the SPA way on top of our APIs for our new front end, but we chose not to, mainly for performance and SEO reasons.
 
 ### *What’s next?*
 
-This is the road to udata 3. We don’t have a release date yet and there are a lot of corner cases yet to be handled. The 3.0 release will probably still have some entanglement between the core part and the theme part but we plan to iterate on that in the 3.x series. 
+This is the road to udata 3. We don’t have a release date yet and there are a lot of corner cases yet to be handled. The 3.0 release will probably still have some entanglement between the core part and the theme part but we plan to iterate on that in the 3.x series.
 
 We hope this has given you at least an insight into the future of udata, which will keep powering data.gouv.fr for the foreseeable future. We’d also love to hear from you if you some insights as a udata user.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -6,9 +6,9 @@ udata follows [Python PEP 440 on versioning][pep440] to version its published re
 
 ### Branches management
 
-There is a main branch on the [udata git repository][github], `master` and some temporary feature branches.
+There is a main branch on the [udata git repository][github], `main` and some temporary feature branches.
 
-The `master` is the stable development branch on which:
+The `main` is the stable development branch on which:
 
 - bug fixes should occur (unless the bug is only present on a maintenance branch)
 - security upgrades are done (unless only necessary on a maintenance branch)
@@ -56,7 +56,7 @@ The steps to make a release are:
 ## Feature branches
 
 Sometimes a new feature or an EPIC requires more than one pull request and a lot of testing.
-For these cases, it's not desirable to use the `master` branch to test until it's stable because we want to keep the `master` branch as stable as possible.
+For these cases, it's not desirable to use the `main` branch to test until it's stable because we want to keep the `main` branch as stable as possible.
 
 To handle these cases we are using feature branches, named like `feature/my-feature`. These branches will build on CircleCI and produce a [local version](pep440-local) package.
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "baseBranches": ["master"],
+  "baseBranches": ["main"],
   "enabledManagers": ["pep621"],
   "pep621": {
     "fileMatch": ["pyproject.toml"]

--- a/udata/translations/ar/LC_MESSAGES/udata.po
+++ b/udata/translations/ar/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: ar\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1914,4 +1914,3 @@ msgstr "مستخدم بشكل كبير"
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr ""
-

--- a/udata/translations/de/LC_MESSAGES/udata.po
+++ b/udata/translations/de/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: de\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1914,4 +1914,3 @@ msgstr "Stark wiederverwendet"
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr ""
-

--- a/udata/translations/es/LC_MESSAGES/udata.po
+++ b/udata/translations/es/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: es-ES\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1914,4 +1914,3 @@ msgstr ""
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr ""
-

--- a/udata/translations/fr/LC_MESSAGES/udata.po
+++ b/udata/translations/fr/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: fr\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1917,4 +1917,3 @@ msgstr "Souvent réutilisé"
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr "Suppression de votre compte {site} inactif"
-

--- a/udata/translations/it/LC_MESSAGES/udata.po
+++ b/udata/translations/it/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: it\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1914,4 +1914,3 @@ msgstr ""
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr ""
-

--- a/udata/translations/pt/LC_MESSAGES/udata.po
+++ b/udata/translations/pt/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1914,4 +1914,3 @@ msgstr "Muito reutilizado"
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr ""
-

--- a/udata/translations/sr/LC_MESSAGES/udata.po
+++ b/udata/translations/sr/LC_MESSAGES/udata.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Crowdin-Project: udata\n"
 "X-Crowdin-Project-ID: 291291\n"
 "X-Crowdin-Language: sr\n"
-"X-Crowdin-File: /master/udata/translations/udata.pot\n"
+"X-Crowdin-File: /main/udata/translations/udata.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
 #: udata/settings.py:127
@@ -1917,4 +1917,3 @@ msgstr "Популарно"
 #, python-brace-format
 msgid "Deletion of your inactive {site} account"
 msgstr ""
-


### PR DESCRIPTION
Following the renaming from `master` to `main`.

Locally you can run
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```