### PR TITLE
fix: never expose unpublished posts through the search and detail endpoints

### DIFF
--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -101,6 +101,8 @@ class PostAPI(API):
     @api.marshal_with(Post.__read_fields__)
     def get(self, post):
         """Get a given post"""
+        if post.published is None and not AdminPermission().can():
+            api.abort(404)
         return post
 
     @api.doc("update_post")
@@ -129,7 +131,8 @@ class PublishPostAPI(API):
     @api.marshal_with(Post.__read_fields__)
     def post(self, post):
         """Publish an existing post"""
-        post.modify(published=datetime.now(UTC))
+        post.published = datetime.now(UTC)
+        post.save()
         return post
 
     @api.secure(admin_permission)
@@ -137,7 +140,8 @@ class PublishPostAPI(API):
     @api.marshal_with(Post.__read_fields__)
     def delete(self, post):
         """Unpublish an existing post"""
-        post.modify(published=None)
+        post.published = None
+        post.save()
         return post
 
 

--- a/udata/core/post/api.py
+++ b/udata/core/post/api.py
@@ -44,7 +44,7 @@ class PostsAPI(API):
         posts = Post.objects()
 
         if not (AdminPermission().can() and args["with_drafts"]):
-            posts = posts.published()
+            posts = posts.visible()
 
         # The search is already handled by apply_sort_filters if searchable=True
         return Post.apply_pagination(Post.apply_sort_filters(posts))
@@ -76,7 +76,7 @@ class PostsAtomFeedAPI(API):
             link=request.url_root,
         )
 
-        posts: list[Post] = Post.objects(kind="news").published().order_by("-published").limit(15)
+        posts: list[Post] = Post.objects(kind="news").visible().order_by("-published").limit(15)
         for post in posts:
             feed.add_item(
                 post.name,
@@ -101,7 +101,7 @@ class PostAPI(API):
     @api.marshal_with(Post.__read_fields__)
     def get(self, post):
         """Get a given post"""
-        if post.published is None and not AdminPermission().can():
+        if not post.permissions["read"].can():
             api.abort(404)
         return post
 

--- a/udata/core/post/models.py
+++ b/udata/core/post/models.py
@@ -25,13 +25,14 @@ from udata.mongo.url_field import URLField
 from udata.uris import cdata_url
 
 from .constants import BODY_TYPES, IMAGE_SIZES, POST_KINDS
+from .permissions import PostReadPermission
 
 __all__ = ("Post",)
 
 
 class PostQuerySet(UDataQuerySet):
-    def published(self):
-        return self(published__ne=None).order_by("-published")
+    def visible(self):
+        return self(published__ne=None)
 
 
 @generate_fields(
@@ -140,6 +141,14 @@ class Post(Datetimed, Linkable, Document[PostQuerySet]):
     }
 
     verbose_name = _("post")
+
+    @property
+    def is_visible(self):
+        return self.published is not None
+
+    @property
+    def permissions(self):
+        return {"read": PostReadPermission(self)}
 
     def clean(self):
         if self.body_type != "blocs" and not self.content:

--- a/udata/core/post/permissions.py
+++ b/udata/core/post/permissions.py
@@ -1,5 +1,23 @@
+from flask_principal import Permission as BasePermission
+from flask_principal import RoleNeed
+
 from udata.auth import Permission
 
 
 class PostEditPermission(Permission):
     pass
+
+
+class PostReadPermission(BasePermission):
+    """Permission to read a post: everyone for a published one, sysadmins only for a draft.
+
+    We inherit from BasePermission instead of udata's Permission because
+    Permission automatically adds RoleNeed("admin") to all needs. This means
+    a permission with no needs would only allow admins. With BasePermission,
+    an empty needs set allows everyone (Flask-Principal returns True when
+    self.needs is empty).
+    """
+
+    def __init__(self, post):
+        needs = [] if post.is_visible else [RoleNeed("admin")]
+        super().__init__(*needs)

--- a/udata/core/post/search.py
+++ b/udata/core/post/search.py
@@ -30,7 +30,19 @@ class PostSearch(ModelSearchAdapter):
     @classmethod
     def mongo_search(cls, args):
         posts = Post.objects().published()
-        sort = cls.parse_sort(args["sort"]) or "-created_at"
+        if args.get("q"):
+            # Following code splits the 'q' argument by spaces to surround
+            # every word in it with quotes before rebuild it.
+            # This allows the search_text method to tokenise with an AND
+            # between tokens whereas an OR is used without it.
+            phrase_query = " ".join([f'"{elem}"' for elem in args["q"].split(" ")])
+            posts = posts.search_text(phrase_query)
+        if args.get("tag"):
+            posts = posts.filter(tags__all=args["tag"])
+
+        sort = (
+            cls.parse_sort(args["sort"]) or ("$text_score" if args["q"] else None) or "-created_at"
+        )
         return posts.order_by(sort).paginate(args["page"], args["page_size"])
 
     @classmethod

--- a/udata/core/post/search.py
+++ b/udata/core/post/search.py
@@ -22,12 +22,14 @@ class PostSearch(ModelSearchAdapter):
     }
 
     @classmethod
