### PR TITLE
fix(harvest): normalize tag values in TagListField to match harvester input

### DIFF
--- a/udata/mongo/taglist_field.py
+++ b/udata/mongo/taglist_field.py
@@ -1,5 +1,4 @@
 from mongoengine.fields import ListField, StringField
-from slugify import slugify
 
 from udata import tags
 from udata.i18n import lazy_gettext as _
@@ -20,7 +19,7 @@ class TagListField(ListField):
             return []
 
     def clean(self, value):
-        return sorted(list(set([slugify(v, to_lower=True) for v in value])))
+        return sorted({n for n in (tags.normalize(v) for v in value) if n})
 
     def to_python(self, value):
         return super(TagListField, self).to_python(self.clean(value))
@@ -29,6 +28,8 @@ class TagListField(ListField):
         return super(TagListField, self).to_mongo(self.clean(value))
 
     def validate(self, values):
+        if values is not None:
+            values[:] = self.clean(values)
         super(TagListField, self).validate(values)
 
         for tag in values:

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -809,6 +809,28 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
         assert isinstance(dataset, Dataset)
         assert "literal-tag" in dataset.tags
 
+    @pytest.mark.options(TAG_MIN_LENGTH=3, TAG_MAX_LENGTH=10)
+    def test_dirty_keyword_does_not_abort_validation(self, app):
+        """Regression test: a dirty dcat:keyword (punctuation-only, too short or
+        too long) must be normalized away instead of aborting the whole document.
+
+        Harvesters set keywords by attribute (`dataset.tags = themes_from_rdf(d)`),
+        which bypasses TagListField.clean(). Before the fix, a single bad keyword
+        raised at the Mongo-level validator, losing the dataset and its resources.
+        """
+        node = BNode()
+        g = Graph()
+
+        g.add((node, RDF.type, DCAT.Dataset))
+        g.add((node, DCT.title, Literal(faker.sentence())))
+        for keyword in ["valid-tag", "&", "df", "waytoolongkeyword"]:
+            g.add((node, DCAT.keyword, Literal(keyword)))
+
+        dataset = dataset_from_rdf(g)
+        dataset.validate()  # Must not raise.
+
+        assert set(dataset.tags) == {"valid-tag", "waytoolong"}
+
     def test_parse_null_frequency(self):
         assert frequency_from_rdf(None) is None
 

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -61,6 +61,7 @@ from udata.rdf import (
     primary_topic_identifier_from_rdf,
     remote_url_from_rdf,
 )
+from udata.tags import slug as slugify_tag
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
 from udata.tests.helpers import assert200, assert_redirects
 from udata.utils import faker
@@ -498,7 +499,7 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
         assert dataset.acronym == acronym
         assert dataset.description == description
         assert dataset.frequency == UpdateFrequency.DAILY
-        assert set(dataset.tags) == set(tags)
+        assert set(dataset.tags) == {slugify_tag(t) for t in tags}
         assert isinstance(dataset.temporal_coverage, DateRange)
         assert dataset.temporal_coverage.start == start
         assert dataset.temporal_coverage.end == end
@@ -790,7 +791,7 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
         dataset.validate()
 
         assert isinstance(dataset, Dataset)
-        assert set(dataset.tags) == set(tags + themes)
+        assert set(dataset.tags) == {slugify_tag(t) for t in tags + themes}
 
     def test_keyword_as_uriref(self):
         """Regression test: keywords can be URIRef instead of Literal in some DCAT feeds."""

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -9,6 +9,7 @@ from udata.core.dataset.factories import DatasetFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.tags.models import Tag
 from udata.core.tags.tasks import count_tags
+from udata.mongo.taglist_field import TagListField
 from udata.tags import normalize, slug, tags_list
 from udata.tests import PytestOnlyTestCase
 from udata.tests.helpers import assert200
@@ -105,3 +106,24 @@ class TagsUtilsTest(PytestOnlyTestCase):
         assert normalize("aaa") == "aaa"
         assert normalize("aaaaaaaaaaa") == "aaaaaaaaaa"
         assert normalize("aAa a") == "aaa-a"
+
+
+class TagListFieldCleanTest(PytestOnlyTestCase):
+    def test_clean_drops_values_normalizing_to_empty(self):
+        assert TagListField().clean(["valid", "", "   ", "--", "&", "df", "a"]) == ["valid"]
+
+    @pytest.mark.options(TAG_MIN_LENGTH=3, TAG_MAX_LENGTH=10)
+    def test_clean_truncates_too_long_tags(self, app):
+        assert TagListField().clean(["aaaaaaaaaaaaaaa"]) == ["aaaaaaaaaa"]
+
+    def test_clean_preserves_valid_tags(self):
+        assert TagListField().clean(["Open Data", "Élégant", "open-data"]) == [
+            "elegant",
+            "open-data",
+        ]
+
+    def test_validate_drops_invalid_tags_from_harvester_input(self):
+        dataset = DatasetFactory.build(tags=["valid"])
+        dataset.tags = ["valid", "", "   ", "--", "df", "Open Data"]
+        dataset.validate()
+        assert dataset.tags == ["open-data", "valid"]


### PR DESCRIPTION
## What

  A single dcat:keyword that's empty, punctuation-only, too short, or too long
  crashes the whole document save during harvest:

  ValidationError (Dataset:None) (Tag "df" must be between 3 and 96 characters
  long.: ['tags'])

  The harvest aborts the record, losing the dataset and all its resources because of
   one bad tag.

  ## Why this happens

  The 3–96 char tag rule is enforced at three layers, with three different
  behaviors:

  | Layer | Behavior on bad tag |
  |---|---|
  | WTForms UI (`TagField.pre_validate`) | Per-field error shown to the user |
  | CKAN harvester intake (`normalize_tag` in the schema) | **Silently normalized**
  — slug + drop short + truncate long |
  | MongoDB field `validate()` (defensive backstop) | Raises — aborts the whole
  document save |

  CKAN harvests pre-normalize their tags, so the backstop never fires in practice.
  **DCAT (and other harvesters) never had an equivalent intake-normalization step**,
   so dirty keywords reach the backstop and crash the record.

  Separately, `TagListField.clean` does run on the deserialization path (`to_python`
   / `to_mongo`), but **attribute assignment** (which is exactly what every
  harvester does: `dataset.tags = themes_from_rdf(d)`) bypasses it. So validate sees
   the raw, un-normalized list.

  ## What the fix does

  - `TagListField.clean` now applies `udata.tags.normalize` (slug + drop short +
  truncate long) instead of a bare `slugify`, matching what the CKAN intake schema
  already does.
  - `TagListField.validate` calls `clean()` first, so the validate path is
  consistent with the persistence path regardless of how the value was set.

  Net effect: every harvester (DCAT, MAAF, CKAN, future ones) and every assignment
  path silently normalizes tags the same way. The Mongo-level error becomes a true
  backstop that shouldn't fire in normal use — which is what it always seemed to
  have been intended as.