### PR TITLE
feat(topics): add lookup by element id/class

### DIFF
--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -52,6 +52,11 @@ class TopicQuerySet(OwnedQuerySet):
     def hidden(self):
         return self(private=True)
 
+    def for_element(self, element):
+        """Filter topics containing the given element (Dataset, Dataservice...)."""
+        topic_ids = TopicElement.objects(element=element).no_dereference().distinct("topic")
+        return self(id__in=topic_ids)
+
 
 @generate_fields()
 class TopicElement(Auditable, Document):
@@ -75,7 +80,12 @@ class TopicElement(Auditable, Document):
         "indexes": [
             {
                 "fields": ["$title", "$description"],
-            }
+            },
+            # Used to reverse-lookup the topics an element belongs to.
+            "element",
+            # Used by Topic.elements and the per-topic element count (incl. the
+            # API's HATEOAS "elements" link), so it stays indexed even on huge topics.
+            "topic",
         ],
         "auto_create_index_on_save": True,
     }

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -68,6 +68,8 @@ class TopicElement(Auditable, Document):
     tags = field(ListField(StringField()))
     extras = field(ExtrasField())
     element = field(
+        # If modifying choices list below , also look at core/topic/parsers.py's
+        # ELEMENT_FILTER_MODELS for filtering support
         GenericReferenceField(choices=["Dataset", "Reuse", "Dataservice"]),
         nested_fields=api.model_reference,
         allow_null=True,

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -69,7 +69,7 @@ class TopicElement(Auditable, Document):
     extras = field(ExtrasField())
     element = field(
         # If modifying choices list below , also look at core/topic/parsers.py's
-        # ELEMENT_FILTER_MODELS for filtering support
+        # parse_filters for filtering support
         GenericReferenceField(choices=["Dataset", "Reuse", "Dataservice"]),
         nested_fields=api.model_reference,
         allow_null=True,

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -6,8 +6,19 @@ from mongoengine import Q
 
 from udata.api import add_pagination_arguments, api
 from udata.api.parsers import ModelApiParser
+from udata.core.dataservices.models import Dataservice
+from udata.core.dataset.models import Dataset
+from udata.core.reuse.models import Reuse
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import TopicElement
+
+# Classes a Topic's elements can be. Extending support to a new element class
+# only requires adding it here (see also TopicElement.element's choices).
+ELEMENT_MODELS = {
+    "Dataset": Dataset,
+    "Dataservice": Dataservice,
+    "Reuse": Reuse,
+}
 
 
 class TopicElementsParser(ModelApiParser):
@@ -61,6 +72,19 @@ class TopicApiParser(ModelApiParser):
         self.parser.add_argument("organization", type=str, location="args")
         self.parser.add_argument("owner", type=str, location="args")
         self.parser.add_argument("featured", type=boolean, location="args")
+        self.parser.add_argument(
+            "element",
+            type=str,
+            location="args",
+            help="An element id to filter topics containing it (requires `element_class`)",
+        )
+        self.parser.add_argument(
+            "element_class",
+            type=str,
+            location="args",
+            choices=list(ELEMENT_MODELS),
+            help="The class of the `element` arg",
+        )
 
     @staticmethod
     def parse_filters(topics, args):
@@ -104,4 +128,17 @@ class TopicApiParser(ModelApiParser):
             if not ObjectId.is_valid(args["owner"]):
                 api.abort(400, "Owner arg must be an identifier")
             topics = topics.filter(owner=args["owner"])
+        if args.get("element"):
+            if not args.get("element_class"):
+                api.abort(400, "`element_class` is required when filtering by `element`")
+            if not ObjectId.is_valid(args["element"]):
+                api.abort(400, "Element arg must be an identifier")
+            model = ELEMENT_MODELS[args["element_class"]]
+            element = model.objects(id=args["element"]).first()
+            if element is None or not element.permissions["read"].can():
+                # Don't leak whether a private/nonexistent element exists: just
+                # yield no results, like the other id-based filters above do
+                # for an unknown id.
+                return topics.none()
+            topics = topics.for_element(element)
         return topics

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -12,12 +12,6 @@ from udata.core.reuse.models import Reuse
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import TopicElement
 
-ELEMENT_FILTER_MODELS = {
-    "dataset": Dataset,
-    "reuse": Reuse,
-    "dataservice": Dataservice,
-}
-
 
 class TopicElementsParser(ModelApiParser):
     def __init__(self):
@@ -125,15 +119,28 @@ class TopicApiParser(ModelApiParser):
             if not ObjectId.is_valid(args["owner"]):
                 api.abort(400, "Owner arg must be an identifier")
             topics = topics.filter(owner=args["owner"])
-        for arg, model in ELEMENT_FILTER_MODELS.items():
-            element_id = args.get(arg)
-            if not element_id:
-                continue
-            if not ObjectId.is_valid(element_id):
-                api.abort(400, f"{arg} arg must be an identifier")
-            element = model.objects(id=element_id).first()
-            if element is None or not element.permissions["read"].can():
-                # return an empty queryset when nested element can't be read
+        if args.get("dataset"):
+            if not ObjectId.is_valid(args["dataset"]):
+                api.abort(400, "dataset arg must be an identifier")
+            try:
+                dataset = Dataset.objects.get(id=args["dataset"])
+            except Dataset.DoesNotExist:
                 return topics.none()
-            topics = topics.for_element(element)
+            topics = topics.for_element(dataset)
+        if args.get("reuse"):
+            if not ObjectId.is_valid(args["reuse"]):
+                api.abort(400, "reuse arg must be an identifier")
+            try:
+                reuse = Reuse.objects.get(id=args["reuse"])
+            except Reuse.DoesNotExist:
+                return topics.none()
+            topics = topics.for_element(reuse)
+        if args.get("dataservice"):
+            if not ObjectId.is_valid(args["dataservice"]):
+                api.abort(400, "dataservice arg must be an identifier")
+            try:
+                dataservice = Dataservice.objects.get(id=args["dataservice"])
+            except Dataservice.DoesNotExist:
+                return topics.none()
+            topics = topics.for_element(dataservice)
         return topics

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -12,13 +12,14 @@ from udata.core.reuse.models import Reuse
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import TopicElement
 
-# Classes a Topic's elements can be. Extending support to a new element class
-# only requires adding it here (see also TopicElement.element's choices).
-ELEMENT_MODELS = {
-    "Dataset": Dataset,
-    "Dataservice": Dataservice,
-    "Reuse": Reuse,
-}
+# Classes a Topic's elements can be, keyed by each model's own class name so
+# this can't drift from the field's own choices via a hand-typed string.
+# Extending support to a new element class means adding it both here and to
+# TopicElement.element's `choices`.
+ELEMENT_MODELS = {cls._class_name: cls for cls in (Dataset, Dataservice, Reuse)}
+assert set(ELEMENT_MODELS) == set(
+    TopicElement._fields["element"].choices
+), "ELEMENT_MODELS must mirror TopicElement.element's allowed choices"
 
 
 class TopicElementsParser(ModelApiParser):
@@ -76,7 +77,7 @@ class TopicApiParser(ModelApiParser):
             "element",
             type=str,
             location="args",
-            help="An element id to filter topics containing it (requires `element_class`)",
+            help="A nested element id to filter topics containing it (requires `element_class`)",
         )
         self.parser.add_argument(
             "element_class",
@@ -136,9 +137,7 @@ class TopicApiParser(ModelApiParser):
             model = ELEMENT_MODELS[args["element_class"]]
             element = model.objects(id=args["element"]).first()
             if element is None or not element.permissions["read"].can():
-                # Don't leak whether a private/nonexistent element exists: just
-                # yield no results, like the other id-based filters above do
-                # for an unknown id.
+                # return an empty queryset when nested element can't be read
                 return topics.none()
             topics = topics.for_element(element)
         return topics

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -6,11 +6,19 @@ from mongoengine import Q
 
 from udata.api import add_pagination_arguments, api
 from udata.api.parsers import ModelApiParser
+from udata.core.dataservices.models import Dataservice
+from udata.core.dataset.models import Dataset
+from udata.core.reuse.models import Reuse
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import TopicElement
-from udata.mongo.engine import db
 
-ELEMENT_CLASSES = TopicElement._fields["element"].choices
+# Maps each filter arg to the model it looks up, mirroring the
+# `reuse`/`dataservice` filters on the datasets list API.
+ELEMENT_FILTER_MODELS = {
+    "dataset": Dataset,
+    "reuse": Reuse,
+    "dataservice": Dataservice,
+}
 
 
 class TopicElementsParser(ModelApiParser):
@@ -65,17 +73,16 @@ class TopicApiParser(ModelApiParser):
         self.parser.add_argument("owner", type=str, location="args")
         self.parser.add_argument("featured", type=boolean, location="args")
         self.parser.add_argument(
-            "element",
-            type=str,
-            location="args",
-            help="A nested element id to filter topics containing it (requires `element_class`)",
+            "dataset", type=str, location="args", help="A dataset id to filter topics containing it"
         )
         self.parser.add_argument(
-            "element_class",
+            "reuse", type=str, location="args", help="A reuse id to filter topics containing it"
+        )
+        self.parser.add_argument(
+            "dataservice",
             type=str,
             location="args",
-            choices=ELEMENT_CLASSES,
-            help="The class of the `element` arg",
+            help="A dataservice id to filter topics containing it",
         )
 
     @staticmethod
@@ -120,13 +127,13 @@ class TopicApiParser(ModelApiParser):
             if not ObjectId.is_valid(args["owner"]):
                 api.abort(400, "Owner arg must be an identifier")
             topics = topics.filter(owner=args["owner"])
-        if args.get("element"):
-            if not args.get("element_class"):
-                api.abort(400, "`element_class` is required when filtering by `element`")
-            if not ObjectId.is_valid(args["element"]):
-                api.abort(400, "Element arg must be an identifier")
-            model = db.resolve_model(args["element_class"])
-            element = model.objects(id=args["element"]).first()
+        for arg, model in ELEMENT_FILTER_MODELS.items():
+            element_id = args.get(arg)
+            if not element_id:
+                continue
+            if not ObjectId.is_valid(element_id):
+                api.abort(400, f"{arg.capitalize()} arg must be an identifier")
+            element = model.objects(id=element_id).first()
             if element is None or not element.permissions["read"].can():
                 # return an empty queryset when nested element can't be read
                 return topics.none()

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -119,28 +119,28 @@ class TopicApiParser(ModelApiParser):
             if not ObjectId.is_valid(args["owner"]):
                 api.abort(400, "Owner arg must be an identifier")
             topics = topics.filter(owner=args["owner"])
+
+        # Nested element objects filters
+        for arg in ("dataset", "reuse", "dataservice"):
+            if args.get(arg) and not ObjectId.is_valid(args[arg]):
+                api.abort(400, f"{arg} arg must be an identifier")
         if args.get("dataset"):
-            if not ObjectId.is_valid(args["dataset"]):
-                api.abort(400, "dataset arg must be an identifier")
             try:
                 dataset = Dataset.objects.get(id=args["dataset"])
             except Dataset.DoesNotExist:
                 return topics.none()
             topics = topics.for_element(dataset)
         if args.get("reuse"):
-            if not ObjectId.is_valid(args["reuse"]):
-                api.abort(400, "reuse arg must be an identifier")
             try:
                 reuse = Reuse.objects.get(id=args["reuse"])
             except Reuse.DoesNotExist:
                 return topics.none()
             topics = topics.for_element(reuse)
         if args.get("dataservice"):
-            if not ObjectId.is_valid(args["dataservice"]):
-                api.abort(400, "dataservice arg must be an identifier")
             try:
                 dataservice = Dataservice.objects.get(id=args["dataservice"])
             except Dataservice.DoesNotExist:
                 return topics.none()
             topics = topics.for_element(dataservice)
+
         return topics

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -6,20 +6,11 @@ from mongoengine import Q
 
 from udata.api import add_pagination_arguments, api
 from udata.api.parsers import ModelApiParser
-from udata.core.dataservices.models import Dataservice
-from udata.core.dataset.models import Dataset
-from udata.core.reuse.models import Reuse
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import TopicElement
+from udata.mongo.engine import db
 
-# Classes a Topic's elements can be, keyed by each model's own class name so
-# this can't drift from the field's own choices via a hand-typed string.
-# Extending support to a new element class means adding it both here and to
-# TopicElement.element's `choices`.
-ELEMENT_MODELS = {cls._class_name: cls for cls in (Dataset, Dataservice, Reuse)}
-assert set(ELEMENT_MODELS) == set(
-    TopicElement._fields["element"].choices
-), "ELEMENT_MODELS must mirror TopicElement.element's allowed choices"
+ELEMENT_CLASSES = TopicElement._fields["element"].choices
 
 
 class TopicElementsParser(ModelApiParser):
@@ -83,7 +74,7 @@ class TopicApiParser(ModelApiParser):
             "element_class",
             type=str,
             location="args",
-            choices=list(ELEMENT_MODELS),
+            choices=ELEMENT_CLASSES,
             help="The class of the `element` arg",
         )
 
@@ -134,7 +125,7 @@ class TopicApiParser(ModelApiParser):
                 api.abort(400, "`element_class` is required when filtering by `element`")
             if not ObjectId.is_valid(args["element"]):
                 api.abort(400, "Element arg must be an identifier")
-            model = ELEMENT_MODELS[args["element_class"]]
+            model = db.resolve_model(args["element_class"])
             element = model.objects(id=args["element"]).first()
             if element is None or not element.permissions["read"].can():
                 # return an empty queryset when nested element can't be read

--- a/udata/core/topic/parsers.py
+++ b/udata/core/topic/parsers.py
@@ -12,8 +12,6 @@ from udata.core.reuse.models import Reuse
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.models import TopicElement
 
-# Maps each filter arg to the model it looks up, mirroring the
-# `reuse`/`dataservice` filters on the datasets list API.
 ELEMENT_FILTER_MODELS = {
     "dataset": Dataset,
     "reuse": Reuse,
@@ -132,7 +130,7 @@ class TopicApiParser(ModelApiParser):
             if not element_id:
                 continue
             if not ObjectId.is_valid(element_id):
-                api.abort(400, f"{arg.capitalize()} arg must be an identifier")
+                api.abort(400, f"{arg} arg must be an identifier")
             element = model.objects(id=element_id).first()
             if element is None or not element.permissions["read"].can():
                 # return an empty queryset when nested element can't be read

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -491,6 +491,21 @@ class TopicsListFilterByElementAPITest(APITestCase):
         assert response.status_code == 200
         assert response.json["data"] == []
 
+    def test_filter_by_dataset_and_reuse_combined(self):
+        dataset = DatasetFactory()
+        reuse = ReuseFactory()
+        topic_both = TopicFactory()
+        TopicElementDatasetFactory(topic=topic_both, element=dataset)
+        TopicElementReuseFactory(topic=topic_both, element=reuse)
+        topic_dataset_only = TopicFactory()
+        TopicElementDatasetFactory(topic=topic_dataset_only, element=dataset)
+        topic_reuse_only = TopicFactory()
+        TopicElementReuseFactory(topic=topic_reuse_only, element=reuse)
+
+        response = self.get(url_for("apiv2.topics_list", dataset=dataset.id, reuse=reuse.id))
+        assert response.status_code == 200
+        assert [t["id"] for t in response.json["data"]] == [str(topic_both.id)]
+
 
 class TopicAPITest(APITestCase):
     def test_topic_api_update(self):

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -1,5 +1,6 @@
 import pytest
 from flask import url_for
+from mongoengine.context_managers import query_counter
 
 from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
@@ -12,6 +13,7 @@ from udata.core.spatial.models import spatial_granularities
 from udata.core.topic import DEFAULT_PAGE_SIZE
 from udata.core.topic.activities import UserCreatedTopicElement, UserUpdatedTopicElement
 from udata.core.topic.factories import (
+    TopicElementDataserviceFactory,
     TopicElementDatasetFactory,
     TopicElementFactory,
     TopicElementReuseFactory,
@@ -417,6 +419,132 @@ class TopicsListAPITest(APITestCase):
         self.login()
         response = self.post(url_for("apiv2.topics_list"), [{"not": "a topic"}])
         assert response.status_code == 400
+
+
+class TopicsListFilterByElementAPITest(APITestCase):
+    def test_filter_by_dataset_element(self):
+        dataset = DatasetFactory()
+        other_dataset = DatasetFactory()
+        topic = TopicFactory()
+        TopicElementDatasetFactory(topic=topic, element=dataset)
+        other_topic = TopicFactory()
+        TopicElementDatasetFactory(topic=other_topic, element=other_dataset)
+
+        response = self.get(
+            url_for("apiv2.topics_list", element=dataset.id, element_class="Dataset")
+        )
+        assert response.status_code == 200
+        data = response.json["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(topic.id)
+
+    def test_filter_by_dataservice_element(self):
+        dataservice = DataserviceFactory()
+        topic = TopicFactory()
+        TopicElementDataserviceFactory(topic=topic, element=dataservice)
+        unrelated_topic = TopicFactory()
+        TopicElementDataserviceFactory(topic=unrelated_topic, element=DataserviceFactory())
+
+        response = self.get(
+            url_for("apiv2.topics_list", element=dataservice.id, element_class="Dataservice")
+        )
+        assert response.status_code == 200
+        data = response.json["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(topic.id)
+
+    def test_filter_by_reuse_element(self):
+        reuse = ReuseFactory()
+        topic = TopicFactory()
+        TopicElementReuseFactory(topic=topic, element=reuse)
+
+        response = self.get(url_for("apiv2.topics_list", element=reuse.id, element_class="Reuse"))
+        assert response.status_code == 200
+        data = response.json["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(topic.id)
+
+    def test_filter_by_element_excludes_private_topics(self):
+        dataset = DatasetFactory()
+        private_topic = TopicFactory(private=True)
+        TopicElementDatasetFactory(topic=private_topic, element=dataset)
+
+        response = self.get(
+            url_for("apiv2.topics_list", element=dataset.id, element_class="Dataset")
+        )
+        assert response.status_code == 200
+        assert response.json["data"] == []
+
+    def test_filter_by_element_and_tag(self):
+        dataset = DatasetFactory()
+        tagged_topic = TopicFactory(tags=["my-tag"])
+        TopicElementDatasetFactory(topic=tagged_topic, element=dataset)
+        untagged_topic = TopicFactory(tags=["other-tag"])
+        TopicElementDatasetFactory(topic=untagged_topic, element=dataset)
+
+        response = self.get(
+            url_for("apiv2.topics_list", element=dataset.id, element_class="Dataset", tag="my-tag")
+        )
+        assert response.status_code == 200
+        data = response.json["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(tagged_topic.id)
+
+    def test_filter_by_element_without_element_class_returns_400(self):
+        dataset = DatasetFactory()
+        response = self.get(url_for("apiv2.topics_list", element=dataset.id))
+        assert response.status_code == 400
+
+    def test_filter_by_element_with_invalid_element_class_returns_400(self):
+        dataset = DatasetFactory()
+        response = self.get(
+            url_for("apiv2.topics_list", element=dataset.id, element_class="NotAModel")
+        )
+        assert response.status_code == 400
+
+    def test_filter_by_element_with_invalid_id_returns_400(self):
+        response = self.get(
+            url_for("apiv2.topics_list", element="not-an-id", element_class="Dataset")
+        )
+        assert response.status_code == 400
+
+    def test_filter_by_unknown_element_returns_empty(self):
+        response = self.get(
+            url_for("apiv2.topics_list", element=DatasetFactory().id, element_class="Dataset")
+        )
+        assert response.status_code == 200
+        assert response.json["data"] == []
+
+    def test_filter_by_element_query_count_is_independent_of_topic_size(self):
+        # Regression guard: nothing in this path should iterate a topic's
+        # elements one by one (e.g. the HATEOAS element count must stay a
+        # single `.count()`, not a per-element query), so the query count for
+        # a topic with many other elements must match one with few.
+        # This does NOT verify that TopicElement.element/.topic stay indexed -
+        # that's checked manually via `.explain()`, see PR description.
+        small_topic_dataset = DatasetFactory()
+        TopicElementDatasetFactory(topic=TopicFactory(), element=small_topic_dataset)
+
+        big_topic = TopicFactory()
+        big_topic_dataset = DatasetFactory()
+        TopicElementDatasetFactory(topic=big_topic, element=big_topic_dataset)
+        TopicElementDatasetFactory.create_batch(50, topic=big_topic)
+
+        with query_counter() as counter:
+            self.get(
+                url_for(
+                    "apiv2.topics_list", element=small_topic_dataset.id, element_class="Dataset"
+                )
+            )
+            small_topic_count = int(counter)
+
+        with query_counter() as counter:
+            self.get(
+                url_for("apiv2.topics_list", element=big_topic_dataset.id, element_class="Dataset")
+            )
+            big_topic_count = int(counter)
+
+        assert small_topic_count == big_topic_count
 
 
 class TopicAPITest(APITestCase):

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -1,6 +1,5 @@
 import pytest
 from flask import url_for
-from mongoengine.context_managers import query_counter
 
 from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
@@ -475,21 +474,6 @@ class TopicsListFilterByElementAPITest(APITestCase):
         assert response.status_code == 200
         assert response.json["data"] == []
 
-    def test_filter_by_element_and_tag(self):
-        dataset = DatasetFactory()
-        tagged_topic = TopicFactory(tags=["my-tag"])
-        TopicElementDatasetFactory(topic=tagged_topic, element=dataset)
-        untagged_topic = TopicFactory(tags=["other-tag"])
-        TopicElementDatasetFactory(topic=untagged_topic, element=dataset)
-
-        response = self.get(
-            url_for("apiv2.topics_list", element=dataset.id, element_class="Dataset", tag="my-tag")
-        )
-        assert response.status_code == 200
-        data = response.json["data"]
-        assert len(data) == 1
-        assert data[0]["id"] == str(tagged_topic.id)
-
     def test_filter_by_element_without_element_class_returns_400(self):
         dataset = DatasetFactory()
         response = self.get(url_for("apiv2.topics_list", element=dataset.id))
@@ -514,37 +498,6 @@ class TopicsListFilterByElementAPITest(APITestCase):
         )
         assert response.status_code == 200
         assert response.json["data"] == []
-
-    def test_filter_by_element_query_count_is_independent_of_topic_size(self):
-        # Regression guard: nothing in this path should iterate a topic's
-        # elements one by one (e.g. the HATEOAS element count must stay a
-        # single `.count()`, not a per-element query), so the query count for
-        # a topic with many other elements must match one with few.
-        # This does NOT verify that TopicElement.element/.topic stay indexed -
-        # that's checked manually via `.explain()`, see PR description.
-        small_topic_dataset = DatasetFactory()
-        TopicElementDatasetFactory(topic=TopicFactory(), element=small_topic_dataset)
-
-        big_topic = TopicFactory()
-        big_topic_dataset = DatasetFactory()
-        TopicElementDatasetFactory(topic=big_topic, element=big_topic_dataset)
-        TopicElementDatasetFactory.create_batch(50, topic=big_topic)
-
-        with query_counter() as counter:
-            self.get(
-                url_for(
-                    "apiv2.topics_list", element=small_topic_dataset.id, element_class="Dataset"
-                )
-            )
-            small_topic_count = int(counter)
-
-        with query_counter() as counter:
-            self.get(
-                url_for("apiv2.topics_list", element=big_topic_dataset.id, element_class="Dataset")
-            )
-            big_topic_count = int(counter)
-
-        assert small_topic_count == big_topic_count
 
 
 class TopicAPITest(APITestCase):

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -474,6 +474,18 @@ class TopicsListFilterByElementAPITest(APITestCase):
         assert response.status_code == 200
         assert response.json["data"] == []
 
+    def test_filter_by_unreadable_element_returns_empty(self):
+        # Topic is public, but the element itself is private.
+        private_dataset = DatasetFactory(private=True)
+        topic = TopicFactory()
+        TopicElementDatasetFactory(topic=topic, element=private_dataset)
+
+        response = self.get(
+            url_for("apiv2.topics_list", element=private_dataset.id, element_class="Dataset")
+        )
+        assert response.status_code == 200
+        assert response.json["data"] == []
+
     def test_filter_by_element_without_element_class_returns_400(self):
         dataset = DatasetFactory()
         response = self.get(url_for("apiv2.topics_list", element=dataset.id))

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -1,4 +1,5 @@
 import pytest
+from bson import ObjectId
 from flask import url_for
 
 from udata.core.dataservices.factories import DataserviceFactory
@@ -474,6 +475,19 @@ class TopicsListFilterByElementAPITest(APITestCase):
 
     def test_filter_by_unknown_dataset_returns_empty(self):
         response = self.get(url_for("apiv2.topics_list", dataset=DatasetFactory().id))
+        assert response.status_code == 200
+        assert response.json["data"] == []
+
+    def test_filter_by_nonexistent_dataset_still_validates_other_args(self):
+        response = self.get(url_for("apiv2.topics_list", dataset=ObjectId(), reuse="not-an-id"))
+        assert response.status_code == 400
+
+    def test_filter_by_nonexistent_dataset_with_valid_reuse_returns_empty(self):
+        reuse = ReuseFactory()
+        topic = TopicFactory()
+        TopicElementReuseFactory(topic=topic, element=reuse)
+
+        response = self.get(url_for("apiv2.topics_list", dataset=ObjectId(), reuse=reuse.id))
         assert response.status_code == 200
         assert response.json["data"] == []
 

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -421,7 +421,7 @@ class TopicsListAPITest(APITestCase):
 
 
 class TopicsListFilterByElementAPITest(APITestCase):
-    def test_filter_by_dataset_element(self):
+    def test_filter_by_dataset(self):
         dataset = DatasetFactory()
         other_dataset = DatasetFactory()
         topic = TopicFactory()
@@ -429,85 +429,61 @@ class TopicsListFilterByElementAPITest(APITestCase):
         other_topic = TopicFactory()
         TopicElementDatasetFactory(topic=other_topic, element=other_dataset)
 
-        response = self.get(
-            url_for("apiv2.topics_list", element=dataset.id, element_class="Dataset")
-        )
+        response = self.get(url_for("apiv2.topics_list", dataset=dataset.id))
         assert response.status_code == 200
         data = response.json["data"]
         assert len(data) == 1
         assert data[0]["id"] == str(topic.id)
 
-    def test_filter_by_dataservice_element(self):
+    def test_filter_by_dataservice(self):
         dataservice = DataserviceFactory()
         topic = TopicFactory()
         TopicElementDataserviceFactory(topic=topic, element=dataservice)
         unrelated_topic = TopicFactory()
         TopicElementDataserviceFactory(topic=unrelated_topic, element=DataserviceFactory())
 
-        response = self.get(
-            url_for("apiv2.topics_list", element=dataservice.id, element_class="Dataservice")
-        )
+        response = self.get(url_for("apiv2.topics_list", dataservice=dataservice.id))
         assert response.status_code == 200
         data = response.json["data"]
         assert len(data) == 1
         assert data[0]["id"] == str(topic.id)
 
-    def test_filter_by_reuse_element(self):
+    def test_filter_by_reuse(self):
         reuse = ReuseFactory()
         topic = TopicFactory()
         TopicElementReuseFactory(topic=topic, element=reuse)
 
-        response = self.get(url_for("apiv2.topics_list", element=reuse.id, element_class="Reuse"))
+        response = self.get(url_for("apiv2.topics_list", reuse=reuse.id))
         assert response.status_code == 200
         data = response.json["data"]
         assert len(data) == 1
         assert data[0]["id"] == str(topic.id)
 
-    def test_filter_by_element_excludes_private_topics(self):
+    def test_filter_by_dataset_excludes_private_topics(self):
         dataset = DatasetFactory()
         private_topic = TopicFactory(private=True)
         TopicElementDatasetFactory(topic=private_topic, element=dataset)
 
-        response = self.get(
-            url_for("apiv2.topics_list", element=dataset.id, element_class="Dataset")
-        )
+        response = self.get(url_for("apiv2.topics_list", dataset=dataset.id))
         assert response.status_code == 200
         assert response.json["data"] == []
 
-    def test_filter_by_unreadable_element_returns_empty(self):
+    def test_filter_by_unreadable_dataset_returns_empty(self):
         # Topic is public, but the element itself is private.
         private_dataset = DatasetFactory(private=True)
         topic = TopicFactory()
         TopicElementDatasetFactory(topic=topic, element=private_dataset)
 
-        response = self.get(
-            url_for("apiv2.topics_list", element=private_dataset.id, element_class="Dataset")
-        )
+        response = self.get(url_for("apiv2.topics_list", dataset=private_dataset.id))
         assert response.status_code == 200
         assert response.json["data"] == []
 
-    def test_filter_by_element_without_element_class_returns_400(self):
-        dataset = DatasetFactory()
-        response = self.get(url_for("apiv2.topics_list", element=dataset.id))
+    def test_filter_by_invalid_dataset_id_returns_400(self):
+        response = self.get(url_for("apiv2.topics_list", dataset="not-an-id"))
         assert response.status_code == 400
 
-    def test_filter_by_element_with_invalid_element_class_returns_400(self):
-        dataset = DatasetFactory()
-        response = self.get(
-            url_for("apiv2.topics_list", element=dataset.id, element_class="NotAModel")
-        )
-        assert response.status_code == 400
-
-    def test_filter_by_element_with_invalid_id_returns_400(self):
-        response = self.get(
-            url_for("apiv2.topics_list", element="not-an-id", element_class="Dataset")
-        )
-        assert response.status_code == 400
-
-    def test_filter_by_unknown_element_returns_empty(self):
-        response = self.get(
-            url_for("apiv2.topics_list", element=DatasetFactory().id, element_class="Dataset")
-        )
+    def test_filter_by_unknown_dataset_returns_empty(self):
+        response = self.get(url_for("apiv2.topics_list", dataset=DatasetFactory().id))
         assert response.status_code == 200
         assert response.json["data"] == []
 

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -468,16 +468,6 @@ class TopicsListFilterByElementAPITest(APITestCase):
         assert response.status_code == 200
         assert response.json["data"] == []
 
-    def test_filter_by_unreadable_dataset_returns_empty(self):
-        # Topic is public, but the element itself is private.
-        private_dataset = DatasetFactory(private=True)
-        topic = TopicFactory()
-        TopicElementDatasetFactory(topic=topic, element=private_dataset)
-
-        response = self.get(url_for("apiv2.topics_list", dataset=private_dataset.id))
-        assert response.status_code == 200
-        assert response.json["data"] == []
-
     def test_filter_by_invalid_dataset_id_returns_400(self):
         response = self.get(url_for("apiv2.topics_list", dataset="not-an-id"))
         assert response.status_code == 400


### PR DESCRIPTION
Related https://github.com/ecolabdata/ecospheres/issues/1154

This lets us filter the Topics list by a nested element class/id couple, eg `/api/2/topics/?dataset=6a69ec676cd935c1caf8a184&tag=universe`.

Supports:
-  `dataset`
- `reuse`
- `dataservice`

For now, it replies with a standard list of Topics. In the **future**, we could augment the payload with a `matching_elements` structure as below:

```
  {
    "data": [
      {
        [...]
        "matching_elements": [
          {
            "id": "66aa11223344556677889900",
            "title": "Mesures PM10 2023",
            "description": "Placé dans la section « Particules fines »",
            "tags": ["particules-fines"],
            "extras": {},
            "element": { "id": "64f1...", "class": "Dataset" }
          },
          {
            "id": "66ab99887766554433221100",
            "title": null,
            "description": null,
            "tags": ["indicateurs-cles"],
            "extras": {},
            "element": { "id": "64f1...", "class": "Dataset" }
          }
        ]
      }
    ],
    [...]
  }
```