### PR TITLE
fix: missing new line between breaking and non breaking

### DIFF
--- a/tag-version.sh
+++ b/tag-version.sh
@@ -237,7 +237,7 @@ fi
 # Combine: breaking changes first, then regular commits
 SORTED_COMMITS=""
 if [ -n "$BREAKING_CHANGES" ]; then
-    SORTED_COMMITS="$BREAKING_CHANGES"
+    SORTED_COMMITS="$BREAKING_CHANGES"$'\n'
 fi
 if [ -n "$REGULAR_COMMITS" ]; then
     SORTED_COMMITS="${SORTED_COMMITS}${REGULAR_COMMITS}"


### PR DESCRIPTION
```
  ## 15.0.0 (2026-02-12)                                                                                                                                                                           
                                                                                                                                                                                               
  - **feat!: add MembershipRequest from org ([#3570](https://github.com/opendatateam/udata/pull/3570))**- chore: add breaking change override for `tag-version.sh`                             
  ([#3657](https://github.com/opendatateam/udata/pull/3657))                                                                                                                                   
  - feat: expose organization permissions ([#3656](https://github.com/opendatateam/udata/pull/3656))                                                                                           
  - fix: new line in tag-version with breaking changes ([#3662](https://github.com/opendatateam/udata/pull/3662))                                                                              
  - fix: remove dead code for site form ([#3658](https://github.com/opendatateam/udata/pull/3658))                                                                                             
```