### PR TITLE
fix: dataset deleted in accordion

### DIFF
--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -233,10 +233,25 @@ def convert_db_to_field(key, field, info) -> tuple[Callable | None, Callable | N
                 nested_info,
             )
 
+        # A `ListField(ReferenceField)` may hold dangling `DBRef`s pointing to
+        # deleted documents (e.g. a hard delete that bypassed `reverse_delete_rule`).
+        # MongoEngine leaves them as raw `DBRef`s on access, which crashes nested
+        # marshalling, so we filter them out at read time.
+        inner_is_reference = isinstance(
+            field.field,
+            mongo_fields.ReferenceField | mongo_fields.LazyReferenceField,
+        )
+
         if constructor_read is None:
             # We don't want to set the `constructor_read` if it's already set
             # by the `href` code above.
             def constructor_read(**kwargs):
+                if inner_is_reference and "attribute" not in kwargs:
+                    kwargs["attribute"] = lambda obj, _key=key: [
+                        ref
+                        for ref in (getattr(obj, _key, None) or [])
+                        if not isinstance(ref, DBRef)
+                    ]
                 return restx_fields.List(field_read, **kwargs)
 
         # But we want to keep the `constructor_write` to allow changing the list.

--- a/udata/core/edito_blocs/models.py
+++ b/udata/core/edito_blocs/models.py
@@ -139,18 +139,33 @@ SITE_BLOCS_FIELDS = ("datasets_blocs", "reuses_blocs", "dataservices_blocs")
 
 
 def purge_blocs_references(ref_field, obj_id):
-    """Remove references to a deleted object from all blocs in Post and Site."""
+    """Remove references to a deleted object from all blocs in Post and Site.
+
+    A reference can live both at the top level of a blocs field and nested inside an
+    accordion (`AccordionListBloc.items[].content[]`), so both depths are purged.
+    Accordions cannot themselves be nested (see `BLOCS_DISALLOWED_IN_ACCORDION`), so
+    two levels are enough.
+    """
     from udata.core.post.models import Post
     from udata.core.site.models import Site
 
