### PR TITLE
fix: tchap problems on spam

### DIFF
--- a/udata/core/spam/tests/test_spam.py
+++ b/udata/core/spam/tests/test_spam.py
@@ -13,6 +13,7 @@ from udata.core.reports.constants import REASON_AUTO_SPAM
 from udata.core.reports.models import Report
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import UserFactory
+from udata.notifications.tchap import send_message
 from udata.tests.api import APITestCase
 
 
@@ -274,7 +275,8 @@ class SpamTest(APITestCase):
 
     @pytest.mark.options(
         SPAM_WORDS=["spam"],
-        TCHAP_ROOM_URL="https://matrix.example.org/_matrix/send",
+        TCHAP_HOMESERVER="https://matrix.example.org",
+        TCHAP_ROOM_ID="!room:example.org",
         TCHAP_BOT_TOKEN="token",
     )
     def test_tchap_notification_is_queued_not_sent_during_request(self):
@@ -292,6 +294,33 @@ class SpamTest(APITestCase):
         delay.assert_called_once()
         (message,), _ = delay.call_args
         self.assertTrue(message.startswith("⚠️ @all "))
+
+    @pytest.mark.options(
+        TCHAP_HOMESERVER="https://matrix.example.org",
+        TCHAP_ROOM_ID="!room:example.org",
+        TCHAP_BOT_TOKEN="token",
+    )
+    def test_tchap_send_message_builds_matrix_url(self):
+        with patch("udata.notifications.tchap.requests.put") as put:
+            send_message.run("hello")
+
+        put.assert_called_once()
+        url, _ = put.call_args
+        # Room id is URL-encoded and the path ends with a transaction id.
+        self.assertRegex(
+            url[0],
+            r"^https://matrix\.example\.org/_matrix/client/v3/rooms/"
+            r"%21room%3Aexample\.org/send/m\.room\.message/[0-9a-f]+$",
+        )
+        self.assertEqual(put.call_args.kwargs["json"]["body"], "hello")
+        self.assertEqual(put.call_args.kwargs["headers"]["authorization"], "Bearer token")
+
+    @pytest.mark.options(TCHAP_HOMESERVER=None, TCHAP_ROOM_ID="!room:example.org")
+    def test_tchap_send_message_noop_without_config(self):
+        with patch("udata.notifications.tchap.requests.put") as put:
+            send_message.run("hello")
+
+        put.assert_not_called()
 
     @pytest.mark.options(SPAM_WORDS=["spam"])
     def test_certified_org_reuse_not_flagged(self):

--- a/udata/core/spam/tests/test_spam.py
+++ b/udata/core/spam/tests/test_spam.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -270,6 +271,27 @@ class SpamTest(APITestCase):
         org = OrganizationFactory()
         dataset = DatasetFactory(title="This is spam content", organization=org)
         self.assertTrue(self.has_spam_report(dataset))
+
+    @pytest.mark.options(
+        SPAM_WORDS=["spam"],
+        TCHAP_ROOM_URL="https://matrix.example.org/_matrix/send",
+        TCHAP_BOT_TOKEN="token",
+    )
+    def test_tchap_notification_is_queued_not_sent_during_request(self):
+        """The Tchap notification must be queued, never sent inside the request.
+
+        Sending it synchronously (the prod incident) made a misconfigured URL
+        crash the dataset save with a 400. It must run in a worker instead.
+        """
+        with patch("udata.notifications.tchap.send_message.delay") as delay:
+            dataset = DatasetFactory(title="This is spam content")
+
+        # The user action completed and the spam report was created...
+        self.assertTrue(self.has_spam_report(dataset))
+        # ...while the actual Tchap send was only enqueued, not executed here.
+        delay.assert_called_once()
+        (message,), _ = delay.call_args
+        self.assertTrue(message.startswith("⚠️ @all "))
 
     @pytest.mark.options(SPAM_WORDS=["spam"])
     def test_certified_org_reuse_not_flagged(self):

--- a/udata/core/spam/tests/test_spam.py
+++ b/udata/core/spam/tests/test_spam.py
@@ -301,26 +301,26 @@ class SpamTest(APITestCase):
         TCHAP_BOT_TOKEN="token",
     )
     def test_tchap_send_message_builds_matrix_url(self):
-        with patch("udata.notifications.tchap.requests.put") as put:
+        with patch("udata.notifications.tchap.requests.post") as post:
             send_message.run("hello")
 
