### PR TITLE
fix(harvest): allow sending lowercase properties to GeoIDE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,74 @@ jobs:
           path: reports/
           destination: reports
 
+  # Experimental: spin up real CSW servers (PyCSW + GeoNetwork 3.x) as service
+  # containers and send them our actual GetRecords request, to measure how long
+  # booting them takes in CI and which `apiso:` property casing each accepts.
+  # GeoNetwork (Java + H2 + Lucene) is the slow one — its "Wait for GeoNetwork"
+  # step duration is the timing signal we care about.
+  csw-integration:
+    resource_class: large
+    docker:
+      - image: ghcr.io/astral-sh/uv:python3.11-trixie
+      - image: mongo:7.0.28
+      - image: redis:alpine
+      - image: geopython/pycsw:2.6.1
+      - image: geonetwork:3.12.12
+    environment:
+      BASH_ENV: /root/.bashrc
+      UDATA_TEST_CSW_INTEGRATION: "1"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - py3.11-cache-v1-{{ arch }}-{{ checksum "pyproject.toml" }}-{{ checksum "uv.lock" }}
+            - py3.11-cache-v1-{{ arch }}-
+      - run:
+          name: Install Python dependencies
+          command: |
+            uv sync --frozen
+      - run:
+          name: Install curl
+          command: |
+            apt-get update && apt-get install -y curl
+      - run:
+          name: Wait for PyCSW
+          command: |
+            start=$(date +%s)
+            for i in $(seq 1 60); do
+              if curl -sf "http://localhost:8000/?service=CSW&version=2.0.2&request=GetCapabilities" >/dev/null; then
+                echo "PyCSW ready after $(($(date +%s) - start))s"
+                exit 0
+              fi
+              echo "Waiting for PyCSW... ($i/60)"
+              sleep 2
+            done
+            echo "PyCSW failed to start"
+            exit 1
+      - run:
+          name: Wait for GeoNetwork
+          command: |
+            start=$(date +%s)
+            for i in $(seq 1 120); do
+              code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:8080/geonetwork/srv/eng/csw?service=CSW&request=GetCapabilities")
+              if [ "$code" = "200" ]; then
+                echo "GeoNetwork ready after $(($(date +%s) - start))s"
+                exit 0
+              fi
+              echo "Waiting for GeoNetwork... ($i/120) - HTTP $code"
+              sleep 5
+            done
+            echo "GeoNetwork failed to start"
+            exit 1
+      - run:
+          name: Run CSW integration tests
+          command: |
+            mkdir -p reports/python
+            uv run pytest udata/harvest/tests/test_csw_integration.py -v \
+              --junitxml=reports/python/csw-integration.xml
+      - store_test_results:
+          path: reports/python
+
   dist:
     docker:
       - image: ghcr.io/astral-sh/uv:python<< pipeline.parameters.python-version >>-trixie
@@ -220,6 +288,7 @@ workflows:
               python-version: ["3.11", "3.13"]
               mongo-version: ["7.0.28"]
               elasticsearch-version: ["7.17.28", "8.19.13"]
+      - csw-integration
       - dist:
           requires:
             - python

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -3,6 +3,7 @@ import traceback
 from abc import ABC, abstractmethod
 from datetime import date
 from typing import ClassVar, Generator
+from urllib.parse import urlparse
 
 from flask import current_app
 from rdflib import Graph
@@ -311,19 +312,19 @@ class BaseCswDcatBackend(DcatBackend, ABC):
           <ogc:Filter>
             <ogc:Or>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:type</ogc:PropertyName>
+                <ogc:PropertyName>{type_property}</ogc:PropertyName>
                 <ogc:Literal>dataset</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:type</ogc:PropertyName>
+                <ogc:PropertyName>{type_property}</ogc:PropertyName>
                 <ogc:Literal>nonGeographicDataset</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:type</ogc:PropertyName>
+                <ogc:PropertyName>{type_property}</ogc:PropertyName>
                 <ogc:Literal>series</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:type</ogc:PropertyName>
+                <ogc:PropertyName>{type_property}</ogc:PropertyName>
                 <ogc:Literal>service</ogc:Literal>
               </ogc:PropertyIsEqualTo>
             </ogc:Or>
@@ -331,7 +332,7 @@ class BaseCswDcatBackend(DcatBackend, ABC):
         </csw:Constraint>
         <ogc:SortBy>
           <ogc:SortProperty>
-            <ogc:PropertyName>apiso:identifier</ogc:PropertyName>
+            <ogc:PropertyName>{identifier_property}</ogc:PropertyName>
             <ogc:SortOrder>ASC</ogc:SortOrder>
           </ogc:SortProperty>
         </ogc:SortBy>
@@ -376,18 +377,40 @@ class BaseCswDcatBackend(DcatBackend, ABC):
     def get_format(self) -> str:
         return "xml"
 
+    def build_csw_request(self, start: int) -> str:
+        """
+        Build the CSW GetRecords request for the given start position.
+
+        Per OGC 07-045r2 §7.2.4 the common queryables (type, identifier) are
+        lowercase; GeoIDE follows this, but pycsw only accepts the capitalized
+        form (https://github.com/geopython/pycsw/issues/1235). We default to the
+        capitalized form pycsw needs and send lowercase only to the hosts listed
+        in `HARVEST_CSW_LOWERCASE_APISO_HOSTS`.
+        """
+        lowercase_hosts = current_app.config["HARVEST_CSW_LOWERCASE_APISO_HOSTS"]
+        if urlparse(self.source.url).hostname in lowercase_hosts:
+            type_property, identifier_property = "apiso:type", "apiso:identifier"
+        else:
+            type_property, identifier_property = "apiso:Type", "apiso:Identifier"
+
+        return self.CSW_REQUEST.format(
+            output_schema=self.output_schema,
+            start=start,
+            type_property=type_property,
+            identifier_property=identifier_property,
+        )
+
     @override
     def walk_graph(self, url: str, fmt: str) -> Generator[tuple[int, Graph], None, None]:
         """
         Yield all RDF pages as `Graph` from the source.
         """
-        output_schema = self.output_schema
         page_number = 0
         start = 1
 
         while True:
             log.debug(f"Requesting CSW from start={start}")
-            data = self.CSW_REQUEST.format(output_schema=output_schema, start=start)
+            data = self.build_csw_request(start)
             response = self.post(url, data=data, headers={"Content-Type": "application/xml"})
             response.raise_for_status()
 

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -311,19 +311,19 @@ class BaseCswDcatBackend(DcatBackend, ABC):
           <ogc:Filter>
             <ogc:Or>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>dataset</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>nonGeographicDataset</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>series</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>service</ogc:Literal>
               </ogc:PropertyIsEqualTo>
             </ogc:Or>
