### PR TITLE
fix(harvest): missing new (Geo)DCAT-AP mapping for dct:provenance and dct:*rights

### DIFF
--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -34,6 +34,7 @@ from udata.rdf import (
     GEODCAT,
     HVD_LEGISLATION,
     IANAFORMAT,
+    RDFS,
     SCHEMA,
     SCV,
     SKOS,
@@ -604,7 +605,7 @@ def frequency_from_rdf(term) -> UpdateFrequency | None:
 
 def mime_from_rdf(resource):
     # DCAT.mediaType *should* only be used when defined as IANA
-    mime = rdf_value(resource, DCAT.mediaType, parse_label=True)
+    mime = rdf_value(resource, DCAT.mediaType, unwrap=[RDFS.label])
     if not mime:
         return
     if IANAFORMAT in mime:
@@ -614,7 +615,7 @@ def mime_from_rdf(resource):
 
 
 def format_from_rdf(resource):
-    format = rdf_value(resource, DCT.format, parse_label=True)
+    format = rdf_value(resource, DCT.format, unwrap=[RDFS.label])
     if not format:
         return
     if EUFORMAT in format or IANAFORMAT in format:
@@ -651,7 +652,7 @@ def access_rights_from_rdf(resource: RdfResource) -> set[str]:
     Extract the access rights from a RdfResource
     Cardinality is 0..n (although it should be 0..1 per the spec).
     """
-    return rdf_unique_values(resource, DCT.accessRights, parse_label=True)
+    return rdf_unique_values(resource, DCT.accessRights, unwrap=[RDFS.label, DCT.description])
 
 
 def licenses_from_rdf(resource: RdfResource) -> set[str]:
@@ -660,7 +661,7 @@ def licenses_from_rdf(resource: RdfResource) -> set[str]:
     See `test_dataset_rdf.py > test_licenses_from_rdf` for examples of supported formats.
     Cardinality is 0..n (although it should be 0..1 per the spec).
     """
-    return rdf_unique_values(resource, DCT.license, parse_label=True)
+    return rdf_unique_values(resource, DCT.license, unwrap=[RDFS.label, DCT.description])
 
 
 def rights_from_rdf(resource: RdfResource) -> set[str]:
@@ -668,7 +669,7 @@ def rights_from_rdf(resource: RdfResource) -> set[str]:
     Extract rights from a RDF distribution.
     Cardinality is 0..n.
     """
-    return rdf_unique_values(resource, DCT.rights, parse_label=True)
+    return rdf_unique_values(resource, DCT.rights, unwrap=[RDFS.label, DCT.description])
 
 
 def provenances_from_rdf(resource: RdfResource) -> set[str]:
@@ -676,7 +677,7 @@ def provenances_from_rdf(resource: RdfResource) -> set[str]:
     Extract provenance from a RDF distribution.
     Cardinality is 0..n.
     """
-    return rdf_unique_values(resource, DCT.provenance, parse_label=True)
+    return rdf_unique_values(resource, DCT.provenance, unwrap=[RDFS.label, DCT.description])
 
 
 def infer_dataset_access_rights(

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -38,7 +38,8 @@
         </dct:temporal>
         <dct:provenance>
           <dct:ProvenanceStatement>
-            <rdfs:label xml:lang="fr">Description de la provenance des données</rdfs:label>
+            <!-- older DCAT* standards -->
+            <rdfs:label xml:lang="fr">Description de la provenance des données du dataset 3</rdfs:label>
           </dct:ProvenanceStatement>
         </dct:provenance>
       </dcat:Dataset>
@@ -73,6 +74,11 @@
         <dcat:distribution rdf:resource="http://data.test.org/datasets/1/resources/2"/>
         <dcterms:hasPart rdf:resource="http://data.test.org/datasets/1/resources/3"/>
         <dcat:distribution rdf:resource="http://data.test.org/datasets/1/resources/4"/>
+        <dct:provenance>
+          <dct:ProvenanceStatement>
+            <dct:description xml:lang="fr">Description de la provenance des données du dataset 1</dct:description>
+          </dct:ProvenanceStatement>
+        </dct:provenance>
       </dcat:Dataset>
     </dcat:dataset>
     <dcat:dataset>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -583,7 +583,9 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         assert dataset.extras["dcat"]["accessRights"] == [
             "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e"
         ]
-        assert dataset.extras["dcat"]["provenance"] == ["Description de la provenance des données"]
+        assert dataset.extras["dcat"]["provenance"] == [
+            "Description de la provenance des données du dataset 3"
+        ]
 
         assert "observation-de-la-terre-et-environnement" in dataset.tags
         assert "hvd" in dataset.tags
@@ -601,6 +603,9 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         assert dataset.frequency is None
         # test dct:license nested in distribution
         assert dataset.license.id == "lov1"
+        assert dataset.extras["dcat"]["provenance"] == [
+            "Description de la provenance des données du dataset 1"
+        ]
 
         assert len(dataset.resources) == 4
 

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -229,37 +229,39 @@ CONTEXT = {
 }
 
 
-def serialize_value(value, parse_label=False):
+def serialize_value(value, unwrap: list[URIRef] | None = None):
     """
     If the value is a URIRef or a Literal, return it as a string.
     If the value is a RdfResource:
-        - Return the label of the RdfResource if any and `parse_label`,
-        - or the identifier of the RdfResource.
+        - if `unwrap` is set, look for children of the RdfResource in the order they are listed in
+          `unwrap`, and return the value of the first matching element (if any),
+        - otherwise return the identifier of the RdfResource.
     """
     if isinstance(value, (URIRef, Literal)):
         return value.toPython()
     elif isinstance(value, RdfResource):
-        if parse_label and (rdfs_label := rdf_value(value, RDFS.label)):
-            return rdfs_label
+        for uriref in unwrap or []:
+            if val := rdf_value(value, uriref):
+                return val
         return value.identifier.toPython()
 
 
-def rdf_unique_values(resource, predicate, parse_label=False) -> set[str]:
+def rdf_unique_values(resource, predicate, unwrap: list[URIRef] | None = None) -> set[str]:
     """Returns a set of serialized values for a predicate from a RdfResource"""
     return {
         value
         for info in resource.objects(predicate=predicate)
-        if (value := serialize_value(info, parse_label=parse_label))
+        if (value := serialize_value(info, unwrap=unwrap))
     }
 
 
-def rdf_value(obj, predicate, default=None, parse_label=False):
+def rdf_value(obj, predicate, default=None, unwrap: list[URIRef] | None = None):
     """
     Serialize the value for a predicate on a RdfResource,
     expecting one value only or (at most) one per language for Literals.
     """
     value = default_lang_value(obj, predicate)
-    return serialize_value(value, parse_label=parse_label) if value else default
+    return serialize_value(value, unwrap=unwrap) if value else default
 
 
 def default_lang_value(obj, predicate):

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -33,6 +33,7 @@ from udata.core.dataset.rdf import (
     infer_dataset_access_rights,
     license_to_rdf,
     licenses_from_rdf,
+    provenances_from_rdf,
     resource_from_rdf,
     resource_to_rdf,
     rights_to_rdf,
@@ -1699,3 +1700,54 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
         assert len(rights) == 1
         assert rights[0].identifier == URIRef(InspireLimitationCategory.PUBLIC_AUTHORITIES.url)
         assert access_right and access_right.identifier == URIRef(AccessType.RESTRICTED.url)
+
+    def test_provenances_from_rdf(self):
+        """Test a bunch of cases of provenances detection from RDF"""
+        rdf_xml_data = """<?xml version="1.0" encoding="UTF-8"?>
+            <rdf:RDF
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+            xmlns:foaf="http://xmlns.com/foaf/0.1/"
+            xmlns:dct="http://purl.org/dc/terms/"
+            xmlns:cc="http://creativecommons.org/ns#"
+            xmlns:ex="http://example.org/">
+
+            <rdf:Description rdf:about="http://example.org/dataset1">
+                <dct:title>Comprehensive Provenance Example Dataset</dct:title>
+                <!-- old DCAT* specs -->
+                <dct:provenance>
+                    <dct:ProvenanceStatement>
+                        <rdfs:label>Provenance from label</rdfs:label>
+                    </dct:ProvenanceStatement>
+                </dct:provenance>
+                <!-- new DCAT* specs -->
+                <dct:provenance>
+                    <dct:ProvenanceStatement>
+                        <dct:description>Provenance from description</dct:description>
+                    </dct:ProvenanceStatement>
+                </dct:provenance>
+                <!-- supported theoretical(?) cases -->
+                <dct:provenance>Provenance from value</dct:provenance>
+                <dct:provenance rdf:resource="http://example.org/provenance"/>
+            </rdf:Description>
+
+            <rdf:Description rdf:about="http://example.org/provenance">
+                <dct:description>Provenance from resource</dct:description>
+            </rdf:Description>
+
+            </rdf:RDF>
+        """
+        g = Graph()
+        g.parse(data=rdf_xml_data, format="xml")
+        ex = Namespace("http://example.org/")
+        dataset = RdfResource(g, ex.dataset1)
+        licences = provenances_from_rdf(dataset)
+        expected_licences = set(
+            [
+                "Provenance from label",
+                "Provenance from description",
+                "Provenance from value",
+                "Provenance from resource",
+            ]
+        )
+        assert expected_licences == licences


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1018

`dct:provenance` and `dct:*rights` used to contain a `rdfs:label`, but the GeoDCAT-AP 3 spec mentions that `dct:description` can be used ([doc provenance](https://semiceu.github.io/GeoDCAT-AP/releases/3.1.0/#lineage---lineage), [doc rights](https://semiceu.github.io/GeoDCAT-AP/releases/3.1.0/#conditions-for-access-and-use-and-limitations-on-public-access-use-limitation-and-access-other-constraints)), and the [SEMIC (main branch)](https://github.com/SEMICeu/iso-19139-to-dcat-ap/blob/main/iso-19139-to-dcat-ap.xsl#L825) and [GeoNetwork](https://github.com/geonetwork/core-geonetwork/blob/2f2f187039ba07a66a14446f4ff1eed075125dae/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/eu-dcat-ap/eu-dcat-ap-core.xsl#L149) converters now use that spec.

It is not clear where DCAT stands, and whether GeoDCAT-AP defines `dct:description` as a replacement or an addition to `rdfs:label`. Properties of `dct:*Statements` are not clearly defined so we can only rely on examples provided in the spec.

So we add resolution of `dct:description` but keep `rdfs:label` as well. If an element contains both properties, we take the `rdfs:label` as the more likely "title" of the element.

Even though the recent specs only give URI examples for licenses, we also apply the logic above to `dct:license` to preserve the already implemented coverage of free-text cases.