-    def is_indexable(cls, post):
-        return True
+    def is_indexable(cls, post: Post) -> bool:
+        # Unpublished posts are drafts: they must never reach the search index,
+        # which is public and unauthenticated.
+        return post.published is not None
 
     @classmethod
     def mongo_search(cls, args):
-        posts = Post.objects()
+        posts = Post.objects().published()
         sort = cls.parse_sort(args["sort"]) or "-created_at"
         return posts.order_by(sort).paginate(args["page"], args["page_size"])
 

--- a/udata/core/post/search.py
+++ b/udata/core/post/search.py
@@ -25,11 +25,11 @@ class PostSearch(ModelSearchAdapter):
     def is_indexable(cls, post: Post) -> bool:
         # Unpublished posts are drafts: they must never reach the search index,
         # which is public and unauthenticated.
-        return post.published is not None
+        return post.is_visible
 
     @classmethod
     def mongo_search(cls, args):
-        posts = Post.objects().published()
+        posts = Post.objects().visible()
         if args.get("q"):
             # Following code splits the 'q' argument by spaces to surround
             # every word in it with quotes before rebuild it.

--- a/udata/core/post/tests/test_api.py
+++ b/udata/core/post/tests/test_api.py
@@ -23,6 +23,7 @@ from udata.tests.helpers import (
     assert204,
     assert400,
     assert403,
+    assert404,
     create_test_image,
 )
 
@@ -91,6 +92,20 @@ class PostsAPITest(APITestCase):
         owner = response.json["owner"]
         assert isinstance(owner, dict)
         assert owner["id"] == str(admin.id)
