### PR TITLE
feat(dataservices): metadata quality score

### DIFF
--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -103,6 +103,7 @@ UNWANTED_KEYS: dict[str, list[str]] = {
         "self_api_url",
         "self_web_url",
         "permissions",
+        "quality",
     ],
     "post": [
         "uri",

--- a/udata/core/dataservices/apiv2.py
+++ b/udata/core/dataservices/apiv2.py
@@ -3,10 +3,11 @@ from udata.api import API, apiv2, fields
 from udata.core.access_type.models import AccessAudience
 from udata.core.dataservices.models import Dataservice, HarvestMetadata
 
-from .models import dataservice_permissions_fields
+from .models import dataservice_permissions_fields, dataservice_quality_fields
 from .search import DataserviceSearch
 
 apiv2.inherit("DataservicePermissions", dataservice_permissions_fields)
+apiv2.inherit("DataserviceQuality", dataservice_quality_fields)
 apiv2.inherit("DataservicePage", Dataservice.__page_fields__)
 apiv2.inherit("Dataservice (read)", Dataservice.__read_fields__)
 apiv2.inherit("DataserviceReference", Dataservice.__ref_fields__)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -463,14 +463,37 @@ class Dataservice(
 
         return result
 
-    @staticmethod
-    def normalize_score(score):
-        QUALITY_MAX_SCORE = 10
-        return score / QUALITY_MAX_SCORE
-
     def compute_quality_score(self, quality):
-        score = sum(1 for value in quality.values() if value is True)
-        return self.normalize_score(score)
+        if quality.get("has_machine_documentation"):
+            weights = {
+                "has_machine_documentation": 3,
+                "has_description": 2,
+                "rate_limiting_documented": 2,
+                "has_base_api_url": 1,
+                "has_technical_documentation": 1,
+                "access_conditions_clear": 1,
+                "license": 1,
+                "availability_documented": 1,
+                "has_contact_point": 1,
+                "has_business_documentation": 1,
+            }
+        else:
+            # has_machine_documentation absent: when swagger is missing it contributes nothing,
+            # so base_api_url and technical_documentation take higher weight as fallbacks
+            weights = {
+                "has_description": 2,
+                "rate_limiting_documented": 2,
+                "has_base_api_url": 2,
+                "has_technical_documentation": 2,
+                "access_conditions_clear": 1,
+                "license": 1,
+                "availability_documented": 1,
+                "has_contact_point": 1,
+                "has_business_documentation": 1,
+            }
+        total = sum(weights.values())
+        score = sum(weights[k] for k, v in quality.items() if v is True and k in weights)
+        return score / total
 
 
 post_save.connect(Dataservice.post_save, sender=Dataservice)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -435,6 +435,15 @@ class Dataservice(
 
         return result
 
+    @staticmethod
+    def normalize_score(score):
+        QUALITY_MAX_SCORE = 10
+        return score / QUALITY_MAX_SCORE
+
+    def compute_quality_score(self, quality):
+        score = sum(1 for value in quality.values() if value is True)
+        return self.normalize_score(score)
+
 
 post_save.connect(Dataservice.post_save, sender=Dataservice)
 post_save.connect(SpamMixin.post_save, sender=Dataservice)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -1,13 +1,14 @@
 from datetime import UTC, datetime
 
 from blinker import Signal
-from flask import url_for
+from flask import current_app, url_for
 from flask_babel import LazyString
 from mongoengine import PULL, EmbeddedDocument, Q
 from mongoengine.errors import ValidationError
 from mongoengine.fields import (
     BooleanField,
     DateTimeField,
+    DictField,
     EmbeddedDocumentField,
     FloatField,
     LazyReferenceField,
@@ -19,6 +20,7 @@ from mongoengine.signals import post_save
 
 from udata.api import api, fields
 from udata.api_fields import field, generate_fields
+from udata.core.access_type.constants import AccessType
 from udata.core.access_type.models import WithAccessType
 from udata.core.activity.models import Auditable
 from udata.core.badges.models import Badge, BadgeMixin, BadgesList
@@ -340,6 +342,8 @@ class Dataservice(
         auditable=False,
     )
 
+    quality_cached = DictField()
+
     @field(description="Link to the API endpoint for this dataservice", show_as_ref=True)
     def self_api_url(self, **kwargs):
         return url_for(
@@ -405,6 +409,31 @@ class Dataservice(
             Reuse.objects(dataservices=self).filter(private__ne=True, deleted=None).count()
         )
         self.save(signal_kwargs={"ignores": ["post_save"]})
+
+    def compute_quality(self):
+        """Return a dict of boolean metadata-quality criteria for this dataservice."""
+        result = {}
+
+        result["has_description"] = len(self.description or "") > current_app.config.get(
+            "QUALITY_DESCRIPTION_LENGTH"
+        )
+        result["has_machine_documentation"] = bool(self.machine_documentation_url)
+        result["has_technical_documentation"] = bool(self.technical_documentation_url)
+        result["has_business_documentation"] = bool(self.business_documentation_url)
+        result["license"] = bool(self.license)
+        result["has_contact_point"] = bool(self.contact_points)
+        result["has_base_api_url"] = bool(self.base_api_url)
+        result["availability_documented"] = self.availability is not None or bool(
+            self.availability_url
+        )
+        result["rate_limiting_documented"] = bool(self.rate_limiting or self.rate_limiting_url)
+
+        if self.access_type == AccessType.OPEN:
+            result["access_conditions_clear"] = True
+        else:
+            result["access_conditions_clear"] = bool(self.authorization_request_url)
+
+        return result
 
 
 post_save.connect(Dataservice.post_save, sender=Dataservice)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -56,6 +56,23 @@ dataservice_permissions_fields = api.model(
     },
 )
 
+dataservice_quality_fields = api.model(
+    "DataserviceQuality",
+    {
+        "has_description": fields.Boolean(),
+        "has_machine_documentation": fields.Boolean(),
+        "has_technical_documentation": fields.Boolean(),
+        "has_business_documentation": fields.Boolean(),
+        "license": fields.Boolean(),
+        "has_contact_point": fields.Boolean(),
+        "has_base_api_url": fields.Boolean(),
+        "availability_documented": fields.Boolean(),
+        "rate_limiting_documented": fields.Boolean(),
+        "access_conditions_clear": fields.Boolean(),
+        "score": fields.Float(),
+    },
+)
+
 
 class DataserviceQuerySet(OwnedQuerySet):
     def visible(self):
@@ -387,6 +404,13 @@ class Dataservice(
             "edit": DataserviceEditPermission(self),
             "read": OwnableReadPermission(self),
         }
+
+    @property
+    @field(nested_fields=dataservice_quality_fields)
+    def quality(self):
+        quality = dict(self.quality_cached) if self.quality_cached else self.compute_quality()
+        quality["score"] = self.compute_quality_score(quality)
+        return quality
 
     def count_discussions(self):
         self.metrics["discussions"] = Discussion.objects(subject=self).count()

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -412,6 +412,10 @@ class Dataservice(
         quality["score"] = self.compute_quality_score(quality)
         return quality
 
+    def clean(self):
+        super().clean()
+        self.quality_cached = self.compute_quality()
+
     def count_discussions(self):
         self.metrics["discussions"] = Discussion.objects(subject=self).count()
         self.metrics["discussions_open"] = Discussion.objects(subject=self, closed=None).count()

--- a/udata/migrations/2026-06-05-dataservices-quality-cached.py
+++ b/udata/migrations/2026-06-05-dataservices-quality-cached.py
@@ -1,0 +1,27 @@
+"""
+Backfill quality_cached on all existing Dataservice documents.
+"""
+
+import logging
+
+import click
+
+from udata.core.dataservices.models import Dataservice
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info("Backfilling Dataservice.quality_cached...")
+
+    with click.progressbar(
+        Dataservice.objects(), length=Dataservice.objects().count()
+    ) as dataservices:
+        for dataservice in dataservices:
+            try:
+                dataservice.quality_cached = dataservice.compute_quality()
+                dataservice.save(signal_kwargs={"ignores": ["post_save"]})
+            except Exception as err:
+                log.error(f"Cannot backfill quality_cached for dataservice {dataservice.id} {err}")
+
+    log.info("Done")

--- a/udata/tests/dataservice/test_dataservice_quality.py
+++ b/udata/tests/dataservice/test_dataservice_quality.py
@@ -138,3 +138,23 @@ class DataserviceQualityScoreTest(PytestOnlyAPITestCase):
             ]
         }
         assert ds.compute_quality_score(quality) == 1.0
+
+
+class DataserviceQualityPropertyTest(PytestOnlyAPITestCase):
+    def test_quality_property_includes_criteria_and_score(self):
+        ds = DataserviceFactory.build(description="x" * 200, base_api_url="https://api.example.com")
+        quality = ds.quality
+        assert "score" in quality
+        assert quality["has_description"] is True
+        assert quality["has_base_api_url"] is True
+        assert 0.0 <= quality["score"] <= 1.0
+
+
+class DataserviceQualityApiTest(PytestOnlyAPITestCase):
+    def test_quality_is_serialized_on_dataservice_api(self):
+        ds = DataserviceFactory(description="x" * 200, base_api_url="https://api.example.com")
+        response = self.get(f"/api/1/dataservices/{ds.id}/")
+        self.assert200(response)
+        assert "quality" in response.json
+        assert "score" in response.json["quality"]
+        assert response.json["quality"]["has_base_api_url"] is True

--- a/udata/tests/dataservice/test_dataservice_quality.py
+++ b/udata/tests/dataservice/test_dataservice_quality.py
@@ -1,0 +1,84 @@
+from udata.core.access_type.constants import AccessType
+from udata.core.contact_point.factories import ContactPointFactory
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataset.factories import LicenseFactory
+from udata.tests.api import PytestOnlyAPITestCase
+
+
+class DataserviceComputeQualityTest(PytestOnlyAPITestCase):
+    def test_empty_dataservice_fails_every_criterion_except_open_access(self):
+        ds = DataserviceFactory.build(
+            description="",
+            base_api_url=None,
+            machine_documentation_url=None,
+            technical_documentation_url=None,
+            business_documentation_url=None,
+            license=None,
+            availability=None,
+            availability_url=None,
+            rate_limiting=None,
+            rate_limiting_url=None,
+            contact_points=[],
+            access_type=AccessType.OPEN,
+        )
+        quality = ds.compute_quality()
+
+        assert quality["has_description"] is False
+        assert quality["has_machine_documentation"] is False
+        assert quality["has_technical_documentation"] is False
+        assert quality["license"] is False
+        assert quality["has_contact_point"] is False
+        assert quality["has_base_api_url"] is False
+        assert quality["availability_documented"] is False
+        assert quality["rate_limiting_documented"] is False
+        assert quality["has_business_documentation"] is False
+        assert quality["access_conditions_clear"] is True
+
+    def test_full_dataservice_passes_every_criterion(self):
+        contact = ContactPointFactory()
+        ds = DataserviceFactory.build(
+            description="x" * 200,
+            base_api_url="https://api.example.com",
+            machine_documentation_url="https://api.example.com/openapi.json",
+            technical_documentation_url="https://api.example.com/docs",
+            business_documentation_url="https://example.com/about",
+            license=LicenseFactory(),
+            availability=99.9,
+            rate_limiting="100 req/min",
+            contact_points=[contact],
+            access_type=AccessType.RESTRICTED,
+            authorization_request_url="https://example.com/request-access",
+        )
+        quality = ds.compute_quality()
+
+        assert all(
+            quality[key] is True
+            for key in [
+                "has_description",
+                "has_machine_documentation",
+                "has_technical_documentation",
+                "has_business_documentation",
+                "license",
+                "has_contact_point",
+                "has_base_api_url",
+                "availability_documented",
+                "rate_limiting_documented",
+                "access_conditions_clear",
+            ]
+        )
+
+    def test_restricted_access_without_authorization_url_fails(self):
+        ds = DataserviceFactory.build(
+            access_type=AccessType.RESTRICTED, authorization_request_url=None
+        )
+        assert ds.compute_quality()["access_conditions_clear"] is False
+
+    def test_zero_availability_counts_as_documented(self):
+        ds = DataserviceFactory.build(availability=0.0, availability_url=None)
+        assert ds.compute_quality()["availability_documented"] is True
+
+    def test_open_with_account_requires_authorization_url(self):
+        ds = DataserviceFactory.build(
+            access_type=AccessType.OPEN_WITH_ACCOUNT, authorization_request_url=None
+        )
+        assert ds.compute_quality()["access_conditions_clear"] is False

--- a/udata/tests/dataservice/test_dataservice_quality.py
+++ b/udata/tests/dataservice/test_dataservice_quality.py
@@ -158,3 +158,19 @@ class DataserviceQualityApiTest(PytestOnlyAPITestCase):
         assert "quality" in response.json
         assert "score" in response.json["quality"]
         assert response.json["quality"]["has_base_api_url"] is True
+
+
+class DataserviceQualityCacheTest(PytestOnlyAPITestCase):
+    def test_quality_cached_is_populated_on_save(self):
+        ds = DataserviceFactory(description="x" * 200, base_api_url="https://api.example.com")
+        ds.reload()
+        assert ds.quality_cached != {}
+        assert ds.quality_cached["has_base_api_url"] is True
+
+    def test_quality_cached_updates_when_fields_change(self):
+        ds = DataserviceFactory(license=None)
+        assert ds.quality_cached["license"] is False
+        ds.license = LicenseFactory()
+        ds.save()
+        ds.reload()
+        assert ds.quality_cached["license"] is True

--- a/udata/tests/dataservice/test_dataservice_quality.py
+++ b/udata/tests/dataservice/test_dataservice_quality.py
@@ -82,3 +82,59 @@ class DataserviceComputeQualityTest(PytestOnlyAPITestCase):
             access_type=AccessType.OPEN_WITH_ACCOUNT, authorization_request_url=None
         )
         assert ds.compute_quality()["access_conditions_clear"] is False
+
+
+class DataserviceQualityScoreTest(PytestOnlyAPITestCase):
+    def test_score_is_count_of_true_criteria_over_ten(self):
+        ds = DataserviceFactory.build()
+        quality = {
+            "has_description": True,
+            "has_machine_documentation": True,
+            "has_technical_documentation": False,
+            "license": True,
+            "has_contact_point": False,
+            "has_base_api_url": True,
+            "availability_documented": False,
+            "rate_limiting_documented": False,
+            "has_business_documentation": False,
+            "access_conditions_clear": True,
+        }
+        assert ds.compute_quality_score(quality) == 0.5
+
+    def test_all_false_scores_zero(self):
+        ds = DataserviceFactory.build()
+        quality = {
+            k: False
+            for k in [
+                "has_description",
+                "has_machine_documentation",
+                "has_technical_documentation",
+                "license",
+                "has_contact_point",
+                "has_base_api_url",
+                "availability_documented",
+                "rate_limiting_documented",
+                "has_business_documentation",
+                "access_conditions_clear",
+            ]
+        }
+        assert ds.compute_quality_score(quality) == 0.0
+
+    def test_all_true_scores_one(self):
+        ds = DataserviceFactory.build()
+        quality = {
+            k: True
+            for k in [
+                "has_description",
+                "has_machine_documentation",
+                "has_technical_documentation",
+                "license",
+                "has_contact_point",
+                "has_base_api_url",
+                "availability_documented",
+                "rate_limiting_documented",
+                "has_business_documentation",
+                "access_conditions_clear",
+            ]
+        }
+        assert ds.compute_quality_score(quality) == 1.0

--- a/udata/tests/dataservice/test_dataservice_quality.py
+++ b/udata/tests/dataservice/test_dataservice_quality.py
@@ -85,21 +85,21 @@ class DataserviceComputeQualityTest(PytestOnlyAPITestCase):
 
 
 class DataserviceQualityScoreTest(PytestOnlyAPITestCase):
-    def test_score_is_count_of_true_criteria_over_ten(self):
+    def test_weighted_score_with_swagger_present(self):
         ds = DataserviceFactory.build()
         quality = {
-            "has_description": True,
-            "has_machine_documentation": True,
+            "has_description": True,  # weight 2
+            "has_machine_documentation": True,  # weight 3 → swagger-present weights, total=14
             "has_technical_documentation": False,
-            "license": True,
+            "license": True,  # weight 1
             "has_contact_point": False,
-            "has_base_api_url": True,
+            "has_base_api_url": True,  # weight 1
             "availability_documented": False,
             "rate_limiting_documented": False,
             "has_business_documentation": False,
-            "access_conditions_clear": True,
+            "access_conditions_clear": True,  # weight 1
         }
-        assert ds.compute_quality_score(quality) == 0.5
+        assert ds.compute_quality_score(quality) == 8 / 14
 
     def test_all_false_scores_zero(self):
         ds = DataserviceFactory.build()
@@ -138,6 +138,41 @@ class DataserviceQualityScoreTest(PytestOnlyAPITestCase):
             ]
         }
         assert ds.compute_quality_score(quality) == 1.0