-        put.assert_called_once()
-        url, _ = put.call_args
-        # Room id is URL-encoded and the path ends with a transaction id.
-        self.assertRegex(
+        post.assert_called_once()
+        url, _ = post.call_args
+        # Room id is URL-encoded in the path.
+        self.assertEqual(
             url[0],
-            r"^https://matrix\.example\.org/_matrix/client/v3/rooms/"
-            r"%21room%3Aexample\.org/send/m\.room\.message/[0-9a-f]+$",
+            "https://matrix.example.org/_matrix/client/v3/rooms/"
+            "%21room%3Aexample.org/send/m.room.message",
         )
-        self.assertEqual(put.call_args.kwargs["json"]["body"], "hello")
-        self.assertEqual(put.call_args.kwargs["headers"]["authorization"], "Bearer token")
+        self.assertEqual(post.call_args.kwargs["json"]["body"], "hello")
+        self.assertEqual(post.call_args.kwargs["headers"]["authorization"], "Bearer token")
 
     @pytest.mark.options(TCHAP_HOMESERVER=None, TCHAP_ROOM_ID="!room:example.org")
     def test_tchap_send_message_noop_without_config(self):
-        with patch("udata.notifications.tchap.requests.put") as put:
+        with patch("udata.notifications.tchap.requests.post") as post:
             send_message.run("hello")
 
-        put.assert_not_called()
+        post.assert_not_called()
 
     @pytest.mark.options(SPAM_WORDS=["spam"])
     def test_certified_org_reuse_not_flagged(self):

--- a/udata/notifications/tchap.py
+++ b/udata/notifications/tchap.py
@@ -1,3 +1,6 @@
+import uuid
+from urllib.parse import quote
+
 import requests
 from flask import current_app
 from markdown import markdown
@@ -34,12 +37,21 @@ def send_message(text: str):
     Args:
         text (str): Text to send to the room
     """
-    url = current_app.config.get("TCHAP_ROOM_URL")
+    homeserver = current_app.config.get("TCHAP_HOMESERVER")
+    room_id = current_app.config.get("TCHAP_ROOM_ID")
     token = current_app.config.get("TCHAP_BOT_TOKEN")
-    if not (url and token):
+    if not (homeserver and room_id and token):
         return
 
-    r = requests.post(
+    # Matrix idempotent send: PUT on .../send/{eventType}/{txnId}. The room id
+    # is URL-encoded as it contains reserved chars (e.g. `!` and `:`).
+    txn = uuid.uuid4().hex
+    url = (
+        f"{homeserver.rstrip('/')}/_matrix/client/v3/rooms/"
+        f"{quote(room_id, safe='')}/send/m.room.message/{txn}"
+    )
+
+    r = requests.put(
         url,
         headers={
             "content-type": "application/json",

--- a/udata/notifications/tchap.py
+++ b/udata/notifications/tchap.py
@@ -3,6 +3,7 @@ from flask import current_app
 from markdown import markdown
 
 from udata.core.spam.signals import on_new_potential_spam
+from udata.tasks import task
 
 
 @on_new_potential_spam.connect
@@ -19,11 +20,16 @@ def notify_potential_spam(sender, **kwargs):
     if text:
         message += f"\n\n> {text}"
 
-    send_message(message)
+    # The notification hits an external service (Tchap) and is only a side-effect
+    # of the spam detection. Send it from a worker so a slow, unreachable or
+    # misconfigured Tchap never delays nor breaks the user request that triggered
+    # the detection (e.g. publishing a dataset).
+    send_message.delay(message)
 
 
+@task(route="low.tchap")
 def send_message(text: str):
-    """Send a message to the Tchap moderation room
+    """Send a message to the Tchap moderation room.
 
     Args:
         text (str): Text to send to the room
@@ -41,7 +47,7 @@ def send_message(text: str):
         },
         json={
             "msgtype": "m.text",
-            "body": "_",
+            "body": text,
             "format": "org.matrix.custom.html",
             "formatted_body": markdown(text),
             "m.mentions": {"room": True},

--- a/udata/notifications/tchap.py
+++ b/udata/notifications/tchap.py
@@ -1,4 +1,3 @@
-import uuid
 from urllib.parse import quote
 
 import requests
@@ -43,15 +42,13 @@ def send_message(text: str):
     if not (homeserver and room_id and token):
         return
 
-    # Matrix idempotent send: PUT on .../send/{eventType}/{txnId}. The room id
-    # is URL-encoded as it contains reserved chars (e.g. `!` and `:`).
-    txn = uuid.uuid4().hex
+    # The room id is URL-encoded as it contains reserved chars (e.g. `!` and `:`).
     url = (
         f"{homeserver.rstrip('/')}/_matrix/client/v3/rooms/"
-        f"{quote(room_id, safe='')}/send/m.room.message/{txn}"
+        f"{quote(room_id, safe='')}/send/m.room.message"
     )
 
-    r = requests.put(
+    r = requests.post(
         url,
         headers={
             "content-type": "application/json",

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -649,7 +649,8 @@ class Defaults(object):
 
     # Notification settings
     ###########################################################################
-    TCHAP_ROOM_URL = None
+    TCHAP_HOMESERVER = None
+    TCHAP_ROOM_ID = None
     TCHAP_BOT_TOKEN = None
 
     # Tabular API Dataservice ID

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -174,6 +174,7 @@ def init_app(app):
     import udata.core.badges.tasks  # noqa
     import udata.core.storages.tasks  # noqa
     import udata.features.notifications.tasks  # noqa
+    import udata.notifications.tchap  # noqa
     import udata.harvest.tasks  # noqa
     import udata.db.tasks  # noqa
 


### PR DESCRIPTION
- [x] add missing `body` text (I have witness "_" in Android notifications a few times)
- [x] delay posting to tchap in queue (we do not need this to by sync, it slows down the dataset creation and a problem with Matrix crash the HTTP POST)
- [x] `TCHAP_ROOM_URL` is replaced by `TCHAP_ROOM_ID` and we need to provide the `TCHAP_HOMESERVER` to construct the full URL