### PR TITLE
feat(topic): featured property is read only and has dedicated admin permission routes

### DIFF
--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -323,8 +323,8 @@ def handle_validation_error(error: mongoengine.errors.ValidationError):
 @apiv2.errorhandler(PermissionDenied)
 @apiv2.marshal_with(default_error_v2, code=403)
 def handle_permission_denied_v2(error):
-    message = "You do not have the permission to modify that object."
-    return {"message": message}, 403
+    """Error occuring when the user does not have the required permissions"""
+    return handle_permission_denied(error)
 
 
 @apiv2.errorhandler(mongoengine.errors.ValidationError)

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -249,6 +249,7 @@ def collect_stats(response):
 
 
 default_error = api.model("Error", {"message": fields.String})
+default_error_v2 = apiv2.inherit("Error", default_error)
 
 
 @api.errorhandler(PermissionDenied)
@@ -317,6 +318,13 @@ def handle_validation_error(error: mongoengine.errors.ValidationError):
         },
         400,
     )
+
+
+@apiv2.errorhandler(PermissionDenied)
+@apiv2.marshal_with(default_error_v2, code=403)
+def handle_permission_denied_v2(error):
+    message = "You do not have the permission to modify that object."
+    return {"message": message}, 403
 
 
 @apiv2.errorhandler(mongoengine.errors.ValidationError)

--- a/udata/core/topic/apiv2.py
+++ b/udata/core/topic/apiv2.py
@@ -7,6 +7,7 @@ from flask_security import current_user
 from udata import search
 from udata.api import API, api, apiv2, fields
 from udata.api_fields import lazy_reference, patch, patch_and_save
+from udata.auth import admin_permission
 from udata.core.discussions.models import Discussion
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import Topic, TopicElement
@@ -291,3 +292,25 @@ class TopicElementAPI(API):
         patch_and_save(element, request)
 
         return element
+
+
+@ns.route("/<topic:topic>/featured/", endpoint="topic_featured", doc=common_doc)
+@apiv2.response(404, "Topic not found")
+class TopicFeaturedAPI(API):
+    @apiv2.secure(admin_permission)
+    @apiv2.doc("feature_topic")
+    @apiv2.marshal_with(topic_fields)
+    def post(self, topic):
+        """Mark the topic as featured"""
+        topic.featured = True
+        topic.save()
+        return topic
+
+    @apiv2.secure(admin_permission)
+    @apiv2.doc("unfeature_topic")
+    @apiv2.marshal_with(topic_fields)
+    def delete(self, topic):
+        """Unmark the topic as featured"""
+        topic.featured = False
+        topic.save()
+        return topic

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -118,7 +118,7 @@ class Topic(Datetimed, Auditable, Linkable, Document[OwnedQuerySet], Owned):
     tags = field(ListField(StringField()))
     color = field(IntField())
 
-    featured = field(BooleanField(default=False), auditable=False)
+    featured = field(BooleanField(default=False), readonly=True, auditable=False)
     private = field(BooleanField())
     extras = field(ExtrasField(), auditable=False)
 

