### PR TITLE
feat: replace `private` by `published_at` for `Dataset`

### DIFF
--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -54,6 +54,7 @@ UNWANTED_KEYS: dict[str, list[str]] = {
         "spatial",
         "quality",
         "permissions",
+        "private",  # Computed from published_at, not a real field
     ],
     "resource": ["latest", "preview_url", "last_modified"],
     "organization": ["class", "page", "uri", "logo_thumbnail"],

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -308,7 +308,9 @@ class DatasetListAPI(API):
     def get(self):
         """List or search all datasets"""
         args = dataset_parser.parse()
-        datasets = Dataset.objects.visible_by_user(current_user)
+        datasets = Dataset.objects.visible_by_user(
+            current_user, Q(published_at__ne=None, archived=None, deleted=None)
+        )
         datasets = dataset_parser.parse_filters(datasets, args)
         sort = args["sort"] or ("$text_score" if args["q"] else None) or DEFAULT_SORTING
         return datasets.order_by(sort).paginate(args["page"], args["page_size"])

--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -21,7 +21,6 @@ import logging
 import os
 from datetime import datetime
 
-import mongoengine
 from bson.objectid import ObjectId
 from feedgenerator.django.utils.feedgenerator import Atom1Feed
 from flask import abort, current_app, make_response, redirect, request, url_for
@@ -254,7 +253,10 @@ class DatasetApiParser(ModelApiParser):
         if args.get("private") is not None:
             if current_user.is_anonymous:
                 abort(401)
-            datasets = datasets.filter(private=args["private"])
+            if args["private"]:
+                datasets = datasets.filter(published_at=None)
+            else:
+                datasets = datasets.filter(published_at__ne=None)
         return datasets
 
 
@@ -306,9 +308,7 @@ class DatasetListAPI(API):
     def get(self):
         """List or search all datasets"""
         args = dataset_parser.parse()
-        datasets = Dataset.objects.visible_by_user(
-            current_user, mongoengine.Q(private__ne=True, archived=None, deleted=None)
-        )
+        datasets = Dataset.objects.visible_by_user(current_user)
         datasets = dataset_parser.parse_filters(datasets, args)
         sort = args["sort"] or ("$text_score" if args["q"] else None) or DEFAULT_SORTING
         return datasets.order_by(sort).paginate(args["page"], args["page_size"])
@@ -829,7 +829,7 @@ class DatasetSuggestAPI(API):
     def get(self):
         """Datasets suggest endpoint using mongoDB contains"""
         args = suggest_parser.parse_args()
