### PR TITLE
chore: use renovate best practices config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,10 @@
 {
   "extends": [
-    "config:base"
+    "config:best-practices"
   ],
   "baseBranches": ["main"],
   "enabledManagers": ["pep621"],
   "pep621": {
     "fileMatch": ["pyproject.toml"]
-  },
-  "automerge": true,
-  "prHourlyLimit": 5,
-  "masterIssueApproval": true
+  }
 }


### PR DESCRIPTION
See [`best-practices` documentation](https://docs.renovatebot.com/presets-config/#configbest-practices).
Among other things, it includes:
> [:maintainLockFilesWeekly](https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly): Run lock file maintenance (updates) early Monday mornings.

May replace https://github.com/opendatateam/udata/pull/3739, as it would prevent adding another tool configuration.

We may want to keep using renovate for now as it supports other platforms than Github, preventing vendor lock-in. But as said, I don't have strong opinion, we can switch if relevant.