### PR TITLE
fix: fall back to the default locale on an invalid lang query parameter

### DIFF
--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -3,6 +3,7 @@ import urllib.parse
 from functools import wraps
 
 import mongoengine
+from babel import Locale, UnknownLocaleError
 from flask import (
     Blueprint,
     current_app,
@@ -208,10 +209,16 @@ def output_json(data, code, headers=None):
 @apiv1_blueprint.before_request
 @apiv2_blueprint.before_request
 def set_api_language():
-    if "lang" in request.args:
-        g.lang_code = request.args["lang"]
-    else:
-        g.lang_code = get_locale()
+    lang = request.args.get("lang")
+    if lang is not None:
+        try:
+            # Validate here what Babel would parse later: an invalid value would otherwise
+            # raise on the first translation, far from the request parsing.
+            Locale.parse(lang)
+        except (ValueError, UnknownLocaleError):
+            log.warning("Ignoring unknown `lang` query parameter: %r", lang)
+            lang = None
+    g.lang_code = lang or get_locale()
 
 
 def extract_name_from_path(path):

--- a/udata/tests/api/test_base_api.py
+++ b/udata/tests/api/test_base_api.py
@@ -1,3 +1,4 @@
+import flask_babel
 import pytest
 from flask import url_for
 
@@ -23,6 +24,33 @@ class FakeFormAPI(API):
 
         api.validate(FakeForm)
         return {"success": True}
+
+
+@ns.route("/locale", endpoint="fake-locale")
+class FakeLocaleAPI(API):
+    def get(self):
+        return {"locale": str(flask_babel.get_locale())}
+
+
+class APILanguageTest(APITestCase):
+    def test_lang_query_parameter(self):
+        response = self.get(url_for("api.fake-locale", lang="en"))
+
+        self.assert200(response)
+        self.assertEqual(response.json["locale"], "en")
+
+    def test_no_lang_query_parameter(self):
+        response = self.get(url_for("api.fake-locale"))
+
+        self.assert200(response)
+        self.assertEqual(response.json["locale"], "fr")  # DEFAULT_LANGUAGE
+
+    def test_unknown_lang_query_parameter(self):
+        """An unparseable `lang` (e.g. a front-end sending `undefined`) falls back to the default"""
+        response = self.get(url_for("api.fake-locale", lang="undefined"))
+
+        self.assert200(response)
+        self.assertEqual(response.json["locale"], "fr")
 
 
 class OptionsCORSTest(APITestCase):


### PR DESCRIPTION
Avoid "[UnknownLocaleError](https://errors.data.gouv.fr/organizations/sentry/issues/298649/?referrer=alert_email&alert_type=email&alert_timestamp=1785386083835&alert_rule_id=10&notification_uuid=10f760de-df7c-4260-bac1-e91bd58bec13&environment=data.gouv.fr) api.organization unknown locale 'undefined'" or "[UnknownLocaleError](https://errors.data.gouv.fr/organizations/sentry/issues/298385/?referrer=alert_email&alert_type=email&alert_timestamp=1785104503691&alert_rule_id=10&notification_uuid=4d009b2b-7b03-4bdc-ac1b-77e4946ef8a7&environment=demo.data.gouv.fr) api.recent_datasets_atom_feed unknown locale 'mjzwwy'"