@@ -331,7 +331,7 @@ class BaseCswDcatBackend(DcatBackend, ABC):
         </csw:Constraint>
         <ogc:SortBy>
           <ogc:SortProperty>
-            <ogc:PropertyName>apiso:Identifier</ogc:PropertyName>
+            <ogc:PropertyName>apiso:identifier</ogc:PropertyName>
             <ogc:SortOrder>ASC</ogc:SortOrder>
           </ogc:SortProperty>
         </ogc:SortBy>

--- a/udata/harvest/tests/csw_dcat/records/combles.xml
+++ b/udata/harvest/tests/csw_dcat/records/combles.xml
@@ -1,0 +1,663 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xsi:schemaLocation="http://www.isotc211.org/2005/gmx http://schemas.opengis.net/iso/19139/20060504/gmx/gmx.xsd">
+      <gmd:fileIdentifier>
+        <gco:CharacterString>fr-120066022-ldd-3f4cc8c8-5c3e-4a0e-8b56-0a569a7e12f6</gco:CharacterString>
+      </gmd:fileIdentifier>
+      <gmd:language>
+        <gmd:LanguageCode codeListValue="fre" codeList="http://www.loc.gov/standards/iso639-2/">fre</gmd:LanguageCode>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeListValue="ISO-8859-15" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_CharacterSetCode">ISO-8859-15</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode">dataset</gmd:MD_ScopeCode>
+      </gmd:hierarchyLevel>
+      <gmd:hierarchyLevelName>
+        <gco:CharacterString>lot de données</gco:CharacterString>
+      </gmd:hierarchyLevelName>
+      <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:organisationName>
+            <gco:CharacterString>DDTM 80 (Direction Départementale des Territoires et de la Mer de la Somme)</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>0364572400</gco:CharacterString>
+                  </gmd:voice>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint>
+                    <gco:CharacterString>35 rue de la vallee</gco:CharacterString>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>AMIENS</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>80000</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>FRANCE</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>ddtm-sap-bsig@somme.gouv.fr</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeListValue="pointOfContact" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode">pointOfContact</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:contact>
+      <gmd:dateStamp>
+        <gco:DateTime>2019-03-25T22:56:15.973+01:00</gco:DateTime>
+      </gmd:dateStamp>
+      <gmd:metadataStandardName>
+        <gco:CharacterString>ISO 19115</gco:CharacterString>
+      </gmd:metadataStandardName>
+      <gmd:metadataStandardVersion>
+        <gco:CharacterString>2003 Cor.1:2006</gco:CharacterString>
+      </gmd:metadataStandardVersion>
+      <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+          <gmd:referenceSystemIdentifier>
+            <gmd:RS_Identifier>
+              <gmd:code>
+                <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/2154" xlink:title="RGF93 - Lambert 93">2154</gmx:Anchor>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>EPSG</gco:CharacterString>
+              </gmd:codeSpace>
+            </gmd:RS_Identifier>
+          </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+      </gmd:referenceSystemInfo>
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:citation>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Plan local d'urbanisme de la commune de Combles</gco:CharacterString>
+              </gmd:title>
+              <gmd:alternateTitle>
+                <gco:CharacterString>Plan local d'urbanisme de la commune de Combles</gco:CharacterString>
+              </gmd:alternateTitle>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2017-10-07</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeListValue="publication" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2003-06-02</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeListValue="creation" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode">creation</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>http://catalogue.geo-ide.developpement-durable.gouv.fr/fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4</gco:CharacterString>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:citation>
+          <gmd:abstract>
+            <gco:CharacterString>Le présent standard de données COVADIS concerne les documents de plans locaux d'urbanisme (PLU) et les plans d'occupation des sols (POS qui valent PLU). Ce standard de données offre un cadre technique décrivant en détail la façon de dématérialiser ces documents d'urbanisme en une base de données géographiques qui soit exploitable par un outil SIG et interopérable. Ce standard de données concerne aussi bien les plans graphiques de zonage, les prescriptions s'y superposant que les règlements s'appliquant à chaque type de zone.Ce standard de données COVADIS a été élaboré à partir du cahier des charges pour la dématérialisation des documents d'urbanisme mis à jour en 2012 par le CNIG, lui même basé sur la version consolidée du code de l'urbanisme en date du 16 mars 2012. Les recommandations de ces deux documents sont cohérentes même si leur objet n'est pas le même. Le standard de données COVADIS propose des définitions et une structure pour organiser et ranger dans une infrastructure les données géographiques de PLU/POS existant sous forme numérique tandis que le cahier des charges du CNIG sert à encadrer la numérisation de ces données. La partie 'Structure des données' présentée dans ce standard COVADIS donne des recommandations complémentaires en matière de stockage des fichiers de données (cf. partie C). Il s'agit de choix spécifiques à l'infrastructure de données du MAA et du MEDDE qui ne s'appliquent pas en dehors de leur contexte.Les cartes communales font l'objet d'un autre standard de données COVADIS.</gco:CharacterString>
+          </gmd:abstract>
+          <gmd:purpose>
+            <gco:CharacterString>Les données standardisées visent principalement trois objectifs complémentaires :- Faciliter la dématérialisation des documents d'urbanisme, en particulier leurs documents graphiques, afin qu'ils s'intègrent au mieux à un logiciel d'aide à l'instruction ADS.(application du droit des sols)- Permettre la généralisation des documents d'urbanisme pour leur suivi national et des études d'occupation du sol, d'étalement urbain et de maitrise de l'urbanisation.- Permettre de répondre aux objectifs du Grenelle de l'environnement :« Art. L121-1 Les schémas de cohérence territoriale, les plans locaux d'urbanisme et les cartes communales déterminent les conditions permettant d'assurer, dans le respect des objectifs du développement durable :1° L'équilibre entre :a) Le renouvellement urbain, le développement urbain maîtrisé, la restructuration des espaces urbanisés, la revitalisation des centres urbains et ruraux ;b) L'utilisation économe des espaces naturels, la préservation des espaces affectés aux activités agricoles et forestières, et la protection des sites, des milieux et paysages naturels ;c) La sauvegarde des ensembles urbains et du patrimoine bâti remarquables ;1° bis La qualité urbaine, architecturale et paysagère des entrées de ville ;2° La diversité des fonctions urbaines et rurales et la mixité sociale dans l'habitat, en prévoyant des capacités de construction et de réhabilitation suffisantes pour la satisfaction, sans discrimination, des besoins présents et futurs en matière d'habitat, d'activités économiques, touristiques, sportives, culturelles et d'intérêt général ainsi que d'équipements publics et d'équipement commercial, en tenant compte en particulier des objectifs de répartition géographiquement équilibrée entre emploi, habitat, commerces et services, d'amélioration des performances énergétiques, de développement des communications électroniques, de diminution des obligations de déplacements et de développement des transports collectifs ;</gco:CharacterString>
+          </gmd:purpose>
+          <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+              <gmd:organisationName>
+                <gco:CharacterString>DDTM 80 (Direction Départementale des Territoires et de la Mer de la Somme)</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <gmd:CI_Telephone>
+                      <gmd:voice>
+                        <gco:CharacterString>0364572400</gco:CharacterString>
+                      </gmd:voice>
+                    </gmd:CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:deliveryPoint>
+                        <gco:CharacterString>35 rue de la vallee</gco:CharacterString>
+                      </gmd:deliveryPoint>
+                      <gmd:city>
+                        <gco:CharacterString>AMIENS</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:postalCode>
+                        <gco:CharacterString>80000</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>FRANCE</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>ddtm-sap-bsig@somme.gouv.fr</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeListValue="pointOfContact" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode">pointOfContact</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:pointOfContact>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>Aménagement Urbanisme/Zonages Planification</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeListValue="theme" codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode"/>
+              </gmd:type>
+              <gmd:thesaurusName>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Arborescence thématique de la COVADIS</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2009-04-06</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeListValue="publication" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode">publication</gmd:CI_DateTypeCode>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>Usage des sols</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeListValue="theme" codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode"/>
+              </gmd:type>
+              <gmd:thesaurusName>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2008-06-01</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeListValue="publication" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode">publication</gmd:CI_DateTypeCode>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>combles</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeListValue="theme" codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode">theme</gmd:MD_KeywordTypeCode>
+              </gmd:type>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>document d'urbanisme</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeListValue="theme" codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode">theme</gmd:MD_KeywordTypeCode>
+              </gmd:type>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>plu</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeListValue="theme" codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode">theme</gmd:MD_KeywordTypeCode>
+              </gmd:type>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>usage des sols</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeListValue="theme" codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode">theme</gmd:MD_KeywordTypeCode>
+              </gmd:type>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>données ouvertes</gco:CharacterString>
+              </gmd:keyword>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:resourceConstraints>
+            <gmd:MD_Constraints>
+              <gmd:useLimitation>
+                <gco:CharacterString>Cette mise à disposition, à titre informatif, ne se substitue en rien à la diffusion
+  du document opposable de la responsabilité des communes. Seul le document
+  papier est aujourd'hui opposable, et consultable en mairie</gco:CharacterString>
+              </gmd:useLimitation>
+              <gmd:useLimitation>
+                <gco:CharacterString>En application du code de l'urbanisme, la mise à disposition du public des documents d'urbanisme est à la charge de la collectivité responsable (Commune ou EPCI).-Conditions concernant les services ministérielsLes services du MEDDE et du MAAF sont amenés recevoir des documents numériques provenant des collectivités locales, ne serait-ce que pour être en capacité d'instruire les permis de construire État.Ils peuvent accessoirement être conduits à numériser tout ou partie de ces documents d'urbanisme. Ils peuvent diffuser les données de zonage figurant dans les documents d'urbanisme à tout type d'organisme public ou privé, en prenant bien garde de mentionner que seul le document papier fait foi et que le document diffusé peut ne pas être la version qui a cours.La diffusion d'un lot de données numérisé par un service du MEDDE et du MAAF revêt un caractère obligatoire car ces données sont concernées par le thème « Usage des sols » de l'annexe III d'INSPIRE. L'utilisation en interne des fichiers géographiques obtenus n'est soumise à aucune limitation. Toute production issue d'une utilisation de ces données devra mentionner les mentions légales imposées par le producteur du référentiel géographique source (à préciser localement au moment du catalogage selon le référentiel utilisé - cf. B.5 du standard COVADIS), et, le cas échéant, par la collectivité ayant mis à disposition ses données numériques.-Conditions concernant le publicLes données du document d'urbanisme numérique sont réutilisables sans restriction par le public. Toute production issue d'une réutilisation de ces données doit mentionner les mentions légales imposées par le producteur du référentiel géographique source (à préciser localement au moment du catalogage selon le référentiel utilisé - cf. B.5 du standard COVADIS) et le nom de l'organisme fournisseur.</gco:CharacterString>
+              </gmd:useLimitation>
+            </gmd:MD_Constraints>
+          </gmd:resourceConstraints>
+          <gmd:resourceConstraints>
+            <gmd:MD_LegalConstraints>
+              <gmd:useLimitation>
+                <gco:CharacterString>Mentionner les noms des organismes fournisseurs de données : DDTM80 et d'indiquer la date de mise à jour des données
+
+  Mentionner le producteur des référentiels géographiques : ©IGN (BD Parcellaire®)</gco:CharacterString>
+              </gmd:useLimitation>
+              <gmd:useLimitation>
+                <gco:CharacterString>Licence Ouverte 1.0 http://www.data.gouv.fr/Licence-Ouverte-Open-Licence.</gco:CharacterString>
+              </gmd:useLimitation>
+              <gmd:useLimitation>
+                <gco:CharacterString>Aucun des articles de la loi ne peut être invoqué pour justifier d'une restriction d'accès public.</gco:CharacterString>
+              </gmd:useLimitation>
+              <gmd:accessConstraints>
+                <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode">otherRestrictions</gmd:MD_RestrictionCode>
+              </gmd:accessConstraints>
+              <gmd:useConstraints>
+                <gmd:MD_RestrictionCode codeListValue="license" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode">license</gmd:MD_RestrictionCode>
+              </gmd:useConstraints>
+              <gmd:otherConstraints>
+                <gco:CharacterString>Pas de restriction d'accès public selon INSPIRE</gco:CharacterString>
+              </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+          </gmd:resourceConstraints>
+          <gmd:aggregationInfo>
+            <gmd:MD_AggregateInformation>
+              <gmd:aggregateDataSetIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>fr-120066022-jdd-a2cac64a-2d29-4da8-a567-e1fb79e91c32</gco:CharacterString>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:aggregateDataSetIdentifier>
+              <gmd:associationType>
+                <gmd:DS_AssociationTypeCode codeListValue="partOfSeamlessDatabase" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_AssociationTypeCode">partOfSeamlessDatabase</gmd:DS_AssociationTypeCode>
+              </gmd:associationType>
+              <gmd:initiativeType>
+                <gmd:DS_InitiativeTypeCode codeListValue="collection" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_InitiativeTypeCode">collection</gmd:DS_InitiativeTypeCode>
+              </gmd:initiativeType>
+            </gmd:MD_AggregateInformation>
+          </gmd:aggregationInfo>
+          <gmd:aggregationInfo>
+            <gmd:MD_AggregateInformation>
+              <gmd:aggregateDataSetIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>fr-120066022-jdd-594480f9-c52e-4b81-8921-94cd67a055fd</gco:CharacterString>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:aggregateDataSetIdentifier>
+              <gmd:associationType>
+                <gmd:DS_AssociationTypeCode codeListValue="partOfSeamlessDatabase" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_AssociationTypeCode">partOfSeamlessDatabase</gmd:DS_AssociationTypeCode>
+              </gmd:associationType>
+              <gmd:initiativeType>
+                <gmd:DS_InitiativeTypeCode codeListValue="collection" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_InitiativeTypeCode">collection</gmd:DS_InitiativeTypeCode>
+              </gmd:initiativeType>
+            </gmd:MD_AggregateInformation>
+          </gmd:aggregationInfo>
+          <gmd:aggregationInfo>
+            <gmd:MD_AggregateInformation>
+              <gmd:aggregateDataSetIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>fr-120066022-jdd-5d78c914-1563-43e3-90c6-8f6a75a212a7</gco:CharacterString>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:aggregateDataSetIdentifier>
+              <gmd:associationType>
+                <gmd:DS_AssociationTypeCode codeListValue="partOfSeamlessDatabase" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_AssociationTypeCode">partOfSeamlessDatabase</gmd:DS_AssociationTypeCode>
+              </gmd:associationType>
+              <gmd:initiativeType>
+                <gmd:DS_InitiativeTypeCode codeListValue="collection" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_InitiativeTypeCode">collection</gmd:DS_InitiativeTypeCode>
+              </gmd:initiativeType>
+            </gmd:MD_AggregateInformation>
+          </gmd:aggregationInfo>
+          <gmd:aggregationInfo>
+            <gmd:MD_AggregateInformation>
+              <gmd:aggregateDataSetIdentifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>fr-120066022-jdd-474a5912-f1e8-4698-9a8e-dc152fc1e3d3</gco:CharacterString>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:aggregateDataSetIdentifier>
+              <gmd:associationType>
+                <gmd:DS_AssociationTypeCode codeListValue="partOfSeamlessDatabase" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_AssociationTypeCode">partOfSeamlessDatabase</gmd:DS_AssociationTypeCode>
+              </gmd:associationType>
+              <gmd:initiativeType>
+                <gmd:DS_InitiativeTypeCode codeListValue="collection" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DS_InitiativeTypeCode">collection</gmd:DS_InitiativeTypeCode>
+              </gmd:initiativeType>
+            </gmd:MD_AggregateInformation>
+          </gmd:aggregationInfo>
+          <gmd:spatialRepresentationType>
+            <gmd:MD_SpatialRepresentationTypeCode codeListValue="vector" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode">vector</gmd:MD_SpatialRepresentationTypeCode>
+          </gmd:spatialRepresentationType>
+          <gmd:language>
+            <gmd:LanguageCode codeListValue="fre" codeList="http://www.loc.gov/standards/iso639-2/">fre</gmd:LanguageCode>
+          </gmd:language>
+          <gmd:characterSet>
+            <gmd:MD_CharacterSetCode codeListValue="8859part15" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_CharacterSetCode">8859part15</gmd:MD_CharacterSetCode>
+          </gmd:characterSet>
+          <gmd:topicCategory>
+            <gmd:MD_TopicCategoryCode>planningCadastre</gmd:MD_TopicCategoryCode>
+          </gmd:topicCategory>
+          <gmd:extent>
+            <gmd:EX_Extent>
+              <gmd:description>
+                <gco:CharacterString>département de la Somme, Département de la Somme</gco:CharacterString>
+              </gmd:description>
+              <gmd:geographicElement>
+                <gmd:EX_GeographicBoundingBox>
+                  <gmd:westBoundLongitude>
+                    <gco:Decimal>3.28133559</gco:Decimal>
+                  </gmd:westBoundLongitude>
+                  <gmd:eastBoundLongitude>
+                    <gco:Decimal>1.31279111</gco:Decimal>
+                  </gmd:eastBoundLongitude>
+                  <gmd:southBoundLatitude>
+                    <gco:Decimal>49.38547516</gco:Decimal>
+                  </gmd:southBoundLatitude>
+                  <gmd:northBoundLatitude>
+                    <gco:Decimal>50.48188019</gco:Decimal>
+                  </gmd:northBoundLatitude>
+                </gmd:EX_GeographicBoundingBox>
+              </gmd:geographicElement>
+            </gmd:EX_Extent>
+          </gmd:extent>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+      <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+          <gmd:distributionFormat>
+            <gmd:MD_Format>
+              <gmd:name>
+                <gco:CharacterString>MapInfo TAB</gco:CharacterString>
+              </gmd:name>
+              <gmd:version>
+                <gco:CharacterString/>
+              </gmd:version>
+            </gmd:MD_Format>
+          </gmd:distributionFormat>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>Accès aux métadonnées</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://catalogue.geo-ide.e2.rie.gouv.fr/catalogue/srv/fre/catalog.search#/metadata/fr-120066022-ldd-3f4cc8c8-5c3e-4a0e-8b56-0a569a7e12f6</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Vue HTML des métadonnées sur internet</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://ogc.geo-ide.developpement-durable.gouv.fr/csw/all-dataset?REQUEST=GetRecordById&amp;SERVICE=CSW&amp;VERSION=2.0.2&amp;RESULTTYPE=results&amp;elementSetName=full&amp;TYPENAMES=gmd:MD_Metadata&amp;OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&amp;ID=fr-120066022-ldd-3f4cc8c8-5c3e-4a0e-8b56-0a569a7e12f6</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Vue XML des métadonnées</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>Autres ressources en ligne</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=fr-120066022-ldd-9acf7f5f-edfa-4fc7-82a7-85aabb9650e7&amp;datasetAggregate=true</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Téléchargement direct du lot et des documents associés</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://geostandards.developpement-durable.gouv.fr/afficherPageStandard.do?lot=Plan-local-d-urbanisme-v2.0</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Standard de données COVADIS : Plan local d'urbanisme v2.0</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://atom.geo-ide.developpement-durable.gouv.fr/atomMetadata/GetResourceDescription?id=fr-120066022-orphan-residentifier-8f174fa7-7fcc-4784-b062-dccdd30c9f2e&amp;scope=INTERNET</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Service de téléchargement associé</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=fr-120066022-ldd-cab63273-b3ae-4e8a-ae1c-6192e45faa94&amp;datasetAggregate=true</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Téléchargement direct du lot et des documents associés</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://atom.geo-ide.developpement-durable.gouv.fr/atomMetadata/GetResourceDescription?id=fr-120066022-orphan-residentifier-f05dc5c6-3a6f-4169-9980-40e6e31d0557&amp;scope=INTERNET</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Service de téléchargement associé</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>Accès aux données</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4&amp;dataType=datasetAggregate</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Téléchargement simple (Atom) du lot et des documents associés via internet</gco:CharacterString>
+                  </gmd:name>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>Accès aux données</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://atom.geo-ide.e2.rie.gouv.fr/atomArchive/GetResource?id=fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4&amp;dataType=datasetAggregate</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>Téléchargement simple (Atom) du lot et des documents associés via intranet</gco:CharacterString>
+                  </gmd:name>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>URL du GetCapabilities des services wms/wfs</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://ogc.geo-ide.developpement-durable.gouv.fr/wxs?map=/opt/data/stack/mapfiles/1.4/org_38100/fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4.internet.map&amp;SERVICE=WMS&amp;REQUEST=GetCapabilities</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:name>
+                    <gco:CharacterString>URL du GetCapabilities des services wms/wfs sur internet</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>URL du GetCapabilities des services wms/wfs</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://ogc.geo-ide.developpement-durable.gouv.fr/wxs?map=/opt/data/stack/mapfiles/1.4/org_38100/fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4.internet.map&amp;SERVICE=WFS&amp;REQUEST=GetCapabilities</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:name>
+                    <gco:CharacterString>URL du GetCapabilities des services wms/wfs sur internet</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>URL du GetCapabilities des services wms/wfs</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://ogc.geo-ide.e2.rie.gouv.fr/wxs?map=/opt/data/stack/mapfiles/1.4/org_38100/fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4.intranet.map&amp;SERVICE=WMS&amp;REQUEST=GetCapabilities</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:name>
+                    <gco:CharacterString>URL du GetCapabilities des services wms/wfs sur intranet</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:unitsOfDistribution>
+                <gco:CharacterString>URL du GetCapabilities des services wms/wfs</gco:CharacterString>
+              </gmd:unitsOfDistribution>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://ogc.geo-ide.e2.rie.gouv.fr/wxs?map=/opt/data/stack/mapfiles/1.4/org_38100/fr-120066022-orphan-residentifier-c46794fd-005d-499a-9a9b-0627761d31a4.intranet.map&amp;SERVICE=WFS&amp;REQUEST=GetCapabilities</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:name>
+                    <gco:CharacterString>URL du GetCapabilities des services wms/wfs sur intranet</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+        </gmd:MD_Distribution>
+      </gmd:distributionInfo>
+      <gmd:dataQualityInfo>
+        <gmd:DQ_DataQuality>
+          <gmd:scope>
+            <gmd:DQ_Scope>
+              <gmd:level>
+                <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode">dataset</gmd:MD_ScopeCode>
+              </gmd:level>
+            </gmd:DQ_Scope>
+          </gmd:scope>
+          <gmd:lineage>
+            <gmd:LI_Lineage>
+              <gmd:statement>
+                <gco:CharacterString>Les limites d'une zone sont représentées sur les documents graphiques du PLU ou du POS. Elles correspondent généralement aux limites d'un agrégat de parcelles cadastrales.
+  Une prescription est représentée sur les documents graphiques du PLU ou POS. Sa géométrie est obtenue par numérisation des figurés dessinés sur le plan de zonage règlementaire. La table géographique résultante doit contenir toutes les prescriptions identifiées comme telles dans le document d'urbanisme.
+  Une information surfacique, linéaire ou ponctuelle est représentée sur le document graphique du PLU ou POS. Sa géométrie est généralement obtenue par numérisation des figurés dessinés en surcharge du plan de zonage règlementaire. La table géographique résultante doit contenir tous les objets géographiques à caractère informatif du document d'urbanisme.
+  La géométrie des parcelles cadastrales est une donnée issue du référentiel géographique cadastral choisi au moment de l'élaboration du document d'urbanisme. Ce référentiel géographique cadastral peut être soit la BD Parcellaire fournie par l'IGN, soit le plan cadastral informatisé (PCI) fourni par la DGI.</gco:CharacterString>
+              </gmd:statement>
+            </gmd:LI_Lineage>
+          </gmd:lineage>
+        </gmd:DQ_DataQuality>
+      </gmd:dataQualityInfo>
+    </gmd:MD_Metadata>
+  

