### PR TITLE
fix(tags): move validation in harvest logic to fix tags unpickling

### DIFF
--- a/udata/harvest/backends/maaf.py
+++ b/udata/harvest/backends/maaf.py
@@ -15,6 +15,7 @@ from udata.harvest.filters import (
     force_list,
     is_url,
     normalize_string,
+    normalize_tag,
     taglist,
     to_date,
 )
@@ -167,7 +168,7 @@ class MaafBackend(BaseBackend):
         dataset.frequency = FREQUENCIES.get(metadata["frequency"], UpdateFrequency.UNKNOWN)
         dataset.description = metadata["notes"]
         dataset.private = metadata["private"]
-        dataset.tags = sorted(set(metadata["tags"]))
+        dataset.tags = sorted({normalize_tag(t) for t in metadata["tags"] if normalize_tag(t)})
 
         if metadata.get("license_id"):
             dataset.license = License.objects.get(id=metadata["license_id"])

--- a/udata/harvest/tests/ckan/test_ckan_backend.py
+++ b/udata/harvest/tests/ckan/test_ckan_backend.py
@@ -285,6 +285,23 @@ def spatial_uri(resource_data):
 
 
 @pytest.fixture
+def invalid_tags(resource_data):
+    data = {
+        "name": faker.unique_string(),
+        "title": faker.sentence(),
+        "notes": faker.paragraph(),
+        "tags": [
+            {"name": "a", "id": faker.unique_string()},  # too short
+            {"name": "duplicate", "id": faker.unique_string()},
+            {"name": "DuPliCate", "id": faker.unique_string()},
+            {"name": "WAY TOO LONG KEYWORD THAT WILL BE CROPPED", "id": faker.unique_string()},
+        ],
+        "resources": [resource_data],
+    }
+    return data, {"resource_url": resource_data["url"]}
+
+
+@pytest.fixture
 def skipped_no_resources():
     return {
         "name": faker.unique_string(),
@@ -531,6 +548,12 @@ class CkanBackendTest(PytestOnlyDBTestCase):
         dataset = dataset_for(result)
         assert dataset.extras["ckan:spatial-uri"] == kwargs["spatial"]
         assert dataset.spatial is None
+
+    @pytest.mark.options(TAG_MIN_LENGTH=3, TAG_MAX_LENGTH=10)
+    @pytest.mark.ckan_data("invalid_tags")
+    def test_normalize_and_filter_invalid_tags(self, result, kwargs):
+        dataset = dataset_for(result)
+        assert set(dataset.tags) == {"duplicate", "way-too-lo"}
 
 
 ##############################################################################

--- a/udata/mongo/taglist_field.py
+++ b/udata/mongo/taglist_field.py
@@ -20,7 +20,7 @@ class TagListField(ListField):
             return []
 
     def clean(self, value):
-        return sorted(list(set([slugify_tag(v) for v in value])))
+        return sorted({slugify_tag(v) for v in value})
 
     def to_python(self, value):
         return super(TagListField, self).to_python(self.clean(value))

--- a/udata/mongo/taglist_field.py
+++ b/udata/mongo/taglist_field.py
@@ -1,8 +1,8 @@
 from mongoengine.fields import ListField, StringField
-from slugify import slugify
 
 from udata import tags
 from udata.i18n import lazy_gettext as _
+from udata.tags import slug as slugify_tag
 
 
 class TagListField(ListField):
@@ -20,7 +20,7 @@ class TagListField(ListField):
             return []
 
     def clean(self, value):
-        return sorted(list(set([slugify(v, to_lower=True) for v in value])))
+        return sorted(list(set([slugify_tag(v) for v in value])))
 
     def to_python(self, value):
         return super(TagListField, self).to_python(self.clean(value))

--- a/udata/mongo/taglist_field.py
+++ b/udata/mongo/taglist_field.py
@@ -1,4 +1,5 @@
 from mongoengine.fields import ListField, StringField
+from slugify import slugify
 
 from udata import tags
 from udata.i18n import lazy_gettext as _
@@ -19,7 +20,7 @@ class TagListField(ListField):
             return []
 
     def clean(self, value):
-        return sorted({n for n in (tags.normalize(v) for v in value) if n})
+        return sorted(list(set([slugify(v, to_lower=True) for v in value])))
 
     def to_python(self, value):
         return super(TagListField, self).to_python(self.clean(value))
@@ -28,8 +29,6 @@ class TagListField(ListField):
         return super(TagListField, self).to_mongo(self.clean(value))
 
     def validate(self, values):
-        if values is not None:
-            values[:] = self.clean(values)
         super(TagListField, self).validate(values)
 
         for tag in values:

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -370,8 +370,7 @@ def themes_from_rdf(rdf):
             continue
         tags.append(tag.toPython())
     tags += theme_labels_from_rdf(rdf)
-    normalized_tags = [normalize_tag(tag) for tag in tags if normalize_tag(tag)]
-    return list(set(normalized_tags))
+    return sorted({normalize_tag(tag) for tag in tags if normalize_tag(tag)})
 
 
 def contact_point_name(agent_name: str | None, org_name: str | None) -> str:

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -29,6 +29,7 @@ from rdflib.util import guess_format as raw_guess_format
 from udata import uris
 from udata.core.contact_point.models import ContactPoint
 from udata.frontend.markdown import parse_html
+from udata.harvest.filters import normalize_tag
 from udata.models import Schema
 from udata.mongo.errors import FieldValidationError
 from udata.tags import slug as slugify_tag
@@ -369,7 +370,8 @@ def themes_from_rdf(rdf):
             continue
         tags.append(tag.toPython())
     tags += theme_labels_from_rdf(rdf)
-    return list(set(tags))
+    normalized_tags = [normalize_tag(tag) for tag in tags if normalize_tag(tag)]
+    return list(set(normalized_tags))
 
 
 def contact_point_name(agent_name: str | None, org_name: str | None) -> str:

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -64,8 +64,8 @@ from udata.rdf import (
     default_lang_value,
     primary_topic_identifier_from_rdf,
     remote_url_from_rdf,
+    slugify_tag,
 )
-from udata.tags import slug as slugify_tag
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
 from udata.tests.helpers import assert200, assert_redirects
 from udata.utils import faker

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 from io import StringIO
 
 import pytest
@@ -142,10 +143,6 @@ class TagListFieldCleanNoAppTest:
         This ensures the original bug (TypeError from LocalProxy during unpickling)
         is fixed by verifying clean() doesn't call normalize() during to_python().
         """
-        import pickle
-
-        from udata.mongo.taglist_field import TagListField
-
         field = TagListField()
         pickled = pickle.dumps(field)
         unpickled_field = pickle.loads(pickled)

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -3,6 +3,7 @@ from io import StringIO
 
 import pytest
 from flask import url_for
+from mongoengine.errors import ValidationError
 
 from udata.core import csv
 from udata.core.dataset.factories import DatasetFactory
@@ -109,24 +110,25 @@ class TagsUtilsTest(PytestOnlyTestCase):
 
 
 class TagListFieldCleanTest(PytestOnlyTestCase):
-    def test_clean_drops_values_normalizing_to_empty(self):
-        assert TagListField().clean(["valid", "", "   ", "--", "&", "df", "a"]) == ["valid"]
-
     @pytest.mark.options(TAG_MIN_LENGTH=3, TAG_MAX_LENGTH=10)
-    def test_clean_truncates_too_long_tags(self, app):
-        assert TagListField().clean(["aaaaaaaaaaaaaaa"]) == ["aaaaaaaaaa"]
-
-    def test_clean_preserves_valid_tags(self):
+    def test_clean_slugify_and_deduplicate_values(self):
+        assert TagListField().clean(["valid", "", "   ", "--", "&", "df", "a"]) == [
+            "",
+            "a",
+            "df",
+            "valid",
+        ]
         assert TagListField().clean(["Open Data", "Élégant", "open-data"]) == [
             "elegant",
             "open-data",
         ]
 
-    def test_validate_drops_invalid_tags_from_harvester_input(self):
+    @pytest.mark.options(TAG_MIN_LENGTH=3, TAG_MAX_LENGTH=10)
+    def test_validate_fails_with_invalid_tags(self):
         dataset = DatasetFactory.build(tags=["valid"])
         dataset.tags = ["valid", "", "   ", "--", "df", "Open Data"]
-        dataset.validate()
-        assert dataset.tags == ["open-data", "valid"]
+        with pytest.raises(ValidationError):
+            dataset.validate()
 
 
 class TagListFieldCleanNoAppTest:

--- a/udata/tests/test_tags.py
+++ b/udata/tests/test_tags.py
@@ -127,3 +127,28 @@ class TagListFieldCleanTest(PytestOnlyTestCase):
         dataset.tags = ["valid", "", "   ", "--", "df", "Open Data"]
         dataset.validate()
         assert dataset.tags == ["open-data", "valid"]
+
+
+class TagListFieldCleanNoAppTest:
+    """
+    This test runs in a context where Flask app isn't loaded, ex in celery unpickling.
+    """
+
+    def test_taglist_field_deserialization_no_error(self):
+        """Regression test: TagListField deserialization should not raise errors.
+
+        This ensures the original bug (TypeError from LocalProxy during unpickling)
+        is fixed by verifying clean() doesn't call normalize() during to_python().
+        """
+        import pickle
+
+        from udata.mongo.taglist_field import TagListField
+
+        field = TagListField()
+        pickled = pickle.dumps(field)
+        unpickled_field = pickle.loads(pickled)
+
+        # Should not raise any error during unpickling
+        assert unpickled_field is not None
+        # Test that clean works without calling normalize
+        assert unpickled_field.clean(["test", "Test"]) == ["test"]


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/293060/

```
DecodeError udata.tags in normalize
'<' not supported between instances of 'int' and 'LocalProxy'
```

We can't use `TAG_MIN_LENGTH`  LocalProxy in celery unpickling.
We shouldn't run validation in `clean`, since it is called outside of the app context.
Additionally, we don't want to silently drop invalid tags in most contexts.

Partially reverts https://github.com/opendatateam/udata/pull/3782 by moving tag validation in harvest logic.