### PR TITLE
test: explicit CSV export config

### DIFF
--- a/udata/tests/site/test_site_csv_exports.py
+++ b/udata/tests/site/test_site_csv_exports.py
@@ -49,7 +49,9 @@ class SiteCsvExportsTest(APITestCase):
 
     @pytest.mark.usefixtures("instance_path")
     def test_datasets_csv_w_export_csv_feature(self):
-        # no export generated, 404
+        self.app.config["EXPORT_CSV_MODELS"] = ["dataset"]
+
+        # no export generated yet, 404
         response = self.get(url_for("api.site_datasets_csv"))
         self.assert404(response)
 
@@ -158,7 +160,9 @@ class SiteCsvExportsTest(APITestCase):
 
     @pytest.mark.usefixtures("instance_path")
     def test_resources_csv_w_export_csv_feature(self):
-        # no export generated, 404
+        self.app.config["EXPORT_CSV_MODELS"] = ["resource"]
+
+        # no export generated yet, 404
         response = self.get(url_for("api.site_datasets_resources_csv"))
         self.assert404(response)
 
@@ -240,7 +244,9 @@ class SiteCsvExportsTest(APITestCase):
 
     @pytest.mark.usefixtures("instance_path")
     def test_organizations_csv_w_export_csv_feature(self):
-        # no export generated, 404
+        self.app.config["EXPORT_CSV_MODELS"] = ["organization"]
+
+        # no export generated yet, 404
         response = self.get(url_for("api.site_organizations_csv"))
         self.assert404(response)
 
@@ -285,7 +291,9 @@ class SiteCsvExportsTest(APITestCase):
 
     @pytest.mark.usefixtures("instance_path")
     def test_reuses_csv_w_export_csv_feature(self):
-        # no export generated, 404
+        self.app.config["EXPORT_CSV_MODELS"] = ["reuse"]
+
+        # no export generated yet, 404
         response = self.get(url_for("api.site_reuses_csv"))
         self.assert404(response)
 
@@ -370,7 +378,9 @@ class SiteCsvExportsTest(APITestCase):
 
     @pytest.mark.usefixtures("instance_path")
     def test_dataservices_csv_w_export_csv_feature(self):
-        # no export generated, 404
+        self.app.config["EXPORT_CSV_MODELS"] = ["dataservice"]
+
+        # no export generated yet, 404
         response = self.get(url_for("api.site_dataservices_csv"))
         self.assert404(response)
 
@@ -461,7 +471,9 @@ class SiteCsvExportsTest(APITestCase):
 
     @pytest.mark.usefixtures("instance_path")
     def test_harvest_csv_w_export_csv_feature(self):
-        # no export generated, 404
+        self.app.config["EXPORT_CSV_MODELS"] = ["harvest"]
+
+        # no export generated yet, 404
         response = self.get(url_for("api.site_harvests_csv"))
         self.assert404(response)
 

