### PR TITLE
feat(harvest,catalog): sync dataset/dataservice harvest info

### DIFF
--- a/udata/core/dataservices/csv.py
+++ b/udata/core/dataservices/csv.py
@@ -31,6 +31,14 @@ class DataserviceCsvAdapter(csv.Adapter):
         ("archived", lambda d: d.archived_at or False),
         ("tags", lambda d: ",".join(d.tags)),
         ("datasets", lambda d: ",".join([str(d.id) for d in d.datasets])),
+        ("harvest.backend", lambda r: r.harvest and r.harvest.backend),
+        ("harvest.domain", lambda r: r.harvest and r.harvest.domain),
+        ("harvest.remote_id", lambda r: r.harvest and r.harvest.remote_id),
+        ("harvest.remote_url", lambda r: r.harvest and r.harvest.remote_url),
+        ("harvest.uri", lambda r: r.harvest and r.harvest.uri),
+        ("harvest.created_at", lambda r: r.harvest and r.harvest.created_at),
+        ("harvest.issued_at", lambda r: r.harvest and r.harvest.issued_at),
+        ("harvest.modified_at", lambda r: r.harvest and r.harvest.modified_at),
     )
 
     def dynamic_fields(self):

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -137,10 +137,14 @@ class HarvestMetadata(EmbeddedDocument):
     )
 
     created_at = field(
-        DateTimeField(), description="Date of the creation as provided by the harvested catalog"
+        DateTimeField(), description="Date of creation as provided by the harvested catalog"
     )
     issued_at = field(
-        DateTimeField(), description="Release date as provided by the harvested catalog"
+        DateTimeField(), description="Date of release as provided by the harvested catalog"
+    )
+    modified_at = field(
+        DateTimeField(),
+        description="Date of last modification as provided by the harvested catalog",
     )
     last_update = field(DateTimeField(), description="Date of the last harvesting")
     archived_at = field(DateTimeField())

--- a/udata/core/dataservices/rdf.py
+++ b/udata/core/dataservices/rdf.py
@@ -89,7 +89,9 @@ def dataservice_from_rdf(
     )
     dataservice.harvest.created_at = rdf_value(d, DCT.created)
     dataservice.harvest.issued_at = rdf_value(d, DCT.issued)
-    dataservice.metadata_modified_at = rdf_value(d, DCT.modified)
+    dataservice.harvest.modified_at = rdf_value(d, DCT.modified)
+
+    dataservice.metadata_modified_at = dataservice.harvest.modified_at
 
     dataservice.tags = themes_from_rdf(d)
 

--- a/udata/core/dataset/csv.py
+++ b/udata/core/dataset/csv.py
@@ -50,9 +50,13 @@ class DatasetCsvAdapter(csv.Adapter):
         ("resources_formats", lambda o: ",".join(set(r.format for r in o.resources if r.format))),
         ("harvest.backend", lambda r: r.harvest and r.harvest.backend),
         ("harvest.domain", lambda r: r.harvest and r.harvest.domain),
-        ("harvest.created_at", lambda r: r.harvest and r.harvest.created_at),
-        ("harvest.modified_at", lambda r: r.harvest and r.harvest.modified_at),
+        ("harvest.remote_id", lambda r: r.harvest and r.harvest.remote_id),
         ("harvest.remote_url", lambda r: r.harvest and r.harvest.remote_url),
+        ("harvest.uri", lambda r: r.harvest and r.harvest.uri),
+        ("harvest.created_at", lambda r: r.harvest and r.harvest.created_at),
+        ("harvest.issued_at", lambda r: r.harvest and r.harvest.issued_at),
+        ("harvest.modified_at", lambda r: r.harvest and r.harvest.modified_at),
+        ("harvest.dct_identifier", lambda r: r.harvest and r.harvest.dct_identifier),
         ("quality_score", lambda o: format(o.quality["score"], ".2f")),
         # schema? what is the schema of a dataset?
     )

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -120,18 +120,23 @@ def get_json_ld_extra(key, value):
 @generate_fields()
 class HarvestDatasetMetadata(EmbeddedDocument):
     backend = StringField()
+    domain = StringField()
+
+    source_id = StringField()
+
+    remote_id = StringField()
+    remote_url = URLField()
+
+    uri = StringField()
+
     created_at = DateTimeField()
     issued_at = DateTimeField()
     modified_at = DateTimeField()
-    source_id = StringField()
-    remote_id = StringField()
-    domain = StringField()
     last_update = DateTimeField()
-    remote_url = URLField()
-    uri = StringField()
-    dct_identifier = StringField()
     archived_at = DateTimeField()
     archived = StringField()
+
+    dct_identifier = StringField()
     ckan_name = StringField()
     ckan_source = StringField()
 

--- a/udata/tests/dataservice/test_csv_adapter.py
+++ b/udata/tests/dataservice/test_csv_adapter.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from udata.core.dataservices.csv import DataserviceCsvAdapter
 from udata.core.dataservices.factories import DataserviceFactory
@@ -10,12 +10,30 @@ from udata.tests.api import PytestOnlyDBTestCase
 
 class DataserviceCSVAdapterTest(PytestOnlyDBTestCase):
     def test_dataservices_csv_adapter(self):
