### PR TITLE
fix: error message if failing to download geozones

### DIFF
--- a/udata/core/spatial/commands.py
+++ b/udata/core/spatial/commands.py
@@ -99,7 +99,11 @@ def load(geozones_file, levels_file, drop=False):
     """
     log.info("Loading GeoZones levels")
     if levels_file.startswith("http"):
-        json_levels = requests.get(levels_file).json()
+        response = requests.get(levels_file)
+        # Raise on HTTP errors so a transient error page from the remote server
+        # surfaces clearly instead of an opaque JSONDecodeError on the HTML body.
+        response.raise_for_status()
+        json_levels = response.json()
     else:
         with open(levels_file) as f:
             json_levels = json.load(f)
@@ -119,7 +123,9 @@ def load(geozones_file, levels_file, drop=False):
 
     log.info("Loading Zones")
     if geozones_file.startswith("http"):
-        json_geozones = requests.get(geozones_file).json()
+        response = requests.get(geozones_file)
+        response.raise_for_status()
+        json_geozones = response.json()
     else:
         with open(geozones_file) as f:
             json_geozones = json.load(f)


### PR DESCRIPTION
Prevent these kind of obscure errors:

```
Loading GeoZones levels
Loaded 10 levels
Loading Zones
Traceback (most recent call last):
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/requests/models.py", line 1116, in json
    return complexjson.loads(self.text, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/github/home/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/github/home/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/github/home/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/cdata/cdata/udata/.venv/bin/udata", line 10, in <module>
    sys.exit(cli())
             ^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 1569, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/udata/commands/__init__.py", line 238, in main
    return super(UdataGroup, self).main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 1490, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 1970, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 1970, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 1353, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 907, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/flask/cli.py", line 400, in decorator
    return ctx.invoke(f, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/click/core.py", line 907, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/udata/core/spatial/commands.py", line 122, in load
    json_geozones = requests.get(geozones_file).json()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/cdata/cdata/udata/.venv/lib/python3.11/site-packages/requests/models.py", line 1120, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```