### PR TITLE
fix: return 404 instead of 500 when updating a non-member

### DIFF
--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -587,6 +587,8 @@ class MemberAPI(API):
         """Update member status into a given organization."""
         org.permissions["members"].test()
         member = org.member(user)
+        if not member:
+            api.abort(404)
         old_role = member.role
         patch(member, request)
         org.save()

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -1321,6 +1321,19 @@ class MembershipAPITest(PytestOnlyAPITestCase):
         assert organization.is_member(updated_user)
         assert organization.is_admin(updated_user)
 
+    def test_update_member_not_in_organization(self):
+        user = self.login()
+        other_user = UserFactory()
+        organization = OrganizationFactory(members=[Member(user=user, role="admin")])
+
+        api_url = url_for("api.member", org=organization, user=other_user)
+        response = self.put(api_url, {"role": "admin"})
+
+        assert404(response)
+
+        organization.reload()
+        assert not organization.is_member(other_user)
+
     def test_only_admin_can_update_member(self):
         user = self.login()
         updated_user = UserFactory()


### PR DESCRIPTION
Fix "[AttributeError](https://errors.data.gouv.fr/organizations/sentry/issues/298642/?referrer=alert_email&alert_type=email&alert_timestamp=1785368919601&alert_rule_id=10&notification_uuid=0a362c19-2e48-43ba-bd50-e57d8f5ef2ff&environment=demo.data.gouv.fr) api.member 'NoneType' object has no attribute 'role'"

```
AttributeError: 'NoneType' object has no attribute 'role'
(4 additional frame(s) were not displayed)
...
  File "flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
  File "flask_restx/resource.py", line 41, in dispatch_request
    resp = meth(*args, **kwargs)
  File "udata/api/__init__.py", line 108, in wrapper
    return func(*args, **kwargs)
  File "flask_restx/marshalling.py", line 246, in wrapper
    resp = f(*args, **kwargs)
  File "udata/core/organization/api.py", line 590, in put
    old_role = member.role
```