### PR TITLE
fix: return 400 instead of 500 on malformed member assignments payload

### DIFF
--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -57,6 +57,14 @@ SUGGEST_SORTING = "-metrics.followers"
 
 def resolve_assignment_subjects(raw_assignments, org):
     """Resolve raw {class, id} dicts into model instances belonging to org."""
+    if not isinstance(raw_assignments, list) or not all(
+        isinstance(raw, dict) for raw in raw_assignments
+    ):
+        raise FieldValidationError(
+            field="assignments",
+            message="Expected a list of {class, id} objects",
+        )
+
     subjects = []
     for raw in raw_assignments:
         cls_name = raw.get("class")

--- a/udata/tests/api/test_partial_editor.py
+++ b/udata/tests/api/test_partial_editor.py
@@ -250,6 +250,44 @@ class PartialEditorDatasetAPITest(APITestCase):
         )
         self.assert400(response)
 
+    def test_malformed_assignments_payload_is_rejected(self):
+        """A payload that isn't a list of {class, id} objects returns 400, not 500."""
+        self.login(self.admin_user)
+        url = url_for(
+            "api.member_assignments",
+            org=self.org,
+            user=self.partial_editor_user,
+        )
+
+        for payload in (
+            # Double-encoded JSON: iterating the string yields characters
+            '[{"class": "Dataset", "id": "%s"}]' % self.dataset_assigned.id,
+            # A single object instead of a list: iterating a dict yields keys
+            {"class": "Dataset", "id": str(self.dataset_assigned.id)},
+            # A list of ids instead of a list of objects
+            [str(self.dataset_assigned.id)],
+            42,
+        ):
+            response = self.put(url, payload)
+            self.assert400(response)
+
+        self.assertEqual(
+            Assignment.objects(user=self.partial_editor_user, organization=self.org).count(), 0
+        )
+
+    def test_assignment_with_invalid_id_is_rejected(self):
+        """An id that isn't a valid ObjectId returns 400, not 500."""
+        self.login(self.admin_user)
+        response = self.put(
+            url_for(
+                "api.member_assignments",
+                org=self.org,
+                user=self.partial_editor_user,
+            ),
+            [{"class": "Dataset", "id": "not-an-object-id"}],
+        )
+        self.assert400(response)
+
     def test_cannot_assign_to_non_partial_editor(self):
         """Cannot assign objects to members who are not partial_editors."""
         self.login(self.admin_user)


### PR DESCRIPTION
Fix "[AttributeError](https://errors.data.gouv.fr/organizations/sentry/issues/298643/?referrer=alert_email&alert_type=email&alert_timestamp=1785369271816&alert_rule_id=10&notification_uuid=d878dc18-e063-4c49-95d2-a39296cef076&environment=demo.data.gouv.fr) api.member_assignments 'str' object has no attribute 'get'"

```
AttributeError: 'str' object has no attribute 'get'
(5 additional frame(s) were not displayed)
...
  File "flask_restx/resource.py", line 41, in dispatch_request
    resp = meth(*args, **kwargs)
  File "udata/api/__init__.py", line 108, in wrapper
    return func(*args, **kwargs)
  File "flask_restx/marshalling.py", line 246, in wrapper
    resp = f(*args, **kwargs)
  File "udata/core/organization/api.py", line 646, in put
    desired_subjects = resolve_assignment_subjects(request.json or [], org)
  File "udata/core/organization/api.py", line 62, in resolve_assignment_subjects
    cls_name = raw.get("class")
```