### PR TITLE
fix: infinite recursion on reuse endpoints

### DIFF
--- a/udata/tests/apiv2/test_datasets.py
+++ b/udata/tests/apiv2/test_datasets.py
@@ -17,6 +17,7 @@ from udata.core.dataset.factories import (
 from udata.core.dataset.models import ResourceMixin
 from udata.core.organization.factories import Member, OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory
+from udata.core.storages import images
 from udata.core.user.factories import UserFactory
 from udata.models import Dataset
 from udata.tests.api import APITestCase
@@ -109,6 +110,28 @@ class DatasetAPIV2Test(APITestCase):
         with query_counter() as counter:
             DatasetApiParser.parse_filters(Dataset.objects, {"dataservice": str(dataservice.id)})
             assert counter == 1
+
+    def test_filter_by_reuse_does_not_copy_the_image_storage(self):
+        # Regression: mongoengine deep-copies the document's fields when
+        # auto-dereferencing is off, and `Reuse.image` is an ImageField holding
+        # the image storage, hence its backend. On the S3 backend that backend
+        # owns boto3 clients, which recurse until RecursionError when copied.
+        dataset = DatasetFactory(title="Dataset with reuse")
+        reuse = ReuseFactory(datasets=[dataset.id])
+
+        class UncopyableBackend:
+            def __deepcopy__(self, memo):
+                raise AssertionError("the image storage backend must not be copied")
+
+        original_backend = images.backend
+        images.backend = UncopyableBackend()
+        try:
+            response = self.get(url_for("apiv2.datasets", reuse=reuse.id))
+        finally:
+            images.backend = original_backend
+
+        self.assert200(response)
+        assert [d["id"] for d in response.json["data"]] == [str(dataset.id)]
 
     def test_get_dataset(self):
         resources = [ResourceFactory() for _ in range(2)]

--- a/udata/tests/apiv2/test_reuses.py
+++ b/udata/tests/apiv2/test_reuses.py
@@ -6,6 +6,7 @@ from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory, VisibleReuseFactory
+from udata.core.storages import images
 from udata.core.user.factories import UserFactory
 from udata.models import Reuse
 from udata.search.query import ES_MAX_RESULT_WINDOW
@@ -271,6 +272,27 @@ class ReuseListAPIV2Test(APITestCase):
         assert200(response)
         ids = {r["id"] for r in response.json["data"]}
         assert ids == {str(linked_reuse.id)}
+
+    def test_reuse_list_does_not_copy_the_image_storage(self):
+        # Regression: mongoengine deep-copies the document's fields when
+        # auto-dereferencing is off, and `Reuse.image` is an ImageField holding
+        # the image storage, hence its backend. On the S3 backend that backend
+        # owns boto3 clients, which recurse until RecursionError when copied.
+        reuse = VisibleReuseFactory(datasets=DatasetFactory.create_batch(1))
+
+        class UncopyableBackend:
+            def __deepcopy__(self, memo):
+                raise AssertionError("the image storage backend must not be copied")
+
+        original_backend = images.backend
+        images.backend = UncopyableBackend()
+        try:
+            response = self.get(url_for("apiv2.reuses"))
+        finally:
+            images.backend = original_backend
+
+        assert200(response)
+        assert [r["id"] for r in response.json["data"]] == [str(reuse.id)]
 
     def test_reuse_list_exposes_owner(self):
         """The `owner` reference is dereferenced and serialized under

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 
 [[package]]
 name = "flask-storage"
-version = "1.4.5"
+version = "1.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -863,7 +863,7 @@ dependencies = [
     { name = "werkzeug" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/95/44615202af3620754f4b93a1593ac1c89083674475f1f66fe754fa68616e/flask_storage-1.4.5-py3-none-any.whl", hash = "sha256:dc996bcbe4a46db46377755e04b28f81ec0246b3b4a5111129ab5eb989ac76ab", size = 20081, upload-time = "2026-06-24T08:57:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e5/adca163cab6cd4c7f8938a49d3476c75485faceebf7e831aa32429fa66dc/flask_storage-1.4.6-py3-none-any.whl", hash = "sha256:b65be40978ae56fbc8b12a37fc681064b5da41c27c0477cd5fe93a410338bebb", size = 19320, upload-time = "2026-08-05T08:40:25.002Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Both endpoints return a 500 on dev.data.gouv.fr:

    GET /api/2/datasets/?reuse=<id>
    GET /api/2/reuses/

Both read their documents with `no_dereference()`, which makes mongoengine deep-copy the model's fields. `Reuse.image` is an ImageField holding the image storage, hence its backend, hence the boto3 clients it owns on S3 — and deep-copying a boto3 client recurses until the stack blows.

These tests stand in for the S3 backend with one that refuses to be copied, so they reproduce the production 500 without S3. They are red until flask-storage ships the fix (etalab/flask-storage, `FileField.__deepcopy__`) and this repository requires that version.