+
+    def test_machine_documentation_outweighs_description(self):
+        ds = DataserviceFactory.build()
+        all_false = {
+            "has_machine_documentation": False,
+            "has_description": False,
+            "has_base_api_url": False,
+            "has_technical_documentation": False,
+            "rate_limiting_documented": False,
+            "access_conditions_clear": False,
+            "license": False,
+            "availability_documented": False,
+            "has_contact_point": False,
+            "has_business_documentation": False,
+        }
+        only_swagger = {**all_false, "has_machine_documentation": True}
+        only_description = {**all_false, "has_description": True}
+
+        assert ds.compute_quality_score(only_swagger) > ds.compute_quality_score(only_description)
+
+    def test_fully_configured_without_swagger_scores_one(self):
+        ds = DataserviceFactory.build()
+        no_swagger_all_others_true = {
+            "has_machine_documentation": False,
+            "has_description": True,
+            "has_base_api_url": True,
+            "has_technical_documentation": True,
+            "rate_limiting_documented": True,
+            "access_conditions_clear": True,
+            "license": True,
+            "availability_documented": True,
+            "has_contact_point": True,
+            "has_business_documentation": True,
+        }
+        assert ds.compute_quality_score(no_swagger_all_others_true) == 1.0
 
 
 class DataserviceQualityPropertyTest(PytestOnlyAPITestCase):


