### PR TITLE
feat: expose callbacks_count for reports

### DIFF
--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -26,6 +26,7 @@ For field-specific metadata, see the `field()` function documentation.
 """
 
 import functools
+import typing
 from datetime import datetime
 from typing import Any, Callable, Iterable, TypedDict, TypeVar, Unpack, overload
 
@@ -43,6 +44,12 @@ import udata.api.fields as custom_restx_fields
 from udata.api import api, base_reference
 from udata.mongo.errors import FieldValidationError
 from udata.mongo.queryset import DBPaginator, UDataQuerySet
+
+PYTHON_TYPE_TO_RESTX_FIELD = {
+    int: restx_fields.Integer,
+    float: restx_fields.Float,
+    bool: restx_fields.Boolean,
+}
 
 
 def required_if(**conditions):
@@ -495,8 +502,8 @@ def generate_fields(**kwargs) -> Callable:
 
             nested_fields: dict | None = additional_field_info.get("nested_fields")
             if nested_fields is None:
-                # If there is no `nested_fields` convert the object to the string representation.
-                field_constructor = restx_fields.String
+                return_type = typing.get_type_hints(method).get("return")
+                field_constructor = PYTHON_TYPE_TO_RESTX_FIELD.get(return_type, restx_fields.String)
             else:
 
                 def field_constructor(**kwargs):

--- a/udata/core/reports/models.py
+++ b/udata/core/reports/models.py
@@ -125,10 +125,7 @@ class Report(Document[ReportQuerySet]):
 
     # Callbacks to execute when report is dismissed (for auto-spam reports)
     # Format: {"method_name": {"args": [...], "kwargs": {...}}}
-    callbacks = field(
-        DictField(default=dict),
-        readonly=True,
-    )
+    callbacks = DictField(default=dict)
 
     meta = {
         "queryset_class": ReportQuerySet,
@@ -143,6 +140,10 @@ class Report(Document[ReportQuerySet]):
                 or getattr(subject, "name", None)
                 or getattr(subject, "slug", None)
             )
+
+    @field(description="Number of pending callbacks to execute when dismissed")
+    def callbacks_count(self) -> int:
+        return len(self.callbacks)
 
     @field(description="Link to the API endpoint for this report")
     def self_api_url(self):

--- a/udata/tests/api/test_reports_api.py
+++ b/udata/tests/api/test_reports_api.py
@@ -7,7 +7,9 @@ from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.dataset.models import Dataset
 from udata.core.discussions.factories import DiscussionFactory, MessageDiscussionFactory
+from udata.core.discussions.models import Discussion, Message
 from udata.core.reports.constants import (
+    REASON_AUTO_SPAM,
     REASON_ILLEGAL_CONTENT,
     REASON_SPAM,
     reports_reasons_translations,
@@ -515,3 +517,45 @@ class ReportsAPITest(APITestCase):
         report_on_discussion.reload()
         self.assertIsNone(report_on_discussion.subject_deleted_at)
         self.assertIsNone(report_on_discussion.subject_deleted_by)
+
+    def test_reports_api_callbacks_count_returned_in_response(self):
+        """The API should return the callbacks count, not the full callbacks dict."""
+        admin = AdminFactory()
+        user = UserFactory()
+
+        dataset = Dataset.objects.create(title="Test dataset", owner=user)
+        message = Message(content="bla bla", posted_by=user)
+        discussion = Discussion.objects.create(
+            subject=dataset, user=user, title="Test", discussion=[message]
+        )
+
+        report = Report(
+            subject=discussion,
+            reason=REASON_AUTO_SPAM,
+            callbacks={"signal_new": {"args": [], "kwargs": {}}},
+        ).save()
+
+        self.login(admin)
+
+        # GET single report — should have count, not the full dict
+        response = self.get(url_for("api.report", report=report))
+        self.assert200(response)
+        self.assertNotIn("callbacks", response.json)
+        self.assertEqual(response.json["callbacks_count"], 1)
+
+        # GET list
+        response = self.get(url_for("api.reports"))
+        self.assert200(response)
+        self.assertNotIn("callbacks", response.json["data"][0])
+        self.assertEqual(response.json["data"][0]["callbacks_count"], 1)
+
+        # PATCH dismiss — callbacks are executed and cleared
+        response = self.patch(
+            url_for("api.report", report=report),
+            {"dismissed_at": datetime.now(UTC).isoformat()},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["callbacks_count"], 0)
+
+        report.reload()
+        self.assertEqual(report.callbacks, {})


### PR DESCRIPTION
Require to add a warning on the moderation dashboard if a report is blocking callbacks. And we don't want to expose internals (even for super-admins)