+        date_created = datetime(2022, 12, 31)
+        date_issued = date_created + timedelta(days=1)
+        date_modified = date_created + timedelta(days=2)
         dataservice = DataserviceFactory(
-            created_at=datetime(2022, 12, 31),
-            metadata_modified_at=datetime(2023, 1, 1),
+            created_at=date_created,
+            metadata_modified_at=date_modified,
             organization=OrganizationFactory(),
             datasets=[DatasetFactory(), DatasetFactory()],
             metrics={"views": 42},
+        )
+        harvest_dataservice = DataserviceFactory(
+            created_at=date_created,
+            metadata_modified_at=date_modified,
+            organization=OrganizationFactory(),
+            harvest={
+                "backend": "dummy_backend",
+                "domain": "example.com",
+                "remote_id": "remote-id",
+                "remote_url": "https://www.example.com/",
+                "uri": "https://www.example.com/remote-id",
+                "created_at": date_created,
+                "issued_at": date_issued,
+                "modified_at": date_modified,
+            },
         )
         [DataserviceFactory() for _ in range(10)]
         adapter = DataserviceCsvAdapter(Dataservice.objects.all())
@@ -31,12 +49,19 @@ class DataserviceCSVAdapterTest(PytestOnlyDBTestCase):
         assert dataservice_values["url"] == dataservice.self_web_url()
         assert dataservice_values["organization"] == dataservice.organization.name
         assert dataservice_values["organization_id"] == str(dataservice.organization.id)
-        assert dataservice_values["created_at"] == dataservice.created_at.isoformat()
-        assert (
-            dataservice_values["metadata_modified_at"]
-            == dataservice.metadata_modified_at.isoformat()
-        )
+        assert dataservice_values["created_at"] == date_created.isoformat()
+        assert dataservice_values["metadata_modified_at"] == date_modified.isoformat()
         assert dataservice_values["datasets"] == ",".join(
             str(dataset.id) for dataset in dataservice.datasets
         )
         assert dataservice_values["metric.views"] == dataservice.metrics["views"]
+
+        harvest_dataservice_values = csv[str(harvest_dataservice.id)]
+        assert harvest_dataservice_values["harvest.backend"] == "dummy_backend"
+        assert harvest_dataservice_values["harvest.domain"] == "example.com"
+        assert harvest_dataservice_values["harvest.remote_id"] == "remote-id"
+        assert harvest_dataservice_values["harvest.remote_url"] == "https://www.example.com/"
+        assert harvest_dataservice_values["harvest.uri"] == "https://www.example.com/remote-id"
+        assert harvest_dataservice_values["harvest.created_at"] == date_created.isoformat()
+        assert harvest_dataservice_values["harvest.issued_at"] == date_issued.isoformat()
+        assert harvest_dataservice_values["harvest.modified_at"] == date_modified.isoformat()

--- a/udata/tests/dataset/test_csv_adapter.py
+++ b/udata/tests/dataset/test_csv_adapter.py
@@ -49,14 +49,19 @@ class DatasetCSVAdapterTest(PytestOnlyDBTestCase):
 
     def test_datasets_csv_adapter(self):
         date_created = datetime(2022, 12, 31)
-        date_modified = date_created + timedelta(days=1)
+        date_issued = date_created + timedelta(days=1)
+        date_modified = date_created + timedelta(days=2)
         harvest_dataset = DatasetFactory(
             harvest={
-                "domain": "example.com",
                 "backend": "dummy_backend",
-                "modified_at": date_modified,
-                "created_at": date_created,
+                "domain": "example.com",
+                "remote_id": "remote-id",
                 "remote_url": "https://www.example.com/",
+                "uri": "https://www.example.com/remote-id",
+                "created_at": date_created,
+                "issued_at": date_issued,
+                "modified_at": date_modified,
+                "dct_identifier": "dct-identifier",
             },
         )
         resources_dataset = DatasetFactory(
@@ -92,11 +97,15 @@ class DatasetCSVAdapterTest(PytestOnlyDBTestCase):
             csv[values["id"]] = values
 
         harvest_dataset_values = csv[str(harvest_dataset.id)]
-        assert harvest_dataset_values["harvest.created_at"] == date_created.isoformat()
-        assert harvest_dataset_values["harvest.modified_at"] == date_modified.isoformat()
         assert harvest_dataset_values["harvest.backend"] == "dummy_backend"
         assert harvest_dataset_values["harvest.domain"] == "example.com"
+        assert harvest_dataset_values["harvest.remote_id"] == "remote-id"
         assert harvest_dataset_values["harvest.remote_url"] == "https://www.example.com/"
+        assert harvest_dataset_values["harvest.uri"] == "https://www.example.com/remote-id"
+        assert harvest_dataset_values["harvest.created_at"] == date_created.isoformat()
+        assert harvest_dataset_values["harvest.issued_at"] == date_issued.isoformat()
+        assert harvest_dataset_values["harvest.modified_at"] == date_modified.isoformat()
+        assert harvest_dataset_values["harvest.dct_identifier"] == "dct-identifier"
         assert harvest_dataset_values["resources_count"] == 0
 
         resources_dataset_values = csv[str(resources_dataset.id)]


### PR DESCRIPTION
Needed for https://github.com/ecolabdata/ecospheres/issues/1130.

Changes:
- Expose missing `harvest` information in dataset and dataservices catalog exports.
- Add `harvest.modified_at` to dataservices, for symmetry with dataset harvest info.
- Reorganize fields to facilitate comparison between the datasets/dataservices harvest structures.