### PR TITLE
feat(catalog): compress csv catalog archives

### DIFF
--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -1,4 +1,5 @@
 import collections
+import gzip
 import os
 from datetime import date, datetime
 from tempfile import NamedTemporaryFile
@@ -173,7 +174,12 @@ def export_csv_for_model(model, dataset, replace: bool = False):
             dataset.save()
         # remove previous catalog if exists and replace is True
         if replace and fs_filename_to_remove:
-            storages.resources.delete(fs_filename_to_remove)
+            try:
+                storages.resources.delete(fs_filename_to_remove)
+            except FileNotFoundError:
+                log.error(
+                    f"File not found while deleting resource #{resource.id} ({fs_filename_to_remove}) in export_csv_for_model cleanup"
+                )
         return resource
     finally:
         csvfile.close()
@@ -217,8 +223,8 @@ def export_csv(self, model=None):
             with storages.resources.open(resource.fs_filename, "rb") as f:
                 store_bytes(
                     bucket=current_app.config["EXPORT_CSV_ARCHIVE_S3_BUCKET"],
-                    filename=f"{current_app.config['EXPORT_CSV_ARCHIVE_S3_FILENAME_PREFIX']}{resource.title}",
-                    bytes=f.read(),
+                    filename=f"{current_app.config['EXPORT_CSV_ARCHIVE_S3_FILENAME_PREFIX']}{resource.title}.gz",
+                    bytes=gzip.compress(f.read()),
                 )
 
 


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/3509, we can now archive past catalogs on our S3.

This PR gzip those catalogs for archiving as we don't need raw CSVs and they compress really well.