--- a/udata/harvest/tests/test_csw_integration.py
+++ b/udata/harvest/tests/test_csw_integration.py
@@ -1,0 +1,124 @@
+"""
+End-to-end CSW harvest tests against real CSW servers (PyCSW and GeoNetwork)
+running as CI service containers.
+
+Unlike the mocked tests in `test_dcat_backend.py`, these run the whole harvest
+pipeline against a server's own request parser — the only thing that can catch
+a request that is valid XML but rejected by a real catalog.
+
+Context: PR #3837 capitalized the `apiso:` property names (`apiso:type` ->
+`apiso:Type`, `apiso:identifier` -> `apiso:Identifier`) to satisfy a PyCSW
+instance. These tests reproduce, end to end, what each server family does with
+the *current* code: PyCSW is expected to accept the request, while GeoNetwork
+is expected to reject the capitalized request (the GeoIDE failure mode), which
+makes the harvest fail with a "Failed to query CSW" error.
+
+The GeoNetwork record is pushed over its REST API at the start of the test (no
+records need to be loaded into PyCSW: a request parse error happens before any
+data lookup). Skipped unless `UDATA_TEST_CSW_INTEGRATION=1` and both servers
+are reachable, so they only run in the dedicated CI job.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import requests
+
+from udata.core.organization.factories import OrganizationFactory
+from udata.models import Dataset
+from udata.tests.api import PytestOnlyDBTestCase
+
+from .. import actions
+from .factories import HarvestSourceFactory
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("UDATA_TEST_CSW_INTEGRATION"),
+    reason="Set UDATA_TEST_CSW_INTEGRATION=1 to run CSW integration tests against real servers",
+)
+
+PYCSW_URL = os.environ.get("CSW_PYCSW_URL", "http://localhost:8000/")
+GEONETWORK_URL = os.environ.get(
+    "CSW_GEONETWORK_URL", "http://localhost:8080/geonetwork/srv/eng/csw"
+)
+GEONETWORK_BASE = os.environ.get("CSW_GEONETWORK_BASE", "http://localhost:8080/geonetwork")
+
+RECORD = Path(__file__).parent / "csw_dcat" / "records" / "combles.xml"
+# Title produced by harvesting `records/combles.xml` (same record and mapping
+# as `test_geoide` in test_dcat_backend.py).
+EXPECTED_TITLE = "Plan local d'urbanisme de la commune de Combles"
+
+QUERY_REJECTED = "Failed to query CSW"
+
+
+def load_geonetwork_record():
+    """Push the ISO-19139 test record into GeoNetwork and publish it.
+
+    GeoNetwork requires an XSRF token (set as a cookie on a first authenticated
+    call) to be echoed back as a header on the insert request.
+    """
+    session = requests.Session()
+    session.auth = ("admin", "admin")
+
+    session.get(f"{GEONETWORK_BASE}/srv/api/me", timeout=30)
+    token = session.cookies.get("XSRF-TOKEN")
+
+    response = session.put(
+        f"{GEONETWORK_BASE}/srv/api/records",
+        params={
+            "metadataType": "METADATA",
+            "uuidProcessing": "OVERWRITE",
+            "group": "2",
+            "rejectIfInvalid": "false",
+            "publishToAll": "true",
+        },
+        headers={
+            "X-XSRF-TOKEN": token,
+            "Content-Type": "application/xml",
+            "Accept": "application/json",
+        },
+        data=RECORD.read_bytes(),
+        timeout=30,
+    )
+    response.raise_for_status()
+
+
+@pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
+class CswIntegrationTest(PytestOnlyDBTestCase):
+    def harvest(self, url):
+        source = HarvestSourceFactory(
+            backend="csw-iso-19139",
+            url=url,
+            organization=OrganizationFactory(),
+        )
+        actions.run(source)
+        source.reload()
+        return source.get_last_job()
+
+    def test_pycsw_accepts_request(self):
+        """PyCSW must parse our GetRecords request (the casing it was tuned for).
+
+        We only assert the request was accepted, not on specific datasets: the
+        stock PyCSW image is preloaded with unrelated conformance data, so its
+        records may or may not convert cleanly — that is not what we test here.
+        """
+        job = self.harvest(PYCSW_URL)
+
+        query_errors = [error.message for error in job.errors if QUERY_REJECTED in error.message]
+        assert not query_errors, query_errors
+
+    def test_geonetwork_harvests_record(self):
+        """GeoNetwork must accept the request and yield the published record.
+
+        On the current (capitalized) code this fails: GeoNetwork rejects the
+        request with a "Failed to query CSW" error — the GeoIDE bug, reproduced.
+        """
+        load_geonetwork_record()
+
+        job = self.harvest(GEONETWORK_URL)
+
+        query_errors = [error.message for error in job.errors if QUERY_REJECTED in error.message]
+        assert not query_errors, query_errors
+
+        titles = {dataset.title for dataset in Dataset.objects}
+        assert EXPECTED_TITLE in titles, titles

--- a/udata/harvest/tests/test_csw_integration.py
+++ b/udata/harvest/tests/test_csw_integration.py
@@ -44,6 +44,11 @@ GEONETWORK_URL = os.environ.get(
     "CSW_GEONETWORK_URL", "http://localhost:8080/geonetwork/srv/eng/csw"
 )
 GEONETWORK_BASE = os.environ.get("CSW_GEONETWORK_BASE", "http://localhost:8080/geonetwork")
+# Harvest as admin (credentials in the URL) so GeoNetwork returns the freshly
+# inserted record, which is not published to the anonymous group by default.
+GEONETWORK_AUTH_URL = os.environ.get(
+    "CSW_GEONETWORK_AUTH_URL", "http://admin:admin@localhost:8080/geonetwork/srv/eng/csw"
+)
 
 RECORD = Path(__file__).parent / "csw_dcat" / "records" / "combles.xml"
 # Title produced by harvesting `records/combles.xml` (same record and mapping
@@ -125,7 +130,7 @@ class CswIntegrationTest(PytestOnlyDBTestCase):
         """Full pipeline: push a record into GeoNetwork, harvest it back out."""
         load_geonetwork_record()
 
-        job = self.harvest(GEONETWORK_URL)
+        job = self.harvest(GEONETWORK_AUTH_URL)
 
         query_errors = [error.message for error in job.errors if QUERY_REJECTED in error.message]
         assert not query_errors, query_errors

--- a/udata/harvest/tests/test_csw_integration.py
+++ b/udata/harvest/tests/test_csw_integration.py
@@ -61,24 +61,25 @@ def load_geonetwork_record():
     session = requests.Session()
     session.auth = ("admin", "admin")
 
-    session.get(f"{GEONETWORK_BASE}/srv/eng/info?type=me", timeout=30)
+    # A POST to this endpoint authenticates and sets the XSRF-TOKEN cookie.
+    session.post(f"{GEONETWORK_BASE}/srv/eng/info?type=me", timeout=30)
     token = session.cookies.get("XSRF-TOKEN")
+    assert token, f"no XSRF-TOKEN cookie returned, got: {session.cookies.get_dict()}"
 
+    # Spring accepts the token as the X-XSRF-TOKEN header or the _csrf parameter.
     response = session.put(
         f"{GEONETWORK_BASE}/srv/api/records",
         params={
             "metadataType": "METADATA",
             "uuidProcessing": "OVERWRITE",
-            "group": "2",
-            "category": "",
-            "rejectIfInvalid": "false",
             "publishToAll": "true",
+            "_csrf": token,
         },
         headers={"X-XSRF-TOKEN": token, "Accept": "application/json"},
         files={"file": ("combles.xml", RECORD.read_bytes(), "application/xml")},
         timeout=60,
     )
-    response.raise_for_status()
+    assert response.ok, f"GeoNetwork insert failed {response.status_code}: {response.text[:1000]}"
 
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])

--- a/udata/harvest/tests/test_csw_integration.py
+++ b/udata/harvest/tests/test_csw_integration.py
@@ -8,15 +8,17 @@ a request that is valid XML but rejected by a real catalog.
 
 Context: PR #3837 capitalized the `apiso:` property names (`apiso:type` ->
 `apiso:Type`, `apiso:identifier` -> `apiso:Identifier`) to satisfy a PyCSW
-instance. These tests reproduce, end to end, what each server family does with
-the *current* code: PyCSW is expected to accept the request, while GeoNetwork
-is expected to reject the capitalized request (the GeoIDE failure mode), which
-makes the harvest fail with a "Failed to query CSW" error.
+instance, which was reported to break GeoIDE harvests. These tests show that
+both servers we can containerize accept the capitalized request: PyCSW (it was
+tuned for it) and upstream GeoNetwork (which is lenient about Filter/SortBy
+field names, see note [4] in dcat.py). The GeoIDE rejection is specific to
+GeoSource, an old GeoNetwork fork that is not containerizable — so it cannot be
+reproduced here.
 
-The GeoNetwork record is pushed over its REST API at the start of the test (no
-records need to be loaded into PyCSW: a request parse error happens before any
-data lookup). Skipped unless `UDATA_TEST_CSW_INTEGRATION=1` and both servers
-are reachable, so they only run in the dedicated CI job.
+The GeoNetwork record is pushed over CSW-T at the start of the test; PyCSW
+serves its built-in conformance data, so it needs no loading. Skipped unless
+`UDATA_TEST_CSW_INTEGRATION=1` and both servers are reachable, so they only run
+in the dedicated CI job.
 """
 
 import os
