### PR TITLE
feat(suggest): shared match-quality ranking with accent-insensitive autocomplete

### DIFF
--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -27,7 +27,6 @@ from feedgenerator.django.utils.feedgenerator import Atom1Feed
 from flask import abort, current_app, make_response, redirect, request, url_for
 from flask_restx.inputs import boolean, positive
 from flask_security import current_user
-from mongoengine.queryset.visitor import Q
 
 from udata.api import API, add_pagination_arguments, api, errors
 from udata.api.parsers import ModelApiParser
@@ -44,6 +43,7 @@ from udata.core.legal.mails import add_send_legal_notice_argument, send_legal_no
 from udata.core.organization.models import Organization
 from udata.core.reuse.models import Reuse
 from udata.core.storages.api import handle_upload, upload_parser
+from udata.core.suggest import mongo_suggest
 from udata.core.topic.models import Topic
 from udata.frontend.markdown import md
 from udata.i18n import gettext as _
@@ -877,11 +877,16 @@ class DatasetSuggestAPI(API):
     @api.expect(suggest_parser)
     @api.marshal_with(dataset_suggestion_fields)
     def get(self):
-        """Datasets suggest endpoint using mongoDB contains"""
+        """Datasets autocomplete: accent-insensitive, ranked by match quality then followers."""
         args = suggest_parser.parse_args()
-        datasets_query = Dataset.objects(archived=None, deleted=None, private=False)
-        datasets = datasets_query.filter(
-            Q(title__icontains=args["q"]) | Q(acronym__icontains=args["q"])
+        datasets = mongo_suggest(
+            Dataset.objects(archived=None, deleted=None, private=False),
+            args["q"],
+            match_fields=["title", "acronym"],
+            slug_field="slug",
+            order_by=SUGGEST_SORTING,
+            size=args["size"],
+            blend_popularity=True,
         )
         return [
             {
@@ -898,7 +903,7 @@ class DatasetSuggestAPI(API):
                 ),
                 "page": dataset.self_web_url(),
             }
-            for dataset in datasets.order_by(SUGGEST_SORTING).limit(args["size"])
+            for dataset in datasets
         ]
 
 

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -1,7 +1,6 @@
 from datetime import UTC, datetime
 
 from flask import make_response, redirect, request, url_for
-from mongoengine.queryset.visitor import Q
 
 from udata.api import API, api, errors
 from udata.api.parsers import ModelApiParser
@@ -29,6 +28,7 @@ from udata.core.storages.api import (
     parse_uploaded_image,
     uploaded_image_fields,
 )
+from udata.core.suggest import mongo_suggest
 from udata.mongo import db
 from udata.mongo.errors import FieldValidationError
 from udata.rdf import RDF_EXTENSIONS, graph_response, negociate_content
@@ -358,14 +358,14 @@ class ContactPointSuggestAPI(API):
     @api.expect(suggest_parser)
     @api.marshal_list_with(ContactPoint.__read_fields__)
     def get(self, org):
-        """Contact points suggest endpoint using mongoDB contains"""
+        """Contact points autocomplete, ranked by match quality."""
         args = suggest_parser.parse_args()
-        contact_points = ContactPoint.objects(
-            Q(name__icontains=args["q"])
-            | Q(email__icontains=args["q"])
-            | Q(contact_form__icontains=args["q"])
-        ).owned_by(org)
-        return list(contact_points.limit(args["size"]))
+        return mongo_suggest(
+            ContactPoint.objects.owned_by(org),
+            args["q"],
+            match_fields=["name", "email", "contact_form"],
+            size=args["size"],
+        )
 
 
 requests_parser = api.parser()
@@ -680,10 +680,16 @@ class OrganizationSuggestAPI(API):
     @api.expect(suggest_parser)
     @api.marshal_list_with(org_suggestion_fields)
     def get(self):
-        """Organizations suggest endpoint using mongoDB contains"""
+        """Organizations autocomplete: accent-insensitive, ranked by match quality then followers."""
         args = suggest_parser.parse_args()
