### PR TITLE
perf: skip reload() in update/add/remove_resource

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -1009,42 +1009,53 @@ class Dataset(
                 f"Cannot add resource '{resource.title}'. A resource '{existing_resource.title}' already exists with ID '{existing_resource.id}'"
             )
 
-        # only useful for compute_quality(), we will reload to have a clean object
+        # Update the in-memory document to match what we persist, avoiding a costly
+        # self.reload() (see update_resource).
         self.resources.insert(0, resource)
+        self.quality_cached = self.compute_quality()
+        self.last_modified_internal = datetime.now(UTC)
 
         self.update(
-            set__quality_cached=self.compute_quality(),
+            set__quality_cached=self.quality_cached,
             push__resources={"$each": [resource.to_mongo()], "$position": 0},
-            set__last_modified_internal=datetime.now(UTC),
+            set__last_modified_internal=self.last_modified_internal,
         )
 
-        self.reload()
         self.on_resource_added.send(self.__class__, document=self, resource_id=resource.id)
 
     def update_resource(self, resource):
         """Perform an atomic update for an existing resource"""
 
-        # only useful for compute_quality(), we will reload to have a clean object
+        # Keep the in-memory document consistent with what we persist below, so we
+        # don't need a self.reload() afterwards. reload() would re-read and
+        # re-deserialize every embedded resource (O(N), ~1.3s on a 15k-resource
+        # dataset) for nothing: nothing downstream consumes a fully-reloaded object
+        # (the endpoint returns `resource`, and the on_resource_updated handlers only
+        # read document.resources / document.organization, all up to date here).
         index = next(i for i, r in enumerate(self.resources) if r.id == resource.id)
         self.resources[index] = resource
+        self.quality_cached = self.compute_quality()
+        self.last_modified_internal = datetime.now(UTC)
 
         Dataset.objects(id=self.id, resources__id=resource.id).update_one(
-            set__quality_cached=self.compute_quality(),
+            set__quality_cached=self.quality_cached,
             set__resources__S=resource,
-            set__last_modified_internal=datetime.now(UTC),
+            set__last_modified_internal=self.last_modified_internal,
         )
 
-        self.reload()
         self.on_resource_updated.send(self.__class__, document=self, resource_id=resource.id)
 
     def remove_resource(self, resource):
-        # only useful for compute_quality(), we will reload to have a clean object
+        # Update the in-memory document to match what we persist, avoiding a costly
+        # self.reload() (see update_resource).
         self.resources = [r for r in self.resources if r.id != resource.id]
+        self.quality_cached = self.compute_quality()
+        self.last_modified_internal = datetime.now(UTC)
 
         self.update(
-            set__quality_cached=self.compute_quality(),
+            set__quality_cached=self.quality_cached,
             pull__resources__id=resource.id,
-            set__last_modified_internal=datetime.now(UTC),
+            set__last_modified_internal=self.last_modified_internal,
         )
 
         # Deletes resource's file from file storage
@@ -1056,7 +1067,6 @@ class Dataset(
                     f"File not found while deleting resource #{resource.id} in dataset {self.id}: {e}"
                 )
 
-        self.reload()
         self.on_resource_removed.send(self.__class__, document=self, resource_id=resource.id)
 
     @property

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -1,5 +1,4 @@
 from datetime import UTC, date, datetime, timedelta, timezone
-from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -111,18 +110,6 @@ class DatasetModelTest(PytestOnlyDBTestCase):
         assert dataset.resources[0].id == resource.id
         assert dataset.resources[0].description == "New description"
 
-    def test_update_resource_does_not_reload(self):
-        # update_resource must not reload(): reloading re-deserializes every embedded
-        # resource (O(N), prohibitive on large datasets). The in-memory document is
-        # kept consistent instead.
-        resource = ResourceFactory()
-        dataset = DatasetFactory(resources=[resource])
-        resource.description = "New description"
-
-        with mock.patch.object(Dataset, "reload") as reload:
-            dataset.update_resource(resource)
-        reload.assert_not_called()
-
     def test_update_resource_refreshes_quality_without_reload(self):
         # quality_cached depends on resource extras (check:available feeds
         # all_resources_available). After update_resource — and without any reload —
@@ -138,6 +125,66 @@ class DatasetModelTest(PytestOnlyDBTestCase):
         assert dataset.quality["all_resources_available"] is False
         # persisted
         assert Dataset.objects(id=dataset.id).first().quality["all_resources_available"] is False
