### PR TITLE
fix(dataservices): parse swagger and scope to bouquet fiche for search

### DIFF
--- a/udata/core/dataservices/search.py
+++ b/udata/core/dataservices/search.py
@@ -24,8 +24,9 @@ from udata.utils import raise_if_redirect, to_iso_datetime
 from udata_search_service.consumers import DataserviceConsumer
 from udata_search_service.services import DataserviceService
 
-# Maximum size in bytes for fetched documentation content (100 KB should be enough for a swagger)
-MAX_DOCUMENTATION_SIZE = 100 * 1024
+# Maximum size in bytes for fetched documentation content. Sized for large
+# swaggers like API Entreprise (~2.2 MB).
+MAX_DOCUMENTATION_SIZE = 3 * 1024 * 1024
 
 __all__ = ("DataserviceSearch",)
 


### PR DESCRIPTION
OpenAPI documents (up to 1.5 MB for API Entreprise) were truncated at 100 KB before reaching ES, hiding terms like "transfert de siège" that live deep in the spec. Worse, all ~30 fiches sharing a bouquet swagger got the same indexed text, so a hit on any term matched every fiche.

~~Parse the OpenAPI spec server-side, walk operations × schemas with $ref resolution, and for bouquet fiches keep only paths whose operation summary matches the fiche title (ported from cdata's openapi-bouquet.ts). Cap raised to 3 MB; fall back to raw text if parse fails.~~

fix https://github.com/datagouv/data.gouv.fr/issues/1905

Edit: weird CI bug, fixing