@@ -52,34 +54,35 @@ QUERY_REJECTED = "Failed to query CSW"
 
 
 def load_geonetwork_record():
-    """Push the ISO-19139 test record into GeoNetwork and publish it.
+    """Push the ISO-19139 test record into GeoNetwork via CSW-T and publish it.
 
-    GeoNetwork's REST API is XSRF-protected: a first authenticated call to
-    `/srv/eng/info?type=me` sets the `XSRF-TOKEN` cookie, whose value must be
-    echoed back as the `X-XSRF-TOKEN` header on the (multipart) insert request.
+    We use the OGC CSW transaction endpoint (`/srv/eng/csw-publication`) rather
+    than the REST API: it goes through the same CSW servlet as the (working)
+    harvest endpoint and is not XSRF-protected, only basic-auth.
     """
-    session = requests.Session()
-    session.auth = ("admin", "admin")
+    record = RECORD.read_text(encoding="utf-8")
+    # Drop the XML declaration so the record can be embedded in the transaction.
+    if record.lstrip().startswith("<?xml"):
+        record = record.split("?>", 1)[1]
 
-    # A POST to this endpoint authenticates and sets the XSRF-TOKEN cookie.
-    session.post(f"{GEONETWORK_BASE}/srv/eng/info?type=me", timeout=30)
-    token = session.cookies.get("XSRF-TOKEN")
-    assert token, f"no XSRF-TOKEN cookie returned, got: {session.cookies.get_dict()}"
+    transaction = (
+        '<csw:Transaction xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"'
+        ' service="CSW" version="2.0.2"><csw:Insert>'
+        f"{record}"
+        "</csw:Insert></csw:Transaction>"
+    )
 
-    # Spring accepts the token as the X-XSRF-TOKEN header or the _csrf parameter.
-    response = session.put(
-        f"{GEONETWORK_BASE}/srv/api/records",
-        params={
-            "metadataType": "METADATA",
-            "uuidProcessing": "OVERWRITE",
-            "publishToAll": "true",
-            "_csrf": token,
-        },
-        headers={"X-XSRF-TOKEN": token, "Accept": "application/json"},
-        files={"file": ("combles.xml", RECORD.read_bytes(), "application/xml")},
+    response = requests.post(
+        f"{GEONETWORK_BASE}/srv/eng/csw-publication",
+        data=transaction.encode("utf-8"),
+        headers={"Content-Type": "application/xml"},
+        auth=("admin", "admin"),
         timeout=60,
     )
-    assert response.ok, f"GeoNetwork insert failed {response.status_code}: {response.text[:1000]}"
+    assert response.ok, (
+        f"GeoNetwork CSW-T insert failed {response.status_code}: {response.text[:1000]}"
+    )
+    assert "ExceptionReport" not in response.text, response.text[:1000]
 
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
@@ -107,12 +110,11 @@ class CswIntegrationTest(PytestOnlyDBTestCase):
         assert not query_errors, query_errors
 
     def test_geonetwork_accepts_request(self):
-        """GeoNetwork must parse our GetRecords request.
+        """Upstream GeoNetwork must parse our GetRecords request.
 
-        This reproduces the bug without depending on record loading: a parse
-        error happens before any data lookup. On the current (capitalized) code
-        GeoNetwork rejects the request and the job fails with "Failed to query
-        CSW" — the GeoIDE bug, reproduced.
+        Independent of record loading: a parse error would happen before any
+        data lookup. Upstream GeoNetwork is lenient and accepts the capitalized
+        request — unlike GeoSource/GeoIDE, which is not containerizable here.
         """
         job = self.harvest(GEONETWORK_URL)
 