+
+    def test_add_resource_keeps_in_memory_and_persisted_consistent(self):
+        # add_resource performs a divergent double write: it pushes resource.to_mongo()
+        # to the DB but inserts the live resource object in memory. Since no reload()
+        # re-syncs them anymore, both representations must agree.
+        resource = ResourceFactory(filetype="remote", extras={"check:available": False})
+        dataset = DatasetFactory(resources=[ResourceFactory()])
+
+        dataset.add_resource(resource)
+
+        persisted = Dataset.objects(id=dataset.id).first()
+        assert [r.id for r in dataset.resources] == [r.id for r in persisted.resources]
+        assert dataset.resources[0].id == resource.id
+        assert persisted.resources[0].id == resource.id
+        # quality is recomputed identically in memory and in the DB
+        assert (
+            dataset.quality["all_resources_available"]
+            == persisted.quality["all_resources_available"]
+            is False
+        )
+
+    def test_remove_resource_refreshes_in_memory_and_persisted(self):
+        # remove_resource updates the in-memory document (resources list + quality_cached)
+        # to match what it persists, without a reload(). check:available feeds
+        # all_resources_available: dropping the unavailable resource flips it to True.
+        available = ResourceFactory(filetype="remote", extras={"check:available": True})
+        unavailable = ResourceFactory(filetype="remote", extras={"check:available": False})
+        dataset = DatasetFactory(resources=[available, unavailable])
+        assert dataset.quality["all_resources_available"] is False
+
+        with assert_emit(Dataset.on_resource_removed):
+            dataset.remove_resource(unavailable)
+
+        # in-memory, no reload
+        assert [r.id for r in dataset.resources] == [available.id]
+        assert dataset.quality["all_resources_available"] is True
+        # persisted
+        persisted = Dataset.objects(id=dataset.id).first()
+        assert [r.id for r in persisted.resources] == [available.id]
+        assert persisted.quality["all_resources_available"] is True
+
+    @pytest.mark.parametrize("operation", ["add", "update", "remove"])
+    def test_resource_method_refreshes_last_modified_in_memory(self, operation):
+        # add/update/remove_resource set last_modified_internal in memory. Previously a
+        # reload() re-read it from the DB; now it must be fresh without any reload.
+        existing = ResourceFactory()
+        dataset = DatasetFactory(resources=[existing])
+        # Arrange a clearly stale timestamp so any refresh is unambiguous.
+        old = datetime(2000, 1, 1)
+        dataset.last_modified_internal = old
+
+        if operation == "add":
+            dataset.add_resource(ResourceFactory())
+        elif operation == "update":
+            existing.description = "Updated"
+            dataset.update_resource(existing)
+        else:
+            dataset.remove_resource(existing)
+
+        assert dataset.last_modified > old
 
     def test_update_resource_missing_checksum_type(self):
         user = UserFactory()

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date, datetime, timedelta, timezone
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -109,6 +110,34 @@ class DatasetModelTest(PytestOnlyDBTestCase):
         assert len(dataset.resources) == 1
         assert dataset.resources[0].id == resource.id
         assert dataset.resources[0].description == "New description"
+
+    def test_update_resource_does_not_reload(self):
+        # update_resource must not reload(): reloading re-deserializes every embedded
+        # resource (O(N), prohibitive on large datasets). The in-memory document is
+        # kept consistent instead.
+        resource = ResourceFactory()
+        dataset = DatasetFactory(resources=[resource])
+        resource.description = "New description"
+
+        with mock.patch.object(Dataset, "reload") as reload:
+            dataset.update_resource(resource)
+        reload.assert_not_called()
+
+    def test_update_resource_refreshes_quality_without_reload(self):
+        # quality_cached depends on resource extras (check:available feeds
+        # all_resources_available). After update_resource — and without any reload —
+        # the in-memory document AND the persisted document must reflect the change.
+        resource = ResourceFactory(filetype="remote", extras={"check:available": True})
+        dataset = DatasetFactory(resources=[resource])
+        assert dataset.quality["all_resources_available"] is True
+
+        resource.extras["check:available"] = False
+        dataset.update_resource(resource)
+
+        # in-memory, no reload
+        assert dataset.quality["all_resources_available"] is False
+        # persisted
+        assert Dataset.objects(id=dataset.id).first().quality["all_resources_available"] is False
 
     def test_update_resource_missing_checksum_type(self):
         user = UserFactory()


### PR DESCRIPTION
` PUT /api/1/datasets/:id/resources/:id ` is one of the top endpoint in logs

From haproxy logs:

| Count     | Mean   | P50    | P75    | P95    | P99    | Max      | 5XX      |
| --------: | -----: | -----: | -----: | -----: | -----: | -------: | -------: |
| 1 166 185 | 672 ms | 436 ms | 639 ms | 1,75 s | 5,02 s | 300,00 s | 0,0142 % |

Bench before/after with this PR

| Number of resources      | before (reload) | after      | Gain |
| -----: | -------------: | ---------: | ---: |
| 1 000  | 94,7 ms        | 45,3 ms    | ×2,1 |
| 4 000  | 601,3 ms       | 281,4 ms   | ×2,1 |
| 8 000  | 1 217,5 ms     | 588,3 ms   | ×2,1 |
| 15 000 | 2 677,7 ms     | 1 206,9 ms | ×2,2 |
