### PR TITLE
chore(harvest): partially revert csw xml update

### DIFF
--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -301,6 +301,7 @@ class BaseCswDcatBackend(DcatBackend, ABC):
     <csw:GetRecords xmlns:apiso="http://www.opengis.net/cat/csw/apiso/1.0"
                     xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                     xmlns:ogc="http://www.opengis.net/ogc"
+                    xmlns:gmd="http://www.isotc211.org/2005/gmd"
                     service="CSW" version="2.0.2" outputFormat="application/xml"
                     resultType="results" startPosition="{start}" maxRecords="25"
                     outputSchema="{output_schema}">

--- a/udata/harvest/backends/dcat.py
+++ b/udata/harvest/backends/dcat.py
@@ -301,7 +301,6 @@ class BaseCswDcatBackend(DcatBackend, ABC):
     <csw:GetRecords xmlns:apiso="http://www.opengis.net/cat/csw/apiso/1.0"
                     xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                     xmlns:ogc="http://www.opengis.net/ogc"
-                    xmlns:gmd="http://www.isotc211.org/2005/gmd"
                     service="CSW" version="2.0.2" outputFormat="application/xml"
                     resultType="results" startPosition="{start}" maxRecords="25"
                     outputSchema="{output_schema}">
@@ -311,19 +310,19 @@ class BaseCswDcatBackend(DcatBackend, ABC):
           <ogc:Filter>
             <ogc:Or>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>dataset</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>nonGeographicDataset</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>series</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>apiso:Type</ogc:PropertyName>
+                <ogc:PropertyName>apiso:type</ogc:PropertyName>
                 <ogc:Literal>service</ogc:Literal>
               </ogc:PropertyIsEqualTo>
             </ogc:Or>
@@ -331,7 +330,7 @@ class BaseCswDcatBackend(DcatBackend, ABC):
         </csw:Constraint>
         <ogc:SortBy>
           <ogc:SortProperty>
-            <ogc:PropertyName>apiso:Identifier</ogc:PropertyName>
+            <ogc:PropertyName>apiso:identifier</ogc:PropertyName>
             <ogc:SortOrder>ASC</ogc:SortOrder>
           </ogc:SortProperty>
         </ogc:SortBy>


### PR DESCRIPTION
See discussions in https://github.com/opendatateam/udata/pull/3837 for context.

Waiting for an answer from pycsw, we keep lowercase `apiso:title` and `apiso:identifier` that match the standard.
We keep the `gmd` namespace addition that is compliant.

If we don't have an answer or we need to add a workaround, see https://github.com/opendatateam/udata/pull/3839