### PR TITLE
chore(CI): use recommended UV_PUBLISH_TOKEN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Publish on PyPI
           command: |
-            uv publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
+            uv publish dist/*.whl  # use UV_PUBLISH_TOKEN
 
   trigger-gitlab-pipeline:
     docker:


### PR DESCRIPTION
I have set `UV_PUBLISH_TOKEN` in CI context