### PR TITLE
feat(dataservices): compute reuses metric

### DIFF
--- a/udata/core/dataservices/metrics.py
+++ b/udata/core/dataservices/metrics.py
@@ -1,0 +1,20 @@
+from udata.core.reuse.models import Reuse
+
+from .models import Dataservice
+
+
+@Reuse.on_create.connect
+@Reuse.on_update.connect
+@Reuse.on_delete.connect
+def update_dataservice_reuses_metric(reuse, **kwargs):
+    previous = kwargs.get("previous")
+    if previous and previous.get("dataservices"):
+        dataservices_delta = set(ds.id for ds in reuse.dataservices).symmetric_difference(
+            set(ds.id for ds in previous["dataservices"])
+        )
+    else:
+        dataservices_delta = set(ds.id for ds in reuse.dataservices)
+    for dataservice_id in dataservices_delta:
+        dataservice = Dataservice.objects(id=dataservice_id).first()
+        if dataservice:
+            dataservice.count_reuses()

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -357,6 +357,7 @@ class Dataservice(
         "discussions_open",
         "followers",
         "followers_by_months",
+        "reuses",
         "views",
     ]
 
@@ -392,6 +393,16 @@ class Dataservice(
         self.metrics["followers"] = Follow.objects(until=None).followers(self).count()
         self.metrics["followers_by_months"] = get_stock_metrics(
             Follow.objects(following=self), date_label="since"
+        )
+        self.save(signal_kwargs={"ignores": ["post_save"]})
+
+    def count_reuses(self):
+        from udata.models import Reuse
+
+        # Not using visible() here because it excludes reuses without datasets,
+        # but a reuse can legitimately reference only a dataservice.
+        self.metrics["reuses"] = (
+            Reuse.objects(dataservices=self).filter(private__ne=True, deleted=None).count()
         )
         self.save(signal_kwargs={"ignores": ["post_save"]})
 

--- a/udata/core/metrics/__init__.py
+++ b/udata/core/metrics/__init__.py
@@ -4,5 +4,6 @@ def init_app(app):
     import udata.core.organization.metrics  # noqa
     import udata.core.discussions.metrics  # noqa
     import udata.core.dataset.metrics  # noqa
+    import udata.core.dataservices.metrics  # noqa
     import udata.core.reuse.metrics  # noqa
     import udata.core.followers.metrics  # noqa

--- a/udata/core/metrics/commands.py
+++ b/udata/core/metrics/commands.py
@@ -92,6 +92,7 @@ def update(
                         dataservice.metrics.clear()
                     dataservice.count_discussions()
                     dataservice.count_followers()
+                    dataservice.count_reuses()
                 except Exception as e:
                     log.info(f"Error during update: {e}")
                     continue

--- a/udata/tests/dataservice/test_dataservice_model.py
+++ b/udata/tests/dataservice/test_dataservice_model.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime
+
+from flask import current_app
+
+from udata.core import metrics
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.reuse.factories import ReuseFactory
+from udata.models import Reuse
+from udata.tests.api import PytestOnlyDBTestCase
+from udata.tests.helpers import assert_emit
+
+
+class DataserviceModelTest(PytestOnlyDBTestCase):
+    def test_dataservice_reuses_metric(self):
+        metrics.init_app(current_app)
+
+        dataservice = DataserviceFactory()
+
+        with assert_emit(Reuse.on_create):
+            reuse = ReuseFactory(dataservices=[dataservice])
+            ReuseFactory()
+
+        dataservice.reload()
+        assert dataservice.get_metrics()["reuses"] == 1
+
+        with assert_emit(Reuse.on_delete):
+            reuse.deleted = datetime.now(UTC)
+            reuse.save()
+
+        dataservice.reload()
+        assert dataservice.get_metrics()["reuses"] == 0
+
+        reuse = ReuseFactory(dataservices=[dataservice])
+
+        dataservice.reload()
+        assert dataservice.get_metrics()["reuses"] == 1
+
+        with assert_emit(Reuse.on_update):
+            reuse.dataservices = []
+            reuse.save()
+
+        dataservice.reload()
+        assert dataservice.get_metrics()["reuses"] == 0


### PR DESCRIPTION
Add a 'reuses' metric to the Dataservice model, computed from the reuses that reference it via their 'dataservices' field, mirroring the existing Dataset.count_reuses pattern.

A signal handler recomputes the metric whenever a reuse is created, updated or deleted, so the count stays in sync. Without this the dataservice reuses tab always displayed 'Réutilisations (0)'.

related https://github.com/datagouv/cdata/pull/1120