### PR TITLE
fix: shadowing translation function

### DIFF
--- a/udata/templates/macros/forms.html
+++ b/udata/templates/macros/forms.html
@@ -40,7 +40,7 @@
 {% endmacro %}
 
 {% macro radio_inline(field) %}
-{% for value, label, selected, _ in field.iter_choices() %}
+{% for value, label, selected, _attrs in field.iter_choices() %}
 <label class="radio-inline">
     <input type="radio" name="{{ field.name }}" id="{{ field.id }}-{{ loop.index }}" value="{{ value }}"
         {% if selected %}checked="checked"{% endif %}>
@@ -50,7 +50,7 @@
 {% endmacro %}
 
 {% macro radio_stacked(field) %}
-{% for value, label, selected, _ in field.iter_choices() %}
+{% for value, label, selected, _attrs in field.iter_choices() %}
 <div class="radio">
     <label>
         <input type="radio" name="{{ field.name }}" id="{{ field.id }}-{{ loop.index }}" value="{{ value }}"

--- a/udata/templates/macros/forms.html
+++ b/udata/templates/macros/forms.html
@@ -44,7 +44,7 @@
 <label class="radio-inline">
     <input type="radio" name="{{ field.name }}" id="{{ field.id }}-{{ loop.index }}" value="{{ value }}"
         {% if selected %}checked="checked"{% endif %}>
-    {{ _(label) }}
+    {{ label }}
 </label>
 {% endfor %}
 {% endmacro %}
@@ -55,7 +55,7 @@
     <label>
         <input type="radio" name="{{ field.name }}" id="{{ field.id }}-{{ loop.index }}" value="{{ value }}"
             {% if selected %}checked="checked"{% endif %}>
-        {{ _(label) }}
+        {{ label }}
     </label>
 </div>
 {% endfor %}


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/279254/?environment=data.gouv.fr&project=12&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0

Happening on https://www.data.gouv.fr/tf-validate?next=https://www.data.gouv.fr?flash%3Dconnected but not sure why we don't get a cdata response on this route…

The route is `validate-two-factor` in cdata and in the infra routing…