--- a/udata/harvest/tests/test_csw_integration.py
+++ b/udata/harvest/tests/test_csw_integration.py
@@ -54,13 +54,14 @@ QUERY_REJECTED = "Failed to query CSW"
 def load_geonetwork_record():
     """Push the ISO-19139 test record into GeoNetwork and publish it.
 
-    GeoNetwork requires an XSRF token (set as a cookie on a first authenticated
-    call) to be echoed back as a header on the insert request.
+    GeoNetwork's REST API is XSRF-protected: a first authenticated call to
+    `/srv/eng/info?type=me` sets the `XSRF-TOKEN` cookie, whose value must be
+    echoed back as the `X-XSRF-TOKEN` header on the (multipart) insert request.
     """
     session = requests.Session()
     session.auth = ("admin", "admin")
 
-    session.get(f"{GEONETWORK_BASE}/srv/api/me", timeout=30)
+    session.get(f"{GEONETWORK_BASE}/srv/eng/info?type=me", timeout=30)
     token = session.cookies.get("XSRF-TOKEN")
 
     response = session.put(
@@ -69,16 +70,13 @@ def load_geonetwork_record():
             "metadataType": "METADATA",
             "uuidProcessing": "OVERWRITE",
             "group": "2",
+            "category": "",
             "rejectIfInvalid": "false",
             "publishToAll": "true",
         },
