### PR TITLE
feat: add dataset check-files command to clean up orphan resource files

### DIFF
--- a/udata/core/dataset/commands.py
+++ b/udata/core/dataset/commands.py
@@ -262,13 +262,23 @@ def check_files(delete, days, output, yes):
     header("Deleting orphan files")
     deleted = 0
     errors = 0
-    for fs_filename in orphans:
-        try:
-            storage.delete(fs_filename)
-            deleted += 1
-        except Exception as e:  # noqa  (never stop on a single failure)
-            log.error("Unable to delete %s: %s", fs_filename, e)
-            errors += 1
+
+    def delete_info(_item):
+        return f"{deleted:,} deleted, {errors:,} failed"
+
+    with click.progressbar(
+        orphans,
+        length=len(orphans),
+        label="Deleting",
+        item_show_func=delete_info,
+    ) as bar:
+        for fs_filename in bar:
+            try:
+                storage.delete(fs_filename)
+                deleted += 1
+            except Exception as e:  # noqa  (never stop on a single failure)
+                log.error("Unable to delete %s: %s", fs_filename, e)
+                errors += 1
     success(f"Deleted {deleted:,} files, {errors:,} failed")
 
 

--- a/udata/core/dataset/commands.py
+++ b/udata/core/dataset/commands.py
@@ -183,34 +183,56 @@ def check_files(delete, days, output, yes):
     referenced = collect_referenced_filenames()
     success(f"{len(referenced)} files referenced in database")
 
-    # 2. Single cross-referencing pass over the storage. A first cheap pass only
-    #    counts files (directory metadata, no content read) so the progress bar
-    #    can show a percentage and an ETA.
+    # 2. Count files first (cheap directory metadata pass, no content read) so
+    #    the scan progress bar below can show a percentage and an ETA.
     header("Counting files on storage")
     total = sum(1 for _ in storage.list_files())
     echo(white(f"{total:,} files to scan"))
 
+    # 3. Cross-reference the storage against the database. This is pure set
+    #    logic (no filesystem stat), so it stays backend-agnostic: a file on
+    #    storage referenced by nothing is an orphan candidate; a reference still
+    #    left over once the whole walk is done points to a missing file.
+    header("Scanning storage")
+    orphan_candidates = []
+
+    def scan_info(_item):
+        return f"{len(orphan_candidates):,} orphan candidates"
+
+    with click.progressbar(
+        storage.list_files(),
+        length=total,
+        label="Scanning",
+        item_show_func=scan_info,
+    ) as bar:
+        for fs_filename in bar:
+            if fs_filename in referenced:
+                referenced.discard(fs_filename)
+            else:
+                orphan_candidates.append(fs_filename)
+
+    broken_references = referenced
+
+    # 4. Stat only the orphan candidates (a small subset) to apply the --days
+    #    protection and measure reclaimable space. This is the only step that
+    #    needs direct filesystem access, hence the local-backend requirement
+    #    checked above.
     cutoff = datetime.now() - timedelta(days=days)
     orphans = []
     orphans_size = 0
     skipped_recent = 0
 
-    def progress_info(_item):
+    def check_info(_item):
         return f"{len(orphans):,} orphans, {human_size(orphans_size)}"
 
-    header("Scanning storage")
+    header("Checking orphan candidates")
     with click.progressbar(
-        storage.list_files(),
-        length=total,
-        label="Scanning",
-        item_show_func=progress_info,
+        orphan_candidates,
+        length=len(orphan_candidates),
+        label="Checking",
+        item_show_func=check_info,
     ) as bar:
         for fs_filename in bar:
-            if fs_filename in referenced:
-                # Mark as seen; whatever stays in `referenced` is a broken reference.
-                referenced.discard(fs_filename)
-                continue
-
             try:
                 stat = os.stat(storage.path(fs_filename))
             except FileNotFoundError:
@@ -223,9 +245,7 @@ def check_files(delete, days, output, yes):
                 orphans.append(fs_filename)
                 orphans_size += stat.st_size
 
-    broken_references = referenced
-
-    # 3. Report.
+    # 5. Report.
     header("Result")
     echo(white(f"Files scanned on storage: {total:,}"))
     echo(white(f"Orphan files: {len(orphans):,} ({human_size(orphans_size)} reclaimable)"))

