### PR TITLE
feat: accept webp as image format

### DIFF
--- a/udata/settings.py
+++ b/udata/settings.py
@@ -428,6 +428,7 @@ class Defaults(object):
         "ecw",
         "svgz",
         "jp2",
+        "webp",
         # Geo
         "shp",
         "kml",
@@ -483,6 +484,7 @@ class Defaults(object):
         "image/jpeg",
         "image/png",
         "image/svg+xml",
+        "image/webp",
         "text/html",
         "text/calendar",
         "text/plain",


### PR DESCRIPTION
Accept WebP as image format for upload resource, since we accept many others. WebP is a widely supported web image standard that is increasingly used.

See also https://github.com/datagouv/cdata/pull/1160