--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -16,6 +16,7 @@ from udata.core.dataset.factories import (
 from udata.core.dataset.models import ResourceMixin
 from udata.core.organization.factories import Member, OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory
+from udata.core.user.factories import UserFactory
 from udata.models import Dataset
 from udata.tests.api import APITestCase
 from udata.tests.helpers import assert_not_emit
@@ -472,6 +473,35 @@ class DatasetExtrasAPITest(APITestCase):
         data = response.json
         assert data["test::extra"] == "test-value"
         assert data["check::date"] == "2024-04-14T08:42:00"
+
+    def test_update_dataset_extras_without_permission(self):
+        """It should return a 403 when the user cannot edit the dataset"""
+        someone_else_dataset = DatasetFactory(owner=UserFactory())
+
+        response = self.put(
+            url_for("apiv2.dataset_extras", dataset=someone_else_dataset),
+            {"test::extra": "test-value"},
+        )
+
+        self.assert403(response)
+        assert "message" in response.json
+        someone_else_dataset.reload()
+        assert "test::extra" not in someone_else_dataset.extras
+
+    def test_delete_dataset_extras_without_permission(self):
+        """It should return a 403 when the user cannot delete the dataset extras"""
+        someone_else_dataset = DatasetFactory(owner=UserFactory())
+        someone_else_dataset.extras = {"test::extra": "test-value"}
+        someone_else_dataset.save()
+
+        response = self.delete(
+            url_for("apiv2.dataset_extras", dataset=someone_else_dataset), ["test::extra"]
+        )
+
+        self.assert403(response)
+        assert "message" in response.json
+        someone_else_dataset.reload()
+        assert someone_else_dataset.extras["test::extra"] == "test-value"
 
     def test_update_dataset_extras(self):
         self.dataset.extras = {

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -605,12 +605,23 @@ class TopicAPITest(APITestCase):
         assert topic.featured is False
         assert response.json["featured"] is False
 
+    def test_featured_admin_post_requires_authentication(self):
+        """It should require authentication to feature a topic"""
+        topic = TopicFactory(featured=False)
+        response = self.post(url_for("apiv2.topic_featured", topic=topic))
+        self.assert401(response)
+        topic.reload()
+        assert topic.featured is False
+
     def test_featured_admin_post_requires_admin(self):
         """It should require admin to feature a topic"""
         self.login()
-        topic = TopicFactory()
+        topic = TopicFactory(featured=False)
         response = self.post(url_for("apiv2.topic_featured", topic=topic))
         self.assert403(response)
+        assert "message" in response.json
+        topic.reload()
+        assert topic.featured is False
 
     def test_featured_admin_post_as_admin(self):
         """It should allow admin to feature a topic"""
@@ -622,12 +633,23 @@ class TopicAPITest(APITestCase):
         assert topic.featured is True
         assert response.json["featured"] is True
 
+    def test_featured_admin_delete_requires_authentication(self):
+        """It should require authentication to unfeature a topic"""
+        topic = TopicFactory(featured=True)
+        response = self.delete(url_for("apiv2.topic_featured", topic=topic))
+        self.assert401(response)
+        topic.reload()
+        assert topic.featured is True
+
     def test_featured_admin_delete_requires_admin(self):
         """It should require admin to unfeature a topic"""
         self.login()
         topic = TopicFactory(featured=True)
         response = self.delete(url_for("apiv2.topic_featured", topic=topic))
         self.assert403(response)
+        assert "message" in response.json
+        topic.reload()
+        assert topic.featured is True
 
     def test_featured_admin_delete_as_admin(self):
         """It should allow admin to unfeature a topic"""

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -19,7 +19,7 @@ from udata.core.topic.factories import (
     TopicWithElementsFactory,
 )
 from udata.core.topic.models import Topic, TopicElement
-from udata.core.user.factories import UserFactory
+from udata.core.user.factories import AdminFactory, UserFactory
 from udata.i18n import _
 from udata.tests.api import APITestCase
 from udata.tests.helpers import create_geozones_fixtures
@@ -582,6 +582,62 @@ class TopicAPITest(APITestCase):
 
         self.assertIn("uri", data)
         self.assertTrue(data["uri"].startswith("http"))
+
+    def test_featured_is_readonly_on_create(self):
+        """It should ignore featured when creating a topic (readonly)"""
+        self.login()
+        data = TopicWithElementsFactory.as_payload()
+        data["featured"] = True
+        response = self.post(url_for("apiv2.topics_list"), data)
+        self.assert201(response)
+        topic = Topic.objects.first()
+        assert topic.featured is False
+        assert response.json["featured"] is False
+
+    def test_featured_is_readonly_on_update(self):
+        """It should ignore featured when updating a topic (readonly)"""
+        owner = self.login()
+        topic = TopicFactory(owner=owner, featured=False)
+        data = {"featured": True}
+        response = self.put(url_for("apiv2.topic", topic=topic), data)
+        self.assert200(response)
+        topic.reload()
+        assert topic.featured is False
+        assert response.json["featured"] is False
+
+    def test_featured_admin_post_requires_admin(self):
+        """It should require admin to feature a topic"""
+        self.login()
+        topic = TopicFactory()
+        response = self.post(url_for("apiv2.topic_featured", topic=topic))
+        self.assert403(response)
+
+    def test_featured_admin_post_as_admin(self):
+        """It should allow admin to feature a topic"""
+        self.login(AdminFactory())
+        topic = TopicFactory(featured=False)
+        response = self.post(url_for("apiv2.topic_featured", topic=topic))
+        self.assert200(response)
+        topic.reload()
+        assert topic.featured is True
+        assert response.json["featured"] is True
+
+    def test_featured_admin_delete_requires_admin(self):
+        """It should require admin to unfeature a topic"""
+        self.login()
+        topic = TopicFactory(featured=True)
+        response = self.delete(url_for("apiv2.topic_featured", topic=topic))
+        self.assert403(response)
+
+    def test_featured_admin_delete_as_admin(self):
+        """It should allow admin to unfeature a topic"""
+        self.login(AdminFactory())
+        topic = TopicFactory(featured=True)
+        response = self.delete(url_for("apiv2.topic_featured", topic=topic))
+        self.assert200(response)
+        topic.reload()
+        assert topic.featured is False
+        assert response.json["featured"] is False
 
 
 class TopicElementsAPITest(APITestCase):


### PR DESCRIPTION
It is currently not used, but for future coherence, align `featured` behavior similarly to other objects.