-        orgs = Organization.objects(
-            Q(name__icontains=args["q"]) | Q(acronym__icontains=args["q"]), deleted=None
+        orgs = mongo_suggest(
+            Organization.objects(deleted=None),
+            args["q"],
+            match_fields=["name", "acronym"],
+            slug_field="slug",
+            order_by=SUGGEST_SORTING,
+            size=args["size"],
+            blend_popularity=True,
         )
         return [
             {
@@ -694,7 +700,7 @@ class OrganizationSuggestAPI(API):
                 "image_url": org.logo,
                 "page": org.self_web_url(),
             }
-            for org in orgs.order_by(SUGGEST_SORTING).limit(args["size"])
+            for org in orgs
         ]
 
 

--- a/udata/core/reuse/api.py
+++ b/udata/core/reuse/api.py
@@ -23,6 +23,7 @@ from udata.core.storages.api import (
     parse_uploaded_image,
     uploaded_image_fields,
 )
+from udata.core.suggest import mongo_suggest
 from udata.frontend.markdown import md
 from udata.i18n import gettext as _
 from udata.models import Dataset
@@ -347,10 +348,16 @@ class ReusesSuggestAPI(API):
     @api.expect(suggest_parser)
     @api.marshal_list_with(reuse_suggestion_fields)
     def get(self):
-        """Reuses suggest endpoint using mongoDB contains"""
+        """Reuses autocomplete: accent-insensitive, ranked by match quality then followers."""
         args = suggest_parser.parse_args()
-        reuses = Reuse.objects(
-            archived=None, deleted=None, private__ne=True, title__icontains=args["q"]
+        reuses = mongo_suggest(
+            Reuse.objects(archived=None, deleted=None, private__ne=True),
+            args["q"],
+            match_fields=["title"],
+            slug_field="slug",
+            order_by=SUGGEST_SORTING,
+            size=args["size"],
+            blend_popularity=True,
         )
         return [
             {
@@ -360,7 +367,7 @@ class ReusesSuggestAPI(API):
                 "image_url": reuse.image,
                 "page": reuse.self_web_url(),
             }
-            for reuse in reuses.order_by(SUGGEST_SORTING).limit(args["size"])
+            for reuse in reuses
         ]
 
 

--- a/udata/core/spatial/api.py
+++ b/udata/core/spatial/api.py
@@ -5,6 +5,7 @@ from mongoengine.queryset.visitor import Q
 
 from udata.api import API, api
 from udata.core.dataset.api_fields import dataset_ref_fields
+from udata.core.suggest import normalize, sorted_suggestions
 from udata.i18n import _
 from udata.models import Dataset
 
@@ -13,6 +14,12 @@ from .api_fields import (
     granularity_fields,
     level_fields,
     zone_suggestion_fields,
+)
+from .constants import (
+    DEFAULT_LEVEL_PRIORITY,
+    DEFAULT_SUGGEST_LEVELS,
+    LEVEL_PRIORITY,
+    SUGGESTABLE_LEVELS,
 )
 from .models import GeoLevel, GeoZone, spatial_granularities
 
@@ -25,7 +32,12 @@ ns = api.namespace("spatial", "Spatial references")
 
 suggest_parser = api.parser()
 suggest_parser.add_argument(
-    "q", type=str, help="The string to autocomplete/suggest", location="args", required=True
+    "q",
+    type=str,
+    help="The string to autocomplete/suggest (empty returns default zones)",
+    location="args",
+    required=False,
+    default="",
 )
 suggest_parser.add_argument(
     "size", type=int, help="The amount of suggestion to fetch", location="args", default=10
@@ -52,25 +64,57 @@ class SuggestZonesAPI(API):
     @api.expect(suggest_parser)
     @api.doc("suggest_zones")
     def get(self):
-        """Geospatial zones suggest endpoint using mongoDB contains"""
-        args = suggest_parser.parse_args()
-        geozones = GeoZone.objects(
-            Q(name__icontains=args["q"]) | Q(code__icontains=args["q"]) | Q(id__icontains=args["q"])
-        )
+        """Geospatial zones autocomplete.
 
-        # We're manually sorting based on zone level int (cause we don't have the int value directly in mongo document)
-        level_id_to_int_level = {level.id: level.admin_level for level in GeoLevel.objects()}
-        geozones = sorted(geozones, key=lambda zone: level_id_to_int_level[zone.level])
+        Only well-populated levels are proposed (:data:`SUGGESTABLE_LEVELS`:
+        communes, departments, regions, EPCI, ...); detail levels such as
+        arrondissements are excluded. Matching is accent-insensitive; results
+        are ranked by match quality (exact > prefix > word > substring), then by
+        level relevance (:data:`LEVEL_PRIORITY`), so the city of Paris comes
+        before its department and the "Grand Paris" intercommunalities, and
+        "Val Parisis" (a mere substring) is relegated. An empty query returns
+        broad default zones (regions and departments).
+        """
+        args = suggest_parser.parse_args()
+        query = args["q"]
+        size = args["size"]
+
+        norm = normalize(query)
+        if not norm:
+            zones = GeoZone.objects(level__in=DEFAULT_SUGGEST_LEVELS).order_by("name").limit(size)
+        else:
+            # Candidates are a superset restricted to suggestable levels: match
+            # the name (accent-sensitive) and the accent-folded slug (so
+            # "orleans" finds "Orléans"), plus raw code/id. Match quality is then
+            # refined in Python on the name.
+            candidates = GeoZone.objects(
+                Q(name__icontains=query)
+                | Q(slug__icontains=norm)
+                | Q(code__icontains=query)
+                | Q(id__icontains=query),
+                level__in=SUGGESTABLE_LEVELS,
+            )
+            zones = sorted_suggestions(
+                candidates,
+                query,
+                get_texts=lambda zone: zone.name,
+                secondary=lambda zone: (
+                    LEVEL_PRIORITY.get(zone.level, DEFAULT_LEVEL_PRIORITY),
+                    zone.name,
+                ),
+                size=size,
+            )
 
         return [
             {
-                "id": geozone.id,
-                "name": payload_name(geozone.name),
-                "code": geozone.code,
-                "level": geozone.level,
-                "uri": geozone.uri,
+                "id": zone.id,
+                "name": payload_name(zone.name),
+                "code": zone.code,
+                "level": zone.level,
+                "level_name": zone.level_i18n_name,
+                "uri": zone.uri,
             }
-            for geozone in geozones[: args["size"]]
+            for zone in zones
         ]
 
 

--- a/udata/core/spatial/api_fields.py
+++ b/udata/core/spatial/api_fields.py
@@ -98,6 +98,9 @@ zone_suggestion_fields = api.model(
         "name": fields.String(description="The territory name", required=True),
         "code": fields.String(description="The territory main code", required=True),
         "level": fields.String(description="The territory administrative level", required=True),
+        "level_name": fields.String(
+            description="The human-readable administrative level (e.g. 'Commune', 'Département')"
+        ),
         "uri": fields.String(description="The zone uri", required=True),
     },
 )

--- a/udata/core/spatial/constants.py
+++ b/udata/core/spatial/constants.py
@@ -7,3 +7,35 @@ BASE_GRANULARITIES = [
 
 ADMIN_LEVEL_MIN = 1
 ADMIN_LEVEL_MAX = 110
+
+# Which levels the zones autocomplete proposes, and in which relevance order.
+#
+# We deliberately restrict suggestions to the levels whose metadata is actually
+# well filled: communes, departments, regions and EPCI. Detail levels
+# (arrondissements, cantons, IRIS) are NOT suggested at all — they are sparsely
+# used and would bury the levels people actually mean.
+#
+# The order is NOT `admin_level`: relevance is not monotonic with granularity.
+# On a French portal a commune is the most likely intent; EPCI sit below
+# departments/regions; countries and country groupings (Europe, World) are the
+# least useful. Lower sorts first; it only breaks ties between zones of equal
+# match quality.
+LEVEL_PRIORITY = {
+    "fr:commune": 0,  # the city/town: ~90% of intents
+    "fr:departement": 1,
+    "fr:region": 2,
+    "fr:epci": 3,  # metropolises / intercommunalities: below dept/region
+    "fr:collectivite": 4,  # overseas collectivities are French territory
+    "country": 5,  # a French platform: pays less useful
+    "country-subset": 6,  # technical groupings ("métropole", "DOM")
+    "country-group": 7,  # Europe / World: least useful
+}
+DEFAULT_LEVEL_PRIORITY = 99
+
+# Only these levels are returned by the autocomplete (derived from the ranking
+# above); everything else (arrondissements, cantons, IRIS...) is excluded.
+SUGGESTABLE_LEVELS = list(LEVEL_PRIORITY)
+
+# Levels proposed by default when the autocomplete query is empty: broad, stable
+# entry points rather than "Monde" + countries alphabetically.
+DEFAULT_SUGGEST_LEVELS = ["fr:region", "fr:departement"]

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -58,7 +58,11 @@ class SpatialApiTest(APITestCase):
     def test_suggest_zones_on_name(self):
         """It should suggest zones based on its name"""
         for i in range(4):
-            GeoZoneFactory(name="name-test-{0}".format(i) if i % 2 else faker.word())
+            GeoZoneFactory(
+                name="name-test-{0}".format(i) if i % 2 else faker.word(),
+                level="fr:commune",
+                code=str(i),
+            )
 
         response = self.get(url_for("api.suggest_zones", q="name-test", size=5))
         self.assert200(response)
@@ -71,37 +75,27 @@ class SpatialApiTest(APITestCase):
             self.assertIn("code", suggestion)
             self.assertIn("uri", suggestion)
             self.assertIn("level", suggestion)
+            self.assertIn("level_name", suggestion)
             self.assertIn("name-test", suggestion["name"])
 
     def test_suggest_zones_on_id(self):
         """It should suggest zones based on its id"""
-        zone = GeoZoneFactory()
+        zone = GeoZoneFactory(level="fr:commune")
         for _ in range(2):
-            GeoZoneFactory()
+            GeoZoneFactory(level="fr:commune")
 
         response = self.get(url_for("api.suggest_zones", q=zone.id))
         self.assert200(response)
 
         self.assertEqual(response.json[0]["id"], zone["id"])
 
-    def test_suggest_zones_sorted(self):
-        """It should suggest zones based on its name"""
-        country_level = GeoLevelFactory(id="country", name="country", admin_level=10)
-        region_level = GeoLevelFactory(id="region", name="region", admin_level=20)
-        country_zone = GeoZoneFactory(name="name-test-country", level=country_level.id)
-        region_zone = GeoZoneFactory(name="name-test-region", level=region_level.id)
-
-        response = self.get(url_for("api.suggest_zones", q="name-test", size=5))
-        self.assert200(response)
-
-        self.assertEqual(len(response.json), 2)
-        self.assertEqual((response.json[0]["id"]), country_zone.id)
-        self.assertEqual((response.json[1]["id"]), region_zone.id)
-
     def test_suggest_zones_on_code(self):
         """It should suggest zones based on its code"""
         for i in range(4):
-            GeoZoneFactory(code="code-test-{0}".format(i) if i % 2 else faker.word())
+            GeoZoneFactory(
+                code="code-test-{0}".format(i) if i % 2 else faker.word(),
+                level="fr:commune",
+            )
 
         response = self.get(url_for("api.suggest_zones", q="code-test", size=5))
         self.assert200(response)
@@ -109,45 +103,79 @@ class SpatialApiTest(APITestCase):
         self.assertEqual(len(response.json), 2)
 
         for suggestion in response.json:
-            self.assertIn("id", suggestion)
-            self.assertIn("name", suggestion)
-            self.assertIn("code", suggestion)
-            self.assertIn("level", suggestion)
-            self.assertIn("uri", suggestion)
             self.assertIn("code-test", suggestion["code"])
 
     def test_suggest_zones_no_match(self):
         """It should not provide zones suggestions if no match"""
         for i in range(3):
-            GeoZoneFactory(name=5 * "{0}".format(i), code=3 * "{0}".format(i))
+            GeoZoneFactory(name=5 * "{0}".format(i), code=3 * "{0}".format(i), level="fr:commune")
 
         response = self.get(url_for("api.suggest_zones", q="xxxxxx", size=5))
         self.assert200(response)
         self.assertEqual(len(response.json), 0)
-
-    def test_suggest_zones_unicode(self):
-        """It should suggest zones based on its name"""
-        for i in range(4):
-            GeoZoneFactory(name="name-testé-{0}".format(i) if i % 2 else faker.word())
-
-        response = self.get(url_for("api.suggest_zones", q="name-testé", size=5))
-        self.assert200(response)
-
-        self.assertEqual(len(response.json), 2)
-
-        for suggestion in response.json:
-            self.assertIn("id", suggestion)
-            self.assertIn("name", suggestion)
-            self.assertIn("code", suggestion)
-            self.assertIn("level", suggestion)
-            self.assertIn("uri", suggestion)
-            self.assertIn("name-testé", suggestion["name"])
 
     def test_suggest_zones_empty(self):
         """It should not provide zones suggestion if no data is present"""
         response = self.get(url_for("api.suggest_zones", q="xxxxxx", size=5))
         self.assert200(response)
         self.assertEqual(len(response.json), 0)
+
+    def test_suggest_zones_accent_insensitive(self):
+        """Typing without accents still matches accented names (via the slug)."""
+        GeoZoneFactory(name="Orléans", slug="orleans", level="fr:commune")
+
+        response = self.get(url_for("api.suggest_zones", q="orleans", size=5))
+        self.assert200(response)
+
+        self.assertEqual(len(response.json), 1)
+        self.assertEqual(response.json[0]["name"], "Orléans")
+
+    def test_suggest_zones_match_quality(self):
+        """Exact/prefix/word matches rank above a buried substring ("Val Parisis")."""
+        commune = GeoZoneFactory(name="Paris", level="fr:commune")
+        word = GeoZoneFactory(name="Le Grand Paris", level="fr:epci")
+        substring = GeoZoneFactory(name="Val Parisis", level="fr:epci")
+
+        response = self.get(url_for("api.suggest_zones", q="Paris", size=5))
+        self.assert200(response)
+
+        ids = [suggestion["id"] for suggestion in response.json]
+        self.assertEqual(ids, [commune.id, word.id, substring.id])
+
+    def test_suggest_zones_ranked_by_level(self):
+        """Equal-quality matches are ordered by level relevance, not admin_level."""
+        country = GeoZoneFactory(name="Testville", level="country")
+        region = GeoZoneFactory(name="Testville", level="fr:region")
+        commune = GeoZoneFactory(name="Testville", level="fr:commune")
+
+        response = self.get(url_for("api.suggest_zones", q="Testville", size=5))
+        self.assert200(response)
+
+        ids = [suggestion["id"] for suggestion in response.json]
+        self.assertEqual(ids, [commune.id, region.id, country.id])
+
+    def test_suggest_zones_excludes_detail_levels(self):
+        """Detail levels such as arrondissements are never suggested."""
+        commune = GeoZoneFactory(name="Paris", level="fr:commune")
+        GeoZoneFactory(name="Paris", level="fr:arrondissement")
+
+        response = self.get(url_for("api.suggest_zones", q="Paris", size=5))
+        self.assert200(response)
+
+        ids = [suggestion["id"] for suggestion in response.json]
+        self.assertEqual(ids, [commune.id])
+
+    def test_suggest_zones_default_on_empty_query(self):
+        """An empty query returns default broad zones, never communes."""
+        region = GeoZoneFactory(name="Bretagne", level="fr:region")
+        GeoZoneFactory(name="Rennes", level="fr:commune")
+
+        response = self.get(url_for("api.suggest_zones", q="", size=5))
+        self.assert200(response)
+
+        ids = [suggestion["id"] for suggestion in response.json]
+        self.assertIn(region.id, ids)
+        self.assertTrue(all(s["level"] in ("fr:region", "fr:departement") for s in response.json))
 
     def test_spatial_levels(self):
         levels = [GeoLevelFactory() for _ in range(3)]

--- a/udata/core/suggest.py
+++ b/udata/core/suggest.py
@@ -1,0 +1,165 @@
+"""
+Shared building blocks for the ``.../suggest/`` autocomplete endpoints.
+
+Historically every suggest endpoint (datasets, organizations, reuses, users,
+tags, spatial zones, ...) reimplemented its own matching and sorting, with
+inconsistent behaviour:
+
+- accent-sensitivity: a plain ``name__icontains`` matches "Orléans" but not
+  "orleans", so typing without accents returned nothing;
+- no match-quality ranking: an exact match, a prefix match and a match buried
+  in the middle of a word ("paris" inside "Val Parisis") were all treated
+  equally.
+
+This module centralises the two things that should behave identically
+everywhere: **accent/case normalisation** and **match-quality scoring**. Each
+endpoint keeps its own candidate query, marshalling and secondary sort (e.g.
+by followers, or by administrative level for zones) and only borrows the
+scoring from here.
+"""
+
+import re
+
+from mongoengine.queryset.visitor import Q
+from slugify import slugify
+
+# Match-quality tiers, from best to worst. Lower sorts first.
+EXACT = 0  # normalised name equals the query
+PREFIX = 1  # normalised name starts with the query
+WORD = 2  # query is a whole (hyphen-delimited) token inside the name
+SUBSTRING = 3  # query appears somewhere in the name but not as a word
+NO_MATCH = 4  # query is absent (should not happen for candidates)
+
+
+def normalize(value: str) -> str:
+    """Accent-insensitive, lowercased, hyphen-separated form used for matching.
+
+    Relies on the same ``slugify`` already used by tags and users, so that
+    "Orléans", "orleans" and "ORLEANS" all normalise to ``orleans``.
+    """
+    return slugify(value or "", separator="-", to_lower=True)
+
+
+def match_score(text: str, query: str) -> int:
+    """Rank how well ``text`` matches ``query``.
+
+    Both sides are normalised, so matching is accent- and case-insensitive.
+    Because :func:`normalize` joins tokens with ``-``, word boundaries are
+    simply hyphens: "paris" is a whole word in ``le-grand-paris`` but only a
+    substring of ``val-parisis``.
+    """
+    q = normalize(query)
+    if not q:
+        # An empty query matches everything equally; let the secondary sort decide.
+        return EXACT
+    t = normalize(text)
+    if not t:
+        return NO_MATCH
+    if t == q:
+        return EXACT
+    if t.startswith(q):
+        return PREFIX
+    if re.search(r"(^|-)" + re.escape(q) + r"(-|$)", t):
+        return WORD
+    if q in t:
+        return SUBSTRING
+    return NO_MATCH
+
+
+def best_match_score(texts, query: str, blend_popularity: bool = False) -> int:
+    """Best (lowest) match score across several fields (e.g. name and acronym).
+
+    When ``blend_popularity`` is set, prefix and whole-word matches are merged
+    into a single bucket. This is meant for endpoints that pre-order candidates
+    by popularity (e.g. ``-metrics.followers``): a canonical, much-followed
+    whole-word match then wins over an obscure prefix match, instead of the
+    stricter lexical order relegating it. Exact matches stay on top and mere
+    substrings stay at the bottom.
+    """
+    best = min((match_score(text, query) for text in texts), default=NO_MATCH)
+    if blend_popularity and best == WORD:
+        return PREFIX
+    return best
+
+
+def suggestion_key(get_texts, query: str, secondary=None, blend_popularity: bool = False):
+    """Build a ``sorted`` key: match quality first, then an endpoint-specific tie-break.
+
+    ``get_texts`` returns the matchable string(s) of an item; ``secondary``
+    (optional) returns a tuple used to order items of equal match quality
+    (e.g. ``(LEVEL_PRIORITY[level], name)`` for zones, or ``-followers``).
+    """
+
+    def key(item):
+        texts = get_texts(item)
+        if isinstance(texts, str):
+            texts = (texts,)
+        score = (best_match_score(texts, query, blend_popularity),)
+        if secondary is not None:
+            extra = secondary(item)
+            score += tuple(extra) if isinstance(extra, (tuple, list)) else (extra,)
+        return score
+
+    return key
+
+
+def sorted_suggestions(items, query, get_texts, secondary=None, size=None, blend_popularity=False):
+    """Sort candidate ``items`` by match quality then ``secondary``, capped at ``size``."""
+    ordered = sorted(items, key=suggestion_key(get_texts, query, secondary, blend_popularity))
+    return ordered[:size] if size is not None else ordered
+
+
+# Upper bound on candidates fetched from MongoDB before Python re-ranking, so a
+# common substring on a large collection does not pull the whole table.
+DEFAULT_POOL = 200
+
+
+def mongo_suggest(
+    queryset,
+    query,
+    match_fields,
+    size,
+    slug_field=None,
+    order_by=None,
+    secondary=None,
+    pool=DEFAULT_POOL,
+    blend_popularity=False,
+):
+    """Fetch accent-aware candidates from ``queryset`` and rank them by match quality.
+
+    - ``match_fields``: model fields matched with ``icontains`` (case-insensitive)
+      and scored for match quality.
+    - ``slug_field``: an already-normalised field (e.g. ``slug``) matched against
+      the normalised query, so "orleans" retrieves "Orléans".
+    - ``order_by``: a MongoDB ordering (e.g. ``-metrics.followers``) used to
+      pre-order the fetched pool. Because the final Python sort is *stable*, items
+      of equal match quality keep this order — so popularity ranking is preserved
+      within each tier without an explicit ``secondary`` key.
+    - ``secondary``: optional Python tie-break applied after match quality (used
+      when there is no natural MongoDB pre-order).
+    - ``blend_popularity``: merge prefix and whole-word matches into one bucket so
+      the ``order_by`` popularity decides between them (see :func:`best_match_score`).
+    """
+    norm = normalize(query)
+
+    conditions = None
+    for field in match_fields:
+        condition = Q(**{f"{field}__icontains": query})
+        conditions = condition if conditions is None else conditions | condition
+    if slug_field and norm:
+        condition = Q(**{f"{slug_field}__icontains": norm})
+        conditions = condition if conditions is None else conditions | condition
+
+    candidates = queryset.filter(conditions) if conditions is not None else queryset
+    if order_by:
+        candidates = candidates.order_by(order_by)
+    candidates = list(candidates.limit(pool))
+
+    return sorted_suggestions(
+        candidates,
+        query,
+        get_texts=lambda item: [getattr(item, field, None) for field in match_fields],
+        secondary=secondary,
+        size=size,
+        blend_popularity=blend_popularity,
+    )

--- a/udata/core/tags/api.py
+++ b/udata/core/tags/api.py
@@ -1,6 +1,6 @@
 from udata.api import API, api
+from udata.core.suggest import mongo_suggest
 from udata.models import Tag
-from udata.tags import slug  # TODO: merge this into this package
 
 DEFAULT_SIZE = 8
 
@@ -24,8 +24,13 @@ class SuggestTagsAPI(API):
     @api.doc("suggest_tags")
     @api.expect(parser)
     def get(self):
-        """Suggest tags"""
+        """Suggest tags, ranked by match quality (exact > prefix > word > substring)."""
         args = parser.parse_args()
-        q = slug(args["q"])
-        results = [{"text": i.name} for i in Tag.objects(name__icontains=q).limit(args["size"])]
-        return sorted(results, key=lambda o: len(o["text"]))
+        tags = mongo_suggest(
+            Tag.objects,
+            args["q"],
+            match_fields=["name"],
+            slug_field="name",
+            size=args["size"],
+        )
+        return [{"text": tag.name} for tag in tags]

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 
 from flask import request as flask_request
 from flask_security import current_user, logout_user
-from slugify import slugify
 
 from udata.api import API, api, fields
 from udata.api.parsers import ModelApiParser
@@ -23,6 +22,7 @@ from udata.core.storages.api import (
     parse_uploaded_image,
     uploaded_image_fields,
 )
+from udata.core.suggest import mongo_suggest
 from udata.core.user.constants import BIGGEST_AVATAR_SIZE
 from udata.core.user.models import Role, _visible_login_date
 from udata.models import CommunityResource, Dataset, Reuse, User
@@ -632,12 +632,16 @@ class SuggestUsersAPI(API):
     @api.expect(suggest_parser)
     @api.marshal_list_with(user_suggestion_fields)
     def get(self):
-        """Suggest users"""
+        """Users autocomplete: accent-insensitive (via slug), ranked by match quality."""
         args = suggest_parser.parse_args()
-        users = User.objects(
-            deleted=None, slug__icontains=slugify(args["q"], separator="-", to_lower=True)
+        return mongo_suggest(
+            User.objects(deleted=None),
+            args["q"],
+            match_fields=["slug"],
+            slug_field="slug",
+            order_by=DEFAULT_SORTING,
+            size=args["size"],
         )
-        return list(users.order_by(DEFAULT_SORTING).limit(args["size"]))
 
 
 @ns.route("/roles/", endpoint="user_roles")

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -2563,6 +2563,41 @@ class DatasetResourceAPITest(APITestCase):
         self.assert200(response)
         self.assertEqual(len(response.json), 0)
 
+    def test_suggest_datasets_accent_insensitive(self):
+        """Typing without accents should still match accented titles (via the slug)."""
+        DatasetFactory(title="Élections municipales", visible=True)
+
+        response = self.get(url_for("api.suggest_datasets", q="elections", size=5))
+        self.assert200(response)
+
+        titles = [suggestion["title"] for suggestion in response.json]
+        self.assertIn("Élections municipales", titles)
+
+    def test_suggest_datasets_ranked_by_match_quality(self):
+        """An exact match ranks above a buried substring, even with far fewer followers."""
+        buried = DatasetFactory(
+            title="Metadata catalogue", visible=True, metrics={"followers": 100}
+        )
+        exact = DatasetFactory(title="Data", visible=True, metrics={"followers": 0})
+
+        response = self.get(url_for("api.suggest_datasets", q="data", size=5))
+        self.assert200(response)
+
+        ids = [suggestion["id"] for suggestion in response.json]
+        self.assertEqual(ids[0], str(exact.id))
+        self.assertLess(ids.index(str(exact.id)), ids.index(str(buried.id)))
+
+    def test_suggest_datasets_blend_popularity_over_prefix(self):
+        """A much-followed whole-word match outranks a barely-followed prefix match."""
+        DatasetFactory(title="Paris tourisme", visible=True, metrics={"followers": 1})
+        word = DatasetFactory(title="Open data Paris", visible=True, metrics={"followers": 500})
+
+        response = self.get(url_for("api.suggest_datasets", q="paris", size=5))
+        self.assert200(response)
+
+        ids = [suggestion["id"] for suggestion in response.json]
+        self.assertEqual(ids[0], str(word.id))
+
 
 class DatasetReferencesAPITest(APITestCase):
     def test_dataset_licenses_list(self):

--- a/udata/tests/test_suggest.py
+++ b/udata/tests/test_suggest.py
@@ -1,0 +1,136 @@
+"""Unit tests for the shared suggest scoring (no database needed)."""
+
+import pytest
+
+from udata.core.suggest import (
+    EXACT,
+    NO_MATCH,
+    PREFIX,
+    SUBSTRING,
+    WORD,
+    best_match_score,
+    match_score,
+    normalize,
+    sorted_suggestions,
+)
+
+
+class NormalizeTest:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("Paris", "paris"),
+            ("Orléans", "orleans"),
+            ("Nîmes", "nimes"),
+            ("Île-de-France", "ile-de-france"),
+            ("Le Grand Paris", "le-grand-paris"),
+            ("  Paris  ", "paris"),
+            ("", ""),
+            (None, ""),
+        ],
+    )
+    def test_normalize(self, value, expected):
+        assert normalize(value) == expected
+
+
+class MatchScoreTest:
+    def test_exact(self):
+        assert match_score("Paris", "Paris") == EXACT
+
+    def test_exact_is_accent_insensitive(self):
+        # The whole point: typing without accents must still match.
+        assert match_score("Orléans", "orleans") == EXACT
+        assert match_score("Nîmes", "nimes") == EXACT
+
+    def test_exact_is_case_insensitive(self):
+        assert match_score("PARIS", "paris") == EXACT
+
+    def test_prefix(self):
+        assert match_score("Paris 17e Arrondissement", "paris") == PREFIX
+
+    def test_word_not_prefix(self):
+        # "paris" is a whole token but not at the start.
+        assert match_score("Le Grand Paris", "paris") == WORD
+
+    def test_substring_is_worse_than_word(self):
+        # The Val Parisis case: "paris" is buried inside "parisis", not a word.
+        assert match_score("Val Parisis", "paris") == SUBSTRING
+
+    def test_no_match(self):
+        assert match_score("Bordeaux", "paris") == NO_MATCH
+
+    def test_ordering_paris_family(self):
+        """Exact < prefix < word < substring for the real Paris zones."""
+        scores = {
+            name: match_score(name, "paris")
+            for name in [
+                "Paris",
+                "Paris 2e Arrondissement",
+                "Le Grand Paris",
+                "Val Parisis",
+            ]
+        }
+        assert scores["Paris"] < scores["Paris 2e Arrondissement"]
+        assert scores["Paris 2e Arrondissement"] < scores["Le Grand Paris"]
+        assert scores["Le Grand Paris"] < scores["Val Parisis"]
+
+    def test_multi_token_query(self):
+        assert match_score("Grand Paris Seine et Oise", "grand paris") == PREFIX
+        assert match_score("Le Grand Paris", "grand paris") == WORD
+
+
+class BestMatchScoreTest:
+    def test_best_across_fields(self):
+        # e.g. an org whose acronym matches exactly but whose name only contains it.
+        assert best_match_score(["Institut National", "INSEE"], "insee") == EXACT
+
+    def test_empty_fields(self):
+        assert best_match_score([], "paris") == NO_MATCH
+
+
+class SortedSuggestionsTest:
+    def test_relegates_substring_below_word(self):
+        names = ["Val Parisis", "Le Grand Paris", "Paris"]
+        ordered = sorted_suggestions(names, "paris", get_texts=lambda n: n)
+        assert ordered == ["Paris", "Le Grand Paris", "Val Parisis"]
+
+    def test_secondary_tiebreak(self):
+        # Two exact matches; the secondary key (a level priority) decides.
+        items = [
+            {"name": "Paris", "level": 1},  # departement
+            {"name": "Paris", "level": 0},  # commune -> should come first
+        ]
+        ordered = sorted_suggestions(
+            items,
+            "paris",
+            get_texts=lambda i: i["name"],
+            secondary=lambda i: (i["level"], i["name"]),
+        )
+        assert [i["level"] for i in ordered] == [0, 1]
+
+    def test_size_cap(self):
+        names = ["Paris", "Le Grand Paris", "Val Parisis"]
+        ordered = sorted_suggestions(names, "paris", get_texts=lambda n: n, size=2)
+        assert ordered == ["Paris", "Le Grand Paris"]
+
+
+class BlendPopularityTest:
+    def test_word_is_merged_into_prefix(self):
+        assert best_match_score(["Le Grand Paris"], "paris") == WORD
+        assert best_match_score(["Le Grand Paris"], "paris", blend_popularity=True) == PREFIX
+
+    def test_exact_and_substring_are_unaffected(self):
+        assert best_match_score(["Paris"], "paris", blend_popularity=True) == EXACT
+        assert best_match_score(["Val Parisis"], "paris", blend_popularity=True) == SUBSTRING
+
+    def test_blend_lets_input_order_decide_between_prefix_and_word(self):
+        # Input is pre-ordered by popularity: a word match first, a prefix second.
+        names = ["Open Data Paris", "Paris tourisme"]  # word, then prefix
+
+        # Strict: the prefix always wins, regardless of popularity.
+        strict = sorted_suggestions(names, "paris", get_texts=lambda n: n)
+        assert strict == ["Paris tourisme", "Open Data Paris"]
+
+        # Blended: prefix and word share a bucket, so the (stable) input order wins.
+        blended = sorted_suggestions(names, "paris", get_texts=lambda n: n, blend_popularity=True)
+        assert blended == ["Open Data Paris", "Paris tourisme"]


### PR DESCRIPTION
## Shared, consistent autocomplete ranking across all `/suggest/` endpoints

### Why

Every `/suggest/` endpoint reimplemented its own matching and sorting, with inconsistent and often poor behaviour: accent-sensitive matching (typing `orleans` returned nothing for "Orléans"), no relevance ranking (a match buried mid-word ranked as high as an exact match), and — for zones — a sort by `admin_level` that pushed the city people actually want to the very bottom.

This PR centralises matching/scoring in a new `udata/core/suggest.py` and routes every endpoint through it.

### Shared core (`udata/core/suggest.py`, new)

- **Accent- & case-insensitive** matching via `slugify` normalisation.
- **Match-quality ranking**: `exact > prefix > whole-word > substring` (so "Val Parisis" no longer outranks "Paris").
- **`mongo_suggest` helper**: accent-aware candidate query (name + normalised slug), a bounded candidate pool for performance, and a *stable* re-rank that keeps each endpoint's popularity order within a quality tier.
- **`blend_popularity`** option: for endpoints backed by a followers signal, prefix and whole-word matches are merged into one bucket so a much-followed canonical result is not relegated below an obscure prefix match (exact stays on top, substrings at the bottom).

### Per-endpoint changes

| Endpoint | What was missing / wrong | Now |
|---|---|---|
| **Zones** `/spatial/zones/suggest/` | Sorted by `admin_level` → the commune (city) ranked **last**; accent-sensitive; substrings ("Val Parisis") outranked exact matches; every detail level returned; empty query returned "Monde" + countries alphabetically; response only carried the machine `level`. | Ranked by `(match quality, curated LEVEL_PRIORITY, name)`; accent-insensitive; **only well-filled levels** (commune, department, region, EPCI) — arrondissements/cantons/IRIS excluded; empty query returns **regions + departments**; new **`level_name`** field so the UI can tell "Paris (Commune)" from "Paris (Département)". |
| **Datasets** `/datasets/suggest/` | Accent-sensitive; ranked by followers only (no match relevance). | Accent-insensitive; match quality, then followers, with prefix/word blended by popularity. |
| **Organizations** `/organizations/suggest/` | Accent-sensitive; ranked by followers only. | Accent-insensitive; match quality, then followers, with prefix/word blended by popularity. |
| **Reuses** `/reuses/suggest/` | Accent-sensitive; ranked by followers only. | Accent-insensitive; match quality, then followers, with prefix/word blended by popularity. |
| **Users** `/users/suggest/` | Match by slug only, sorted by **creation date** (no relevance). | Same slug match (accent-insensitive full name, email intentionally excluded), now ranked by match quality. |
| **Tags** `/tags/suggest/` | Ranked by **string length** (heuristic). | Ranked by match quality. |
| **Org contacts** `/<org>/contacts/suggest/` | Accent-sensitive; **no sorting at all** (insertion order). | Match-quality ranking. |

`/datasets/suggest/formats/` and `/mime/` are left as-is (tiny in-memory lists where accents/relevance don't apply).

### Tests

- 25 pure unit tests for the scoring (accents, tiers, tie-breaks, popularity blend) — no DB.
- Zones tests rewritten/extended: accent-insensitivity, match quality, level priority, detail-level exclusion, empty-query default, `level_name`.
- Added dataset tests proving accent-insensitivity, that match quality outweighs followers, and that a much-followed whole-word match beats a barely-followed prefix match.
- All existing suggest tests still pass.

### Follow-ups (out of scope)

- **Population signal** (per-level homonym tie-break + "top cities" empty-query default) — depends on importing population into `GeoZone` (separate data PR).
- **`load_zones`** left untouched (accent matching in prod relies on a zones reload so slugs are normalised) — handled in a separate PR.
- Front: display `name — level_name` and wire the "apply filter" button.
