### PR TITLE
fix(perfs): paginate ressources MongoDB side instead of Python

### DIFF
--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import mongoengine
 from flask import abort, request, url_for
@@ -13,6 +14,7 @@ from udata.core.contact_point.models import ContactPoint
 from udata.core.dataset.api_fields import license_fields
 from udata.core.organization.models import Member, Organization
 from udata.core.spatial.api_fields import geojson
+from udata.mongo.queryset import paginate_embedded_list
 from udata.utils import get_by
 
 from .api import DEFAULT_SORTING, DatasetApiParser, ResourceMixin
@@ -31,7 +33,7 @@ from .api_fields import (
     user_ref_fields,
 )
 from .constants import DEFAULT_LICENSE, FULL_OBJECTS_HEADER, UpdateFrequency
-from .models import CommunityResource, Dataset
+from .models import CommunityResource, Dataset, Resource
 from .search import DatasetSearch
 
 DEFAULT_PAGE_SIZE = 50
@@ -401,7 +403,7 @@ class DatasetExtrasAPI(API):
         return dataset.extras, 204
 
 
-@ns.route("/<dataset:dataset>/resources/", endpoint="resources")
+@ns.route("/<dataset_without_resources:dataset>/resources/", endpoint="resources")
 class ResourcesAPI(API):
     @apiv2.doc("list_resources")
     @apiv2.expect(resources_parser)
@@ -418,31 +420,47 @@ class ResourcesAPI(API):
         list_resources_url = url_for("apiv2.resources", dataset=dataset.id, _external=True)
         next_page = f"{list_resources_url}?page={page + 1}&page_size={page_size}"
         previous_page = f"{list_resources_url}?page={page - 1}&page_size={page_size}"
-        res = dataset.resources
 
+        # Filter the resources server-side so a dataset with many or heavy
+        # resources isn't fully loaded just to serve a single page (the route
+        # loads the dataset without its resources, see the converter).
+        conditions = []
         if args["type"]:
-            res = [elem for elem in res if elem["type"] == args["type"]]
+            conditions.append({"$eq": ["$$item.type", args["type"]]})
             next_page += f"&type={args['type']}"
             previous_page += f"&type={args['type']}"
-
         if args["q"]:
-            res = [elem for elem in res if args["q"].lower() in elem["title"].lower()]
+            # re.escape to match the previous substring (not regex) behaviour
+            conditions.append(
+                {
+                    "$regexMatch": {
+                        "input": "$$item.title",
+                        "regex": re.escape(args["q"]),
+                        "options": "i",
+                    }
+                }
+            )
             next_page += f"&q={args['q']}"
             previous_page += f"&q={args['q']}"
 
-        if page > 1:
-            offset = page_size * (page - 1)
-        else:
-            offset = 0
-        paginated_result = res[offset : (page_size + offset if page_size is not None else None)]
+        paginated_result, total = paginate_embedded_list(
+            Dataset,
+            dataset.id,
+            "resources",
+            Resource,
+            page=page,
+            page_size=page_size,
+            condition={"$and": conditions} if conditions else None,
+        )
+        offset = page_size * (page - 1) if page > 1 else 0
 
         return {
             "data": paginated_result,
-            "next_page": next_page if page_size + offset < len(res) else None,
+            "next_page": next_page if page_size + offset < total else None,
             "page": page,
             "page_size": page_size,
             "previous_page": previous_page if page > 1 else None,
-            "total": len(res),
+            "total": total,
         }
 
 

--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -452,11 +452,9 @@ class ResourcesAPI(API):
             page_size=page_size,
             condition={"$and": conditions} if conditions else None,
         )
