### PR TITLE
fix: return 200 instead of 500 when a nested entry is submitted with an unknown id

### DIFF
--- a/udata/core/dataset/apiv2.py
+++ b/udata/core/dataset/apiv2.py
@@ -33,7 +33,7 @@ from .api_fields import (
     temporal_coverage_fields,
 )
 from .constants import DEFAULT_LICENSE, FULL_OBJECTS_HEADER, UpdateFrequency
-from .models import CommunityResource, Dataset, Resource
+from .models import CommunityResource, Dataset, Resource, get_dataset_by_resource_id
 from .search import DatasetSearch
 
 DEFAULT_PAGE_SIZE = 50
@@ -512,7 +512,7 @@ class DatasetSchemasAPI(API):
 class ResourceAPI(API):
     @apiv2.doc("get_resource")
     def get(self, rid):
-        dataset = Dataset.objects(resources__id=rid).first()
+        dataset = get_dataset_by_resource_id(rid)
         if dataset:
             if not dataset.permissions["read"].can():
                 if not dataset.private and dataset.deleted:

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -1312,9 +1312,25 @@ class ResourceSchema(object):
         return None
 
 
+def get_dataset_by_resource_id(id):
+    """Fetch the dataset holding a resource, given the resource UUID
+
+    Resource ids are resolved globally (see the `/datasets/r/<id>` permalink), but nothing
+    enforces their uniqueness across datasets. An ambiguous id resolves to nothing rather
+    than letting an arbitrary dataset answer for another one's resource.
+    """
+    datasets = list(Dataset.objects(resources__id=id).limit(2))
+    if len(datasets) > 1:
+        # Corrupted data that no API path should be able to produce: report it instead of
+        # silently answering 404 (`log.error` is what reaches Sentry, HTTP errors are ignored)
+        log.error(f"Resource #{id} is duplicated across several datasets")
+        return None
+    return datasets[0] if datasets else None
+
+
 def get_resource(id):
     """Fetch a resource given its UUID"""
-    dataset = Dataset.objects(resources__id=id).first()
+    dataset = get_dataset_by_resource_id(id)
     if dataset:
         return get_by(dataset.resources, id=id)
     else:

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -544,7 +544,7 @@ class Resource(ResourceMixin, WithMetrics, EmbeddedDocument):
                 "Weakly referenced object for resource.dataset no longer exists, "
                 "using a poor performance query instead."
             )
-            return Dataset.objects(resources__id=self.id).first()
+            return get_dataset_by_resource_id(self.id)
 
     def save(self, *args, **kwargs):
         if not self.dataset:

--- a/udata/core/metrics/tasks.py
+++ b/udata/core/metrics/tasks.py
@@ -81,7 +81,10 @@ def update_resources_and_community_resources():
                 },
             )
         else:
