### PR TITLE
fix(spatial): return 404 instead of 500 for unknown zone ids

### DIFF
--- a/udata/core/spatial/api.py
+++ b/udata/core/spatial/api.py
@@ -91,10 +91,12 @@ class ZonesAPI(API):
         """Fetch a zone list as GeoJSON"""
         ids_list = list(map(legacy_geoid, ids))
         zones = GeoZone.objects.in_bulk(ids_list)
-        zones = [zones[id] for id in ids_list]
+        unknown_ids = [id for id in ids_list if id not in zones]
+        if unknown_ids:
+            api.abort(404, "Unknown zone identifiers: {0}".format(", ".join(unknown_ids)))
         return {
             "type": "FeatureCollection",
-            "features": [z.toGeoJSON() for z in zones],
+            "features": [zones[id].toGeoJSON() for id in ids_list],
         }
 
 

--- a/udata/core/spatial/tests/test_api.py
+++ b/udata/core/spatial/tests/test_api.py
@@ -55,6 +55,12 @@ class SpatialApiTest(APITestCase):
             self.assertEqual(properties["level"], zone.level)
             self.assertEqual(properties["uri"], zone.uri)
 
+    def test_zones_api_unknown_id(self):
+        zone = GeoZoneFactory()
+
+        response = self.get(url_for("api.zones", ids=[zone.id, "unknown"]))
+        self.assert404(response)
+
     def test_suggest_zones_on_name(self):
         """It should suggest zones based on its name"""
         for i in range(4):


### PR DESCRIPTION
Fix crash on https://demo.data.gouv.fr/api/1/spatial/zones/country/

> KeyError `api.zones` Level: Error Unhandled 'country' (https://errors.data.gouv.fr/organizations/sentry/issues/299869)