-        offset = page_size * (page - 1) if page > 1 else 0
-
         return {
             "data": paginated_result,
-            "next_page": next_page if page_size + offset < total else None,
+            "next_page": next_page if page * page_size < total else None,
             "page": page,
             "page_size": page_size,
             "previous_page": previous_page if page > 1 else None,

--- a/udata/mongo/queryset.py
+++ b/udata/mongo/queryset.py
@@ -110,3 +110,36 @@ class UDataQuerySet(BaseQuerySet):
             else:
                 self.error("expect a list of string, ObjectId or DBRef")
         return self(__raw__=query)
+
+
+def paginate_embedded_list(
+    document_cls, document_id, field, embedded_cls, *, page, page_size, condition=None
+):
+    """Filter and slice an embedded-document ``ListField`` server-side via an
+    aggregation, so a document with a huge list isn't fully loaded just to serve
+    a single page.
+
+    ``condition`` is an optional aggregation boolean expression over the
+    ``$$item`` variable (e.g. ``{"$eq": ["$$item.type", "main"]}``). Returns a
+    ``(items, total)`` tuple where ``items`` are rebuilt ``embedded_cls``
+    instances and ``total`` is the count after filtering.
+    """
+    source = f"${field}"
+    filtered = (
+        {"$filter": {"input": source, "as": "item", "cond": condition}} if condition else source
+    )
+    offset = page_size * (page - 1) if page > 1 else 0
+    pipeline = [
+        {"$match": {"_id": document_id}},
+        {"$project": {"items": filtered}},
+        {
+            "$project": {
+                "total": {"$size": "$items"},
+                "data": {"$slice": ["$items", offset, page_size]},
+            }
+        },
+    ]
+    result = next(document_cls.objects.aggregate(*pipeline), None)
+    if not result:
+        return [], 0
+    return [embedded_cls._from_son(item) for item in result["data"]], result["total"]

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -366,6 +366,34 @@ class DatasetResourceAPIV2Test(APITestCase):
         assert data["next_page"] is None
         assert data["previous_page"] is None
 
+    def test_get_with_query_string_special_chars(self):
+        """The query string is matched as a literal substring, not as a regex"""
+        resources = [
+            ResourceFactory(title="Total (2024)"),
+            ResourceFactory(title="Total 2024"),
+        ]
+        dataset = DatasetFactory(resources=resources)
+        response = self.get(url_for("apiv2.resources", dataset=dataset.id, q="(2024)"))
+        self.assert200(response)
+        data = response.json
+        # A naive regex would treat "(2024)" as a group and match both titles
+        assert data["total"] == 1
+        assert data["data"][0]["title"] == "Total (2024)"
+
+    def test_get_with_type_and_query_string(self):
+        """The type and query string filters combine (AND)"""
+        resources = [
+            ResourceFactory(type="main", title="alpha report"),
+            ResourceFactory(type="main", title="beta report"),
+            ResourceFactory(type="documentation", title="alpha doc"),
+        ]
+        dataset = DatasetFactory(resources=resources)
+        response = self.get(url_for("apiv2.resources", dataset=dataset.id, type="main", q="alpha"))
+        self.assert200(response)
+        data = response.json
+        assert data["total"] == 1
+        assert data["data"][0]["title"] == "alpha report"
+
 
 class DatasetExtrasAPITest(APITestCase):
     def setUp(self):


### PR DESCRIPTION
Part of https://github.com/datagouv/data.gouv.fr/issues/2036

### Problem

`GET /api/2/datasets/<id>/resources/` loads the **entire** dataset document — all its resources — on every request, then filters (`type`, `q`) and slices in Python, just to return one page. The cost scales with the *total* resources of the dataset, not with `page_size`.

This makes the endpoint slow on heavy datasets, for two unrelated data reasons:
- **BD TOPO®** (149 resources): ~96% of the 7.4 MB document is a single unused `extras["analysis:parsing:ogc_metadata"].layers` field.
- **RNCP** (8021 resources): a 13 MB document built from a very large number of normal resources.

Both end up loading several MB to serve ~10 resources (TTFB ~0.6–4 s in production).

### Fix

- The route now uses the `<dataset_without_resources:dataset>` converter, so the dataset is loaded **without** its resources list.
- Filtering, slicing and counting are done server-side through a MongoDB aggregation (`$match` → `$filter` → `$size`/`$slice`), so the full list is never materialised.
- Extracted the reusable mechanics into `paginate_embedded_list()` in `udata/mongo/queryset.py` (filter + paginate an embedded `ListField`, returns `(items, total)`).

Behaviour is unchanged: same `type` / `q` (case-insensitive substring) filtering, same pagination links. `q` is now matched via `$regexMatch` with `re.escape`, preserving the literal-substring semantics.