### PR TITLE
feat: improve cors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Current (in progress)
-
-- fix(security): only allow credentialed CORS requests from trusted origins and set the session cookie to `SameSite=Lax`
-
 ## 16.5.0 (2026-05-18)
 
 - chore(deps): update dependency faker to >=40.18, <40.19 ([#3769](https://github.com/opendatateam/udata/pull/3769))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Current (in progress)
+
+- fix(security): only allow credentialed CORS requests from trusted origins and set the session cookie to `SameSite=Lax`
+
 ## 16.5.0 (2026-05-18)
 
 - chore(deps): update dependency faker to >=40.18, <40.19 ([#3769](https://github.com/opendatateam/udata/pull/3769))

--- a/udata/cors.py
+++ b/udata/cors.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlsplit
 
 from flask import current_app, request
 from werkzeug.datastructures import Headers
@@ -13,13 +14,47 @@ def add_vary(headers: Headers, header: str):
     headers.set("Vary", ", ".join(values))
 
 
+def get_allowed_origins() -> set[str]:
+    """Origins allowed to make *credentialed* cross-origin requests.
+
+    The trusted front-end (cdata) is derived from `CDATA_BASE_URL` so it works
+    out of the box, and operators can declare extra origins via
+    `CORS_ALLOWED_ORIGINS`.
+    """
+    origins = set(current_app.config.get("CORS_ALLOWED_ORIGINS") or [])
+
+    cdata_base_url = current_app.config.get("CDATA_BASE_URL")
+    if cdata_base_url:
+        parts = urlsplit(cdata_base_url)
+        if parts.scheme and parts.netloc:
+            origins.add(f"{parts.scheme}://{parts.netloc}")
+
+    return origins
+
+
+def set_allow_origin_headers(headers: Headers, origin: str) -> None:
+    if origin in get_allowed_origins():
+        # Trusted front-end: allow credentialed requests so the session cookie
+        # can be sent and read cross-origin.
+        headers.set("Access-Control-Allow-Origin", origin)
+        headers.set("Access-Control-Allow-Credentials", "true")
+    else:
+        # Any other origin only gets anonymous access. Reflecting an arbitrary
+        # origin together with `Allow-Credentials: true` is what would, in
+        # theory, let a malicious site read a logged-in user's private data or
+        # act on their behalf. In practice the session cookie is `SameSite=Lax`,
+        # so browsers don't send it on cross-site requests anyway; this stricter
+        # CORS policy is defense in depth so the protection doesn't rely on that
+        # single browser-enforced mechanism.
+        headers.set("Access-Control-Allow-Origin", "*")
+
+
 def add_actual_request_headers(headers: Headers) -> Headers:
     origin = request.headers.get("Origin", None)
     add_vary(headers, "Origin")
 
     if origin:
-        headers.set("Access-Control-Allow-Origin", origin)
-        headers.set("Access-Control-Allow-Credentials", "true")
+        set_allow_origin_headers(headers, origin)
 
     return headers
 
@@ -67,8 +102,7 @@ def add_preflight_request_headers(headers: Headers) -> Headers:
     add_vary(headers, "Origin")
 
     if origin:
-        headers.set("Access-Control-Allow-Origin", origin)
-        headers.set("Access-Control-Allow-Credentials", "true")
+        set_allow_origin_headers(headers, origin)
 
         # The API allows all methods, so just copy the browser requested methods from the request headers.
         headers.set(

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -75,7 +75,18 @@ class Defaults(object):
     # Flask security settings
 
     SESSION_COOKIE_SECURE = True
-    SESSION_COOKIE_SAMESITE = None  # Can be set to 'Lax' or 'Strict'. See https://flask.palletsprojects.com/en/2.3.x/security/#security-cookie
+    # 'Lax' prevents the session cookie from being sent on cross-site subrequests
+    # (the CSRF/CORS exfiltration vector), while still flowing on same-site
+    # requests from the front-end (cdata shares udata's registrable domain) and
+    # on top-level navigations. Can be tightened to 'Strict' or, if the front-end
+    # lives on a different registrable domain, set to 'None' (requires Secure).
+    # See https://flask.palletsprojects.com/en/2.3.x/security/#security-cookie
+    SESSION_COOKIE_SAMESITE = "Lax"
+
+    # Origins allowed to make *credentialed* cross-origin requests to the API.
+    # Other origins still get anonymous (`Access-Control-Allow-Origin: *`) access.
+    # The `CDATA_BASE_URL` origin is always allowed (see `udata.cors`).
+    CORS_ALLOWED_ORIGINS = []
     SECURITY_USE_REGISTER_V2 = True
 
     # Flask-Security-Too settings

--- a/udata/tests/api/test_base_api.py
+++ b/udata/tests/api/test_base_api.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import url_for
 
 from udata.api import API, api
@@ -25,6 +26,7 @@ class FakeFormAPI(API):
 
 
 class OptionsCORSTest(APITestCase):
+    @pytest.mark.options(CORS_ALLOWED_ORIGINS=["http://localhost"])
     def test_should_allow_options_and_cors(self):
         """Should allow OPTIONS operation and give cors parameters"""
         response = self.options(

--- a/udata/tests/test_cors.py
+++ b/udata/tests/test_cors.py
@@ -1,10 +1,14 @@
 from datetime import datetime
 
+import pytest
 from flask import url_for
 
 from udata.core.dataset.factories import DatasetFactory, ResourceFactory
 from udata.tests.api import APITestCase
 from udata.tests.helpers import assert_status
+
+TRUSTED_ORIGIN = "https://www.data.gouv.fr"
+UNTRUSTED_ORIGIN = "https://evil.example.com"
 
 
 class CorsTest(APITestCase):
@@ -83,3 +87,51 @@ class CorsTest(APITestCase):
             },
         )
         assert_status(response, 204)
+
+    @pytest.mark.options(CDATA_BASE_URL=TRUSTED_ORIGIN + "/", CORS_ALLOWED_ORIGINS=[])
+    def test_cors_credentials_only_for_trusted_origin(self):
+        """An untrusted origin must never get credentials, only anonymous `*`.
+
+        Reflecting an arbitrary origin together with `Allow-Credentials: true`
+        would let any website read a logged-in user's private data using their
+        session cookie.
+        """
+        dataset = DatasetFactory()
+        url = url_for("api.dataset", dataset=dataset.id)
+
+        # Trusted front-end (derived from CDATA_BASE_URL): credentialed access.
+        response = self.get(url, headers={"Origin": TRUSTED_ORIGIN})
+        assert_status(response, 200)
+        assert response.headers["Access-Control-Allow-Origin"] == TRUSTED_ORIGIN
+        assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+        # Any other origin: anonymous access only, never credentials.
+        response = self.get(url, headers={"Origin": UNTRUSTED_ORIGIN})
+        assert_status(response, 200)
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+        assert "Access-Control-Allow-Credentials" not in response.headers
+
+    @pytest.mark.options(CDATA_BASE_URL=None, CORS_ALLOWED_ORIGINS=[TRUSTED_ORIGIN])
+    def test_cors_credentials_for_explicit_allowed_origin(self):
+        dataset = DatasetFactory()
+        url = url_for("api.dataset", dataset=dataset.id)
+
+        response = self.get(url, headers={"Origin": TRUSTED_ORIGIN})
+        assert response.headers["Access-Control-Allow-Origin"] == TRUSTED_ORIGIN
+        assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+    @pytest.mark.options(CDATA_BASE_URL=TRUSTED_ORIGIN + "/", CORS_ALLOWED_ORIGINS=[])
+    def test_cors_preflight_credentials_only_for_trusted_origin(self):
+        dataset = DatasetFactory()
+        url = url_for("api.dataset", dataset=dataset.id)
+        preflight_headers = {"Access-Control-Request-Method": "POST"}
+
+        response = self.options(url, headers={"Origin": TRUSTED_ORIGIN, **preflight_headers})
+        assert_status(response, 204)
+        assert response.headers["Access-Control-Allow-Origin"] == TRUSTED_ORIGIN
+        assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+        response = self.options(url, headers={"Origin": UNTRUSTED_ORIGIN, **preflight_headers})
+        assert_status(response, 204)
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+        assert "Access-Control-Allow-Credentials" not in response.headers


### PR DESCRIPTION
## Harden CORS and session cookie configuration

Fix https://github.com/datagouv/data.gouv.fr/issues/2017

### Context

The CORS layer reflected **any** request `Origin` back in `Access-Control-Allow-Origin` while also sending `Access-Control-Allow-Credentials: true`. Combined with the API accepting the Flask-Login session cookie (not just Bearer tokens), this is a configuration we'd rather not rely on.

In practice this was **not exploitable**: the session cookie behaves as `SameSite=Lax` in current browsers, so it's never sent on cross-site subrequests — Chrome and Firefox both block the credentialed cross-origin request before it reaches the API. The change below is **defense in depth**, so the protection no longer depends solely on browser cookie behaviour.

### Changes

- **`cors.py`**: credentials are now only granted to **trusted origins**. The trusted set is derived from `CDATA_BASE_URL` (so the existing front-end keeps working out of the box) plus an optional `CORS_ALLOWED_ORIGINS` list. Any other origin still gets anonymous cross-origin access via `Access-Control-Allow-Origin: *` (the public API stays readable by third parties) but never receives `Allow-Credentials`. The origin/credentials logic, previously duplicated between the actual-request and preflight handlers, is now factored into `set_allow_origin_headers()`.
- **`settings.py`**: `SESSION_COOKIE_SAMESITE` set to `"Lax"` (was `None`, i.e. no attribute emitted — relying on the browser default). This is safe for data.gouv since cdata shares udata's registrable domain (same-site requests still carry the cookie); a comment documents how to relax it to `None` if a deployment puts the front-end on a different registrable domain. Added `CORS_ALLOWED_ORIGINS = []`.

### Tests

Added 3 cases in `test_cors.py`: an untrusted origin never receives credentials (only `*`), a trusted origin does (both via `CDATA_BASE_URL` and via `CORS_ALLOWED_ORIGINS`), and the same on preflight requests. Existing CORS tests still pass (7 passed).

### Not in scope

Requiring an explicit Bearer token instead of the session cookie for write operations would be a stronger model but is an architectural change that would break cdata's cookie-based auth — left for a separate discussion.