### PR TITLE
fix: errors on high pages on search endpoints

### DIFF
--- a/udata/search/query.py
+++ b/udata/search/query.py
@@ -4,11 +4,13 @@ import logging
 import urllib.parse
 
 from elasticsearch.exceptions import BadRequestError
-from flask import current_app, request
+from flask import abort, current_app, request
 
 from udata.search.result import SearchResult
 
 DEFAULT_PAGE_SIZE = 20
+# Elasticsearch default max_result_window is 10000
+ES_MAX_RESULT_WINDOW = 10000
 log = logging.getLogger(__name__)
 
 
@@ -17,8 +19,17 @@ class SearchQuery:
     model = None
 
     def __init__(self, params):
-        self.page = int(params.pop("page", 1))
-        self.page_size = int(params.pop("page_size", DEFAULT_PAGE_SIZE))
+        self.page = max(1, int(params.pop("page", 1)))
+        self.page_size = max(1, int(params.pop("page_size", DEFAULT_PAGE_SIZE)))
+        offset = (self.page - 1) * self.page_size + self.page_size
+        if offset > ES_MAX_RESULT_WINDOW:
+            max_page = ES_MAX_RESULT_WINDOW // self.page_size
+            abort(
+                400,
+                f"Result window is too large: page {self.page} with page_size {self.page_size} "
+                f"exceeds the maximum of {ES_MAX_RESULT_WINDOW} results. "
+                f"Maximum page for this page_size is {max_page}.",
+            )
         self._query = params.pop("q", "")
         self.sort = params.pop("sort", None)
         self._filters = {}

--- a/udata/tests/apiv2/test_reuses.py
+++ b/udata/tests/apiv2/test_reuses.py
@@ -1,4 +1,5 @@
 from udata.core.reuse.factories import ReuseFactory
+from udata.search.query import ES_MAX_RESULT_WINDOW
 from udata.tests.api import APITestCase
 
 
@@ -9,3 +10,9 @@ class ReuseSearchAPIV2Test(APITestCase):
 
         response = self.get("/api/2/reuses/search/?model=malicious")
         self.assert200(response)
+
+    def test_search_returns_400_when_pagination_exceeds_es_max_result_window(self):
+        response = self.get("/api/2/reuses/search/?page=8925&page_size=20")
+        self.assert400(response)
+        max_page = ES_MAX_RESULT_WINDOW // 20
+        assert f"Maximum page for this page_size is {max_page}" in response.json["message"]


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/286646 and https://errors.data.gouv.fr/organizations/sentry/issues/28664

You can reproduce with https://www.data.gouv.fr/api/2/datasets/search/?organization=534fff91a3a7292c64a77f53&q=%C3%A9lections+pr%C3%A9sidentielles&page=1678&page_size=20&lang=fr