### PR TITLE
feat: add POST /users endpoint in API

### DIFF
--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -734,12 +734,11 @@ def patch(obj, request) -> type:
                 for check in checks:
                     check(
                         value,
-                        **{
-                            "is_creation": obj._created,
-                            "is_update": not obj._created,
-                            "field": key,
-                        },
-                    )  # TODO add other model attributes in function parameters
+                        is_creation=obj._created,
+                        is_update=not obj._created,
+                        field=key,
+                        request_data=data,
+                    )
 
             setattr(obj, key, value)
 

--- a/udata/core/user/checks.py
+++ b/udata/core/user/checks.py
@@ -1,0 +1,39 @@
+from flask import current_app
+from urlextract import URLExtract
+
+from udata.auth.password_validation import UdataPasswordUtil
+from udata.i18n import lazy_gettext as _
+from udata.mongo.errors import FieldValidationError
+
+
+def password_rules(value, *, is_creation, field, **kwargs):
+    if not value:
+        if is_creation:
+            raise FieldValidationError(field=field, message=_("Password not provided"))
+        return
+
+    password_util = UdataPasswordUtil(current_app)
+    errors, _normalized = password_util.validate(value, is_register=is_creation)
+    if errors:
+        raise FieldValidationError(field=field, message=errors[0])
+
+
+def confirmed(value, *, field, request_data, **kwargs):
+    if not value:
+        return
+
+    confirmation_field = f"{field}_confirmation"
+    confirmation_value = request_data.get(confirmation_field)
+
+    if value != confirmation_value:
+        raise FieldValidationError(field=confirmation_field, message=_("Passwords do not match"))
+
+
+def no_urls(value, *, field, **kwargs):
+    if not value:
+        return
+
+    extractor = URLExtract()
+    urls = extractor.find_urls(value)
+    if urls:
+        raise FieldValidationError(field=field, message=_("URLs not allowed in this field"))

--- a/udata/tests/api/test_user_api.py
+++ b/udata/tests/api/test_user_api.py
@@ -282,28 +282,6 @@ class UserAPITest(APITestCase):
         response = self.get(url_for("api.user", user=user))
         self.assert200(response)
 
-    def test_user_api_create_as_admin(self):
-        """It should create a user"""
-        self.login(AdminFactory())
-        data = {
-            "first_name": faker.first_name(),
-            "last_name": faker.last_name(),
-            "email": faker.email(),
-        }
-        response = self.post(url_for("api.users"), data=data)
-        self.assert201(response)
-
-    def test_user_api_create_as_no_admin(self):
-        """It should not create a user"""
-        self.login(UserFactory())
-        data = {
-            "first_name": faker.first_name(),
-            "last_name": faker.last_name(),
-            "email": faker.email(),
-        }
-        response = self.post(url_for("api.users"), data=data)
-        self.assert403(response)
-
     def test_user_api_update(self):
         """It should update a user"""
         self.login(AdminFactory())

--- a/udata/tests/api/test_user_registration.py
+++ b/udata/tests/api/test_user_registration.py
@@ -1,0 +1,125 @@
+import pytest
+from flask import url_for
+
+from udata.core.user.factories import UserFactory
+from udata.models import User
+from udata.tests.helpers import capture_mails
+
+from . import APITestCase
+
+
+@pytest.mark.options(CAPTCHETAT_BASE_URL=None)
+class UserRegistrationAPITest(APITestCase):
+    def test_registration_success(self):
+        """It should create a user and send confirmation email"""
+        data = {
+            "email": "newuser@example.com",
+            "password": "StrongPass123",
+            "password_confirmation": "StrongPass123",
+            "first_name": "Test",
+            "last_name": "User",
+            "accept_conditions": True,
+        }
+        with capture_mails() as mails:
+            response = self.post(url_for("api.users"), data)
+
+        self.assert201(response)
+        assert "message" in response.json
+
+        user = User.objects.get(email=data["email"])
+        assert user is not None
+        assert user.first_name == "Test"
+        assert user.last_name == "User"
+        # In test mode (SEND_MAIL=False), user is auto-confirmed
+        assert user.confirmed_at is not None
+        assert user.active is True
+
+        assert len(mails) == 1
+        assert "confirm" in mails[0].subject.lower()  # "Confirmez" en français
+
+    def test_registration_duplicate_email_sends_existing_account_mail(self):
+        """It should return 201 and send existing account email for duplicate email"""
+        UserFactory(email="existing@example.com")
+        data = {
+            "email": "existing@example.com",
+            "password": "StrongPass123",
+            "password_confirmation": "StrongPass123",
+            "first_name": "Test",
+            "last_name": "User",
+            "accept_conditions": True,
+        }
+        with capture_mails() as mails:
+            response = self.post(url_for("api.users"), data)
+
+        self.assert201(response)
+
+        assert User.objects.count() == 1
+
+        assert len(mails) == 1
+        assert "déjà" in mails[0].subject.lower()
+
+    def test_registration_weak_password(self):
+        """It should reject weak passwords"""
+        data = {
+            "email": "newuser@example.com",
+            "password": "weak",
+            "password_confirmation": "weak",
+            "first_name": "Test",
+            "last_name": "User",
+            "accept_conditions": True,
+        }
+        response = self.post(url_for("api.users"), data)
+        self.assert400(response)
+
+    def test_registration_password_mismatch(self):
+        """It should reject mismatched password confirmation"""
+        data = {
+            "email": "newuser@example.com",
+            "password": "StrongPass123",
+            "password_confirmation": "DifferentPass123",
+            "first_name": "Test",
+            "last_name": "User",
+            "accept_conditions": True,
+        }
+        response = self.post(url_for("api.users"), data)
+        self.assert400(response)
+
+    def test_registration_url_in_name(self):
+        """It should reject URLs in first/last name"""
+        data = {
+            "email": "newuser@example.com",
+            "password": "StrongPass123",
+            "password_confirmation": "StrongPass123",
+            "first_name": "Test http://spam.com",
+            "last_name": "User",
+            "accept_conditions": True,
+        }
+        response = self.post(url_for("api.users"), data)
+        self.assert400(response)
+
+    def test_registration_read_only_mode(self):
+        """It should reject registration in read-only mode"""
+        self.app.config["READ_ONLY_MODE"] = True
+        data = {
+            "email": "newuser@example.com",
+            "password": "StrongPass123",
+            "password_confirmation": "StrongPass123",
+            "first_name": "Test",
+            "last_name": "User",
+            "accept_conditions": True,
+        }
+        response = self.post(url_for("api.users"), data)
+        self.assertStatus(response, 423)
+
+    def test_registration_without_accept_conditions(self):
+        """It should reject registration without accepting conditions"""
+        data = {
+            "email": "newuser@example.com",
+            "password": "StrongPass123",
+            "password_confirmation": "StrongPass123",
+            "first_name": "Test",
+            "last_name": "User",
+            "accept_conditions": False,
+        }
+        response = self.post(url_for("api.users"), data)
+        self.assert400(response)


### PR DESCRIPTION
- \+ 125 lines of tests
- \+ 40 lines of validation
- \+ 50 lines of API
- \- 65 lines of `ExtendedRegisterForm` that could be remove in another PR

Net result: + 25 lines for taking control of the registration ;-)

Not really tested with cdata, waiting for the approval to try it in real conditions (it may miss some stuff, have small bugs)