### PR TITLE
diag: probe stdin tty state at task module import

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from datetime import datetime
 from os.path import join
 from sys import exit
@@ -9,6 +11,25 @@ from invoke import task
 from .helpers import ROOT, header, info, success
 
 I18N_DOMAIN = "udata"
+
+
+# Diagnostic probe: see PR #3783 — investigating an invoke v3 TTY crash
+# that hit one PR 100% but not others. Fires once at module import,
+# captures fd 0 properties so we can compare runs.
+try:
+    _pgrp = f"tcgetpgrp(0)={os.tcgetpgrp(0)}"
+except OSError as _e:
+    _pgrp = f"tcgetpgrp(0) FAILS: {_e}"
+try:
+    _mode = f"mode=0o{os.fstat(0).st_mode:o}"
+except OSError as _e:
+    _mode = f"fstat: {_e}"
+print(
+    f"[stdin-diag] sys.stdin.isatty()={sys.stdin.isatty()} "
+    f"os.isatty(0)={os.isatty(0)} getpgrp()={os.getpgrp()} {_pgrp} fd0 {_mode}",
+    file=sys.stderr,
+    flush=True,
+)
 
 
 @task


### PR DESCRIPTION
## Why

Investigating a CI-only crash on PR #3783: invoke v3's `handle_stdin` thread calls `tcgetpgrp(stdin)` which returns ENOTTY on CircleCI when stdin reports as a TTY but isn't a session controller. That PR hits the crash 100% of the time; every other branch passes 100%. This branch off main carries **only** a one-shot stderr probe printing `fd 0` properties so we can compare against the failing PR's run.

## What we already saw on PR #3783

```
[stdin-diag] sys.stdin.isatty()=True os.isatty(0)=True getpgrp()=99 tcgetpgrp(0) FAILS: [Errno 25] Inappropriate ioctl for device fd0 mode=0o20620
```

If this PR shows different values (e.g. `isatty=False`), it confirms runner-allocation asymmetry — same CircleCI config, different stdin allocation per build.
If it shows the same `isatty=True`, then either (a) the crash is timing/race-sensitive and most PRs get lucky, or (b) something in PR #3783's code path actually does trigger the bug deterministically.

## Plan

- Wait for CircleCI to finish (or crash early).
- Read the diagnostic from the build log.
- Throw this branch away.

**Do not merge.**