-    Post._get_collection().update_many(
-        {f"blocs.{ref_field}": obj_id},
-        {"$pull": {f"blocs.$[b].{ref_field}": obj_id}},
-        array_filters=[{f"b.{ref_field}": obj_id}],
-    )
-    for blocs_field in SITE_BLOCS_FIELDS:
-        Site._get_collection().update_many(
+    def purge(collection, blocs_field):
+        # Top-level blocs: <blocs_field>[].<ref_field>
+        collection.update_many(
             {f"{blocs_field}.{ref_field}": obj_id},
             {"$pull": {f"{blocs_field}.$[b].{ref_field}": obj_id}},
             array_filters=[{f"b.{ref_field}": obj_id}],
         )
+        # Blocs nested in an accordion: <blocs_field>[].items[].content[].<ref_field>
+        collection.update_many(
+            {f"{blocs_field}.items.content.{ref_field}": obj_id},
+            {"$pull": {f"{blocs_field}.$[b].items.$[].content.$[c].{ref_field}": obj_id}},
+            array_filters=[
+                {f"b.items.content.{ref_field}": obj_id},
+                {f"c.{ref_field}": obj_id},
+            ],
+        )
+
+    purge(Post._get_collection(), "blocs")
+    for blocs_field in SITE_BLOCS_FIELDS:
+        purge(Site._get_collection(), blocs_field)

--- a/udata/core/post/tests/test_api.py
+++ b/udata/core/post/tests/test_api.py
@@ -2,7 +2,13 @@ from flask import url_for
 
 from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
-from udata.core.edito_blocs.models import DataservicesListBloc, DatasetsListBloc, ReusesListBloc
+from udata.core.edito_blocs.models import (
+    AccordionItemBloc,
+    AccordionListBloc,
+    DataservicesListBloc,
+    DatasetsListBloc,
+    ReusesListBloc,
+)
 from udata.core.post.factories import PostFactory
 from udata.core.post.models import Post
 from udata.core.reuse.factories import ReuseFactory
@@ -75,6 +81,70 @@ class PostsAPITest(APITestCase):
         owner = response.json["owner"]
         assert isinstance(owner, dict)
         assert owner["id"] == str(admin.id)
+
+    def test_post_api_get_with_dangling_dataset_reference(self):
+        """Getting a post should not crash when one of its datasets was hard-deleted,
+        leaving a dangling DBRef that bypassed `reverse_delete_rule=PULL`."""
+        kept = DatasetFactory()
+        deleted = DatasetFactory()
+        post = PostFactory(datasets=[kept, deleted])
+
+        # Hard-delete the dataset bypassing MongoEngine signals (and thus the
+        # reverse_delete_rule), so the post keeps a dangling DBRef.
+        deleted_id = deleted.id
+        DatasetFactory._meta.model._get_collection().delete_one({"_id": deleted_id})
+
+        response = self.get(url_for("api.post", post=post))
+        assert200(response)
+        dataset_ids = [d["id"] for d in response.json["datasets"]]
+        assert dataset_ids == [str(kept.id)]
+
+    def test_post_api_get_with_dangling_dataset_in_bloc(self):
+        """Getting a post should not crash when a `DatasetsListBloc` references a
+        hard-deleted dataset. Bloc references live in `EmbeddedDocument`s, which
+        MongoEngine never cleans through `reverse_delete_rule`, so dangling DBRefs
+        are expected there."""
+        kept = DatasetFactory()
+        deleted = DatasetFactory()
+        post = PostFactory(
+            body_type="blocs",
+            blocs=[DatasetsListBloc(title="Featured", datasets=[kept, deleted])],
+        )
+
+        DatasetFactory._meta.model._get_collection().delete_one({"_id": deleted.id})
+
+        response = self.get(url_for("api.post", post=post))
+        assert200(response)
+        bloc_datasets = response.json["blocs"][0]["datasets"]
+        assert [d["id"] for d in bloc_datasets] == [str(kept.id)]
+
+    def test_post_api_get_with_dangling_dataset_in_nested_accordion_bloc(self):
+        """Reproduces the production crash: a `DatasetsListBloc` nested inside an
+        `AccordionListBloc` references a hard-deleted dataset. `purge_blocs_references`
+        does not descend into accordion items, so the dangling DBRef survives the purge."""
+        kept = DatasetFactory()
+        deleted = DatasetFactory()
+        post = PostFactory(
+            body_type="blocs",
+            blocs=[
+                AccordionListBloc(
+                    title="Accordion",
+                    items=[
+                        AccordionItemBloc(
+                            title="Item",
+                            content=[DatasetsListBloc(title="Featured", datasets=[kept, deleted])],
+                        )
+                    ],
+                )
+            ],
+        )
+
+        DatasetFactory._meta.model._get_collection().delete_one({"_id": deleted.id})
+
+        response = self.get(url_for("api.post", post=post))
+        assert200(response)
+        bloc_datasets = response.json["blocs"][0]["items"][0]["content"][0]["datasets"]
+        assert [d["id"] for d in bloc_datasets] == [str(kept.id)]
 
     def test_post_api_create(self):
         """It should create a post from the API"""

--- a/udata/tests/dataset/test_dataset_tasks.py
+++ b/udata/tests/dataset/test_dataset_tasks.py
@@ -7,7 +7,11 @@ from udata.core.dataset import tasks
 from udata.core.dataset.csv import DatasetCsvAdapter, ResourcesCsvAdapter  # noqa
 from udata.core.dataset.factories import CommunityResourceFactory, DatasetFactory
 from udata.core.discussions.factories import DiscussionFactory
-from udata.core.edito_blocs.models import DatasetsListBloc
+from udata.core.edito_blocs.models import (
+    AccordionItemBloc,
+    AccordionListBloc,
+    DatasetsListBloc,
+)
 from udata.core.organization.csv import OrganizationCsvAdapter  # noqa
 from udata.core.post.factories import PostFactory
 from udata.core.post.models import Post
@@ -107,6 +111,45 @@ class DatasetTasksTest(PytestOnlyDBTestCase):
         site = Site.objects.get(id="test-site")
         assert len(site.datasets_blocs[0].datasets) == 1
         assert site.datasets_blocs[0].datasets[0].id == dataset_keep.id
+
+    def test_purge_datasets_cleans_dataset_in_nested_accordion_bloc(self):
+        """Purging a dataset must remove it from `DatasetsListBloc`s nested inside an
+        `AccordionListBloc`, not only top-level blocs. Otherwise a dangling DBRef
+        survives the purge and crashes the post serialization."""
+        dataset_to_delete = Dataset.objects.create(title="delete me", deleted="2016-01-01")
+        dataset_keep = Dataset.objects.create(title="keep me")
+
+        nested_bloc = DatasetsListBloc(title="Featured", datasets=[dataset_to_delete, dataset_keep])
+        PostFactory(
+            body_type="blocs",
+            blocs=[
+                AccordionListBloc(
+                    title="Accordion",
+                    items=[AccordionItemBloc(title="Item", content=[nested_bloc])],
+                )
+            ],
+        )
+
+        tasks.purge_datasets()
+
+        inner = Post.objects.first().blocs[0].items[0].content[0]
+        assert len(inner.datasets) == 1
+        assert inner.datasets[0].id == dataset_keep.id
+
+    def test_purge_datasets_cleans_post_datasets_reference(self):
+        """Purging a dataset must pull it from `Post.datasets` (and `Post.reuses`)
+        thanks to `reverse_delete_rule=PULL`, otherwise a dangling DBRef remains
+        and crashes the post serialization."""
+        dataset_to_delete = Dataset.objects.create(title="delete me", deleted="2016-01-01")
+        dataset_keep = Dataset.objects.create(title="keep me")
+
+        post = PostFactory(datasets=[dataset_to_delete, dataset_keep])
+
+        tasks.purge_datasets()
+
+        post.reload()
+        assert len(post.datasets) == 1
+        assert post.datasets[0].id == dataset_keep.id
 
     def test_purge_datasets_community(self):
         dataset = Dataset.objects.create(title="delete me", deleted="2016-01-01")


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/293899

And broken page in https://www.data.gouv.fr/posts/jeux-de-donnees-liees-aux-elections-municipales

- [x] fix missing accordion refs in purge
- [x] add a auto cleanup in marshalling to prevent 500 on page if purge fail in some way