### PR TITLE
fix(harvest): add missing click argument to delete command

### DIFF
--- a/udata/harvest/commands.py
+++ b/udata/harvest/commands.py
@@ -51,6 +51,7 @@ def validate(identifier):
 
 
 @grp.command()
+@click.argument("identifier")
 def delete(identifier):
     """Delete a harvest source"""
     log.info('Deleting source "%s"', identifier)


### PR DESCRIPTION
The `udata harvest delete` CLI command was unusable: it declared an `identifier` positional parameter but lacked the corresponding `@click.argument('identifier')` decorator. Running it raised:

    TypeError: delete() missing 1 required positional argument: 'identifier'

while passing an identifier produced:

    Error: Got unexpected extra argument (<slug>)

Add the missing decorator to match the pattern used by sibling commands (`launch`, `run`, `validate`).