### PR TITLE
fix 3540: add password rotation error msg and password reset message

### DIFF
--- a/udata/auth/__init__.py
+++ b/udata/auth/__init__.py
@@ -77,6 +77,11 @@ def init_app(app):
             "SECURITY_CONFIRM_ERROR_VIEW",
             app.config["CDATA_BASE_URL"] + "?flash=confirm_error",
         )
+        # set redirect after password reset - user is not automatically logged in after password reset
+        app.config.setdefault(
+            "SECURITY_POST_RESET_VIEW",
+            app.config["CDATA_BASE_URL"] + "?flash=password_reset",
+        )
 
     # Same logic as in our own mail system :DisableMail
     debug = app.config.get("DEBUG", False)

--- a/udata/auth/forms.py
+++ b/udata/auth/forms.py
@@ -67,12 +67,15 @@ class ExtendedRegisterForm(WithCaptcha, RegisterFormV2):
 
 
 class ExtendedLoginForm(LoginForm):
+    # error message for password rotation to identify this specific error in views
+    PASSWORD_ROTATION_ERROR = _("Password must be changed for security reasons")
+
     def validate(self, **kwargs):
         if not super().validate(**kwargs):
             return False
 
         if self.user.password_rotation_demanded:
-            self.password.errors.append(_("Password must be changed for security reasons"))
+            self.password.errors.append(self.PASSWORD_ROTATION_ERROR)
             return False
 
         return True

--- a/udata/i18n.py
+++ b/udata/i18n.py
@@ -19,8 +19,8 @@ def get_translation_directories_and_domains():
     for pkg in entry_points(group="udata.i18n"):
         module = pkg.load()
         path = resources.files(module)
-        # `/ ""` is  here to transform MultiplexedPath to a simple str
-        translations_dirs.append(str(path / ""))
+        # Convert path to string (works with MultiplexedPath in Python 3.13+)
+        translations_dirs.append(str(path))
         domains.append(pkg.name)
 
     return translations_dirs, domains

--- a/udata/tests/api/test_security_api.py
+++ b/udata/tests/api/test_security_api.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 import pytest
 from flask import url_for
+from flask_login import current_user
 from flask_security.recoverable import generate_reset_password_token
 
+from udata.auth.forms import ExtendedLoginForm
 from udata.commands.fixtures import UserFactory
 from udata.i18n import lazy_gettext as _
 from udata.tests.api import PytestOnlyAPITestCase
@@ -122,3 +124,122 @@ class SecurityAPITest(PytestOnlyAPITestCase):
             },
         )
         self.assertStatus(response, 200)
+
+    @pytest.mark.options(CAPTCHETAT_BASE_URL=None, SECURITY_RETURN_GENERIC_RESPONSES=True)
+    def test_reset_password_user_not_authenticated_after_reset(self):
+        """
+        After resetting a password, the user should NOT be automatically logged in, no flash message.
+        """
+        user = UserFactory(email="jane@example.org", confirmed_at=datetime.now())
+        token = generate_reset_password_token(user)
+
+        response = self.post(
+            url_for("security.reset_password", token=token),
+            {
+                "password": "Password123",
+                "password_confirm": "Password123",
+                "submit": True,
+            },
+        )
+        self.assertStatus(response, 200)
+
+        # Verify user is NOT authenticated after password reset
+        assert not current_user.is_authenticated
+
+    @pytest.mark.options(CAPTCHETAT_BASE_URL=None)
+    def test_login_with_password_rotation_demanded(self):
+        """
+        When a user has password_rotation_demanded set, login fail with error message + flag.
+        """
+        UserFactory(
+            email="jane@example.org",
+            password="password",
+            confirmed_at=datetime.now(),
+            password_rotation_demanded=datetime.now(),
+        )
+
+        response = self.post(
+            url_for("security.login"),
+            {
+                "email": "jane@example.org",
+                "password": "password",
+                "submit": True,
+            },
+        )
+        self.assertStatus(response, 400)
+
+        # Verify the response contains the password rotation error
+        response_data = response.json
+        assert "response" in response_data
+
+        # Flask-Security can return errors as a list or dict depending on configuration
+        errors = response_data["response"].get("errors", [])
+        expected_error = str(ExtendedLoginForm.PASSWORD_ROTATION_ERROR)
+
+        # Check that the password rotation error is in the errors (handle both list and dict format)
+        if isinstance(errors, dict):
+            password_errors = errors.get("password", [])
+            assert any(
+                expected_error in str(err) for err in password_errors
+            ), f"Expected '{expected_error}' in password errors, got {password_errors}"
+        else:
+            # errors is a list of error strings
+            assert any(
+                expected_error in str(err) for err in errors
+            ), f"Expected '{expected_error}' in errors, got {errors}"
+
+        # Check that the password_reset_required flag is set
+        assert response_data["response"].get("password_reset_required") is True
+        assert "password_reset_url" in response_data["response"]
+
+        # Verify user is NOT authenticated
+        assert not current_user.is_authenticated
+
+    @pytest.mark.options(CAPTCHETAT_BASE_URL=None)
+    def test_login_with_password_rotation_clears_after_reset(self):
+        """
+        After resetting password, the password_rotation_demanded should be cleared
+        and user should be able to log in.
+        See: https://github.com/opendatateam/udata/issues/3540
+        """
+        user = UserFactory(
+            email="jane@example.org",
+            password="password",
+            confirmed_at=datetime.now(),
+            password_rotation_demanded=datetime.now(),
+        )
+
+        # Generate reset token and reset password
+        token = generate_reset_password_token(user)
+        response = self.post(
+            url_for("security.reset_password", token=token),
+            {
+                "password": "NewPassword123",
+                "password_confirm": "NewPassword123",
+                "submit": True,
+            },
+        )
+        self.assertStatus(response, 200)
+
+        # Reload user from database
+        user.reload()
+
+        # Verify password_rotation_demanded is cleared
+        assert user.password_rotation_demanded is None
+        # Verify password_rotation_performed is set
+        assert user.password_rotation_performed is not None
+
+        # Now login should succeed
+        response = self.post(
+            url_for("security.login"),
+            {
+                "email": "jane@example.org",
+                "password": "NewPassword123",
+                "submit": True,
+            },
+        )
+        self.assertStatus(response, 200)
+
+        # Verify no password rotation error in response
+        response_data = response.json
+        assert response_data["response"].get("password_reset_required") is not True


### PR DESCRIPTION
Fixing issue #3540

- Add SECURITY_POST_RESET_VIEW to redirect with flash=password_reset
- add password_reset_required flag and password_reset_url to login response
- Fix Python 3.13 compatibility issue in i18n.py
- tests for password reset and password rotation behavior