### PR TITLE
fix(harvest): csw-* harvesters fail on some XML comments

### DIFF
--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -402,6 +402,9 @@ class BaseCswDcatBackend(DcatBackend, ABC):
                 return
 
             for result in search_results.children:
+                if result.node_kind_str != "element":
+                    # Saxonche returns all children, including comments and other non-element nodes
+                    continue
                 subgraph = Graph(namespace_manager=namespace_manager)
                 doc = self.as_dcat(result).to_string("utf-8")
                 subgraph.parse(data=doc, format=fmt)

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -1191,6 +1191,37 @@ class CswDcatBackendTest(PytestOnlyDBTestCase):
         assert job.status == "done"
         assert len(job.items) == 1
 
+    def test_ignore_xml_comments(self, rmock):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+          <csw:SearchStatus timestamp="2023-03-03T16:09:50.697645Z" />
+          <csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" elementSet="full" nextRecord="0">
+            <rdf:RDF xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="https://example.com/test/">
+                <dct:identifier>https://example.com/test/</dct:identifier>
+                <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+                <dct:title>test</dct:title>
+              </rdf:Description>
+            </rdf:RDF>
+            <!-- this should be ignored -->
+          </csw:SearchResults>
+        </csw:GetRecordsResponse>
+        """
+
+        rmock.head(rmock.ANY, headers={"Content-Type": "application/xml"})
+        rmock.post(rmock.ANY, text=xml)
+        source = HarvestSourceFactory(backend="csw-dcat")
+
+        actions.run(source)
+
+        source.reload()
+        job = source.get_last_job()
+
+        assert job.status == "done"
+        assert len(job.items) == 1
+
     @pytest.mark.parametrize(
         "remote_url_prefix",
         [


### PR DESCRIPTION
Fix https://github.com/opendatateam/udata/issues/3757

Locally tested with https://demo.data.gouv.fr/admin/harvesters/58b68fdcc751df10ea84f9cc/configuration => no more error.

Note: Most items are now ignored because of missing identifiers. This is a separate, known problem, to be fixed at the source catalog level.