### PR TITLE
docs: update deprecated commands related to dev optional deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ udata is a customizable and skinnable social platform dedicated to (open) data. 
 
 ```bash
 # Install dependencies with uv (recommended)
-uv sync
+uv sync --frozen
 
 # Install with pip (alternative)
 pip install --group dev -e .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,10 @@ udata is a customizable and skinnable social platform dedicated to (open) data. 
 
 ```bash
 # Install dependencies with uv (recommended)
-uv sync --extra dev
+uv sync
 
 # Install with pip (alternative)
-pip install -e ".[dev]"
+pip install --group dev -e .
 
 # Initialize database, search index, create admin user, load fixtures
 udata init

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -38,7 +38,7 @@ def update(ctx):
     header(msg)
     info("Updating Python dependencies")
     with ctx.cd(ROOT):
-        ctx.run('pip install -e ".[dev]"')
+        ctx.run("pip install --group dev -e .")
     info("Note: Dependencies are now managed in pyproject.toml")
 
 


### PR DESCRIPTION
`dev` is now a group and not extra dependencies