### PR TITLE
chore: add dependabot config for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      day: "monday"
+      time: "02:00"
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
For now, we only have security updates ([example](https://github.com/opendatateam/udata/pull/3736)) with renovate.

Adds a weekly dependabot update for deps.

I don't have strong opinion on the two tools, but if we should use one over the other, I'm all ears.