### PR TITLE
refactor(test): extract parametrize_with_ids helper

### DIFF
--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -19,7 +19,7 @@ from udata.harvest.models import HarvestJob
 from udata.models import Dataset
 from udata.storage.s3 import get_from_json
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
-from udata.tests.helpers import assert200
+from udata.tests.helpers import assert200, parametrize_with_ids
 
 from .. import actions
 from ..backends.dcat import URIS_TO_REPLACE
@@ -977,14 +977,17 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         assert len(job.errors) == 1
         assert "404 Client Error" in job.errors[0].message
 
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "exception",
         [
-            requests.exceptions.ConnectTimeout("Connection timed out"),
-            requests.exceptions.ConnectionError(
-                "Failed to resolve 'example.com' (Name resolution failed)"
+            ("timeout", requests.exceptions.ConnectTimeout("Connection timed out")),
+            (
+                "resolution",
+                requests.exceptions.ConnectionError(
+                    "Failed to resolve 'example.com' (Name resolution failed)"
+                ),
             ),
-            requests.exceptions.SSLError("SSL: CERTIFICATE_VERIFY_FAILED"),
+            ("certificate", requests.exceptions.SSLError("SSL: CERTIFICATE_VERIFY_FAILED")),
         ],
     )
     def test_connection_errors_are_handled_without_sentry(self, rmock, mocker, exception):
@@ -1071,9 +1074,13 @@ class DcatBackendTest(PytestOnlyDBTestCase):
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
 class CswDcatBackendTest(PytestOnlyDBTestCase):
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "schema_name, schema_uri",
-        [("dcat", "http://www.w3.org/ns/dcat#"), ("geodcatap", "http://data.europa.eu/930/")],
+        [
+            ("dcat", "http://www.w3.org/ns/dcat#"),
+            ("geodcatap", "http://data.europa.eu/930/"),
+        ],
+        idgetter=0,
     )
     def test_geonetwork(self, rmock, schema_name, schema_uri):
         geodcatap = schema_name == "geodcatap"
@@ -1274,12 +1281,12 @@ class CswDcatBackendTest(PytestOnlyDBTestCase):
         assert job.status == "done"
         assert len(job.items) == 1
 
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "remote_url_prefix",
         [
-            None,
-            "http://catalog.example.com",  # no trailing slash
-            "http://catalog.example.com/",  # trailing slash
+            ("none", None),
+            ("trailing-slash", "http://catalog.example.com/"),
+            ("no-trailing-slash", "http://catalog.example.com"),
         ],
     )
     def test_url_prefix(self, rmock, remote_url_prefix: str):
@@ -1376,14 +1383,18 @@ class CswDcatBackendTest(PytestOnlyDBTestCase):
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
 class CswIso19139DcatBackendTest(PytestOnlyDBTestCase):
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "remote_url_prefix",
         [
-            None,
-            # trailing slash
-            "http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/fre/catalog.search#/metadata/",
-            # no trailing slash
-            "http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/fre/catalog.search#/metadata",
+            ("none", None),
+            (
+                "trailing-slash",
+                "http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/fre/catalog.search#/metadata/",
+            ),
+            (
+                "no-trailing-slash",
+                "http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/fre/catalog.search#/metadata",
+            ),
         ],
     )
     def test_geo2france(self, rmock, remote_url_prefix: str):

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -1079,7 +1079,7 @@ class CswDcatBackendTest(PytestOnlyDBTestCase):
         argvalues(
             ("dcat", "http://www.w3.org/ns/dcat#"),
             ("geodcatap", "http://data.europa.eu/930/"),
-            ids=0,
+            ids=lambda values: values[0],
         ),
     )
     def test_geonetwork(self, rmock, schema_name, schema_uri):

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -19,7 +19,7 @@ from udata.harvest.models import HarvestJob
 from udata.models import Dataset
 from udata.storage.s3 import get_from_json
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
-from udata.tests.helpers import assert200, parametrize_with_ids
+from udata.tests.helpers import argvalues, assert200
 
 from .. import actions
 from ..backends.dcat import URIS_TO_REPLACE
@@ -977,18 +977,18 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         assert len(job.errors) == 1
         assert "404 Client Error" in job.errors[0].message
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "exception",
-        [
-            ("timeout", requests.exceptions.ConnectTimeout("Connection timed out")),
+        argvalues(
+            (requests.exceptions.ConnectTimeout("Connection timed out"), "timeout"),
             (
-                "resolution",
                 requests.exceptions.ConnectionError(
                     "Failed to resolve 'example.com' (Name resolution failed)"
                 ),
+                "resolution",
             ),
-            ("certificate", requests.exceptions.SSLError("SSL: CERTIFICATE_VERIFY_FAILED")),
-        ],
+            (requests.exceptions.SSLError("SSL: CERTIFICATE_VERIFY_FAILED"), "certificate"),
+        ),
     )
     def test_connection_errors_are_handled_without_sentry(self, rmock, mocker, exception):
         """Connection exceptions should be logged as warning, not sent to Sentry."""
@@ -1074,13 +1074,13 @@ class DcatBackendTest(PytestOnlyDBTestCase):
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
 class CswDcatBackendTest(PytestOnlyDBTestCase):
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "schema_name, schema_uri",
-        [
+        argvalues(
             ("dcat", "http://www.w3.org/ns/dcat#"),
             ("geodcatap", "http://data.europa.eu/930/"),
-        ],
-        idgetter=0,
+            ids=0,
+        ),
     )
     def test_geonetwork(self, rmock, schema_name, schema_uri):
         geodcatap = schema_name == "geodcatap"