--- a/udata/core/dataset/commands.py
+++ b/udata/core/dataset/commands.py
@@ -1,13 +1,16 @@
 import json
 import logging
+import os
+from datetime import datetime, timedelta
 
 import click
 import requests
 from bson import ObjectId
 
-from udata.commands import cli, exit_with_error, success
+from udata.commands import cli, echo, exit_with_error, header, success, white
+from udata.core import storages
 from udata.core.dataset.constants import DEFAULT_LICENSE
-from udata.models import Dataset, License
+from udata.models import CommunityResource, Dataset, License
 
 from . import actions
 
@@ -82,6 +85,191 @@ def archive_one(dataset_id, comment):
         exit_with_error("Cannot find a dataset with id %s" % dataset_id)
     else:
         actions.archive(dataset, comment)
+
+
+def human_size(num):
+    """Human readable byte size (binary units)."""
+    value = float(num)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} PiB"
+
+
+def collect_referenced_filenames():
+    """Set of every fs_filename referenced by a resource in database.
+
+    Includes resources embedded in *every* dataset (soft-deleted and archived
+    ones too: their files stay legitimate until `udata purge` runs) and every
+    CommunityResource.
+    """
+    referenced = set()
+
+    dataset_pipeline = [
+        {"$unwind": "$resources"},
+        {"$match": {"resources.fs_filename": {"$ne": None}}},
+        {"$project": {"_id": 0, "f": "$resources.fs_filename"}},
+    ]
+    for row in Dataset.objects.aggregate(*dataset_pipeline):
+        referenced.add(row["f"])
+
+    community_pipeline = [
+        {"$match": {"fs_filename": {"$ne": None}}},
+        {"$project": {"_id": 0, "f": "$fs_filename"}},
+    ]
+    for row in CommunityResource.objects.aggregate(*community_pipeline):
+        referenced.add(row["f"])
+
+    return referenced
+
+
+@grp.command()
+@click.option(
+    "--delete",
+    is_flag=True,
+    help="Actually delete orphan files. Without it the command is a dry-run (report only).",
+)
+@click.option(
+    "--days",
+    default=7,
+    show_default=True,
+    help="Ignore files modified within the last N days "
+    "(protects in-flight uploads not yet committed to the database snapshot).",
+)
+@click.option(
+    "--output",
+    default="orphan-resources.txt",
+    show_default=True,
+    help="File where the list of orphan files is written (one fs_filename per line).",
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Do not ask for confirmation before deleting (for non-interactive runs).",
+)
+def check_files(delete, days, output, yes):
+    """Find (and optionally delete) orphan resource files on storage.
+
+    Cross-references every file in the `resources` storage against the
+    fs_filename of every resource in database (dataset resources, including
+    soft-deleted datasets, and community resources). A single pass over the
+    storage reports both:
+
+    \b
+    - orphan files: on storage but referenced by no resource (wasted space);
+    - broken references: referenced by a resource but missing on storage.
+
+    Only orphan files are deletable, and only with --delete.
+    """
+    storage = storages.resources
+
+    # This command relies on direct filesystem access (os.stat below) to read
+    # each file's size and mtime cheaply. The storage-agnostic alternative
+    # (storage.metadata()) would re-read every file in full to recompute a sha1
+    # on the local backend, which is prohibitive when scanning the whole bucket.
+    # So we require a local backend and fail fast with a clear message instead
+    # of crashing mid-scan on an S3 backend (storage.path() raises there).
+    if not storage.backend.root:
+        exit_with_error(
+            f"`dataset check-files` only supports a local filesystem backend, "
+            f"but the `resources` storage uses {storage.backend.__class__.__name__}."
+        )
+
+    # 1. Snapshot every referenced file BEFORE walking the storage, so a file
+    #    uploaded during the walk can never be mistaken for an orphan.
+    header("Collecting referenced files from database")
+    referenced = collect_referenced_filenames()
+    success(f"{len(referenced)} files referenced in database")
+
+    # 2. Single cross-referencing pass over the storage. A first cheap pass only
+    #    counts files (directory metadata, no content read) so the progress bar
+    #    can show a percentage and an ETA.
+    header("Counting files on storage")
+    total = sum(1 for _ in storage.list_files())
+    echo(white(f"{total:,} files to scan"))
+
+    cutoff = datetime.now() - timedelta(days=days)
+    orphans = []
+    orphans_size = 0
+    skipped_recent = 0
+
+    def progress_info(_item):
+        return f"{len(orphans):,} orphans, {human_size(orphans_size)}"
+
+    header("Scanning storage")
+    with click.progressbar(
+        storage.list_files(),
+        length=total,
+        label="Scanning",
+        item_show_func=progress_info,
+    ) as bar:
+        for fs_filename in bar:
+            if fs_filename in referenced:
+                # Mark as seen; whatever stays in `referenced` is a broken reference.
+                referenced.discard(fs_filename)
+                continue
+
+            try:
+                stat = os.stat(storage.path(fs_filename))
+            except FileNotFoundError:
+                # Vanished between listing and stat (concurrent delete): skip.
+                continue
+
+            if datetime.fromtimestamp(stat.st_mtime) > cutoff:
+                skipped_recent += 1
+            else:
+                orphans.append(fs_filename)
+                orphans_size += stat.st_size
+
+    broken_references = referenced
+
+    # 3. Report.
+    header("Result")
+    echo(white(f"Files scanned on storage: {total:,}"))
+    echo(white(f"Orphan files: {len(orphans):,} ({human_size(orphans_size)} reclaimable)"))
+    echo(white(f"Recent files protected (< {days} days): {skipped_recent:,}"))
+    echo(
+        white(f"Broken references (referenced but missing on storage): {len(broken_references):,}")
+    )
+
+    with open(output, "w") as f:
+        f.write("\n".join(orphans))
+        if orphans:
+            f.write("\n")
+    success(f"Orphan list written to {output}")
+
+    if broken_references:
+        broken_output = output + ".broken-references"
+        with open(broken_output, "w") as f:
+            f.write("\n".join(sorted(broken_references)) + "\n")
+        success(f"Broken references list written to {broken_output}")
+
+    if not orphans:
+        return
+
+    if not delete:
+        echo("Dry-run: nothing deleted. Re-run with --delete to remove the orphan files.")
+        return
+
+    if not yes:
+        click.confirm(
+            f"Delete {len(orphans):,} orphan files ({human_size(orphans_size)})?",
+            abort=True,
+        )
+
+    header("Deleting orphan files")
+    deleted = 0
+    errors = 0
+    for fs_filename in orphans:
+        try:
+            storage.delete(fs_filename)
+            deleted += 1
+        except Exception as e:  # noqa  (never stop on a single failure)
+            log.error("Unable to delete %s: %s", fs_filename, e)
+            errors += 1
+    success(f"Deleted {deleted:,} files, {errors:,} failed")
 
 
 @grp.command()