-        headers={
-            "X-XSRF-TOKEN": token,
-            "Content-Type": "application/xml",
-            "Accept": "application/json",
-        },
-        data=RECORD.read_bytes(),
-        timeout=30,
+        headers={"X-XSRF-TOKEN": token, "Accept": "application/json"},
+        files={"file": ("combles.xml", RECORD.read_bytes(), "application/xml")},
+        timeout=60,
     )
     response.raise_for_status()
 
@@ -107,12 +105,21 @@ class CswIntegrationTest(PytestOnlyDBTestCase):
         query_errors = [error.message for error in job.errors if QUERY_REJECTED in error.message]
         assert not query_errors, query_errors
 
-    def test_geonetwork_harvests_record(self):
-        """GeoNetwork must accept the request and yield the published record.
+    def test_geonetwork_accepts_request(self):
+        """GeoNetwork must parse our GetRecords request.
 
-        On the current (capitalized) code this fails: GeoNetwork rejects the
-        request with a "Failed to query CSW" error — the GeoIDE bug, reproduced.
+        This reproduces the bug without depending on record loading: a parse
+        error happens before any data lookup. On the current (capitalized) code
+        GeoNetwork rejects the request and the job fails with "Failed to query
+        CSW" — the GeoIDE bug, reproduced.
         """
+        job = self.harvest(GEONETWORK_URL)
+
+        query_errors = [error.message for error in job.errors if QUERY_REJECTED in error.message]
+        assert not query_errors, query_errors
+
+    def test_geonetwork_harvests_record(self):
+        """Full pipeline: push a record into GeoNetwork, harvest it back out."""
         load_geonetwork_record()
 
         job = self.harvest(GEONETWORK_URL)

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -1080,13 +1080,18 @@ class CswApisoQueryableCasingTest(PytestOnlyDBTestCase):
         source = HarvestSourceFactory(backend="csw-dcat", url=url)
         return get_backend("csw-dcat")(source).build_csw_request(start=1)
 
-    def test_default_uses_capitalized_queryables(self):
-        request = self.build_request("https://meta.atmosud.org/csw")
+    def test_capitalized_queryables_by_default(self):
+        # No hosts configured by default: every server gets the capitalized form.
+        request = self.build_request("https://ogc.geo-ide.developpement-durable.gouv.fr/csw")
         assert "apiso:Type" in request
         assert "apiso:Identifier" in request
         assert "apiso:type" not in request
 
-    def test_geoide_uses_lowercase_queryables(self):
+    def test_listed_host_uses_lowercase_queryables(self):
+        self.app.config["HARVEST_CSW_LOWERCASE_APISO_HOSTS"] = [
+            "ogc.geo-ide.developpement-durable.gouv.fr"
+        ]
+
         request = self.build_request(
             "https://ogc.geo-ide.developpement-durable.gouv.fr/csw/all-dataset"
         )
@@ -1094,11 +1099,10 @@ class CswApisoQueryableCasingTest(PytestOnlyDBTestCase):
         assert "apiso:identifier" in request
         assert "apiso:Type" not in request
 
-    def test_lowercase_hosts_is_configurable(self):
-        self.app.config["HARVEST_CSW_LOWERCASE_APISO_HOSTS"] = ["example.org"]
-        request = self.build_request("https://example.org/csw")
-        assert "apiso:type" in request
-        assert "apiso:Type" not in request
+        # A host that is not configured keeps the capitalized form.
+        other = self.build_request("https://meta.atmosud.org/csw")
+        assert "apiso:Type" in other
+        assert "apiso:type" not in other
 
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -1069,6 +1069,39 @@ class DcatBackendTest(PytestOnlyDBTestCase):
 
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
+class CswApisoQueryableCasingTest(PytestOnlyDBTestCase):
+    """The apiso queryable casing depends on the target server (see dcat.py).
+
+    pycsw only accepts the capitalized common queryables (apiso:Type), while
+    GeoIDE only accepts the spec-compliant lowercase form (apiso:type).
+    """
+
+    def build_request(self, url):
+        source = HarvestSourceFactory(backend="csw-dcat", url=url)
+        return get_backend("csw-dcat")(source).build_csw_request(start=1)
+
+    def test_default_uses_capitalized_queryables(self):
+        request = self.build_request("https://meta.atmosud.org/csw")
+        assert "apiso:Type" in request
+        assert "apiso:Identifier" in request
+        assert "apiso:type" not in request
+
+    def test_geoide_uses_lowercase_queryables(self):
+        request = self.build_request(
+            "https://ogc.geo-ide.developpement-durable.gouv.fr/csw/all-dataset"
+        )
+        assert "apiso:type" in request
+        assert "apiso:identifier" in request
+        assert "apiso:Type" not in request
+
+    def test_lowercase_hosts_is_configurable(self):
+        self.app.config["HARVEST_CSW_LOWERCASE_APISO_HOSTS"] = ["example.org"]
+        request = self.build_request("https://example.org/csw")
+        assert "apiso:type" in request
+        assert "apiso:Type" not in request
+
+
+@pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
 class CswDcatBackendTest(PytestOnlyDBTestCase):
     @pytest.mark.parametrize(
         "schema_name, schema_uri",

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -352,8 +352,9 @@ class Defaults(object):
 
     # Hosts whose CSW server only accepts the spec-compliant lowercase apiso
     # common queryables (apiso:type) and rejects the capitalized form (apiso:Type)
-    # that pycsw requires. See `udata/harvest/backends/dcat.py`.
-    HARVEST_CSW_LOWERCASE_APISO_HOSTS = ["ogc.geo-ide.developpement-durable.gouv.fr"]
+    # that pycsw requires. Set per deployment, e.g.
+    # ["ogc.geo-ide.developpement-durable.gouv.fr"]. See harvest/backends/dcat.py.
+    HARVEST_CSW_LOWERCASE_APISO_HOSTS = []
 
     # If set, harvest emit activities associated with this user as actor
     # It should be a dedicated service account

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -350,6 +350,11 @@ class Defaults(object):
 
     HARVEST_ISO19139_XSLT_URL = "https://raw.githubusercontent.com/SEMICeu/iso-19139-to-dcat-ap/refs/heads/geodcat-ap-2.0.0/iso-19139-to-dcat-ap.xsl"
 
+    # Hosts whose CSW server only accepts the spec-compliant lowercase apiso
+    # common queryables (apiso:type) and rejects the capitalized form (apiso:Type)
+    # that pycsw requires. See `udata/harvest/backends/dcat.py`.
+    HARVEST_CSW_LOWERCASE_APISO_HOSTS = ["ogc.geo-ide.developpement-durable.gouv.fr"]
+
     # If set, harvest emit activities associated with this user as actor
     # It should be a dedicated service account
     HARVEST_ACTIVITY_USER_ID = None


### PR DESCRIPTION
Need to add `HARVEST_CSW_LOWERCASE_APISO_HOSTS = ["ogc.geo-ide.developpement-durable.gouv.fr"]` into production

Related to https://github.com/opendatateam/udata/pull/3837