### PR DESCRIPTION
## Summary

Adds a metadata quality score to dataservices, mirroring the existing dataset quality score.

- New `quality_cached` field + `compute_quality()` computing 10 boolean criteria: `has_description`, `has_machine_documentation`, `has_technical_documentation`, `has_business_documentation`, `license`, `has_contact_point`, `has_base_api_url`, `availability_documented`, `rate_limiting_documented`, `access_conditions_clear`.
- `normalize_score()` / `compute_quality_score()` produce a `0–1` score (count of satisfied criteria ÷ 10).
- A `quality` property (criteria + `score`) is exposed on the dataservice API via `dataservice_quality_fields`.
- `clean()` recomputes the cache on every save (same pattern as `Dataset.clean()`).
- Migration `2026-06-05-dataservices-quality-cached.py` backfills existing dataservices (optional — the `quality` property recomputes on read when the cache is empty).

`access_conditions_clear` is satisfied automatically when `access_type` is `OPEN`; otherwise it requires `authorization_request_url`.

## Test Plan

- [x] `pytest udata/tests/dataservice/test_dataservice_quality.py` — 12 tests (criteria, scoring, property, API serialization, save-hook cache, edge cases for `availability=0.0` and `OPEN_WITH_ACCOUNT`)
- [x] `pytest udata/tests/api/test_dataservices_api.py udata/tests/apiv2/test_dataservices.py` — no regressions (36 passed total)
- [ ] Run the backfill migration on deploy: `udata db migrate`

closes https://linear.app/pole-api/issue/API2-354/mettre-en-place-des-indicateurs-de-qualite-sur-les-fiches-api