+
+    def test_post_api_get_draft(self):
+        """An unpublished post should only be readable by a sysadmin"""
+        draft = PostFactory(published=None)
+
+        assert404(self.get(url_for("api.post", post=draft)))
+
+        self.login(UserFactory())
+        assert404(self.get(url_for("api.post", post=draft)))
+
+        self.login(AdminFactory())
+        response = self.get(url_for("api.post", post=draft))
+        assert200(response)
+        assert response.json["id"] == str(draft.id)
 
     def test_post_api_get_with_dangling_dataset_reference(self):
         """Getting a post should not crash when one of its datasets was hard-deleted,
@@ -255,6 +270,22 @@ class PostsAPITest(APITestCase):
         response = self.get(url_for("api.posts", with_drafts=True))
         assert200(response)
         assert len(response.json["data"]) == 3
+
+    def test_post_search_api_excludes_drafts(self):
+        """The v2 search endpoint should never expose unpublished posts"""
+        published = PostFactory.create_batch(3)
+        draft = PostFactory(published=None)
+
+        response = self.get(url_for("apiv2.post_search"))
+        assert200(response)
+        assert response.json["total"] == 3
+        assert {p["id"] for p in response.json["data"]} == {str(post.id) for post in published}
+
+        self.login(AdminFactory())
+
+        response = self.get(url_for("apiv2.post_search"))
+        assert200(response)
+        assert str(draft.id) not in [p["id"] for p in response.json["data"]]
 
     def test_post_api_create_with_blocs(self):
         """It should create a post with body_type='blocs' and inline blocs"""

--- a/udata/core/post/tests/test_api.py
+++ b/udata/core/post/tests/test_api.py
@@ -274,18 +274,40 @@ class PostsAPITest(APITestCase):
     def test_post_search_api_excludes_drafts(self):
         """The v2 search endpoint should never expose unpublished posts"""
         published = PostFactory.create_batch(3)
-        draft = PostFactory(published=None)
+        PostFactory(published=None)
+        expected = {str(post.id) for post in published}
 
         response = self.get(url_for("apiv2.post_search"))
         assert200(response)
         assert response.json["total"] == 3
-        assert {p["id"] for p in response.json["data"]} == {str(post.id) for post in published}
+        assert {p["id"] for p in response.json["data"]} == expected
 
+        # Unlike the v1 list endpoint, the v2 search has no `with_drafts` bypass:
+        # drafts are not indexed at all, so sysadmins do not see them either.
         self.login(AdminFactory())
 
         response = self.get(url_for("apiv2.post_search"))
         assert200(response)
-        assert str(draft.id) not in [p["id"] for p in response.json["data"]]
+        assert response.json["total"] == 3
+        assert {p["id"] for p in response.json["data"]} == expected
+
+    def test_post_search_api_filters_on_query_and_tags(self):
+        """The Mongo fallback of the v2 search should actually apply `q` and `tag`"""
+        named = PostFactory(name="Foobar", tags=["transport"])
+        both_tags = PostFactory(name="Something else", tags=["transport", "sante"])
+        PostFactory(name="Something else", tags=["sante"])
+
+        response = self.get(url_for("apiv2.post_search", q="Foobar"))
+        assert200(response)
+        assert [p["id"] for p in response.json["data"]] == [str(named.id)]
+
+        response = self.get(url_for("apiv2.post_search", tag="transport"))
+        assert200(response)
+        assert {p["id"] for p in response.json["data"]} == {str(named.id), str(both_tags.id)}
+
+        response = self.get(url_for("apiv2.post_search", tag=["transport", "sante"]))
+        assert200(response)
+        assert [p["id"] for p in response.json["data"]] == [str(both_tags.id)]
 
     def test_post_api_create_with_blocs(self):
         """It should create a post with body_type='blocs' and inline blocs"""

--- a/udata/tests/search/test_search_integration.py
+++ b/udata/tests/search/test_search_integration.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import url_for
 
 from udata.core.access_type.constants import AccessType
 from udata.core.dataservices.factories import DataserviceFactory
@@ -10,7 +11,7 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.core.post.factories import PostFactory
 from udata.core.reuse.factories import VisibleReuseFactory
 from udata.core.topic.factories import TopicElementFactory, TopicFactory
-from udata.core.user.factories import UserFactory
+from udata.core.user.factories import AdminFactory, UserFactory
 from udata.tests.api import APITestCase
 from udata.tests.helpers import requires_search_service
 
@@ -396,6 +397,33 @@ class SearchIntegrationTest(APITestCase):
         assert response.json["total"] >= 1
         names = [p["name"] for p in response.json["data"]]
         assert "Actualités open data" in names
+
+    def test_post_search_follows_publication_state(self):
+        """A post should be searchable only while it is published."""
+        post = PostFactory(name="Brouillon confidentiel", published=None)
+
+        self.refresh_index()
+
+        response = self.get("/api/2/posts/search/?q=confidentiel")
+        self.assert200(response)
+        assert response.json["total"] == 0
+
+        self.login(AdminFactory())
+        self.assert200(self.post(url_for("api.publish_post", post=post)))
+
+        self.refresh_index()
+
+        response = self.get("/api/2/posts/search/?q=confidentiel")
+        self.assert200(response)
+        assert [p["id"] for p in response.json["data"]] == [str(post.id)]
+
+        self.assert200(self.delete(url_for("api.publish_post", post=post)))
+
+        self.refresh_index()
+
+        response = self.get("/api/2/posts/search/?q=confidentiel")
+        self.assert200(response)
+        assert response.json["total"] == 0
 
     def test_dataset_filter_by_multiple_tags(self):
         """Test filtering datasets by multiple tags."""

--- a/udata/tests/search/test_search_integration.py
+++ b/udata/tests/search/test_search_integration.py
@@ -400,11 +400,11 @@ class SearchIntegrationTest(APITestCase):
 
     def test_post_search_follows_publication_state(self):
         """A post should be searchable only while it is published."""
-        post = PostFactory(name="Brouillon confidentiel", published=None)
+        post = PostFactory(name="Draft not yet published", published=None)
 
         self.refresh_index()
 
-        response = self.get("/api/2/posts/search/?q=confidentiel")
+        response = self.get("/api/2/posts/search/?q=draft")
         self.assert200(response)
         assert response.json["total"] == 0
 
@@ -413,7 +413,7 @@ class SearchIntegrationTest(APITestCase):
 
         self.refresh_index()
 
-        response = self.get("/api/2/posts/search/?q=confidentiel")
+        response = self.get("/api/2/posts/search/?q=draft")
         self.assert200(response)
         assert [p["id"] for p in response.json["data"]] == [str(post.id)]
 
@@ -421,7 +421,7 @@ class SearchIntegrationTest(APITestCase):
 
         self.refresh_index()
 
-        response = self.get("/api/2/posts/search/?q=confidentiel")
+        response = self.get("/api/2/posts/search/?q=draft")
         self.assert200(response)
         assert response.json["total"] == 0
 


### PR DESCRIPTION
Need a `udata search index post`