@@ -1281,13 +1281,13 @@ class CswDcatBackendTest(PytestOnlyDBTestCase):
         assert job.status == "done"
         assert len(job.items) == 1
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "remote_url_prefix",
-        [
-            ("none", None),
-            ("trailing-slash", "http://catalog.example.com/"),
-            ("no-trailing-slash", "http://catalog.example.com"),
-        ],
+        argvalues(
+            (None, "none"),
+            ("http://catalog.example.com/", "trailing-slash"),
+            ("http://catalog.example.com", "no-trailing-slash"),
+        ),
     )
     def test_url_prefix(self, rmock, remote_url_prefix: str):
         xml = """<?xml version="1.0" encoding="UTF-8"?>
@@ -1383,19 +1383,19 @@ class CswDcatBackendTest(PytestOnlyDBTestCase):
 
 @pytest.mark.options(HARVESTER_BACKENDS=["csw*"])
 class CswIso19139DcatBackendTest(PytestOnlyDBTestCase):
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "remote_url_prefix",
-        [
-            ("none", None),
+        argvalues(
+            (None, "none"),
             (
-                "trailing-slash",
                 "http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/fre/catalog.search#/metadata/",
+                "trailing-slash",
             ),
             (
-                "no-trailing-slash",
                 "http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/fre/catalog.search#/metadata",
+                "no-trailing-slash",
             ),
-        ],
+        ),
     )
     def test_geo2france(self, rmock, remote_url_prefix: str):
         mock_xslt(rmock)

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -71,7 +71,7 @@ from udata.rdf import (
     slugify_tag,
 )
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
-from udata.tests.helpers import assert200, assert_redirects
+from udata.tests.helpers import assert200, assert_redirects, parametrize_with_ids
 from udata.utils import faker
 
 GOV_UK_REF = "http://reference.data.gov.uk/id/year/2017"
@@ -1432,62 +1432,59 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
         assert temporal_from_rdf(g.resource(node)) is None
         assert temporal_from_rdf(Literal("unparseable")) is None
 
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "node_type, geom_type, datatype, serialize",
-        (
-            pytest.param(*params, id=id)
-            for id, *params in [
-                (
-                    "bbox-geojson",
-                    DCT.Location,
-                    DCAT.bbox,
-                    GEOSPARQL.geoJSONLiteral,
-                    _to_geojson,
-                ),
-                (  # replaced by GEOSPARQL.geoJSONLiteral
-                    "bbox-geojson-deprecated",
-                    DCT.Location,
-                    DCAT.bbox,
-                    "https://www.iana.org/assignments/media-types/application/vnd.geo+json",
-                    _to_geojson,
-                ),
-                (
-                    "bbox-wkt",
-                    DCT.Location,
-                    DCAT.bbox,
-                    GEOSPARQL.wktLiteral,
-                    _to_wkt,
-                ),
-                (
-                    "geometry-geojson",
-                    DCT.Location,
-                    LOCN.geometry,
-                    GEOSPARQL.geoJSONLiteral,
-                    _to_geojson,
-                ),
-                (
-                    "geometry-wkt",
-                    DCT.Location,
-                    LOCN.geometry,
-                    GEOSPARQL.wktLiteral,
-                    _to_wkt,
-                ),
-                (  # old GeoNetwork dcat exposition
-                    "polygon-geometry",
-                    Namespace("http://www.opengis.net/rdf#").Polygon,
-                    LOCN.geometry,
-                    "http://www.opengis.net/rdf#wktLiteral",
-                    _to_wkt,
-                ),
-                (  # old GeoNetwork dcat exposition
-                    "polygon-aswkt",
-                    Namespace("http://www.opengis.net/rdf#").Polygon,
-                    GEOSPARQL.asWKT,
-                    "http://www.opengis.net/rdf#wktLiteral",
-                    _to_wkt,
-                ),
-            ]
-        ),
+        [
+            (
+                "bbox-geojson",
+                DCT.Location,
+                DCAT.bbox,
+                GEOSPARQL.geoJSONLiteral,
+                _to_geojson,
+            ),
+            (  # replaced by GEOSPARQL.geoJSONLiteral
+                "bbox-geojson-deprecated",
+                DCT.Location,
+                DCAT.bbox,
+                "https://www.iana.org/assignments/media-types/application/vnd.geo+json",
+                _to_geojson,
+            ),
+            (
+                "bbox-wkt",
+                DCT.Location,
+                DCAT.bbox,
+                GEOSPARQL.wktLiteral,
+                _to_wkt,
+            ),
+            (
+                "geometry-geojson",
+                DCT.Location,
+                LOCN.geometry,
+                GEOSPARQL.geoJSONLiteral,
+                _to_geojson,
+            ),
+            (
+                "geometry-wkt",
+                DCT.Location,
+                LOCN.geometry,
+                GEOSPARQL.wktLiteral,
+                _to_wkt,
+            ),
+            (  # old GeoNetwork dcat exposition
+                "polygon-geometry",
+                Namespace("http://www.opengis.net/rdf#").Polygon,
+                LOCN.geometry,
+                "http://www.opengis.net/rdf#wktLiteral",
+                _to_wkt,
+            ),
+            (  # old GeoNetwork dcat exposition
+                "polygon-aswkt",
+                Namespace("http://www.opengis.net/rdf#").Polygon,
+                GEOSPARQL.asWKT,
+                "http://www.opengis.net/rdf#wktLiteral",
+                _to_wkt,
+            ),
+        ],
     )
     def test_parse_spatial_geometry(self, node_type, geom_type, datatype, serialize):
         g = Graph()
@@ -2015,13 +2012,11 @@ class DatasetRdfViewsTest(PytestOnlyAPITestCase):
 
 
 class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "xml, expected_licenses",
         [
-            pytest.param(
-                XML_RDF_TEMPLATE.format(xml_fragment=xml_fragment), expected_licenses, id=id
-            )
-            for id, xml_fragment, expected_licenses in [
+            (t[0], XML_RDF_TEMPLATE.format(xml_fragment=t[1]), t[2])
+            for t in [
                 (
                     "uriref",
                     """
