### PR TITLE
fix(harvest): invalid remote URL on record identifiers with "urn:uuid" codespace

### DIFF
--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -500,10 +500,34 @@ def remote_url_from_rdf(rdf: RdfResource, graph: Graph, remote_url_prefix: str |
     Otherwise, use DCAT.landingPage if found and uri validation succeeds.
     In this latter case, use RDF identifier as fallback if uri validation succeeds.
     """
-    if remote_url_prefix and (
-        primary_topic_identifier := primary_topic_identifier_from_rdf(graph, rdf)
-    ):
-        return f"{remote_url_prefix.rstrip('/')}/{primary_topic_identifier}"
+    if remote_url_prefix and (identifier := primary_topic_identifier_from_rdf(graph, rdf)):
+        # Some ISO-19115-3 GeoNetwork templates set a codespace for the record IDs (e.g. the
+        # geodata-multilingual.xml template,), i.e. they set:
+        # - mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code to the record ID, and
+        # - mdb:metadataIdentifier/mcc:MD_Identifier/mcc:codeSpace to "urn:uuid".
+        # It is not clear why only some templates set a codespace, git blame didn't yield any clue.
+        #
+        # That codespace ends up collapsed in the record dct:identifier, since dct:identifier has no
+        # separate codespace. This means dct:identifier differs (by the codespace) from the record
+        # ID that GeoNetwork uses internally, and we need to extract that original record ID from
+        # dct:identifier to build a valid remote_url.
+        #
+        # It is impractical to reliably infer the codespace from dct:identifier since parsing of
+        # URNs is namespace dependent. So we restrict the heuristic to the "uuid" namespace, which
+        # is both clearly specified (RFC-4122) and used in the wild by GeoNetwork (e.g. OFB,
+        # Sextant, and likely most future ISO-19115-3 catalogs given it's in the templates).
+        #
+        # Note that the test on datatype being xsd:anyURI is important, because some ISO-19139
+        # catalogs (e.g. Geo2France) are using "urn:...:" prefixes in their gmd:fileIdentifier.
+        # ISO-19139 having no concept of codespace (for fileIdentifier), that prefix is treated as
+        # as a regular part of the gco:CharacterString record ID, meaning:
+        # - dct:identifier is typed xsd:string, and
+        # - the prefix is part of the record URL, so it must stay in remote_url.
+        uuid_prefix = "urn:uuid:"
+        if identifier.datatype == XSD.anyURI and identifier.value.startswith(uuid_prefix):
+            offset = len(uuid_prefix)
+            identifier = identifier.value[offset:]
+        return f"{remote_url_prefix.rstrip('/')}/{identifier}"
 
     landing_page = url_from_rdf(rdf, DCAT.landingPage)
     uri = rdf.identifier.toPython()

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -501,28 +501,25 @@ def remote_url_from_rdf(rdf: RdfResource, graph: Graph, remote_url_prefix: str |
     In this latter case, use RDF identifier as fallback if uri validation succeeds.
     """
     if remote_url_prefix and (identifier := primary_topic_identifier_from_rdf(graph, rdf)):
-        # Some ISO-19115-3 GeoNetwork templates set a codespace for the record IDs (e.g. the
-        # geodata-multilingual.xml template,), i.e. they set:
-        # - mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code to the record ID, and
-        # - mdb:metadataIdentifier/mcc:MD_Identifier/mcc:codeSpace to "urn:uuid".
-        # It is not clear why only some templates set a codespace, git blame didn't yield any clue.
+        # Some ISO-19115-3 GeoNetwork templates set a codeSpace for the record ID (e.g. the
+        # geodata-multilingual.xml template), meaning we have:
+        # - mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code = the record ID,
+        # - mdb:metadataIdentifier/mcc:MD_Identifier/mcc:codeSpace = "urn:uuid".
         #
-        # That codespace ends up collapsed in the record dct:identifier, since dct:identifier has no
-        # separate codespace. This means dct:identifier differs (by the codespace) from the record
-        # ID that GeoNetwork uses internally, and we need to extract that original record ID from
-        # dct:identifier to build a valid remote_url.
+        # That codeSpace ends up collapsed in the record dct:identifier. This means dct:identifier
+        # differs (by the codeSpace) from the record ID that GeoNetwork uses internally, including
+        # for its URLs. So we need to extract the original record ID from dct:identifier to build a
+        # valid remote_url.
         #
-        # It is impractical to reliably infer the codespace from dct:identifier since parsing of
-        # URNs is namespace dependent. So we restrict the heuristic to the "uuid" namespace, which
-        # is both clearly specified (RFC-4122) and used in the wild by GeoNetwork (e.g. OFB,
-        # Sextant, and likely most future ISO-19115-3 catalogs given it's in the templates).
+        # URN parsing rules depend on the namespace of the URN (urn:<namespace>:...), so there is no
+        # generic way to extract the codeSpace. Here we only handle the "uuid" namespace (RFC-4122),
+        # which is used in the wild by GeoNetwork (e.g. OFB, Sextant, and likely most future
+        # ISO-19115-3 catalogs that use the default templates).
         #
-        # Note that the test on datatype being xsd:anyURI is important, because some ISO-19139
-        # catalogs (e.g. Geo2France) are using "urn:...:" prefixes in their gmd:fileIdentifier.
-        # ISO-19139 having no concept of codespace (for fileIdentifier), that prefix is treated as
-        # as a regular part of the gco:CharacterString record ID, meaning:
-        # - dct:identifier is typed xsd:string, and
-        # - the prefix is part of the record URL, so it must stay in remote_url.
+        # Note that the datatype == xsd:anyURI test is important. Some *ISO-19139* catalogs are
+        # using "urn:...:" prefixes in their gmd:fileIdentifier (e.g. Geo2France), but ISO-19139 has
+        # no concept of codeSpace, it's simply a string. So in ISO-19139, what looks like a "prefix"
+        # is just an arbitrary part the plain string identifier, with no special meaning.
         uuid_prefix = "urn:uuid:"
         if identifier.datatype == XSD.anyURI and identifier.value.startswith(uuid_prefix):
             offset = len(uuid_prefix)

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 from flask import url_for
 from rdflib import BNode, Graph, Literal, Namespace, URIRef
-from rdflib.namespace import FOAF, ORG, RDF, RDFS
+from rdflib.namespace import FOAF, ORG, RDF, RDFS, XSD
 from rdflib.resource import Resource as RdfResource
 
 from udata.core.access_type.constants import AccessType, InspireLimitationCategory
@@ -57,6 +57,7 @@ from udata.rdf import (
     VCARD,
     default_lang_value,
     primary_topic_identifier_from_rdf,
+    remote_url_from_rdf,
 )
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
 from udata.tests.helpers import assert200, assert_redirects
@@ -1390,6 +1391,58 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
 
         pti = primary_topic_identifier_from_rdf(g, g.resource(node))
         assert pti == Literal("primary-topic-identifier")
+
+    def test_remote_url_from_rdf_urnuuid_iso191153(self):
+        """
+        Check that ISO-19115-3 records with a "urn:uuid" codeSpace return their ID *without* the codeSpace.
+        See remote_url_from_rdf() for details.
+        """
+        g = Graph()
+
+        node = BNode()
+        g.add((node, RDF.type, DCAT.Dataset))
+        g.add((node, DCT.title, Literal(faker.sentence())))
+
+        primary_topic_node = BNode()
+        g.add((primary_topic_node, RDF.type, DCAT.CatalogRecord))
+        g.add(
+            (
+                primary_topic_node,
+                DCT.identifier,
+                Literal("urn:uuid:ff685ba4-587e-4bb3-bc87-eae919b56857", datatype=XSD.anyURI),
+            )
+        )
+        g.add((primary_topic_node, FOAF.primaryTopic, node))
+
+        remote_url = remote_url_from_rdf(g.resource(node), g, "http://example.com/dataset")
+        assert remote_url == "http://example.com/dataset/ff685ba4-587e-4bb3-bc87-eae919b56857"
+
+    def test_remote_url_from_rdf_urnuuid_iso19139(self):
+        """
+        Check that ISO-19139 records with a "urn:uuid" prefix return their ID *with* the prefix.
+        See remote_url_from_rdf() for details.
+        """
+        g = Graph()
+
+        node = BNode()
+        g.add((node, RDF.type, DCAT.Dataset))
+        g.add((node, DCT.title, Literal(faker.sentence())))
+
+        primary_topic_node = BNode()
+        g.add((primary_topic_node, RDF.type, DCAT.CatalogRecord))
+        g.add(
+            (
+                primary_topic_node,
+                DCT.identifier,
+                Literal("urn:uuid:ff685ba4-587e-4bb3-bc87-eae919b56857", datatype=XSD.string),
+            )
+        )
+        g.add((primary_topic_node, FOAF.primaryTopic, node))
+
+        remote_url = remote_url_from_rdf(g.resource(node), g, "http://example.com/dataset")
+        assert (
+            remote_url == "http://example.com/dataset/urn:uuid:ff685ba4-587e-4bb3-bc87-eae919b56857"
+        )
 
     def test_rdf_value_with_preferred_language(self, app):
         """Check that rdf_value gets the Literal with preferred language if multiple exists"""


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1019