### PR TITLE
feat: detect geozone from spatial.geom

### DIFF
--- a/docs/administrative-tasks.md
+++ b/docs/administrative-tasks.md
@@ -187,6 +187,30 @@ It's possible to index or reindex only last modified documents.
 time udata search index -f 2022-02-20-20-02
 ```
 
+## Geospatial zones
+
+To load zone bounding boxes (used for automatic zone detection from a dataset's spatial
+geometry) onto existing `GeoZone` documents:
+
+```shell
+$ udata spatial load-geozones-bboxes <geozones-bboxes-file>
+```
+
+`<geozones-bboxes-file>` can be either a local path or a remote URL. It's a JSON file: a flat
+object mapping each zone id to its bounding box `[minx, miny, maxx, maxy]` (WGS84
+longitude/latitude), e.g.:
+
+```json
+{
+  "fr:departement:32": [-0.2821, 43.3108, 1.2032, 44.08],
+  "fr:commune:32019": [0.6007, 43.5626, 0.6645, 43.5936]
+}
+```
+
+Zone ids must match existing `GeoZone` ids (run `udata spatial load` first if they don't
+exist yet). Ids present in the file with no matching `GeoZone` are skipped and logged as
+warnings, not fatal.
+
 ## Workers
 
 Start a worker with:

--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -13,10 +13,11 @@ import slugify
 from mongoengine import errors
 from mongoengine.context_managers import switch_collection
 
+from udata.app import cache
 from udata.commands import cli
 from udata.core.dataset.models import Dataset
 from udata.core.spatial import geoids
-from udata.core.spatial.models import GeoLevel, GeoZone, SpatialCoverage
+from udata.core.spatial.models import GEOZONE_BBOXES_CACHE_KEY, GeoLevel, GeoZone, SpatialCoverage
 
 log = logging.getLogger(__name__)
 
@@ -60,6 +61,17 @@ def load_zones(col, json_geozones):
             log.warning("Validation error (%s) for %s with %s", e, geozone["nom"], params)
             continue
     return loaded_geozones
+
+
+def load_geozones_bboxes(col, geozones_bboxes):
+    loaded = 0
+    for zone_id, bbox in geozones_bboxes.items():
+        result = col.objects(id=zone_id).update(set__bbox=bbox)
+        if result:
+            loaded += 1
+        else:
+            log.warning("No matching GeoZone for id %s: skipped", zone_id)
+    return loaded
 
 
 @contextmanager
@@ -139,6 +151,35 @@ def load(geozones_file, levels_file, drop=False):
     log.info("Clean removed geozones in datasets")
     count = fixup_removed_geozone()
     log.info(f"{count} geozones removed from datasets")
+
+
+@grp.command("load-geozones-bboxes")
+@click.argument("geozones-bboxes-file")
+def load_geozones_bboxes_command(geozones_bboxes_file):
+    """
+    Load zone bounding boxes from <geozones-bboxes-file> onto existing GeoZone documents.
+
+    <geozones-bboxes-file> can be either a local path or a remote URL. It's a JSON file:
+    a flat object mapping each zone id to its bounding box, e.g.:
+
+    {
+        "fr:departement:32": [-0.2821, 43.3108, 1.2032, 44.08],
+        "fr:commune:32019": [0.6007, 43.5626, 0.6645, 43.5936]
+    }
+
+    Each bounding box is [minx, miny, maxx, maxy] in WGS84 longitude/latitude.
+    """
+    if geozones_bboxes_file.startswith("http"):
+        json_bboxes = requests.get(geozones_bboxes_file).json()
+    else:
+        with open(geozones_bboxes_file) as f:
+            json_bboxes = json.load(f)
+
+    log.info("Loading zone bboxes")
+    total = load_geozones_bboxes(GeoZone, json_bboxes)
+    log.info("Loaded {total} zone bboxes".format(total=total))
+
+    cache.delete(GEOZONE_BBOXES_CACHE_KEY)
 
 
 @grp.command()

--- a/udata/core/spatial/models.py
+++ b/udata/core/spatial/models.py
@@ -1,7 +1,14 @@
 import geojson
 from mongoengine import EmbeddedDocument
 from mongoengine.errors import ValidationError
-from mongoengine.fields import IntField, ListField, MultiPolygonField, ReferenceField, StringField
+from mongoengine.fields import (
+    FloatField,
+    IntField,
+    ListField,
+    MultiPolygonField,
+    ReferenceField,
+    StringField,
+)
 from werkzeug.local import LocalProxy
 from werkzeug.utils import cached_property
 
@@ -50,6 +57,7 @@ class GeoZone(WithMetrics, Document[GeoZoneQuerySet]):
     code = StringField(required=True)
     level = StringField(required=True)
     uri = StringField()
+    bbox = ListField(FloatField())
 
     meta = {
         "indexes": [
@@ -134,6 +142,22 @@ def get_spatial_admin_levels():
 
 
 admin_levels = LocalProxy(get_spatial_admin_levels)
+
+
+GEOZONE_BBOXES_CACHE_KEY = "geozone-bboxes"
+
+
+# cache is invalidated explicitely by `load-geozones-bboxes` cmd
+@cache.cached(timeout=-1, key_prefix=GEOZONE_BBOXES_CACHE_KEY)
+def get_zone_bboxes():
+    # `bbox` defaults to `[]` when never set, hence the `bbox__size=4` filter
+    return {
+        zone.id: zone.bbox
+        for zone in GeoZone.objects(bbox__exists=True, bbox__size=4).only("id", "bbox")
+    }
+
+
+zone_bboxes = LocalProxy(get_zone_bboxes)
 
 
 @generate_fields()

--- a/udata/core/spatial/tasks.py
+++ b/udata/core/spatial/tasks.py
@@ -1,8 +1,54 @@
-from udata.core.spatial.models import GeoZone
-from udata.tasks import job
+from celery.utils.log import get_task_logger
+
+from udata.core.dataset.models import Dataset
+from udata.core.spatial.models import GeoZone, zone_bboxes
+from udata.core.spatial.zone_detection import detect_zone, geom_to_bbox
+from udata.tasks import job, task
+
+log = get_task_logger(__name__)
 
 
 @job("compute-geozones-metrics")
 def compute_geozones_metrics(self):
     for geozone in GeoZone.objects.timeout(False):
         geozone.count_datasets()
+
+
+@task(route="low.spatial")
+def detect_and_write_zone(dataset_id):
+    dataset = Dataset.objects(id=dataset_id).first()
+    if dataset is None:
+        return
+
+    zone_ids = None
+    # Zones and geom are mutually exclusive (SpatialCoverage.clean()), so an
+    # explicit zones already covers this dataset -- nothing to detect.
+    if dataset.spatial and dataset.spatial.geom and not dataset.spatial.zones:
+        bbox = geom_to_bbox(dataset.spatial.geom)
+        if bbox is not None:
+            zone_ids = detect_zone(bbox, zone_bboxes)
+
+    if zone_ids:
+        log.info("Detected zone(s) %s for dataset %s", zone_ids, dataset_id)
+        Dataset.objects(id=dataset_id).update(**{"set__extras__analysis:spatial:zones": zone_ids})
+    else:
+        # Covers "no match" as well as "no longer applicable" (geom cleared,
+        # zones set explicitly, etc.) -- clears any stale previous match.
+        # No-op (and harmless) if the key was never set.
+        log.debug("No zone match for dataset %s", dataset_id)
+        Dataset.objects(id=dataset_id).update(**{"unset__extras__analysis:spatial:zones": 1})
+
+
+@Dataset.on_create.connect
+def detect_zone_on_create(document, **kwargs):
+    # on_create doesn't carry changed_fields, so guard on geom presence directly
+    # (most datasets have no spatial data -- avoid dispatching a task for all of them).
+    if document.spatial and document.spatial.geom:
+        detect_and_write_zone.delay(str(document.id))
+
+
+@Dataset.on_update.connect
+def detect_zone_on_spatial_change(document, **kwargs):
+    changed_fields = kwargs.get("changed_fields", [])
+    if any(f == "spatial" or f.startswith("spatial.") for f in changed_fields):
+        detect_and_write_zone.delay(str(document.id))

--- a/udata/core/spatial/tests/test_commands.py
+++ b/udata/core/spatial/tests/test_commands.py
@@ -1,0 +1,45 @@
+import json
+from tempfile import NamedTemporaryFile
+
+from udata.core.spatial.factories import GeoZoneFactory
+from udata.core.spatial.models import get_zone_bboxes, zone_bboxes
+from udata.tests.api import DBTestCase
+
+
+class LoadGeozonesBboxesCommandTest(DBTestCase):
+    def _write_bboxes_file(self, bboxes):
+        with NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(bboxes, f)
+            return f.name
+
+    def test_load_geozones_bboxes(self):
+        zone = GeoZoneFactory()
+        other_zone = GeoZoneFactory()
+        path = self._write_bboxes_file(
+            {
+                zone.id: [0.0, 0.0, 1.0, 1.0],
+                "unknown:zone:id": [2.0, 2.0, 3.0, 3.0],
+            }
+        )
+
+        result = self.cli(f"spatial load-geozones-bboxes {path}")
+
+        self.assertEqual(result.exit_code, 0)
+
+        zone.reload()
+        self.assertEqual(zone.bbox, [0.0, 0.0, 1.0, 1.0])
+
+        other_zone.reload()
+        self.assertFalse(other_zone.bbox)
+
+    def test_load_geozones_bboxes_refreshes_cache(self):
+        zone = GeoZoneFactory()
+        path = self._write_bboxes_file({zone.id: [0.0, 0.0, 1.0, 1.0]})
+
+        # warm the cache before the zone has a bbox
+        get_zone_bboxes()
+        self.assertNotIn(zone.id, zone_bboxes)
+
+        self.cli(f"spatial load-geozones-bboxes {path}")
+
+        self.assertEqual(zone_bboxes[zone.id], [0.0, 0.0, 1.0, 1.0])

--- a/udata/core/spatial/tests/test_tasks.py
+++ b/udata/core/spatial/tests/test_tasks.py
@@ -1,0 +1,129 @@
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.spatial.factories import GeoZoneFactory
+from udata.core.spatial.models import SpatialCoverage
+from udata.tests.api import DBTestCase
+
+RECTANGLE_GEOM = {
+    "type": "MultiPolygon",
+    "coordinates": [[[[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]]]],
+}
+
+
+class DetectZoneOnSpatialChangeTest(DBTestCase):
+    def test_writes_matching_zone_on_geom_save(self):
+        zone = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory()
+
+        dataset.spatial = SpatialCoverage(geom=RECTANGLE_GEOM)
+        dataset.save()
+
+        dataset.reload()
+        self.assertEqual(dataset.extras.get("analysis:spatial:zones"), [zone.id])
+
+    def test_writes_matching_zone_on_creation_with_geom(self):
+        # dataset created with geom already set in a single save -- fires
+        # Dataset.on_create, not on_update (e.g. harvesters do exactly this)
+        zone = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory(spatial=SpatialCoverage(geom=RECTANGLE_GEOM))
+
+        dataset.reload()
+        self.assertEqual(dataset.extras.get("analysis:spatial:zones"), [zone.id])
+
+    def test_writes_matching_zone_on_in_place_geom_mutation(self):
+        zone = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory(spatial=SpatialCoverage())
+
+        # in-place subfield mutation produces changed_fields=['spatial.geom'],
+        # not ['spatial'] -- both forms must trigger detection
+        dataset.spatial.geom = RECTANGLE_GEOM
+        dataset.save()
+
+        dataset.reload()
+        self.assertEqual(dataset.extras.get("analysis:spatial:zones"), [zone.id])
+
+    def test_writes_all_tied_zones_on_exact_tie(self):
+        # e.g. a region and a department sharing identical geometry (DOM-TOM)
+        region = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        departement = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory()
+
+        dataset.spatial = SpatialCoverage(geom=RECTANGLE_GEOM)
+        dataset.save()
+
+        dataset.reload()
+        self.assertEqual(
+            sorted(dataset.extras.get("analysis:spatial:zones")),
+            sorted([region.id, departement.id]),
+        )
+
+    def test_no_match_below_threshold(self):
+        GeoZoneFactory(bbox=[100.0, 100.0, 110.0, 110.0])
+        dataset = DatasetFactory()
+
+        dataset.spatial = SpatialCoverage(geom=RECTANGLE_GEOM)
+        dataset.save()
+
+        dataset.reload()
+        # no write on first pass, to avoid noise for datasets that never match
+        self.assertNotIn("analysis:spatial:zones", dataset.extras)
+
+    def test_no_match_clears_stale_match(self):
+        matching_zone = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory()
+
+        dataset.spatial = SpatialCoverage(geom=RECTANGLE_GEOM)
+        dataset.save()
+        dataset.reload()
+        self.assertEqual(dataset.extras.get("analysis:spatial:zones"), [matching_zone.id])
+
+        # geometry moves away from the matching zone -- stale match must be cleared
+        dataset.spatial.geom = {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[200.0, 200.0], [210.0, 200.0], [210.0, 210.0], [200.0, 210.0], [200.0, 200.0]]]
+            ],
+        }
+        dataset.save()
+
+        dataset.reload()
+        self.assertNotIn("analysis:spatial:zones", dataset.extras)
+
+    def test_clearing_geom_for_explicit_zones_clears_stale_match(self):
+        matching_zone = GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory()
+
+        dataset.spatial = SpatialCoverage(geom=RECTANGLE_GEOM)
+        dataset.save()
+        dataset.reload()
+        self.assertEqual(dataset.extras.get("analysis:spatial:zones"), [matching_zone.id])
+
+        # geom cleared and an explicit zone set instead, in the same save --
+        # the inferred match is no longer applicable and must be cleared
+        explicit_zone = GeoZoneFactory()
+        dataset.spatial.geom = None
+        dataset.spatial.zones = [explicit_zone]
+        dataset.save()
+
+        dataset.reload()
+        self.assertNotIn("analysis:spatial:zones", dataset.extras)
+
+    def test_dataset_with_explicit_zones_is_left_untouched(self):
+        zone = GeoZoneFactory()
+        dataset = DatasetFactory(spatial=SpatialCoverage(zones=[zone]))
+
+        # trigger another (non-spatial) change; on_update fires but spatial
+        # itself didn't change, and zones+geom are mutually exclusive anyway
+        dataset.title = "updated title"
+        dataset.save()
+
+        dataset.reload()
+        self.assertNotIn("analysis:spatial:zones", dataset.extras)
+
+    def test_unrelated_field_change_does_not_trigger_detection(self):
+        GeoZoneFactory(bbox=[0.0, 0.0, 10.0, 10.0])
+        dataset = DatasetFactory()
+        dataset.title = "updated title"
+        dataset.save()
+
+        dataset.reload()
+        self.assertNotIn("analysis:spatial:zones", dataset.extras)

--- a/udata/core/spatial/tests/test_zone_detection.py
+++ b/udata/core/spatial/tests/test_zone_detection.py
@@ -1,0 +1,86 @@
+from udata.core.spatial.zone_detection import detect_zone, geom_to_bbox, iou
+
+
+class IouTest:
+    def test_identical_boxes(self):
+        assert iou([0, 0, 10, 10], [0, 0, 10, 10]) == 1.0
+
+    def test_no_overlap(self):
+        assert iou([0, 0, 1, 1], [5, 5, 6, 6]) == 0.0
+
+    def test_partial_overlap(self):
+        # [0,0,10,10] vs [5,5,15,15]: intersection 5x5=25, union 100+100-25=175
+        assert iou([0, 0, 10, 10], [5, 5, 15, 15]) == 25 / 175
+
+    def test_touching_edges_no_overlap(self):
+        assert iou([0, 0, 5, 5], [5, 0, 10, 5]) == 0.0
+
+    def test_contained_box(self):
+        # [0,0,10,10] fully contains [2,2,8,8]: intersection = area of smaller box
+        assert iou([0, 0, 10, 10], [2, 2, 8, 8]) == 36 / 100
+
+
+class DetectZoneTest:
+    def test_no_zones(self):
+        assert detect_zone([0, 0, 10, 10], {}) is None
+
+    def test_skips_malformed_bboxes(self):
+        # e.g. GeoZone.bbox defaults to [] rather than being absent
+        zones = {"empty": [], "malformed": [0, 0, 10], "ok": [0, 0, 10, 10]}
+        assert detect_zone([0, 0, 10, 10], zones) == ["ok"]
+
+    def test_all_malformed_returns_none(self):
+        assert detect_zone([0, 0, 10, 10], {"empty": []}) is None
+
+    def test_match_above_threshold(self):
+        zones = {"a": [0, 0, 10, 10], "b": [100, 100, 110, 110]}
+        assert detect_zone([0, 0, 10, 10], zones) == ["a"]
+
+    def test_no_match_below_threshold(self):
+        zones = {"a": [0, 0, 10, 10]}
+        # 25/175 overlap is well below the 0.8 threshold
+        assert detect_zone([5, 5, 15, 15], zones) is None
+
+    def test_picks_best_of_multiple_candidates(self):
+        zones = {
+            "exact": [0, 0, 10, 10],
+            "close": [1, 1, 11, 11],
+        }
+        assert detect_zone([0, 0, 10, 10], zones) == ["exact"]
+
+    def test_custom_threshold(self):
+        zones = {"a": [0, 0, 10, 10]}
+        assert detect_zone([5, 5, 15, 15], zones, threshold=0.1) == ["a"]
+
+    def test_exact_tie_returns_all_matching_zones(self):
+        # e.g. a region and a department sharing identical geometry (DOM-TOM)
+        zones = {
+            "fr:region:03": [0, 0, 10, 10],
+            "fr:departement:972": [0, 0, 10, 10],
+            "unrelated": [100, 100, 110, 110],
+        }
+        assert sorted(detect_zone([0, 0, 10, 10], zones)) == ["fr:departement:972", "fr:region:03"]
+
+
+class GeomToBboxTest:
+    def test_multipolygon(self):
+        geom = {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]]
+            ],
+        }
+        assert geom_to_bbox(geom) == [102.0, 2.0, 103.0, 3.0]
+
+    def test_multiple_polygons_takes_envelope(self):
+        geom = {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]],
+                [[[10.0, 10.0], [11.0, 10.0], [11.0, 11.0], [10.0, 11.0], [10.0, 10.0]]],
+            ],
+        }
+        assert geom_to_bbox(geom) == [0.0, 0.0, 11.0, 11.0]
+
+    def test_empty_coordinates(self):
+        assert geom_to_bbox({"type": "MultiPolygon", "coordinates": []}) is None

--- a/udata/core/spatial/zone_detection.py
+++ b/udata/core/spatial/zone_detection.py
@@ -1,0 +1,68 @@
+"""
+Bbox-based zone detection.
+
+Matches a dataset's spatial geometry against zone bounding boxes using
+Intersection over Union (IoU) scoring. Pure Python, no geospatial dependencies.
+"""
+
+IOU_THRESHOLD = 0.8
+
+
+def iou(bbox, zone_bbox):
+    """Intersection over Union between two [minx, miny, maxx, maxy] boxes."""
+    minx1, miny1, maxx1, maxy1 = bbox
+    minx2, miny2, maxx2, maxy2 = zone_bbox
+
+    iw = max(0, min(maxx1, maxx2) - max(minx1, minx2))
+    ih = max(0, min(maxy1, maxy2) - max(miny1, miny2))
+    intersection = iw * ih
+
+    area1 = (maxx1 - minx1) * (maxy1 - miny1)
+    area2 = (maxx2 - minx2) * (maxy2 - miny2)
+    union = area1 + area2 - intersection
+
+    return intersection / union if union > 0 else 0.0
+
+
+def detect_zone(bbox, zones, threshold=IOU_THRESHOLD):
+    """
+    Return the ids of the best-matching zone(s) for `bbox`, or None.
+
+    Ties (exactly equal top score, e.g. a region and a department sharing
+    identical geometry) are all returned rather than arbitrarily picking one.
+
+    bbox: [minx, miny, maxx, maxy]
+    zones: {zone_id: [minx, miny, maxx, maxy]}
+    """
+    scores = {
+        zone_id: iou(bbox, zone_bbox)
+        for zone_id, zone_bbox in zones.items()
+        if zone_bbox and len(zone_bbox) == 4
+    }
+    if not scores:
+        return None
+    best_score = max(scores.values())
+    if best_score < threshold:
+        return None
+    return [zone_id for zone_id, score in scores.items() if score == best_score]
+
+
+def geom_to_bbox(geom):
+    """Compute the [minx, miny, maxx, maxy] envelope of a GeoJSON geometry dict."""
+    xs = []
+    ys = []
+
+    def walk(coords):
+        if not coords:
+            return
+        if isinstance(coords[0], (int, float)):
+            xs.append(coords[0])
+            ys.append(coords[1])
+        else:
+            for c in coords:
+                walk(c)
+
+    walk(geom.get("coordinates", []))
+    if not xs:
+        return None
+    return [min(xs), min(ys), max(xs), max(ys)]


### PR DESCRIPTION
This feed `dataset.extras['analysis:spatial:zones']` with one or more detected geozones from `dataset.spatial.geom`. 

We're not using `dataset.spatial.zones` because:
- we don't want to override a producer's available attribute
- there currently can't be both a geom and zones in `dataset.spatial`

I believe this belongs in `udata` since it's working on dataset's metadata. The `analysis:` namespace might be wrong though.

The matching is done by comparing the geozone bbox to the spatial geometry bbox. This makes it fast and doesn't require any geo lib. See https://github.com/abulte/dataset-geom-to-zone for more info on matching method. It's triggered through Celery on dataset creation and dataset geometry update.

This requires associating a bbox to geozones, which this PR introduces a CLI command for. See attached file for a working draft of the expected input file. This should probably be industrialised through a DAG and published on data.gouv.fr. See https://github.com/abulte/dataset-geom-to-zone for more info on building the required input file.

Performance insights:

```
# no cache
In [3]: %timeit zones = get_zone_bboxes()
557 ms ± 3.69 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# with cache
In [3]: %timeit zones = get_zone_bboxes()
19.6 ms ± 153 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [8]: %timeit bbox = geom_to_bbox(poissy)
27.3 μs ± 66.3 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [10]: %timeit detect_zone(bbox, zones)
19.3 ms ± 790 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

I'm leaving this in draft for now since I want to take more time to review the code and do more tests on the matching threshold, but don't hesitate to comment on the principle and implementation choices.

[zones_bboxes.json](https://github.com/user-attachments/files/29630035/zones_bboxes.json)