--- a/udata/tests/dataset/test_dataset_commands.py
+++ b/udata/tests/dataset/test_dataset_commands.py
@@ -1,6 +1,17 @@
-from tempfile import NamedTemporaryFile
+import os
+from datetime import UTC, datetime, timedelta
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest.mock import patch
 
-from udata.core.dataset.factories import DatasetFactory
+import pytest
+
+from udata.commands import cli as cli_cmd
+from udata.core import storages
+from udata.core.dataset.factories import (
+    CommunityResourceFactory,
+    DatasetFactory,
+    ResourceFactory,
+)
 from udata.tests.api import PytestOnlyDBTestCase
 
 
@@ -25,3 +36,118 @@ class DatasetCommandTest(PytestOnlyDBTestCase):
         for dataset in datasets:
             dataset.reload()
             assert dataset.archived is not None
+
+
+@pytest.mark.usefixtures("instance_path")
+class DatasetCheckFilesCommandTest(PytestOnlyDBTestCase):
+    def write_file(self, fs_filename, *, age_days=30, content=b"data"):
+        """Write a real file in the resources storage and backdate its mtime."""
+        with self.app.app_context():
+            storages.resources.write(fs_filename, content)
+            path = storages.resources.path(fs_filename)
+        past = (datetime.now() - timedelta(days=age_days)).timestamp()
+        os.utime(path, (past, past))
+        return path
+
+    def exists(self, fs_filename):
+        with self.app.app_context():
+            return storages.resources.exists(fs_filename)
+
+    def run_check(self, *extra_args):
+        """Run `dataset check-files` and return (orphans, broken_references)."""
+        with TemporaryDirectory() as tmp:
+            output = os.path.join(tmp, "orphans.txt")
+            self.cli("dataset", "check-files", "--output", output, *extra_args)
+            with open(output) as f:
+                orphans = [line for line in f.read().splitlines() if line]
+            broken_path = output + ".broken-references"
+            broken = []
+            if os.path.exists(broken_path):
+                with open(broken_path) as f:
+                    broken = [line for line in f.read().splitlines() if line]
+        return orphans, broken
+
+    def test_dry_run_lists_orphans_and_keeps_files(self):
+        referenced = "ds/20200101-000000/kept.csv"
+        orphan = "ds/20200101-000000/orphan.csv"
+        self.write_file(referenced)
+        self.write_file(orphan)
+        DatasetFactory(resources=[ResourceFactory(fs_filename=referenced)])
+
+        orphans, broken = self.run_check()
+
+        assert orphans == [orphan]
+        assert broken == []
+        # Dry-run: nothing is deleted.
+        assert self.exists(orphan)
+        assert self.exists(referenced)
+
+    def test_delete_removes_only_orphans(self):
+        referenced = "ds/20200101-000000/kept.csv"
+        orphan = "ds/20200101-000000/orphan.csv"
+        self.write_file(referenced)
+        self.write_file(orphan)
+        DatasetFactory(resources=[ResourceFactory(fs_filename=referenced)])
+
+        self.run_check("--delete", "--yes")
+
+        assert not self.exists(orphan)
+        assert self.exists(referenced)
+
+    def test_recent_files_are_protected_from_deletion(self):
+        old_orphan = "ds/20200101-000000/old.csv"
+        recent_orphan = "ds/20200101-000000/recent.csv"
+        self.write_file(old_orphan, age_days=30)
+        self.write_file(recent_orphan, age_days=1)
+
+        orphans, _ = self.run_check("--delete", "--yes")
+
+        # The recent file is never even considered an orphan.
+        assert orphans == [old_orphan]
+        assert not self.exists(old_orphan)
+        assert self.exists(recent_orphan)
+
+    def test_soft_deleted_dataset_files_are_kept(self):
+        """Files of a soft-deleted (not yet purged) dataset are still legitimate."""
+        fs_filename = "ds/20200101-000000/soft-deleted.csv"
+        self.write_file(fs_filename)
+        DatasetFactory(
+            resources=[ResourceFactory(fs_filename=fs_filename)],
+            deleted=datetime.now(UTC),
+        )
+
+        orphans, _ = self.run_check("--delete", "--yes")
+
+        assert orphans == []
+        assert self.exists(fs_filename)
+
+    def test_community_resource_files_are_kept(self):
+        fs_filename = "ds/20200101-000000/community.csv"
+        self.write_file(fs_filename)
+        CommunityResourceFactory(fs_filename=fs_filename)
+
+        orphans, _ = self.run_check("--delete", "--yes")
+
+        assert orphans == []
+        assert self.exists(fs_filename)
+
+    def test_broken_references_are_reported_not_deleted(self):
+        """A resource pointing to a missing file is a broken reference, not an orphan."""
+        missing = "ds/20200101-000000/missing.csv"
+        DatasetFactory(resources=[ResourceFactory(fs_filename=missing)])
+
+        orphans, broken = self.run_check("--delete", "--yes")
+
+        assert orphans == []
+        assert broken == [missing]
+
+    def test_non_local_backend_fails_fast(self):
+        """On a backend without direct filesystem access (e.g. S3), the command
+        refuses to run upfront instead of crashing mid-scan."""
+        backend = storages.resources.backend
+        # A non-local backend has no `root` (BaseBackend.root is None).
+        with patch.object(backend, "root", None):
+            result = self.app.test_cli_runner().invoke(cli_cmd, ["dataset", "check-files"])
+
+        assert result.exit_code != 0
+        assert "local filesystem backend" in result.output


### PR DESCRIPTION
The FS is telling us 6.5To used but the MongoDB database give:

Dataset resources : 147,921 | 1.6 TiB (1,770,172,415,342.0 o) | 2,290 sans filesize
Community resources : 1,107 | 24.4 GiB (26,176,521,412.0 o) | 0 sans filesize
TOTAL hébergé : 1.6 TiB (1,796,348,936,754.0 o)

We could scan faster without using `os.stat()` I think, by just listing files and comparing but we'll loose the reclaimable space info and the security of the mtime (to not delete new files, but we could do a second pass on MongoDB to confirm the new files)