### PR TITLE
ci: redirect inv stdin to /dev/null to bypass invoke v3 tty crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,12 @@ jobs:
           name: Run tests
           command: |
             mkdir -p reports/python
-            uv run inv test --report --ci
+            # Redirect stdin from /dev/null to avoid an invoke v3 crash:
+            # handle_stdin thread calls tcgetpgrp(stdin) which fails with
+            # ENOTTY on CircleCI when stdin is a TTY-flagged char device
+            # but the inv process isn't the session leader. /dev/null is
+            # not a TTY, so invoke's isatty() check short-circuits cleanly.
+            uv run inv test --report --ci < /dev/null
       - store_test_results:
           path: reports/python
       - store_artifacts:
@@ -129,7 +134,7 @@ jobs:
       - run:
           name: Build a distributable package as a wheel release
           command: |
-            uv run inv pydist
+            uv run inv pydist < /dev/null
       - store_artifacts:
           path: dist
       - persist_to_workspace:


### PR DESCRIPTION
## Summary
- Split out of #3783: CircleCI's Docker step assigns stdin a TTY-flagged character device. On runs where `uv` has work to do (cache key miss → fallback restore → `uv sync` re-reconciles deps), `uv`'s subprocess management leaves the `inv` process without a controlling terminal, and invoke v3's `handle_stdin` thread crashes in `tcgetpgrp`.
- Redirects `inv`'s stdin from `/dev/null` so `isatty()` returns `False`, short-circuiting before the broken `tcgetpgrp` call.

## Test plan
- [x] CI passes on this branch