-            Dataset.objects(resources__id=data["resource_id"]).update(
+            # Scoped to the dataset the metrics API reports the resource under, so that a
+            # resource id duplicated across datasets cannot spread views to all of them.
+            # `resources__id` only anchors the positional `$` operator on the right entry.
+            Dataset.objects(id=data["dataset_id"], resources__id=data["resource_id"]).update_one(
                 **{"set__resources__$__metrics__views": data["download_resource"]}
             )
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -596,17 +596,19 @@ class NestedModelList(fields.FieldList):
             idkey = basekey.format("id")
             if prefix in formdata:
                 formdata[idkey] = formdata.pop(prefix)
+            data = None
             if hasattr(self.nested_model, "id") and idkey in formdata:
                 id = self.nested_model.id.to_python(formdata[idkey])
-                data = get_by(self.initial_data, id=id)
+                # `initial_data` is unset when there is no instance yet, and the submitted id
+                # may not match any existing entry: there is then nothing to prefill and the
+                # entry is treated as a new one, keeping the submitted id.
+                data = get_by(self.initial_data or [], id=id)
+                if data is not None:
+                    initial = flatten_json(self.nested_form, data.to_mongo(), prefix)
 
-                initial = flatten_json(self.nested_form, data.to_mongo(), prefix)
-
-                for key, value in initial.items():
-                    if key not in formdata:
-                        formdata[key] = value
-            else:
-                data = None
+                    for key, value in initial.items():
+                        if key not in formdata:
+                            formdata[key] = value
         return super(NestedModelList, self)._add_entry(formdata, data, index)
 
 

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -543,7 +543,8 @@ class NestedModelList(fields.FieldList):
 
     def process(self, formdata, data=unset_value, **kwargs):
         self._formdata = formdata
-        self.initial_data = data
+        # `data` is `unset_value` when the form is built without an instance
+        self.initial_data = data or []
         self.is_list_data = formdata and self.name in formdata
         self.is_dict_data = formdata and any(k.startswith(self.prefix) for k in formdata)
         self.has_data = self.is_list_data or self.is_dict_data
@@ -599,16 +600,26 @@ class NestedModelList(fields.FieldList):
             data = None
             if hasattr(self.nested_model, "id") and idkey in formdata:
                 id = self.nested_model.id.to_python(formdata[idkey])
-                # `initial_data` is unset when there is no instance yet, and the submitted id
-                # may not match any existing entry: there is then nothing to prefill and the
-                # entry is treated as a new one, keeping the submitted id.
-                data = get_by(self.initial_data or [], id=id)
+                data = get_by(self.initial_data, id=id)
                 if data is not None:
                     initial = flatten_json(self.nested_form, data.to_mongo(), prefix)
 
                     for key, value in initial.items():
                         if key not in formdata:
                             formdata[key] = value
+                else:
+                    try:
+                        self.nested_model.id.validate(id)
+                    except MongoValidationError:
+                        # Keep the malformed id so the nested form rejects the whole payload
+                        pass
+                    else:
+                        # The id is well-formed but matches no existing entry, e.g. a client
+                        # sending back an entry deleted in the meantime. Drop it so the entry
+                        # is created with a server-generated id: resource ids are resolved
+                        # globally by `/datasets/r/<id>`, so honouring a client-chosen one
+                        # would let anyone squat another dataset's permalink.
+                        del formdata[idkey]
         return super(NestedModelList, self)._add_entry(formdata, data, index)
 
 

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -894,15 +894,19 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(len(dataset.resources), initial_length + 1)
 
     def test_dataset_api_update_with_resource_unknown_id(self):
-        """A resource submitted with an id matching nothing should be added as a new one
+        """A resource submitted with an id matching nothing is added with a server-generated id
 
         Regression test: it used to crash with a 500 while looking for the initial
         values to prefill the resource with (e.g. a client sending back a resource
-        deleted in the meantime).
+        deleted in the meantime). The submitted id is dropped rather than honoured,
+        so a client cannot pick the id of an existing resource.
         """
         user = self.login()
         dataset = DatasetFactory(owner=user, nb_resources=1)
+        initial_id = dataset.resources[0].id
         data = dataset.to_dict()
+        # to_dict() serializes embedded resources with the mongo `_id` key
+        data["resources"][0]["id"] = str(initial_id)
         unknown_id = str(uuid4())
         resource_data = ResourceFactory.as_dict()
         resource_data["id"] = unknown_id
@@ -913,8 +917,80 @@ class DatasetAPITest(APITestCase):
 
         dataset.reload()
         self.assertEqual(len(dataset.resources), 2)
-        self.assertEqual(str(dataset.resources[1].id), unknown_id)
+        self.assertEqual(dataset.resources[0].id, initial_id)
         self.assertEqual(dataset.resources[1].title, resource_data["title"])
+        self.assertNotEqual(str(dataset.resources[1].id), unknown_id)
+
+    def test_dataset_api_update_with_malformed_resource_id(self):
+        """A malformed resource id is a client error, not an entry to create"""
+        user = self.login()
+        dataset = DatasetFactory(owner=user)
+        data = dataset.to_dict()
+        resource_data = ResourceFactory.as_dict()
+        resource_data["id"] = "not-an-uuid"
+        data["resources"] = [resource_data]
+
+        response = self.put(url_for("api.dataset", dataset=dataset), data)
+        self.assert400(response)
+
+    def test_dataset_api_update_cannot_squat_another_dataset_resource_id(self):
+        """A client cannot give one of its resources the id of someone else's resource
+
+        Resource ids are resolved globally by `/datasets/r/<id>`, so honouring a
+        client-chosen id would let anyone hijack another dataset's permalink.
+        """
+        victim = DatasetFactory(nb_resources=1)
+        victim_id = victim.resources[0].id
+
+        user = self.login()
+        dataset = DatasetFactory(owner=user)
+        data = dataset.to_dict()
+        resource_data = ResourceFactory.as_dict()
+        resource_data["id"] = str(victim_id)
+        data["resources"] = [resource_data]
+
+        response = self.put(url_for("api.dataset", dataset=dataset), data)
+        self.assert200(response)
+
+        dataset.reload()
+        self.assertEqual(len(dataset.resources), 1)
+        self.assertNotEqual(dataset.resources[0].id, victim_id)
+        self.assertEqual(Dataset.objects(resources__id=victim_id).count(), 1)
+
+    def test_dataset_api_create_cannot_choose_resource_id(self):
+        """Same guarantee on creation, where there is no instance to prefill from"""
+        self.login()
+        chosen_id = str(uuid4())
+        resource_data = ResourceFactory.as_dict()
+        resource_data["id"] = chosen_id
+        data = DatasetFactory.as_dict()
+        data["resources"] = [resource_data]
+
+        response = self.post(url_for("api.datasets"), data)
+        self.assert201(response)
+
+        dataset = Dataset.objects.get(id=response.json["id"])
+        self.assertEqual(len(dataset.resources), 1)
+        self.assertNotEqual(str(dataset.resources[0].id), chosen_id)
+
+    def test_dataset_api_update_from_api_payload_keeps_resource_ids(self):
+        """A client doing GET then PUT must not renumber the resources
+
+        Resource ids are public permalinks (`/datasets/r/<id>`): they have to survive a
+        round-trip through the API, which is how clients update a dataset.
+        """
+        user = self.login()
+        dataset = DatasetFactory(owner=user, nb_resources=2)
+        initial_ids = [resource.id for resource in dataset.resources]
+
+        response = self.get(url_for("api.dataset", dataset=dataset))
+        self.assert200(response)
+
+        response = self.put(url_for("api.dataset", dataset=dataset), response.json)
+        self.assert200(response)
+
+        dataset.reload()
+        self.assertEqual([resource.id for resource in dataset.resources], initial_ids)
 
     def test_dataset_api_update_private(self):
         user = self.login()
@@ -2398,6 +2474,27 @@ class DatasetResourceAPITest(APITestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.location, "https://example.com/data.csv")
+
+    def test_resource_redirect_ignores_ambiguous_id(self):
+        """A duplicated resource id resolves to nothing rather than to an arbitrary dataset
+
+        Nothing enforces the uniqueness of resource ids across datasets (they are
+        embedded documents), so the global lookup has to fail closed. The duplication is
+        reported as an error since no API path should be able to produce it.
+        """
+        shared_id = uuid4()
+        DatasetFactory(resources=[ResourceFactory(id=shared_id)])
+        DatasetFactory(resources=[ResourceFactory(id=shared_id)])
+
+        with self.assertLogs("udata.core.dataset.models", level="ERROR") as logs:
+            response = self.get(
+                url_for("api.resource_redirect", id=shared_id), follow_redirects=False
+            )
+        self.assert404(response)
+        self.assertIn(str(shared_id), logs.output[0])
+
+        response = self.get(url_for("apiv2.resource", rid=shared_id))
+        self.assert404(response)
 
     def test_follow_dataset(self):
         """It should follow a dataset on POST"""

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -893,6 +893,29 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(len(dataset.resources), initial_length + 1)
 
+    def test_dataset_api_update_with_resource_unknown_id(self):
+        """A resource submitted with an id matching nothing should be added as a new one
+
+        Regression test: it used to crash with a 500 while looking for the initial
+        values to prefill the resource with (e.g. a client sending back a resource
+        deleted in the meantime).
+        """
+        user = self.login()
+        dataset = DatasetFactory(owner=user, nb_resources=1)
+        data = dataset.to_dict()
+        unknown_id = str(uuid4())
+        resource_data = ResourceFactory.as_dict()
+        resource_data["id"] = unknown_id
+        data["resources"].append(resource_data)
+
+        response = self.put(url_for("api.dataset", dataset=dataset), data)
+        self.assert200(response)
+
+        dataset.reload()
+        self.assertEqual(len(dataset.resources), 2)
+        self.assertEqual(str(dataset.resources[1].id), unknown_id)
+        self.assertEqual(dataset.resources[1].title, resource_data["title"])
+
     def test_dataset_api_update_private(self):
         user = self.login()
         dataset = HiddenDatasetFactory(owner=user)

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -1,3 +1,5 @@
+import gc
+import logging
 from datetime import UTC, date, datetime, timedelta, timezone
 from uuid import uuid4
 
@@ -632,6 +634,28 @@ class ResourceModelTest(PytestOnlyDBTestCase):
         with assert_not_emit(*unexpected_signals), assert_emit(post_save):
             resource.title = "New title"
             resource.save(signal_kwargs={"ignores": ["post_save"]})
+
+    def test_dataset_fallback_ignores_ambiguous_id(self, caplog):
+        """A resource whose id is duplicated across datasets has no resolvable dataset
+
+        Once the weak reference to the parent dataset is collected, the only way back is
+        a global lookup on the resource id, which nothing makes unique across datasets.
+        Answering an arbitrary dataset would make `save()` write to that other dataset,
+        silently dropping the change made here.
+        """
+        shared_id = uuid4()
+        DatasetFactory(resources=[ResourceFactory(id=shared_id)])
+        dataset = DatasetFactory(resources=[ResourceFactory(id=shared_id)])
+        resource = dataset.resources[0]
+        del dataset
+        gc.collect()
+
+        with caplog.at_level(logging.ERROR, logger="udata.core.dataset.models"):
+            assert resource.dataset is None
+        assert str(shared_id) in caplog.text
+
+        with pytest.raises(RuntimeError):
+            resource.save()
 
 
 class LicenseModelTest(PytestOnlyDBTestCase):

--- a/udata/tests/forms/test_nested_model_list_field.py
+++ b/udata/tests/forms/test_nested_model_list_field.py
@@ -238,8 +238,9 @@ class NestedModelListFieldTest(TestCase):
         form.populate_obj(fake)
 
         self.assertEqual(len(fake.nested), 1)
-        self.assertEqual(str(fake.nested[0].id), unknown_id)
         self.assertEqual(fake.nested[0].name, name)
+        self.assertIsNotNone(fake.nested[0].id)
+        self.assertNotEqual(str(fake.nested[0].id), unknown_id)
 
     def test_with_id_without_instance(self):
         fake = Fake()
@@ -253,8 +254,37 @@ class NestedModelListFieldTest(TestCase):
         form.populate_obj(fake)
 
         self.assertEqual(len(fake.nested), 1)
-        self.assertEqual(str(fake.nested[0].id), unknown_id)
         self.assertEqual(fake.nested[0].name, name)
+        self.assertIsNotNone(fake.nested[0].id)
+        self.assertNotEqual(str(fake.nested[0].id), unknown_id)
+
+    def test_with_malformed_id(self):
+        """A malformed id is a client error, not an entry to create"""
+        fake = Fake.objects.create(nested=[Nested(name=faker.name())])
+        form = self.factory({"nested": [{"id": "not-an-uuid", "name": faker.name()}]}, fake)
+
+        self.assertFalse(form.validate())
+        self.assertIn("nested", form.errors)
+
+    def test_with_unknown_id_still_resolves_the_known_ones(self):
+        known = Nested(name=faker.name())
+        fake = Fake.objects.create(nested=[known])
+        unknown_id = str(uuid4())
+        name = faker.name()
+        form = self.factory(
+            {"nested": [{"id": str(known.id)}, {"id": unknown_id, "name": name}]}, fake
+        )
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(len(fake.nested), 2)
+        self.assertEqual(fake.nested[0].id, known.id)
+        self.assertEqual(fake.nested[0].name, known.name)
+        self.assertEqual(fake.nested[1].name, name)
+        self.assertNotEqual(str(fake.nested[1].id), unknown_id)
 
     def test_with_non_submitted_initial_elements(self):
         fake = Fake.objects.create(

--- a/udata/tests/forms/test_nested_model_list_field.py
+++ b/udata/tests/forms/test_nested_model_list_field.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from mongoengine import EmbeddedDocument
 from mongoengine.fields import DictField, EmbeddedDocumentField, ListField, StringField
 from werkzeug.datastructures import MultiDict
@@ -223,6 +225,36 @@ class NestedModelListFieldTest(TestCase):
         for idx, id in enumerate(order):
             self.assertEqual(fake.nested[idx].id, id)
         self.assertIsNotNone(fake.nested[2].id)
+
+    def test_with_unknown_id_on_existing_instance(self):
+        fake = Fake.objects.create(nested=[Nested(name=faker.name())])
+        unknown_id = str(uuid4())
+        name = faker.name()
+        form = self.factory({"nested": [{"id": unknown_id, "name": name}]}, fake)
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(len(fake.nested), 1)
+        self.assertEqual(str(fake.nested[0].id), unknown_id)
+        self.assertEqual(fake.nested[0].name, name)
+
+    def test_with_id_without_instance(self):
+        fake = Fake()
+        unknown_id = str(uuid4())
+        name = faker.name()
+        form = self.factory({"nested": [{"id": unknown_id, "name": name}]})
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(len(fake.nested), 1)
+        self.assertEqual(str(fake.nested[0].id), unknown_id)
+        self.assertEqual(fake.nested[0].name, name)
 
     def test_with_non_submitted_initial_elements(self):
         fake = Fake.objects.create(

--- a/udata/tests/metrics/test_tasks.py
+++ b/udata/tests/metrics/test_tasks.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 
 from udata.core.dataservices.factories import DataserviceFactory
@@ -172,4 +174,41 @@ class TasksMetricsTest(PytestOnlyTestCase):
         assert dataset_a_with_resources.resources[1].metrics.get("views") == 1337
         assert dataset_a_with_resources.resources[4].metrics.get("views") == 2
 
+        # The positional `$` operator has to land on the reported resource only
+        assert dataset_a_with_resources.resources[2].metrics.get("views") is None
+        assert dataset_a_with_resources.resources[3].metrics.get("views") is None
+
         assert dataset_b_with_resource.resources[0].metrics.get("views") == 1404
+
+    def test_update_resources_metrics_only_updates_the_reported_dataset(self, app, rmock):
+        """A resource id duplicated across datasets only updates the reported one
+
+        Nothing enforces the uniqueness of resource ids across datasets, and the update
+        used to match on the resource id alone, spreading the views to every dataset
+        holding that id.
+        """
+        shared_id = uuid4()
+        reported = DatasetFactory(resources=[ResourceFactory(id=shared_id)])
+        other = DatasetFactory(resources=[ResourceFactory(id=shared_id)])
+
+        mock_metrics_api(
+            app,
+            rmock,
+            "resources",
+            ["download_resource"],
+            [
+                {
+                    "resource_id": str(shared_id),
+                    "dataset_id": str(reported.id),
+                    "download_resource": 42,
+                },
+            ],
+        )
+
+        update_resources_and_community_resources()
+
+        reported.reload()
+        other.reload()
+
+        assert reported.resources[0].metrics.get("views") == 42
+        assert other.resources[0].metrics.get("views") is None


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/299180/ on `PUT` https://demo.data.gouv.fr/api/1/datasets/67f988bf9ea6979ac6079373/

```
AttributeError: 'NoneType' object has no attribute 'to_mongo'
(15 additional frame(s) were not displayed)
...
  File "udata/forms/__init__.py", line 20, in process
    super(CommonFormMixin, self).process(
  File "wtforms/form.py", line 128, in process
    field.process(formdata, data, extra_filters=field_extra_filters)
  File "udata/forms/fields.py", line 551, in process
    super(NestedModelList, self).process(formdata, data, **kwargs)
  File "wtforms/fields/list.py", line 91, in process
    self._add_entry(formdata, obj_data, index=index)
  File "udata/forms/fields.py", line 603, in _add_entry
    initial = flatten_json(self.nested_form, data.to_mongo(), prefix)
```