@@ -2211,13 +2206,11 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
         assert rights[0].identifier == URIRef(InspireLimitationCategory.PUBLIC_AUTHORITIES.url)
         assert access_right and access_right.identifier == URIRef(AccessType.RESTRICTED.url)
 
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "xml, expected_provenances",
         [
-            pytest.param(
-                XML_RDF_TEMPLATE.format(xml_fragment=xml_fragment), expected_provenances, id=id
-            )
-            for id, xml_fragment, expected_provenances in [
+            (t[0], XML_RDF_TEMPLATE.format(xml_fragment=t[1]), t[2])
+            for t in [
                 # Old DCAT* specs
                 (
                     "label",
@@ -2286,11 +2279,11 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
         provenances = provenances_from_rdf(dataset)
         assert provenances == expected_provenances
 
-    @pytest.mark.parametrize(
+    @parametrize_with_ids(
         "xml, expected_format",
         [
-            pytest.param(XML_RDF_TEMPLATE.format(xml_fragment=xml_fragment), expected_format, id=id)
-            for id, xml_fragment, expected_format in [
+            (t[0], XML_RDF_TEMPLATE.format(xml_fragment=t[1]), t[2])
+            for t in [
                 # DCAT* and GeoDCAT-AP for distributions other than services
                 (
                     "dct:format",

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -71,7 +71,7 @@ from udata.rdf import (
     slugify_tag,
 )
 from udata.tests.api import PytestOnlyAPITestCase, PytestOnlyDBTestCase
-from udata.tests.helpers import assert200, assert_redirects, parametrize_with_ids
+from udata.tests.helpers import argvalues, assert200, assert_redirects
 from udata.utils import faker
 
 GOV_UK_REF = "http://reference.data.gov.uk/id/year/2017"
@@ -1432,59 +1432,59 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
         assert temporal_from_rdf(g.resource(node)) is None
         assert temporal_from_rdf(Literal("unparseable")) is None
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "node_type, geom_type, datatype, serialize",
-        [
+        argvalues(
             (
-                "bbox-geojson",
                 DCT.Location,
                 DCAT.bbox,
                 GEOSPARQL.geoJSONLiteral,
                 _to_geojson,
+                "bbox-geojson",
             ),
             (  # replaced by GEOSPARQL.geoJSONLiteral
-                "bbox-geojson-deprecated",
                 DCT.Location,
                 DCAT.bbox,
                 "https://www.iana.org/assignments/media-types/application/vnd.geo+json",
                 _to_geojson,
+                "bbox-geojson-deprecated",
             ),
             (
-                "bbox-wkt",
                 DCT.Location,
                 DCAT.bbox,
                 GEOSPARQL.wktLiteral,
                 _to_wkt,
+                "bbox-wkt",
             ),
             (
-                "geometry-geojson",
                 DCT.Location,
                 LOCN.geometry,
                 GEOSPARQL.geoJSONLiteral,
                 _to_geojson,
+                "geometry-geojson",
             ),
             (
-                "geometry-wkt",
                 DCT.Location,
                 LOCN.geometry,
                 GEOSPARQL.wktLiteral,
                 _to_wkt,
+                "geometry-wkt",
             ),
             (  # old GeoNetwork dcat exposition
-                "polygon-geometry",
                 Namespace("http://www.opengis.net/rdf#").Polygon,
                 LOCN.geometry,
                 "http://www.opengis.net/rdf#wktLiteral",
                 _to_wkt,
+                "polygon-geometry",
             ),
             (  # old GeoNetwork dcat exposition
-                "polygon-aswkt",
                 Namespace("http://www.opengis.net/rdf#").Polygon,
                 GEOSPARQL.asWKT,
                 "http://www.opengis.net/rdf#wktLiteral",
                 _to_wkt,
+                "polygon-aswkt",
             ),
-        ],
+        ),
     )
     def test_parse_spatial_geometry(self, node_type, geom_type, datatype, serialize):
         g = Graph()
@@ -2012,27 +2012,26 @@ class DatasetRdfViewsTest(PytestOnlyAPITestCase):
 
 
 class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "xml, expected_licenses",
         [
-            (t[0], XML_RDF_TEMPLATE.format(xml_fragment=t[1]), t[2])
+            pytest.param(XML_RDF_TEMPLATE.format(xml_fragment=t[0]), t[1], id=t[2])
             for t in [
                 (
-                    "uriref",
                     """
                     <dct:license rdf:resource="https://www.etalab.gouv.fr/wp-content/uploads/2014/05/Licence_Ouverte.pdf"/>
                     """,
                     {"https://www.etalab.gouv.fr/wp-content/uploads/2014/05/Licence_Ouverte.pdf"},
+                    "uriref",
                 ),
                 (
-                    "value",
                     """
                     <dct:license>License from value</dct:license>
                     """,
                     {"License from value"},
+                    "value",
                 ),
                 (
-                    "label",
                     """
                     <dct:license>
                        <rdf:Description>
@@ -2041,9 +2040,9 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dct:license>
                     """,
                     {"License from label"},
+                    "label",
                 ),
                 (
-                    "uriref-precedence",
                     """
                     <dct:license rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">
                        No conditions apply to access and use.
@@ -2052,9 +2051,9 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     {
                         "http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply"
                     },
+                    "uriref-precedence",
                 ),
                 (
-                    "resource",
                     """
                        <dct:license rdf:resource="http://example.org/custom-license"/>
                     </rdf:Description>
@@ -2063,9 +2062,9 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                        <dct:description>A license specific to our organization</dct:description>
                     """,
                     {"License from resource"},
+                    "resource",
                 ),
                 (
-                    "multiple",
                     """
                     <dct:license>License 1</dct:license>
                     <dct:license>
@@ -2075,6 +2074,7 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dct:license>
                     """,
                     {"License 1", "License 2"},
+                    "multiple",
                 ),
             ]
         ],
@@ -2206,14 +2206,13 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
         assert rights[0].identifier == URIRef(InspireLimitationCategory.PUBLIC_AUTHORITIES.url)
         assert access_right and access_right.identifier == URIRef(AccessType.RESTRICTED.url)
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "xml, expected_provenances",
         [
-            (t[0], XML_RDF_TEMPLATE.format(xml_fragment=t[1]), t[2])
+            pytest.param(XML_RDF_TEMPLATE.format(xml_fragment=t[0]), t[1], id=t[2])
             for t in [
                 # Old DCAT* specs
                 (
-                    "label",
                     """
                     <dct:provenance>
                        <dct:ProvenanceStatement>
@@ -2222,10 +2221,10 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dct:provenance>
                     """,
                     {"Provenance from label"},
+                    "label",
                 ),
                 # New DCAT* specs
                 (
-                    "description",
                     """
                     <dct:provenance>
                        <dct:ProvenanceStatement>
@@ -2234,9 +2233,9 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dct:provenance>
                     """,
                     {"Provenance from description"},
+                    "description",
                 ),
                 (
-                    "multiple",
                     """
                     <dct:provenance>
                        <dct:ProvenanceStatement>
@@ -2250,17 +2249,17 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dct:provenance>
                     """,
                     {"Statement 1", "Statement 2"},
+                    "multiple",
                 ),
                 # Supported theoretical(?) cases
                 (
-                    "value",
                     """
                     <dct:provenance>Provenance from value</dct:provenance>
                     """,
                     {"Provenance from value"},
+                    "value",
                 ),
                 (
-                    "resource",
                     """
                        <dct:provenance rdf:resource="http://example.org/provenance"/>
                     </rdf:Description>
@@ -2268,6 +2267,7 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                        <dct:description>Provenance from separate resource</dct:description>
                     """,
                     {"Provenance from separate resource"},
+                    "resource",
                 ),
             ]
         ],
@@ -2279,14 +2279,12 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
         provenances = provenances_from_rdf(dataset)
         assert provenances == expected_provenances
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "xml, expected_format",
         [
-            (t[0], XML_RDF_TEMPLATE.format(xml_fragment=t[1]), t[2])
+            pytest.param(XML_RDF_TEMPLATE.format(xml_fragment=t[0]), t[1], id=t[2])
             for t in [
-                # DCAT* and GeoDCAT-AP for distributions other than services
-                (
-                    "dct:format",
+                (  # DCAT* and GeoDCAT-AP for distributions other than services
                     """
                     <dcat:distribution>
                        <dcat:Distribution>
@@ -2299,10 +2297,9 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dcat:distribution>
                     """,
                     "zip",
+                    "dct:format",
                 ),
-                # DCAT* and older GeoDCAT-AP for service distributions
-                (
-                    "dct:conformsTo",
+                (  # DCAT* and older GeoDCAT-AP for service distributions
                     """
                     <dcat:distribution>
                        <dcat:Distribution>
@@ -2322,10 +2319,9 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dcat:distribution>
                     """,
                     "wms",
+                    "dct:conformsTo",
                 ),
-                # GeoDCAT-AP 3+ for service distributions
-                (
-                    "geodcatap:serviceProtocol",
+                (  # GeoDCAT-AP 3+ for service distributions
                     """
                     <dcat:distribution>
                        <dcat:Distribution>
@@ -2348,6 +2344,7 @@ class DatasetFromRdfUtilsTest(PytestOnlyDBTestCase):
                     </dcat:distribution>
                     """,
                     "wfs",
+                    "geodcatap:serviceProtocol",
                 ),
             ]
         ],

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -1,6 +1,7 @@
 from datetime import UTC, date, datetime
 from uuid import UUID
 
+import pytest
 from mongoengine.fields import (
     BooleanField,
     DateTimeField,
@@ -18,7 +19,7 @@ from udata.mongo.document import UDataDocument as Document
 from udata.mongo.extras_fields import ExtrasField
 from udata.mongo.url_field import URLField
 from udata.tests import PytestOnlyTestCase
-from udata.tests.helpers import parametrize_with_ids
+from udata.tests.helpers import argvalues
 
 
 class ExtrasFieldTest(PytestOnlyTestCase):
@@ -133,9 +134,9 @@ class ExtrasFieldTest(PytestOnlyTestCase):
             }
         }
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "dbfield, value, type, expected",
-        [
+        argvalues(
             (
                 DateTimeField,
                 "2018-05-29T13:15:04.397603",
@@ -154,8 +155,8 @@ class ExtrasFieldTest(PytestOnlyTestCase):
                 UUID,
                 UUID("e3b06d6d-90c0-4407-adc0-de81d327f181"),
             ),
-        ],
-        idgetter=lambda t: t[0].__name__,
+            ids=lambda t: t[0].__name__,
+        ),
     )
     def test_can_parse_registered_data(self, dbfield, value, type, expected):
         Fake, FakeForm = self.factory()
@@ -173,9 +174,9 @@ class ExtrasFieldTest(PytestOnlyTestCase):
         assert isinstance(fake.extras["my:extra"], type)
         assert fake.extras["my:extra"] == expected
 
-    @parametrize_with_ids(
+    @pytest.mark.parametrize(
         "dbfield, value",
-        [
+        argvalues(
             (DateTimeField, "xxxx"),
             (DateField, "xxxx"),
             (IntField, "xxxx"),
@@ -183,8 +184,8 @@ class ExtrasFieldTest(PytestOnlyTestCase):
             (FloatField, "xxxx"),
             (URLField, "not-an-url"),
             (UUIDField, "not-a-uuid"),
-        ],
-        idgetter=lambda t: t[0].__name__,
+            ids=lambda t: t[0].__name__,
+        ),
     )
     def test_fail_bad_registered_data(self, dbfield, value):
         Fake, FakeForm = self.factory()

--- a/udata/tests/forms/test_extras_fields.py
+++ b/udata/tests/forms/test_extras_fields.py
@@ -1,7 +1,6 @@
 from datetime import UTC, date, datetime
 from uuid import UUID
 
-import pytest
 from mongoengine.fields import (
     BooleanField,
     DateTimeField,
@@ -19,6 +18,7 @@ from udata.mongo.document import UDataDocument as Document
 from udata.mongo.extras_fields import ExtrasField
 from udata.mongo.url_field import URLField
 from udata.tests import PytestOnlyTestCase
+from udata.tests.helpers import parametrize_with_ids
 
 
 class ExtrasFieldTest(PytestOnlyTestCase):
@@ -133,31 +133,29 @@ class ExtrasFieldTest(PytestOnlyTestCase):
             }
         }
 
-    @pytest.mark.parametrize(
-        "dbfield,value,type,expected",
+    @parametrize_with_ids(
+        "dbfield, value, type, expected",
         [
-            pytest.param(*p, id=p[0].__name__)
-            for p in [
-                (
-                    DateTimeField,
-                    "2018-05-29T13:15:04.397603",
-                    datetime,
-                    datetime(2018, 5, 29, 13, 15, 4, 397603),
-                ),
-                (DateField, "2018-05-29", date, date(2018, 5, 29)),
-                (BooleanField, "true", bool, True),
-                (IntField, 42, int, 42),
-                (StringField, "42", str, "42"),
-                (FloatField, "42.0", float, 42.0),
-                (URLField, "http://test.com", str, "http://test.com"),
-                (
-                    UUIDField,
-                    "e3b06d6d-90c0-4407-adc0-de81d327f181",
-                    UUID,
-                    UUID("e3b06d6d-90c0-4407-adc0-de81d327f181"),
-                ),
-            ]
+            (
+                DateTimeField,
+                "2018-05-29T13:15:04.397603",
+                datetime,
+                datetime(2018, 5, 29, 13, 15, 4, 397603),
+            ),
+            (DateField, "2018-05-29", date, date(2018, 5, 29)),
+            (BooleanField, "true", bool, True),
+            (IntField, 42, int, 42),
+            (StringField, "42", str, "42"),
+            (FloatField, "42.0", float, 42.0),
+            (URLField, "http://test.com", str, "http://test.com"),
+            (
+                UUIDField,
+                "e3b06d6d-90c0-4407-adc0-de81d327f181",
+                UUID,
+                UUID("e3b06d6d-90c0-4407-adc0-de81d327f181"),
+            ),
         ],
+        idgetter=lambda t: t[0].__name__,
     )
     def test_can_parse_registered_data(self, dbfield, value, type, expected):
         Fake, FakeForm = self.factory()
@@ -175,20 +173,18 @@ class ExtrasFieldTest(PytestOnlyTestCase):
         assert isinstance(fake.extras["my:extra"], type)
         assert fake.extras["my:extra"] == expected
 
-    @pytest.mark.parametrize(
-        "dbfield,value",
+    @parametrize_with_ids(
+        "dbfield, value",
         [
-            pytest.param(*p, id=p[0].__name__)
-            for p in [
-                (DateTimeField, "xxxx"),
-                (DateField, "xxxx"),
-                (IntField, "xxxx"),
-                (StringField, 42),
-                (FloatField, "xxxx"),
-                (URLField, "not-an-url"),
-                (UUIDField, "not-a-uuid"),
-            ]
+            (DateTimeField, "xxxx"),
+            (DateField, "xxxx"),
+            (IntField, "xxxx"),
+            (StringField, 42),
+            (FloatField, "xxxx"),
+            (URLField, "not-an-url"),
+            (UUIDField, "not-a-uuid"),
         ],
+        idgetter=lambda t: t[0].__name__,
     )
     def test_fail_bad_registered_data(self, dbfield, value):
         Fake, FakeForm = self.factory()

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -243,11 +243,15 @@ def security_gettext(string):
     return FsDomain(current_app).gettext(string)
 
 
-def argvalues(*argvalues: tuple, ids: Callable[[tuple], str] | None = None) -> list[ParameterSet]:
+def argvalues(
+    *argvalues: tuple | Iterable[tuple], ids: Callable[[tuple], str] | None = None
+) -> list[ParameterSet]:
     """
     `pytest.mark.parametrize` helper with nicer support for parameter-set ids.
 
-    :param argvalues: parameter-set tuples, each one ending with its `id` when `ids` is None
+    :param argvalues: parameter-set tuples, each one ending with its `id` when `ids` is None.
+       A single iterable of such tuples is also accepted, so that parameter sets can be built
+       by a comprehension: `argvalues((foo(x), x) for x in values)`.
 
     :param ids: build each parameter-set `id` from its whole values tuple. Unlike the `ids`
        callable of `pytest.mark.parametrize`, which is called on each value separately.
@@ -259,6 +263,9 @@ def argvalues(*argvalues: tuple, ids: Callable[[tuple], str] | None = None) -> l
       @pytest.mark.parametrize("a, b", argvalues((1, 2), (3, 4), ids=lambda v: f"sum-{sum(v)}"))
       => @pytest.mark.parametrize("a, b", [(1, 2), (3, 4)], ids=["sum-3", "sum-7"])
     """
+    if len(argvalues) == 1 and not isinstance(argvalues[0], tuple):
+        argvalues = tuple(argvalues[0])
+
     if ids is None:
         return [pytest.param(*values, id=param_id) for *values, param_id in argvalues]
 

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,11 +1,12 @@
 import os
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from io import BytesIO
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from _pytest.mark import ParameterSet
 from flask import current_app, json
 from flask_security.babel import FsDomain
 from PIL import Image
@@ -242,41 +243,23 @@ def security_gettext(string):
     return FsDomain(current_app).gettext(string)
 
 
-def argvalues(
-    *argvalues, ids: int | Callable[..., object] | None = None
-) -> Iterable[pytest.mark.ParameterSet]:
+def argvalues(*argvalues: tuple, ids: Callable[[tuple], str] | None = None) -> list[ParameterSet]:
     """
     `pytest.mark.parametrize` helper with nicer support for parameter-set ids.
 
-    :param argvalues: same as `pytest.mark.parametrize`, or `(*argvalues, id)` when `ids` is None
+    :param argvalues: parameter-set tuples, each one ending with its `id` when `ids` is None
 
-    :param ids: set parameter-set `id` from its `argvalues` tuple
-       - None: use last value in `argvalues`, removing it from tuple
-       - integer: use value at given position in `argvalues`
-       - callable: use return value of `ids(argvalues)`
+    :param ids: build each parameter-set `id` from its whole values tuple. Unlike the `ids`
+       callable of `pytest.mark.parametrize`, which is called on each value separately.
 
     Examples::
-      @parameterize("a, b", argvalues((1, 2, "x"), (3, 4, "y")))
-      => @parameterize("a, b", [(1, 2), (3, 4)], ids=["x", "y"])
+      @pytest.mark.parametrize("a, b", argvalues((1, 2, "x"), (3, 4, "y")))
+      => @pytest.mark.parametrize("a, b", [(1, 2), (3, 4)], ids=["x", "y"])
 
-      @parametrize("a, b", argvalues((1, 2), (3, 4), ids=0))
-      => @parameterize("a, b", [(1, 2), (3, 4)], ids=[1, 3])
-
-      @parametrize("a, b", argvalues((1, 2), (3, 4), ids=sum))
-      => @parameterize("a, b", [(1, 2), (3, 4)], ids=[3, 7])
+      @pytest.mark.parametrize("a, b", argvalues((1, 2), (3, 4), ids=lambda v: f"sum-{sum(v)}"))
+      => @pytest.mark.parametrize("a, b", [(1, 2), (3, 4)], ids=["sum-3", "sum-7"])
     """
-    if (
-        len(argvalues) == 1
-        and not isinstance(argvalues[0], tuple)
-        and isinstance(argvalues[0], Iterable)
-    ):
-        argvalues = list(argvalues[0])
+    if ids is None:
+        return [pytest.param(*values, id=param_id) for *values, param_id in argvalues]
 
-    if isinstance(ids, int):
-        _argvalues = [(*v, v[ids]) for v in argvalues]
-    elif isinstance(ids, Callable):
-        _argvalues = [(*v, ids(v)) for v in argvalues]
-    else:
-        _argvalues = argvalues
-
-    return [pytest.param(*values, id=name) for *values, name in _argvalues]
+    return [pytest.param(*values, id=ids(values)) for values in argvalues]

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -242,37 +242,41 @@ def security_gettext(string):
     return FsDomain(current_app).gettext(string)
 
 
-def parametrize_with_ids(argnames, argvalues, idgetter: int | Callable[..., object] | None = None):
+def argvalues(
+    *argvalues, ids: int | Callable[..., object] | None = None
+) -> Iterable[pytest.mark.ParameterSet]:
     """
-    `pytest.mark.parametrize`-like decorator with nicer support for parameter-set ids.
+    `pytest.mark.parametrize` helper with nicer support for parameter-set ids.
 
-    :param argnames: same as `pytest.mark.parametrize`
+    :param argvalues: same as `pytest.mark.parametrize`, or `(*argvalues, id)` when `ids` is None
 
-    :param argvalues: same as `pytest.mark.parametrize`, or `(id, *argvalues)` when `idgetter` is None
-
-    :param idgetter: set parameter-set `id` from its `argvalues` tuple
-       None: use first value in `argvalues`, removing it from tuple
-       integer: use value at given position in `argvalues`
-       callable: use return value of `idgetter(argvalues)`
+    :param ids: set parameter-set `id` from its `argvalues` tuple
+       - None: use last value in `argvalues`, removing it from tuple
+       - integer: use value at given position in `argvalues`
+       - callable: use return value of `ids(argvalues)`
 
     Examples::
-      @parametrize_with_ids("a, b", [("x", 1, 2), ("y", 3, 4)])
-      => ids=["x", "y"], argvalues=[(1, 2), (3, 4)]
+      @parameterize("a, b", argvalues((1, 2, "x"), (3, 4, "y")))
+      => @parameterize("a, b", [(1, 2), (3, 4)], ids=["x", "y"])
 
-      @parametrize_with_ids("a, b", [(1, 2), (3, 4)], idgetter=0)
-      => ids=[1, 3], argvalues=[(1, 2), (3, 4)]
+      @parametrize("a, b", argvalues((1, 2), (3, 4), ids=0))
+      => @parameterize("a, b", [(1, 2), (3, 4)], ids=[1, 3])
 
-      @parametrize_with_ids("a, b", [(1, 2), (3, 4)], idgetter=sum)
-      => ids=[3, 7], argvalues=[(1, 2), (3, 4)]
+      @parametrize("a, b", argvalues((1, 2), (3, 4), ids=sum))
+      => @parameterize("a, b", [(1, 2), (3, 4)], ids=[3, 7])
     """
-    if isinstance(idgetter, int):
-        _argvalues = [(r[idgetter], *r) for r in argvalues]
-    elif isinstance(idgetter, Callable):
-        _argvalues = [(idgetter(r), *r) for r in argvalues]
+    if (
+        len(argvalues) == 1
+        and not isinstance(argvalues[0], tuple)
+        and isinstance(argvalues[0], Iterable)
+    ):
+        argvalues = list(argvalues[0])
+
+    if isinstance(ids, int):
+        _argvalues = [(*v, v[ids]) for v in argvalues]
+    elif isinstance(ids, Callable):
+        _argvalues = [(*v, ids(v)) for v in argvalues]
     else:
         _argvalues = argvalues
 
-    return pytest.mark.parametrize(
-        argnames,
-        [pytest.param(*v, id=i) for i, *v in _argvalues],
-    )
+    return [pytest.param(*values, id=name) for *values, name in _argvalues]

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -239,3 +240,39 @@ def create_geozones_fixtures():
 
 def security_gettext(string):
     return FsDomain(current_app).gettext(string)
+
+
+def parametrize_with_ids(argnames, argvalues, idgetter: int | Callable[..., object] | None = None):
+    """
+    `pytest.mark.parametrize`-like decorator with nicer support for parameter-set ids.
+
+    :param argnames: same as `pytest.mark.parametrize`
+
+    :param argvalues: same as `pytest.mark.parametrize`, or `(id, *argvalues)` when `idgetter` is None
+
+    :param idgetter: set parameter-set `id` from its `argvalues` tuple
+       None: use first value in `argvalues`, removing it from tuple
+       integer: use value at given position in `argvalues`
+       callable: use return value of `idgetter(argvalues)`
+
+    Examples::
+      @parametrize_with_ids("a, b", [("x", 1, 2), ("y", 3, 4)])
+      => ids=["x", "y"], argvalues=[(1, 2), (3, 4)]
+
+      @parametrize_with_ids("a, b", [(1, 2), (3, 4)], idgetter=0)
+      => ids=[1, 3], argvalues=[(1, 2), (3, 4)]
+
+      @parametrize_with_ids("a, b", [(1, 2), (3, 4)], idgetter=sum)
+      => ids=[3, 7], argvalues=[(1, 2), (3, 4)]
+    """
+    if isinstance(idgetter, int):
+        _argvalues = [(r[idgetter], *r) for r in argvalues]
+    elif isinstance(idgetter, Callable):
+        _argvalues = [(idgetter(r), *r) for r in argvalues]
+    else:
+        _argvalues = argvalues
+
+    return pytest.mark.parametrize(
+        argnames,
+        [pytest.param(*v, id=i) for i, *v in _argvalues],
+    )

--- a/udata/tests/test_helpers.py
+++ b/udata/tests/test_helpers.py
@@ -17,6 +17,11 @@ class ArgvaluesTest:
             (("http://example.com/",), "trailing-slash"),
         ]
 
+    def test_single_iterable_of_parameter_sets(self):
+        params = argvalues((n * 2, str(n)) for n in (1, 2))
+
+        assert [(p.values, p.id) for p in params] == [((2,), "1"), ((4,), "2")]
+
     def test_ids_callable_receives_the_whole_values_tuple(self):
         params = argvalues((1, 2), (3, 4), ids=lambda values: f"sum-{sum(values)}")
 

--- a/udata/tests/test_helpers.py
+++ b/udata/tests/test_helpers.py
@@ -1,0 +1,27 @@
+import pytest
+
+from udata.tests.helpers import argvalues
+
+
+class ArgvaluesTest:
+    def test_last_tuple_value_becomes_the_id(self):
+        params = argvalues((1, 2, "x"), (3, 4, "y"))
+
+        assert [(p.values, p.id) for p in params] == [((1, 2), "x"), ((3, 4), "y")]
+
+    def test_single_argument_parameter_sets(self):
+        params = argvalues((None, "none"), ("http://example.com/", "trailing-slash"))
+
+        assert [(p.values, p.id) for p in params] == [
+            ((None,), "none"),
+            (("http://example.com/",), "trailing-slash"),
+        ]
+
+    def test_ids_callable_receives_the_whole_values_tuple(self):
+        params = argvalues((1, 2), (3, 4), ids=lambda values: f"sum-{sum(values)}")
+
+        assert [(p.values, p.id) for p in params] == [((1, 2), "sum-3"), ((3, 4), "sum-7")]
+
+    @pytest.mark.parametrize("value", argvalues((1, "one"), (2, "two")))
+    def test_ids_are_used_by_pytest_as_parameter_set_ids(self, request, value):
+        assert request.node.callspec.id == {1: "one", 2: "two"}[value]

--- a/udata/tests/workers/test_tasks_routing.py
+++ b/udata/tests/workers/test_tasks_routing.py
@@ -2,32 +2,13 @@ import pytest
 
 from udata.tasks import celery, job, task
 from udata.tests import PytestOnlyTestCase
+from udata.tests.helpers import argvalues
 from udata.utils import unique_string
-
-TASKS = [
-    ({}, "default", None),
-    ({"queue": "low"}, "low", "low.{name}"),
-    ({"queue": "low", "routing_key": "key"}, "low", "key"),
-    ({"routing_key": "key"}, None, "key"),
-    ({"route": "low.topic"}, "low", "low.topic"),
-    ({"route": "low.topic", "queue": "q"}, "low", "low.topic"),
-    ({"route": "low.topic", "routing_key": "rk"}, "low", "low.topic"),
-]
-
-JOBS = [
-    ({}, "low", "low.{name}"),
-    ({"queue": "high"}, "high", "high.{name}"),
-    ({"queue": "high", "routing_key": "key"}, "high", "key"),
-    ({"routing_key": "key"}, "low", "key"),
-    ({"route": "high.topic"}, "high", "high.topic"),
-    ({"route": "high.topic", "queue": "q"}, "high", "high.topic"),
-    ({"route": "high.topic", "routing_key": "rk"}, "high", "high.topic"),
-]
 
 
 def idify(params):
     """Proper param display for easier debugging"""
-    return [", ".join("=".join(tup) for tup in row[0].items()) or "none" for row in params]
+    return ", ".join(f"{k}={v}" for k, v in params[0].items()) or "none"
 
 
 def fake_task(*args, **kwargs):
@@ -60,10 +41,34 @@ class TasksRoutingTest(PytestOnlyTestCase):
 
         return assertion
 
-    @pytest.mark.parametrize("kwargs,queue,key", TASKS, ids=idify(TASKS))
+    @pytest.mark.parametrize(
+        "kwargs, queue, key",
+        argvalues(
+            ({}, "default", None),
+            ({"queue": "low"}, "low", "low.{name}"),
+            ({"queue": "low", "routing_key": "key"}, "low", "key"),
+            ({"routing_key": "key"}, None, "key"),
+            ({"route": "low.topic"}, "low", "low.topic"),
+            ({"route": "low.topic", "queue": "q"}, "low", "low.topic"),
+            ({"route": "low.topic", "routing_key": "rk"}, "low", "low.topic"),
+            ids=idify,
+        ),
+    )
     def test_tasks_routing(self, route_to, kwargs, queue, key):
         route_to(task, [], kwargs, queue, key)
 
-    @pytest.mark.parametrize("kwargs,queue,key", JOBS, ids=idify(JOBS))
+    @pytest.mark.parametrize(
+        "kwargs, queue, key",
+        argvalues(
+            ({}, "low", "low.{name}"),
+            ({"queue": "high"}, "high", "high.{name}"),
+            ({"queue": "high", "routing_key": "key"}, "high", "key"),
+            ({"routing_key": "key"}, "low", "key"),
+            ({"route": "high.topic"}, "high", "high.topic"),
+            ({"route": "high.topic", "queue": "q"}, "high", "high.topic"),
+            ({"route": "high.topic", "routing_key": "rk"}, "high", "high.topic"),
+            ids=idify,
+        ),
+    )
     def test_job_routing(self, route_to, kwargs, queue, key):
         route_to(job, [unique_string()], kwargs, queue, key)


### PR DESCRIPTION
Got tired of copy-pasting the same `parametrize` pattern over and over (more instances to come in https://github.com/opendatateam/udata/pull/3862).

Also, some instances generated test names that couldn't be called from the pytest cli:
```
$ pytest udata -k 'test_geonetwork[dcat-http://www.w3.org/ns/dcat#]'
ERROR: Wrong expression passed to '-k': test_geonetwork[dcat-http://www.w3.org/ns/dcat#]: at column 47: unexpected character "#"
```