--- a/udata/tests/site/test_site_csv_exports.py
+++ b/udata/tests/site/test_site_csv_exports.py
@@ -16,8 +16,8 @@ from udata.tests.api import APITestCase
 
 
 class SiteCsvExportsTest(APITestCase):
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_datasets_csv(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         datasets = [DatasetFactory(resources=[ResourceFactory()]) for _ in range(5)]
         archived_datasets = [DatasetFactory(archived=datetime.now(UTC)) for _ in range(3)]
         hidden_dataset = DatasetFactory(private=True)
@@ -48,9 +48,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertNotIn(str(hidden_dataset.id), ids)
 
     @pytest.mark.usefixtures("instance_path")
+    @pytest.mark.options(EXPORT_CSV_MODELS=["dataset"])
     def test_datasets_csv_w_export_csv_feature(self):
-        self.app.config["EXPORT_CSV_MODELS"] = ["dataset"]
-
         # no export generated yet, 404
         response = self.get(url_for("api.site_datasets_csv"))
         self.assert404(response)
@@ -100,8 +99,8 @@ class SiteCsvExportsTest(APITestCase):
             self.assertNotIn(str(dataset.id), ids)
         self.assertNotIn(str(hidden_dataset.id), ids)
 
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_datasets_csv_with_badge_filter(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         dataset_with_badge = DatasetFactory(resources=[ResourceFactory()])
         dataset_with_badge.add_badge(SPD)
         dataset_without_badge = DatasetFactory(resources=[ResourceFactory()])
@@ -121,8 +120,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertIn(str(dataset_with_badge.id), ids)
         self.assertNotIn(str(dataset_without_badge.id), ids)
 
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_resources_csv(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         datasets = [
             DatasetFactory(resources=[ResourceFactory(), ResourceFactory()]) for _ in range(3)
         ]
@@ -159,9 +158,8 @@ class SiteCsvExportsTest(APITestCase):
                 self.assertIn((str(dataset.id), str(resource.id)), ids)
 
     @pytest.mark.usefixtures("instance_path")
+    @pytest.mark.options(EXPORT_CSV_MODELS=["resource"])
     def test_resources_csv_w_export_csv_feature(self):
-        self.app.config["EXPORT_CSV_MODELS"] = ["resource"]
-
         # no export generated yet, 404
         response = self.get(url_for("api.site_datasets_resources_csv"))
         self.assert404(response)
@@ -213,8 +211,8 @@ class SiteCsvExportsTest(APITestCase):
             for resource in dataset.resources:
                 self.assertIn((str(dataset.id), str(resource.id)), ids)
 
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_organizations_csv(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         orgs = [OrganizationFactory() for _ in range(5)]
         hidden_org = OrganizationFactory(deleted=datetime.now(UTC))
 
@@ -243,9 +241,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertNotIn(str(hidden_org.id), ids)
 
     @pytest.mark.usefixtures("instance_path")
+    @pytest.mark.options(EXPORT_CSV_MODELS=["organization"])
     def test_organizations_csv_w_export_csv_feature(self):
-        self.app.config["EXPORT_CSV_MODELS"] = ["organization"]
-
         # no export generated yet, 404
         response = self.get(url_for("api.site_organizations_csv"))
         self.assert404(response)
@@ -258,8 +255,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertStatus(response, 302)
         self.assertIn("export-organization-", response.location)
 
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_reuses_csv(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         reuses = [ReuseFactory(datasets=[DatasetFactory()]) for _ in range(5)]
         archived_reuses = [ReuseFactory(archived=datetime.now(UTC)) for _ in range(3)]
         hidden_reuse = ReuseFactory(private=True)
@@ -290,9 +287,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertNotIn(str(hidden_reuse.id), ids)
 
     @pytest.mark.usefixtures("instance_path")
+    @pytest.mark.options(EXPORT_CSV_MODELS=["reuse"])
     def test_reuses_csv_w_export_csv_feature(self):
-        self.app.config["EXPORT_CSV_MODELS"] = ["reuse"]
-
         # no export generated yet, 404
         response = self.get(url_for("api.site_reuses_csv"))
         self.assert404(response)
@@ -342,8 +338,8 @@ class SiteCsvExportsTest(APITestCase):
             self.assertNotIn(str(reuse.id), ids)
         self.assertNotIn(str(hidden_reuse.id), ids)
 
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_dataservices_csv(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         dataservices = [DataserviceFactory(datasets=[DatasetFactory()]) for _ in range(5)]
         archived_dataservices = [
             DataserviceFactory(archived_at=datetime.now(UTC)) for _ in range(3)
@@ -351,7 +347,6 @@ class SiteCsvExportsTest(APITestCase):
         hidden_dataservice = DataserviceFactory(private=True)
 
         response = self.get(url_for("api.site_dataservices_csv"))
-        print(response.json)
 
         self.assert200(response)
         self.assertEqual(response.mimetype, "text/csv")
@@ -377,9 +372,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertNotIn(str(hidden_dataservice.id), ids)
 
     @pytest.mark.usefixtures("instance_path")
+    @pytest.mark.options(EXPORT_CSV_MODELS=["dataservice"])
     def test_dataservices_csv_w_export_csv_feature(self):
-        self.app.config["EXPORT_CSV_MODELS"] = ["dataservice"]
-
         # no export generated yet, 404
         response = self.get(url_for("api.site_dataservices_csv"))
         self.assert404(response)
@@ -427,8 +421,8 @@ class SiteCsvExportsTest(APITestCase):
         for dataservice in dataservices:
             self.assertNotIn(str(dataservice.id), ids)
 
+    @pytest.mark.options(EXPORT_CSV_MODELS=[])
     def test_harvest_csv(self):
-        self.app.config["EXPORT_CSV_MODELS"] = []
         organization = OrganizationFactory()
         harvests = [
             HarvestSource.objects.create(
@@ -470,9 +464,8 @@ class SiteCsvExportsTest(APITestCase):
         self.assertNotIn(str(hidden_harvest.id), ids)
 
     @pytest.mark.usefixtures("instance_path")
+    @pytest.mark.options(EXPORT_CSV_MODELS=["harvest"])
     def test_harvest_csv_w_export_csv_feature(self):
-        self.app.config["EXPORT_CSV_MODELS"] = ["harvest"]
-
         # no export generated yet, 404
         response = self.get(url_for("api.site_harvests_csv"))
         self.assert404(response)


### PR DESCRIPTION
Current tests rely on `EXPORT_CSV_MODELS` from existing `udata.cfg`.
So for instance, if "dataset" is not present in `EXPORT_CSV_MODELS`, the following test fails:
```
$ pytest udata -k test_datasets_csv_w_export_csv_feature 

...
self = <udata.tests.site.test_site_csv_exports.SiteCsvExportsTest testMethod=test_datasets_csv_w_export_csv_feature>

    @pytest.mark.usefixtures("instance_path")
    def test_datasets_csv_w_export_csv_feature(self):
        # no export generated, 404
        response = self.get(url_for("api.site_datasets_csv"))
>       self.assert404(response)
E       AssertionError: HTTP Status 404 expected but got 200

udata/tests/site/test_site_csv_exports.py:54: AssertionError
...
```