-        datasets_query = Dataset.objects(archived=None, deleted=None, private=False)
+        datasets_query = Dataset.objects.visible()
         datasets = datasets_query.filter(
             Q(title__icontains=args["q"]) | Q(acronym__icontains=args["q"])
         )

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -353,7 +353,7 @@ dataset_fields = api.model(
             description="Is the dataset private (DEPRECATED: use published_at instead)"
         ),
         "published_at": fields.ISODateTime(
-            description="Publication date (null if unpublished/private)"
+            description="Last publication date, null if unpublished/private. Updated each time the dataset is republished."
         ),
         "tags": fields.List(fields.String),
         "badges": fields.List(

--- a/udata/core/dataset/api_fields.py
+++ b/udata/core/dataset/api_fields.py
@@ -274,6 +274,7 @@ DEFAULT_MASK = ",".join(
         "last_modified",
         "deleted",
         "private",
+        "published_at",
         "tags",
         "badges",
         "resources",
@@ -349,7 +350,10 @@ dataset_fields = api.model(
         "archived": fields.ISODateTime(description="The archival date if archived"),
         "featured": fields.Boolean(description="Is the dataset featured"),
         "private": fields.Boolean(
-            description="Is the dataset private to the owner or the organization"
+            description="Is the dataset private (DEPRECATED: use published_at instead)"
+        ),
+        "published_at": fields.ISODateTime(
+            description="Publication date (null if unpublished/private)"
         ),
         "tags": fields.List(fields.String),
         "badges": fields.List(

--- a/udata/core/dataset/csv.py
+++ b/udata/core/dataset/csv.py
@@ -38,6 +38,7 @@ class DatasetCsvAdapter(csv.Adapter):
         "last_modified",
         ("tags", lambda o: ",".join(o.tags)),
         ("archived", lambda o: o.archived or False),
+        "published_at",
         ("resources_count", lambda o: len(o.resources)),
         ("main_resources_count", lambda o: len([r for r in o.resources if r.type == "main"])),
         ("resources_formats", lambda o: ",".join(set(r.format for r in o.resources if r.format))),
@@ -71,6 +72,7 @@ class ResourcesCsvAdapter(csv.NestedAdapter):
         ),
         dataset_field("license"),
         dataset_field("private"),
+        dataset_field("published_at"),
         dataset_field("archived", lambda r: r.archived or False),
     )
     nested_fields = (

--- a/udata/core/dataset/factories.py
+++ b/udata/core/dataset/factories.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from os.path import join
 
 import factory
@@ -19,6 +20,7 @@ class DatasetFactory(ModelFactory):
     title = factory.Faker("sentence")
     description = factory.Faker("text")
     frequency = UpdateFrequency.UNKNOWN
+    published_at = factory.LazyFunction(datetime.utcnow)
     resources = factory.LazyAttribute(lambda o: ResourceFactory.build_batch(o.nb_resources))
 
     class Params:
@@ -31,7 +33,7 @@ class DatasetFactory(ModelFactory):
 
 
 class HiddenDatasetFactory(DatasetFactory):
-    private = True
+    published_at = None
 
 
 class ChecksumFactory(ModelFactory):

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from udata.core.access_type.constants import (
     AccessAudienceCondition,
     AccessAudienceType,
@@ -213,12 +215,67 @@ class DatasetForm(ModelForm):
         _("Private"),
         description=_("Restrict the dataset visibility to you or your organization only."),
     )
+    published_at = fields.DateTimeField(_("Publication date"))
 
     owner = fields.CurrentUserField()
     organization = fields.PublishAsField(_("Publish as"))
     extras = fields.ExtrasField()
     resources = fields.NestedModelList(ResourceForm)
     contact_points = fields.ContactPointListField(validators=[validate_contact_point])
+
+    # ==================================================================================
+    # Backward compatibility layer for `private` field
+    # ==================================================================================
+    # The `private` boolean field has been replaced by `published_at` (datetime) on the
+    # Dataset model. However, we need to maintain API backward compatibility.
+    #
+    # Challenges encountered:
+    # 1. MongoEngine rejects unknown fields in constructor - we can't just add a
+    #    `private` property with a setter on the model because ModelForm.save() passes
+    #    self.data directly to the model constructor, which fails with FieldDoesNotExist.
+    #
+    # 2. WTForms BooleanField.process_formdata() doesn't update self.data when the value
+    #    is empty/None, so we can't rely on self.private.data to detect explicit None.
+    #
+    # 3. self.data is a read-only property computed from field values, so we can't
+    #    modify it directly (e.g., self.data.pop("private") fails).
+    #
+    # Solution:
+    # - Override __init__ to populate private.data from the existing instance
+    # - Override populate_obj to skip the private field (model has no such field)
+    # - Override save to:
+    #   a) Check self.formdata (raw JSON dict) to detect if private was explicitly sent
+    #   b) Convert private -> published_at before creating/updating the instance
+    #   c) Exclude private from the data dict when creating new instances
+    # ==================================================================================
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance:
+            self.private.data = self.instance.published_at is None
+
+    def populate_obj(self, obj):
+        for name, field in self._fields.items():
+            if name != "private":
+                field.populate_obj(obj, name)
+
+    def save(self, commit=True, **kwargs):
+        if self.formdata and "private" in self.formdata:
+            private_value = self.formdata.get("private")
+            if private_value is True:
+                self.published_at.data = None
+            elif private_value is False or private_value is None:
+                self.published_at.data = datetime.utcnow()
+
+        if self.instance:
+            self.populate_obj(self.instance)
+        else:
+            data = {k: v for k, v in self.data.items() if k != "private"}
+            self.instance = self.model_class(**data)
+
+        if commit:
+            self.instance.save(**kwargs)
+        return self.instance
 
 
 class ResourcesListForm(ModelForm):

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -260,7 +260,9 @@ class DatasetForm(ModelForm):
                 field.populate_obj(obj, name)
 
     def save(self, commit=True, **kwargs):
-        if self.formdata and "private" in self.formdata:
+        # Handle backward compatibility: if `private` is sent, convert to published_at.
+        # Only do this if published_at was NOT explicitly provided in the request.
+        if self.formdata and "private" in self.formdata and "published_at" not in self.formdata:
             private_value = self.formdata.get("private")
             if private_value is True:
                 self.published_at.data = None

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -340,10 +340,15 @@ class License(db.Document):
 
 class DatasetQuerySet(OwnedQuerySet):
     def visible(self):
-        return self(private__ne=True, deleted=None, archived=None)
+        return self(published_at__ne=None, deleted=None, archived=None)
 
     def hidden(self):
-        return self(db.Q(private=True) | db.Q(deleted__ne=None) | db.Q(archived__ne=None))
+        return self(db.Q(published_at=None) | db.Q(deleted__ne=None) | db.Q(archived__ne=None))
+
+    def visible_by_user(self, user):
+        return super().visible_by_user(
+            user, db.Q(published_at__ne=None, archived=None, deleted=None)
+        )
 
     def with_badge(self, kind):
         return self(badges__kind=kind)
@@ -553,7 +558,7 @@ class Dataset(
     tags = field(db.TagListField())
     resources = field(db.ListField(db.EmbeddedDocumentField(Resource)), auditable=False)
 
-    private = field(db.BooleanField(default=False))
+    published_at = field(db.DateTimeField())
 
     frequency = field(db.EnumField(UpdateFrequency))
     frequency_date = field(db.DateTimeField(verbose_name=_("Future date of update")))
@@ -599,6 +604,11 @@ class Dataset(
 
     def __str__(self):
         return self.title or ""
+
+    def to_dict(self, exclude=None):
+        data = super().to_dict(exclude=exclude)
+        data["private"] = self.private
+        return data
 
     __metrics_keys__ = [
         "discussions",
@@ -743,7 +753,12 @@ class Dataset(
 
     @property
     def is_hidden(self):
-        return self.private or self.deleted or self.archived
+        return self.published_at is None or self.deleted or self.archived
+
+    @property
+    def private(self) -> bool:
+        """Computed property for backward compatibility."""
+        return self.published_at is None
 
     @property
     def full_title(self):

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -345,11 +345,6 @@ class DatasetQuerySet(OwnedQuerySet):
     def hidden(self):
         return self(db.Q(published_at=None) | db.Q(deleted__ne=None) | db.Q(archived__ne=None))
 
-    def visible_by_user(self, user):
-        return super().visible_by_user(
-            user, db.Q(published_at__ne=None, archived=None, deleted=None)
-        )
-
     def with_badge(self, kind):
         return self(badges__kind=kind)
 

--- a/udata/core/dataset/tasks.py
+++ b/udata/core/dataset/tasks.py
@@ -91,10 +91,15 @@ def get_queryset(model_cls):
     if model_cls.__name__ == "Resource":
         model_cls = getattr(udata_models, "Dataset")
     params = {}
-    attrs = ("private", "deleted", "deleted_at")
-    for attr in attrs:
+    # Dataset uses published_at instead of private; other models still use private
+    if model_cls.__name__ == "Dataset":
+        params["published_at__ne"] = None
+    elif getattr(model_cls, "private", None):
+        params["private"] = False
+    # Filter out deleted/soft-deleted items
+    for attr in ("deleted", "deleted_at"):
         if getattr(model_cls, attr, None):
-            params[attr] = False
+            params[attr] = None
     # no_cache to avoid eating up too much RAM
     return model_cls.objects.filter(**params).no_cache()
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -580,7 +580,7 @@ class OrgDatasetsAPI(API):
         args = dataset_parser.parse()
         qs = Dataset.objects.owned_by(org)
         if not OrganizationPrivatePermission(org).can():
-            qs = qs(private__ne=True)
+            qs = qs(published_at__ne=None)
         return qs.order_by(args["sort"]).paginate(args["page"], args["page_size"])
 
 

--- a/udata/migrations/2024-01-29-fix-reuse-and-dataset-with-private-None.py
+++ b/udata/migrations/2024-01-29-fix-reuse-and-dataset-with-private-None.py
@@ -4,19 +4,16 @@ Some old dataset/reuse don't have a `private` field. It should be False by defau
 
 import logging
 
-from udata.models import Dataset, Reuse
-
 log = logging.getLogger(__name__)
 
 
 def migrate(db):
     log.info("Processing Reuse…")
+    result = db.reuse.update_many({"private": None}, {"$set": {"private": False}})
+    log.info(f"Fixed {result.modified_count} Reuse objects from private None to private False.")
 
-    count = Reuse.objects(private=None).update(private=False)
-    log.info(f"Fixed {count} Reuse objects from private None to private False.")
-
-    log.info("Processing Datasets…")
-    count = Dataset.objects(private=None).update(private=False)
-    log.info(f"Fixed {count} Dataset objects from private None to private False.")
+    log.info("Processing Dataset…")
+    result = db.dataset.update_many({"private": None}, {"$set": {"private": False}})
+    log.info(f"Fixed {result.modified_count} Dataset objects from private None to private False.")
 
     log.info("Done")

--- a/udata/migrations/2025-12-10-add-published_at-field.py
+++ b/udata/migrations/2025-12-10-add-published_at-field.py
@@ -47,3 +47,7 @@ def migrate(db):
                 updated += 1
 
     log.info(f"Phase 2 done: {updated} datasets refined with activity date")
+
+    log.info("Phase 3: Remove deprecated private field...")
+    result = db.dataset.update_many({"private": {"$exists": True}}, {"$unset": {"private": ""}})
+    log.info(f"Phase 3 done: {result.modified_count} datasets cleaned")

--- a/udata/migrations/2025-12-10-add-published_at-field.py
+++ b/udata/migrations/2025-12-10-add-published_at-field.py
@@ -1,0 +1,49 @@
+"""
+Migration: Add published_at field and populate from private field history.
+
+Phase 1 (fast): Bulk update all public datasets with created_at_internal
+Phase 2 (slow): Refine dates using activity history for more accuracy
+"""
+
+import logging
+
+import click
+
+from udata.core.dataset.activities import UserUpdatedDataset
+from udata.models import Dataset
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info("Phase 1: Bulk update with created_at_internal...")
+
+    # Avoid downtime: set a default value immediately so the system stays functional
+    result = db.dataset.update_many(
+        {"private": False, "published_at": {"$exists": False}},
+        [{"$set": {"published_at": "$created_at_internal"}}],
+    )
+    log.info(f"Phase 1 done: {result.modified_count} datasets updated")
+
+    log.info("Phase 2: Refining dates from activity history...")
+
+    datasets = Dataset.objects(published_at__ne=None).only("id", "created_at_internal")
+    count = datasets.count()
+    updated = 0
+
+    with click.progressbar(
+        datasets.no_cache().timeout(False), length=count, label="Refining dates"
+    ) as progress:
+        for dataset in progress:
+            activity = (
+                UserUpdatedDataset.objects(related_to=dataset.id, changes="private")
+                .order_by("-created_at")
+                .only("created_at")
+                .first()
+            )
+
+            if activity and activity.created_at != dataset.created_at_internal:
+                Dataset.objects(id=dataset.id).update_one(set__published_at=activity.created_at)
+                updated += 1
+
+    log.info(f"Phase 2 done: {updated} datasets refined with activity date")

--- a/udata/tests/api/test_activities_api.py
+++ b/udata/tests/api/test_activities_api.py
@@ -73,7 +73,7 @@ class ActivityAPITest(APITestCase):
         """It should fetch an activity list from the API"""
         activities: list[Activity] = [
             FakeDatasetActivity.objects.create(
-                actor=UserFactory(), related_to=DatasetFactory(private=True)
+                actor=UserFactory(), related_to=DatasetFactory(published_at=None)
             ),
             FakeReuseActivity.objects.create(
                 actor=UserFactory(), related_to=ReuseFactory(private=True)

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -878,6 +878,32 @@ class DatasetAPITest(APITestCase):
         dataset.reload()
         self.assertEqual(dataset.private, True)
 
+    def test_dataset_api_update_published_at(self):
+        """It should allow setting published_at to control visibility"""
+        user = self.login()
+        dataset = DatasetFactory(owner=user)
+        assert dataset.private is False
+        assert dataset.published_at is not None
+
+        # Setting published_at to None makes the dataset private
+        data = dataset.to_dict()
+        data["published_at"] = None
+        response = self.put(url_for("api.dataset", dataset=dataset), data)
+        self.assert200(response)
+        dataset.reload()
+        assert dataset.published_at is None
+        assert dataset.private is True
+
+        # Setting published_at to a date makes the dataset public
+        new_date = "2024-06-15T10:30:00"
+        data["published_at"] = new_date
+        response = self.put(url_for("api.dataset", dataset=dataset), data)
+        self.assert200(response)
+        dataset.reload()
+        assert dataset.published_at is not None
+        assert dataset.published_at.isoformat().startswith("2024-06-15")
+        assert dataset.private is False
+
     def test_dataset_api_update_new_resource_with_extras(self):
         """It should update a dataset with a new resource with extras"""
         user = self.login()

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -342,7 +342,7 @@ class DatasetAPITest(APITestCase):
         org = OrganizationFactory(members=[Member(user=owner)])
 
         public_datasets = [DatasetFactory() for i in range(2)]
-        private_datasets = [DatasetFactory(organization=org, private=True) for i in range(3)]
+        private_datasets = [DatasetFactory(organization=org, published_at=None) for i in range(3)]
         archived_datasets = [
             DatasetFactory(organization=org, archived=datetime.utcnow()) for i in range(4)
         ]
@@ -424,8 +424,8 @@ class DatasetAPITest(APITestCase):
         owner = UserFactory()
         org = OrganizationFactory()
         public_dataset = DatasetFactory()
-        private_user_dataset = DatasetFactory(private=True, owner=owner)
-        private_org_dataset = DatasetFactory(private=True, organization=org)
+        private_user_dataset = DatasetFactory(published_at=None, owner=owner)
+        private_org_dataset = DatasetFactory(published_at=None, organization=org)
 
         # Only public datasets for non-authenticated user.
         response = self.get(url_for("api.datasets"))
@@ -513,7 +513,7 @@ class DatasetAPITest(APITestCase):
 
     def test_dataset_api_get_private(self):
         """It should not fetch a private dataset from the API and raise 404"""
-        dataset = DatasetFactory(private=True)
+        dataset = HiddenDatasetFactory()
 
         response = self.get(url_for("api.dataset", dataset=dataset))
         self.assert404(response)
@@ -521,7 +521,7 @@ class DatasetAPITest(APITestCase):
     def test_dataset_api_get_private_but_authorized(self):
         """It should fetch a private dataset from the API if user is authorized"""
         self.login()
-        dataset = DatasetFactory(owner=self.user, private=True)
+        dataset = HiddenDatasetFactory(owner=self.user)
 
         response = self.get(url_for("api.dataset", dataset=dataset))
         self.assert200(response)
@@ -1325,7 +1325,7 @@ class DatasetAPITest(APITestCase):
         }
 
         # Empty dataset (no resources)
-        empty_dataset = Dataset.objects.create(title="test", resources=None)
+        empty_dataset = DatasetFactory(resources=[])
         response = self.get(url_for("apiv2.dataset_schemas", dataset=empty_dataset))
         assert len(response.json) == 0
 

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -809,7 +809,7 @@ class OrganizationDatasetsAPITest(PytestOnlyAPITestCase):
         user = self.login()
         member = Member(user=user, role="admin")
         org = OrganizationFactory(members=[member])
-        datasets = DatasetFactory.create_batch(3, organization=org, private=True)
+        datasets = DatasetFactory.create_batch(3, organization=org, published_at=None)
 
         response = self.get(url_for("api.org_datasets", org=org))
 
@@ -820,7 +820,7 @@ class OrganizationDatasetsAPITest(PytestOnlyAPITestCase):
         """Should not include private datasets when not member"""
         org = OrganizationFactory()
         datasets = DatasetFactory.create_batch(3, organization=org)
-        DatasetFactory.create_batch(2, organization=org, private=True)
+        DatasetFactory.create_batch(2, organization=org, published_at=None)
 
         response = self.get(url_for("api.org_datasets", org=org))
 
@@ -1038,7 +1038,7 @@ class OrganizationCsvExportsTest(PytestOnlyAPITestCase):
             for _ in range(3)
         ]
         not_org_dataset = DatasetFactory(resources=[ResourceFactory()])
-        hidden_dataset = DatasetFactory(private=True)
+        hidden_dataset = DatasetFactory(published_at=None)
 
         response = self.get(url_for("api.organization_datasets_resources_csv", org=org))
 

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -302,17 +302,24 @@ class DatasetModelTest(PytestOnlyDBTestCase):
             dataset.title = "New title"
             dataset.save(signal_kwargs={"ignores": ["post_save"]})
 
-    def test_dataset_without_private(self):
+    def test_dataset_published_at_and_private_property(self):
+        """Test the published_at field and computed private property."""
+        # A published dataset has published_at set and private=False
         dataset = DatasetFactory()
+        assert dataset.published_at is not None
         assert dataset.private is False
 
-        dataset.private = None
-        dataset.save()
-        assert dataset.private is False
-
-        dataset.private = True
+        # Setting published_at to None makes the dataset private
+        dataset.published_at = None
         dataset.save()
         assert dataset.private is True
+
+        # Setting published_at back makes the dataset public
+        from datetime import datetime
+
+        dataset.published_at = datetime.utcnow()
+        dataset.save()
+        assert dataset.private is False
 
     def test_dataset_fetch_exclude_resource(self):
         # Having a dataset with multiple resources

--- a/udata/tests/site/test_site_csv_exports.py
+++ b/udata/tests/site/test_site_csv_exports.py
@@ -19,7 +19,7 @@ class SiteCsvExportsTest(APITestCase):
         self.app.config["EXPORT_CSV_MODELS"] = []
         datasets = [DatasetFactory(resources=[ResourceFactory()]) for _ in range(5)]
         archived_datasets = [DatasetFactory(archived=datetime.utcnow()) for _ in range(3)]
-        hidden_dataset = DatasetFactory(private=True)
+        hidden_dataset = DatasetFactory(published_at=None)
 
         response = self.get(url_for("api.site_datasets_csv"))
 
@@ -66,7 +66,7 @@ class SiteCsvExportsTest(APITestCase):
             DatasetFactory(resources=[ResourceFactory()], tags=["selected"]) for _ in range(6)
         ]
         datasets = [DatasetFactory(resources=[ResourceFactory()]) for _ in range(3)]
-        hidden_dataset = DatasetFactory(private=True)
+        hidden_dataset = DatasetFactory(published_at=None)
 
         response = self.get(url_for("api.site_datasets_csv", tag="selected", page_size=3))
 


### PR DESCRIPTION
Fix https://github.com/etalab/transport-site/issues/4240

Need to be done for `Reuse` and `Dataservice` too in other PRs. `cdata` is working without any change, but could be updated to use and send the new `published_at` field instead of `private`.