### PR TITLE
fix: harvest previews bugs

### DIFF
--- a/udata/harvest/backends/base.py
+++ b/udata/harvest/backends/base.py
@@ -4,6 +4,7 @@ from datetime import UTC, date, datetime, timedelta
 from uuid import UUID
 
 import requests
+from bson import ObjectId
 from flask import current_app, g
 from voluptuous import MultipleInvalid, RequiredFieldInvalid
 
@@ -275,6 +276,12 @@ class BaseBackend(object):
 
             if self.dryrun:
                 dataset.validate()
+                # A preview never saves, so the dataset would keep no pk and could not
+                # be referenced by a dataservice harvested in the same run. Give it the
+                # client-side id that save() would have generated so cross-references
+                # between previewed objects stay valid and distinct.
+                if dataset.pk is None:
+                    dataset.id = ObjectId()
             else:
                 dataset.save()
             item.dataset = dataset

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -29,6 +29,16 @@ from .factories import HarvestJobFactory, HarvestSourceFactory, MockBackendsMixi
 log = logging.getLogger(__name__)
 
 
+def assert_preview_datasets_have_no_link(response):
+    """A preview lists datasets that are not persisted yet: it must not expose links
+    (page/API URL) pointing to resources that do not exist."""
+    datasets = [item["dataset"] for item in response.json["items"] if item["dataset"] is not None]
+    assert datasets
+    for dataset in datasets:
+        assert dataset["uri"] is None
+        assert dataset["page"] is None
+
+
 class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
     def test_list_backends(self):
         """It should fetch the harvest backends list from the API"""
@@ -483,6 +493,8 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         response = self.get(url)
         assert200(response)
 
+        assert_preview_datasets_have_no_link(response)
+
     @pytest.mark.options(HARVEST_ENABLE_MANUAL_RUN=True)
     def test_run_source(self, mocker: MockerFixture):
         launch = mocker.patch.object(actions.harvest, "delay")
@@ -557,6 +569,8 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         data = {"name": faker.word(), "url": faker.url(), "backend": "factory"}
         response = self.post(url_for("api.preview_harvest_source_config"), data)
         assert200(response)
+
+        assert_preview_datasets_have_no_link(response)
 
     def test_delete_source(self):
         user = self.login()

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -1016,6 +1016,42 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         # No datasets should have been created either
         assert Dataset.objects.count() == 0
 
+    def test_preview_dataservice_serving_datasets(self, rmock):
+        """Preview a dataservice serving datasets that are created during the same run.
+
+        In dryrun the harvested datasets are never saved. They used to keep no pk, which
+        (1) made `dataservice.validate()` raise `ValidationError (... ['datasets'])` on
+        the `datasets` LazyReferenceField, and (2) collapsed every served dataset into a
+        single reference (they all compared equal through `pk=None`). Datasets now get a
+        client-side id during the preview, so both issues are gone.
+        """
+        rmock.get("https://example.com/schemas", json=ResourceSchemaMockData.get_mock_data())
+
+        url = mock_dcat(rmock, "bnodes.xml")
+        org = OrganizationFactory()
+        source = HarvestSourceFactory(backend="dcat", url=url, organization=org)
+
+        job = actions.preview(source)
+
+        assert job.status == "done"
+
+        dataservice_items = [item for item in job.items if item.dataservice is not None]
+        assert len(dataservice_items) == 1
+        dataservice_item = dataservice_items[0]
+        assert dataservice_item.status == "done", dataservice_item.errors
+        assert dataservice_item.dataservice.title == "Explore API v2"
+
+        # The dataservice serves dataset-2 and dataset-3: both stay attached as two
+        # distinct references (the dedup no longer collapses them through pk=None).
+        attached = dataservice_item.dataservice.datasets
+        assert len(attached) == 2
+        assert all(dataset.pk is not None for dataset in attached)
+        assert attached[0].pk != attached[1].pk
+
+        # A preview must not persist anything
+        assert Dataset.objects.count() == 0
+        assert Dataservice.objects.count() == 0
+
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
 class CswDcatBackendTest(PytestOnlyDBTestCase):


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/292144 by creating a local `ObjectId` in preview