### PR TITLE
fix: enforce contact point ownership on the model and carry them over on transfer

### DIFF
--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -402,12 +402,17 @@ def import_fixtures(source):
                 DiscussionFactory(**discussion, subject=dataset)
             for dataservice in fixture["dataservices"]:
                 dataservice = remove_unwanted_keys(dataservice, "dataservice")
-                dataservice["organization"] = get_or_create_organization(dataservice)
+                # An exported dataservice without an organization belongs to the fixture
+                # user, like the dataset above: a contact point needs an owner to belong to.
+                dataservice_owner = get_or_create_organization(dataservice) or user
+                dataservice.pop("organization", None)
                 dataservice["contact_points"] = [
-                    get_or_create_contact_point(contact_point, dataservice["organization"])
+                    get_or_create_contact_point(contact_point, dataservice_owner)
                     for contact_point in dataservice.get("contact_points") or []
                 ]
-                DataserviceFactory(**dataservice, datasets=[dataset])
+                DataserviceFactory(
+                    **dataservice, datasets=[dataset], **ownership_filter(dataservice_owner)
+                )
 
     # Import posts
     for post_data in json_fixtures.get("posts", []):

--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -354,6 +354,10 @@ def import_fixtures(source):
             user = UserFactory()
             dataset = fixture["dataset"]
             dataset = remove_unwanted_keys(dataset, "dataset")
+            # The exported ownership is dropped rather than listed in UNWANTED_KEYS, which is
+            # applied at export time, while `organization` is still needed to build the fixture.
+            dataset.pop("organization", None)
+            dataset.pop("owner", None)
             # The owner comes first: contact points belong to whoever owns the dataset.
             if fixture.get("organization"):
                 organization = fixture["organization"]

--- a/udata/commands/fixtures.py
+++ b/udata/commands/fixtures.py
@@ -36,6 +36,7 @@ from udata.core.edito_blocs.models import (
 )
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Member, Organization
+from udata.core.owned import ownership_filter
 from udata.core.post.factories import PostFactory
 from udata.core.post.models import Post
 from udata.core.reuse.factories import ReuseFactory
@@ -92,6 +93,8 @@ UNWANTED_KEYS: dict[str, list[str]] = {
         "preview_url",
         "permissions",
     ],
+    # The owner is not the exported one: it is whoever owns the object being imported.
+    "contact_point": ["organization", "owner"],
     "discussion": ["subject", "url", "self_web_url", "class", "permissions", "spam"],
     "discussion_message": ["permissions", "spam"],
     "user": ["uri", "page", "class", "avatar_thumbnail", "email"],
@@ -312,15 +315,15 @@ def get_or_create_user(data):
     return get_or_create(data, "user", User, UserFactory)
 
 
-def get_or_create_contact_point(data):
+def get_or_create_contact_point(data, owner):
     obj = ContactPoint.objects(id=data["id"]).first()
-    if not obj:
-        if not data.get("role"):
-            data["role"] = (
-                "contact" if (data.get("email") or data.get("contact_form")) else "creator"
-            )
-        obj = ContactPointFactory(**data)
-    return obj
+    if obj:
+        # A contact point exported from one owner can be referenced by objects of another.
+        return obj.for_owner(owner)
+    data = remove_unwanted_keys(data, "contact_point")
+    if not data.get("role"):
+        data["role"] = "contact" if (data.get("email") or data.get("contact_form")) else "creator"
+    return ContactPointFactory(**data, **ownership_filter(owner))
 
 
 @cli.command()
@@ -351,10 +354,7 @@ def import_fixtures(source):
             user = UserFactory()
             dataset = fixture["dataset"]
             dataset = remove_unwanted_keys(dataset, "dataset")
-            contact_points = []
-            for contact_point in dataset.get("contact_points") or []:
-                contact_points.append(get_or_create_contact_point(contact_point))
-            dataset["contact_points"] = contact_points
+            # The owner comes first: contact points belong to whoever owns the dataset.
             if fixture.get("organization"):
                 organization = fixture["organization"]
                 organization["members"] = [
@@ -362,10 +362,14 @@ def import_fixtures(source):
                     for member in organization["members"]
                 ]
                 fixture["organization"] = organization
-                org = get_or_create_organization(fixture)
-                dataset = DatasetFactory(**dataset, organization=org)
+                owner = get_or_create_organization(fixture)
             else:
-                dataset = DatasetFactory(**dataset, owner=user)
+                owner = user
+            dataset["contact_points"] = [
+                get_or_create_contact_point(contact_point, owner)
+                for contact_point in dataset.get("contact_points") or []
+            ]
+            dataset = DatasetFactory(**dataset, **ownership_filter(owner))
             for resource in fixture["resources"]:
                 resource = remove_unwanted_keys(resource, "resource")
                 res = ResourceFactory(**resource)
@@ -394,11 +398,11 @@ def import_fixtures(source):
                 DiscussionFactory(**discussion, subject=dataset)
             for dataservice in fixture["dataservices"]:
                 dataservice = remove_unwanted_keys(dataservice, "dataservice")
-                contact_points = []
-                for contact_point in dataservice.get("contact_points") or []:
-                    contact_points.append(get_or_create_contact_point(contact_point))
-                dataservice["contact_points"] = contact_points
                 dataservice["organization"] = get_or_create_organization(dataservice)
+                dataservice["contact_points"] = [
+                    get_or_create_contact_point(contact_point, dataservice["organization"])
+                    for contact_point in dataservice.get("contact_points") or []
+                ]
                 DataserviceFactory(**dataservice, datasets=[dataset])
 
     # Import posts

--- a/udata/commands/tests/test_fixtures.py
+++ b/udata/commands/tests/test_fixtures.py
@@ -34,7 +34,7 @@ class FixturesTest(PytestOnlyAPITestCase):
         org = OrganizationFactory(
             members=[Member(user=user, role="editor"), Member(user=admin, role="admin")]
         )
-        contact_point = ContactPointFactory(role="contact")
+        contact_point = ContactPointFactory(role="contact", organization=org)
         # Set the same slug we're 'exporting' from the FIXTURE_DATASET_SLUG config, see the
         # @pytest.mark.options above.
         dataset = DatasetFactory(

--- a/udata/core/contact_point/models.py
+++ b/udata/core/contact_point/models.py
@@ -3,9 +3,12 @@ from mongoengine.fields import StringField
 
 from udata.api_fields import field, generate_fields
 from udata.core.checks import check_is_email, check_no_urls
-from udata.core.owned import Owned, OwnedQuerySet
+from udata.core.organization.models import Organization
+from udata.core.owned import Owned, OwnedQuerySet, ownership_filter
+from udata.core.user.models import User
 from udata.i18n import lazy_gettext as _
 from udata.mongo.document import UDataDocument as Document
+from udata.mongo.errors import FieldValidationError
 from udata.mongo.url_field import URLField
 
 __all__ = ("ContactPoint",)
@@ -43,3 +46,42 @@ class ContactPoint(Document, Owned):
                 _("At least an email or a contact form is required for a contact point")
             )
         return super().validate(clean=clean)
+
+    def for_owner(self, owner: Organization | User) -> "ContactPoint":
+        """The same contact point, owned by `owner`, created if it does not exist yet.
+
+        Contact points are never moved from one owner to another: a single one is shared
+        by all the objects of its owner, so moving it would silently change the contact
+        of the objects that stayed behind.
+        """
+        contact_point, _created = ContactPoint.objects.get_or_create(
+            name=self.name,
+            email=self.email,
+            contact_form=self.contact_form,
+            role=self.role,
+            **ownership_filter(owner),
+        )
+        return contact_point
+
+
+def validate_contact_points_ownership(document) -> None:
+    """Check that the contact points of `document` belong to whoever owns it.
+
+    Enforced on the model rather than on the API layer because ownership also changes
+    through transfers and harvesting, and neither goes through a form or through `patch()`.
+    Call it from `validate()` and after `Owned.clean` has run: errors raised from `clean()`
+    are re-wrapped by mongoengine under `__all__`, losing the field this one is about, and
+    ownership is ambiguous until `Owned.clean` clears the field the object is moving away
+    from.
+    """
+    for contact_point in document.contact_points:
+        if (
+            contact_point.organization != document.organization
+            or contact_point.owner != document.owner
+        ):
+            raise FieldValidationError(
+                _("Contact point {id} does not belong to the owner of this object").format(
+                    id=contact_point.id
+                ),
+                field="contact_points",
+            )

--- a/udata/core/contact_point/models.py
+++ b/udata/core/contact_point/models.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from mongoengine.errors import ValidationError
 from mongoengine.fields import StringField
 
@@ -10,6 +12,10 @@ from udata.i18n import lazy_gettext as _
 from udata.mongo.document import UDataDocument as Document
 from udata.mongo.errors import FieldValidationError
 from udata.mongo.url_field import URLField
+
+if TYPE_CHECKING:
+    from udata.core.dataservices.models import Dataservice
+    from udata.core.dataset.models import Dataset
 
 __all__ = ("ContactPoint",)
 
@@ -45,6 +51,15 @@ class ContactPoint(Document, Owned):
             raise ValidationError(
                 _("At least an email or a contact form is required for a contact point")
             )
+        # `only_creation` says the same but lets sysadmins through, and a contact point that
+        # moves leaves the objects referencing it pointing at somebody else's, which they
+        # now reject: they could never be saved again. `for_owner` is the way to move.
+        moved = {"owner", "organization"} & set(self._get_changed_fields())
+        if moved and not self._created:
+            raise FieldValidationError(
+                _("A contact point cannot change owner."),
+                field="organization" if "organization" in moved else "owner",
+            )
         return super().validate(clean=clean)
 
     def for_owner(self, owner: Organization | User) -> "ContactPoint":
@@ -64,7 +79,7 @@ class ContactPoint(Document, Owned):
         return contact_point
 
 
-def validate_contact_points_ownership(document) -> None:
+def validate_contact_points_ownership(document: "Dataset | Dataservice") -> None:
     """Check that the contact points of `document` belong to whoever owns it.
 
     Enforced on the model rather than on the API layer because ownership also changes

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -229,9 +229,8 @@ class Dataservice(
         return self.title or ""
 
     def validate(self, clean=True):
-        result = super().validate(clean=clean)
+        super().validate(clean=clean)
         validate_contact_points_ownership(self)
-        return result
 
     title = field(
         StringField(required=True), example="My awesome API", sortable=True, show_as_ref=True

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -23,7 +23,7 @@ from udata.core.access_type.models import WithAccessType
 from udata.core.activity.models import Auditable
 from udata.core.badges.models import Badge, BadgeMixin, BadgesList
 from udata.core.constants import HVD
-from udata.core.contact_point.models import ContactPoint
+from udata.core.contact_point.models import ContactPoint, validate_contact_points_ownership
 from udata.core.dataservices.constants import DATASERVICE_FORMATS
 from udata.core.dataset.api_fields import dataset_ref_fields
 from udata.core.dataset.models import Dataset
@@ -227,6 +227,11 @@ class Dataservice(
 
     def __str__(self):
         return self.title or ""
+
+    def validate(self, clean=True):
+        result = super().validate(clean=clean)
+        validate_contact_points_ownership(self)
+        return result
 
     title = field(
         StringField(required=True), example="My awesome API", sortable=True, show_as_ref=True

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -163,23 +163,6 @@ def unmarshal_frequency(form, field):
     field.data = UpdateFrequency(field.data)
 
 
-def validate_contact_point(form, field):
-    """Validates contact point with dataset's org or owner"""
-    from udata.models import ContactPoint
-
-    for contact_point in field.data or []:
-        if form.organization.data:
-            contact_point = ContactPoint.objects(
-                id=contact_point.id, organization=form.organization.data
-            ).first()
-        elif form.owner.data:
-            contact_point = ContactPoint.objects(id=contact_point.id, owner=form.owner.data).first()
-        if not contact_point:
-            raise validators.ValidationError(
-                _("Wrong contact point id or contact point ownership mismatch")
-            )
-
-
 class AccessAudienceForm(ModelForm):
     model_class = AccessAudience
 
@@ -250,7 +233,7 @@ class DatasetForm(ModelForm):
     organization = fields.PublishAsField(_("Publish as"))
     extras = fields.ExtrasField()
     resources = fields.NestedModelList(ResourceForm)
-    contact_points = fields.ContactPointListField(validators=[validate_contact_point])
+    contact_points = fields.ContactPointListField()
 
 
 class ResourcesListForm(ModelForm):

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -38,6 +38,7 @@ from udata.core.badges.models import Badge, BadgeMixin, BadgesList
 from udata.core.constants import HVD
 from udata.core.contact_point.models import (
     ContactPoint,  # noqa: F401 — must be registered before Dataset
+    validate_contact_points_ownership,
 )
 from udata.core.dataset.api_fields import temporal_coverage_fields
 from udata.core.dataset.preview import TabularAPIPreview
@@ -741,6 +742,11 @@ class Dataset(
     @classmethod
     def pre_save(cls, sender, document, **kwargs):
         cls.before_save.send(document)
+
+    def validate(self, clean=True):
+        result = super().validate(clean=clean)
+        validate_contact_points_ownership(self)
+        return result
 
     def clean(self):
         super(Dataset, self).clean()

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -744,9 +744,8 @@ class Dataset(
         cls.before_save.send(document)
 
     def validate(self, clean=True):
-        result = super().validate(clean=clean)
+        super().validate(clean=clean)
         validate_contact_points_ownership(self)
-        return result
 
     def clean(self):
         super(Dataset, self).clean()

--- a/udata/core/owned.py
+++ b/udata/core/owned.py
@@ -39,8 +39,18 @@ class OwnedQuerySet(UDataQuerySet):
 
 
 def ownership_filter(owner: Organization | User) -> dict:
-    """Query filter selecting what `owner` owns, whichever kind of owner it is."""
-    return {"organization" if isinstance(owner, Organization) else "owner": owner}
+    """The ownership fields of `owner`, whichever kind of owner it is.
+
+    Both fields are always set: an owner owns through one of them and, just as importantly,
+    not through the other. A filter naming only one would also match documents whose other
+    field points at somebody else — an inconsistent state nothing forbids, since `Owned.clean`
+    only clears a field an object is moving away from.
+    """
+    is_organization = isinstance(owner, Organization)
+    return {
+        "organization": owner if is_organization else None,
+        "owner": None if is_organization else owner,
+    }
 
 
 def only_creation(_value, is_update, field, **_kwargs):

--- a/udata/core/owned.py
+++ b/udata/core/owned.py
@@ -38,6 +38,11 @@ class OwnedQuerySet(UDataQuerySet):
         return self(visible_query | owned_qs._query_obj)
 
 
+def ownership_filter(owner: Organization | User) -> dict:
+    """Query filter selecting what `owner` owns, whichever kind of owner it is."""
+    return {"organization" if isinstance(owner, Organization) else "owner": owner}
+
+
 def only_creation(_value, is_update, field, **_kwargs):
     from udata.auth import admin_permission, current_user
 

--- a/udata/core/post/tests/test_api.py
+++ b/udata/core/post/tests/test_api.py
@@ -157,7 +157,7 @@ class PostsAPITest(APITestCase):
         or not, so the comparison would hold without checking anything.
         """
         org = OrganizationFactory()
-        contact_point = ContactPointFactory(role="contact")
+        contact_point = ContactPointFactory(role="contact", organization=org)
         audiences = [
             AccessAudience(role=AccessAudienceType.COMPANY, condition=AccessAudienceCondition.YES)
         ]

--- a/udata/features/transfer/actions.py
+++ b/udata/features/transfer/actions.py
@@ -31,6 +31,19 @@ def accept_transfer(transfer, comment=None):
     """Accept an incoming a transfer request"""
     TransferResponsePermission(transfer).test()
 
+    subject = transfer.subject
+    recipient = transfer.recipient
+
+    # Contact points belong to an owner, so they cannot follow the subject as-is: each one
+    # is replaced by its equivalent under the recipient. Reuses have no contact points at
+    # all, hence the `getattr`. Resolved before the transfer is marked accepted because
+    # `for_owner` writes to the database and can fail, and a transfer that has already
+    # responded is refused by the API, leaving no way to retry.
+    contact_points = [
+        contact_point.for_owner(recipient)
+        for contact_point in getattr(subject, "contact_points", None) or []
+    ]
+
     transfer.responded = datetime.now(UTC)
     transfer.responder = current_user._get_current_object()
     transfer.status = "accepted"
@@ -38,20 +51,12 @@ def accept_transfer(transfer, comment=None):
     transfer.save()
     Transfer.after_handle.send(transfer)
 
-    subject = transfer.subject
-    recipient = transfer.recipient
     if isinstance(recipient, Organization):
         subject.organization = recipient
     elif isinstance(recipient, User):
         subject.owner = recipient
-
-    # Contact points belong to an owner, so they cannot follow the subject as-is:
-    # each one is replaced by its equivalent under the recipient. Reuses have no
-    # contact points at all, hence the `getattr`.
-    if contact_points := getattr(subject, "contact_points", None):
-        subject.contact_points = [
-            contact_point.for_owner(recipient) for contact_point in contact_points
-        ]
+    if contact_points:
+        subject.contact_points = contact_points
 
     subject.save()
 

--- a/udata/features/transfer/actions.py
+++ b/udata/features/transfer/actions.py
@@ -45,6 +45,14 @@ def accept_transfer(transfer, comment=None):
     elif isinstance(recipient, User):
         subject.owner = recipient
 
+    # Contact points belong to an owner, so they cannot follow the subject as-is:
+    # each one is replaced by its equivalent under the recipient. Reuses have no
+    # contact points at all, hence the `getattr`.
+    if contact_points := getattr(subject, "contact_points", None):
+        subject.contact_points = [
+            contact_point.for_owner(recipient) for contact_point in contact_points
+        ]
+
     subject.save()
 
     return transfer

--- a/udata/migrations/2026-08-18-fix-contact-points-ownership.py
+++ b/udata/migrations/2026-08-18-fix-contact-points-ownership.py
@@ -1,0 +1,77 @@
+"""
+Accepting a transfer used to move a dataset or a dataservice to its new owner while leaving
+its contact points behind, so those objects ended up referencing contact points owned by
+someone else. `Dataset.clean` and `Dataservice.clean` now reject that state, which would
+make every subsequent save of those objects fail.
+"""
+
+import logging
+
+from udata.core.contact_point.models import ContactPoint
+from udata.core.dataservices.models import Dataservice
+from udata.core.dataset.models import Dataset
+
+log = logging.getLogger(__name__)
+
+MISMATCHED_CONTACT_POINTS = [
+    {"$match": {"contact_points.0": {"$exists": True}}},
+    {
+        "$lookup": {
+            "from": ContactPoint._get_collection_name(),
+            "localField": "contact_points",
+            "foreignField": "_id",
+            "as": "contacts",
+        }
+    },
+    {
+        "$addFields": {
+            "mismatched": {
+                "$filter": {
+                    "input": "$contacts",
+                    "cond": {
+                        "$or": [
+                            {
+                                "$ne": [
+                                    {"$ifNull": ["$$this.organization", None]},
+                                    {"$ifNull": ["$organization", None]},
+                                ]
+                            },
+                            {
+                                "$ne": [
+                                    {"$ifNull": ["$$this.owner", None]},
+                                    {"$ifNull": ["$owner", None]},
+                                ]
+                            },
+                        ]
+                    },
+                }
+            }
+        }
+    },
+    {"$match": {"mismatched.0": {"$exists": True}}},
+    {"$project": {"_id": 1}},
+]
+
+
+def migrate(db):
+    for model in (Dataset, Dataservice):
+        ids = [
+            document["_id"]
+            for document in db[model._get_collection_name()].aggregate(MISMATCHED_CONTACT_POINTS)
+        ]
+
+        fixed = 0
+        for document in model.objects(id__in=ids):
+            owner = document.organization or document.owner
+            if not owner:
+                # Nothing to resolve the contact points against. Ownerless objects are not
+                # what transfers produce, so leave them to be looked at by hand.
+                log.warning(f"{model.__name__} #{document.id} has contact points but no owner.")
+                continue
+            document.contact_points = [
+                contact_point.for_owner(owner) for contact_point in document.contact_points
+            ]
+            document.save()
+            fixed += 1
+
+        log.info(f"{fixed} {model.__name__.lower()}s given contact points of their own owner.")

--- a/udata/migrations/2026-08-18-fix-contact-points-ownership.py
+++ b/udata/migrations/2026-08-18-fix-contact-points-ownership.py
@@ -1,7 +1,7 @@
 """
 Accepting a transfer used to move a dataset or a dataservice to its new owner while leaving
 its contact points behind, so those objects ended up referencing contact points owned by
-someone else. `Dataset.clean` and `Dataservice.clean` now reject that state, which would
+someone else. `Dataset.validate` and `Dataservice.validate` now reject that state, which would
 make every subsequent save of those objects fail.
 """
 
@@ -68,10 +68,18 @@ def migrate(db):
                 # what transfers produce, so leave them to be looked at by hand.
                 log.warning(f"{model.__name__} #{document.id} has contact points but no owner.")
                 continue
-            document.contact_points = [
-                contact_point.for_owner(owner) for contact_point in document.contact_points
-            ]
-            document.save()
+            try:
+                document.contact_points = [
+                    contact_point.for_owner(owner) for contact_point in document.contact_points
+                ]
+                document.save()
+            except Exception as error:
+                # A document can fail validation for reasons of its own — a duplicate resource
+                # id, a legacy contact point missing a name. Reporting it and moving on lets the
+                # migration complete, where raising would leave it unapplied and replay forever
+                # on the same document.
+                log.warning(f"{model.__name__} #{document.id} could not be fixed: {error}")
+                continue
             fixed += 1
 
         log.info(f"{fixed} {model.__name__.lower()}s given contact points of their own owner.")

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -31,6 +31,7 @@ from rdflib.util import guess_format as raw_guess_format
 from udata import uris
 from udata.core.contact_point.models import ContactPoint
 from udata.core.organization.models import Organization
+from udata.core.owned import ownership_filter
 from udata.core.user.models import User
 from udata.frontend.markdown import parse_html
 from udata.harvest.filters import normalize_tag
@@ -431,13 +432,12 @@ def contact_points_from_rdf(
         name, email, contact_form = infos
 
         # Create of get contact point object
-        owner_label = "organization" if isinstance(owner, Organization) else "owner"
         filters = {
             "name": name,
             "email": email,
             "contact_form": contact_form,
             "role": role,
-            owner_label: owner,
+            **ownership_filter(owner),
         }
         try:
             if dryrun:

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -4,6 +4,7 @@ from udata.core.contact_point.factories import ContactPointFactory
 from udata.core.contact_point.models import CONTACT_ROLES
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Member
+from udata.core.user.factories import AdminFactory
 from udata.i18n import gettext as _
 from udata.models import ContactPoint
 from udata.tests.api import APITestCase
@@ -181,6 +182,20 @@ class ContactPointAPITest(APITestCase):
 
         contact_point_a.reload()
         assert contact_point_a.email == "a@example.org"
+
+    def test_contact_point_api_update_owner_as_sysadmin(self):
+        """Sysadmins bypass `only_creation`, but a contact point still never moves."""
+        self.login(AdminFactory())
+        org = OrganizationFactory()
+        contact_point = ContactPointFactory(organization=org)
+
+        data = contact_point.to_dict()
+        data["organization"] = str(OrganizationFactory().id)
+        response = self.put(url_for("api.contact_point", contact_point=contact_point), data)
+
+        assert400(response)
+        contact_point.reload()
+        assert contact_point.organization == org
 
     def test_contact_point_api_update_forbidden(self):
         self.login()

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -1266,8 +1266,10 @@ class DatasetAPITest(APITestCase):
         response = self.put(url_for("api.dataset", dataset=dataset), data)
         self.assert400(response)
         self.assertEqual(
-            response.json["errors"]["contact_points"][0],
-            _("Wrong contact point id or contact point ownership mismatch"),
+            response.json["errors"]["contact_points"],
+            _("Contact point {id} does not belong to the owner of this object").format(
+                id=contact_point_id
+            ),
         )
 
     def test_dataset_api_delete(self):

--- a/udata/tests/contact_point/test_contact_point_models.py
+++ b/udata/tests/contact_point/test_contact_point_models.py
@@ -2,7 +2,53 @@ import pytest
 from mongoengine.errors import ValidationError
 
 from udata.core.contact_point.factories import ContactPointFactory
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.organization.factories import OrganizationFactory
+from udata.core.user.factories import UserFactory
 from udata.tests.api import PytestOnlyDBTestCase
+
+
+class ContactPointOwnershipTest(PytestOnlyDBTestCase):
+    """A contact point belongs to an owner, and so must the objects referencing it."""
+
+    def test_dataset_rejects_a_contact_point_of_another_organization(self):
+        contact_point = ContactPointFactory(organization=OrganizationFactory())
+
+        with pytest.raises(ValidationError):
+            DatasetFactory(organization=OrganizationFactory(), contact_points=[contact_point])
+
+    def test_dataset_rejects_a_contact_point_of_a_user(self):
+        contact_point = ContactPointFactory(owner=UserFactory())
+
+        with pytest.raises(ValidationError):
+            DatasetFactory(organization=OrganizationFactory(), contact_points=[contact_point])
+
+    def test_dataservice_rejects_a_contact_point_of_another_organization(self):
+        contact_point = ContactPointFactory(organization=OrganizationFactory())
+
+        with pytest.raises(ValidationError):
+            DataserviceFactory(organization=OrganizationFactory(), contact_points=[contact_point])
+
+    def test_own_contact_point_is_accepted(self):
+        org = OrganizationFactory()
+        contact_point = ContactPointFactory(organization=org)
+
+        DatasetFactory(organization=org, contact_points=[contact_point])
+        DataserviceFactory(organization=org, contact_points=[contact_point])
+
+    def test_for_owner_reuses_an_existing_equivalent(self):
+        org = OrganizationFactory()
+        contact_point = ContactPointFactory(owner=UserFactory())
+        existing = ContactPointFactory(
+            organization=org,
+            name=contact_point.name,
+            email=contact_point.email,
+            contact_form=contact_point.contact_form,
+            role=contact_point.role,
+        )
+
+        assert contact_point.for_owner(org) == existing
 
 
 class ContactPointTest(PytestOnlyDBTestCase):

--- a/udata/tests/contact_point/test_contact_point_models.py
+++ b/udata/tests/contact_point/test_contact_point_models.py
@@ -24,11 +24,23 @@ class ContactPointOwnershipTest(PytestOnlyDBTestCase):
         with pytest.raises(ValidationError):
             DatasetFactory(organization=OrganizationFactory(), contact_points=[contact_point])
 
+    def test_dataset_rejects_a_contact_point_of_another_user(self):
+        contact_point = ContactPointFactory(owner=UserFactory())
+
+        with pytest.raises(ValidationError):
+            DatasetFactory(owner=UserFactory(), contact_points=[contact_point])
+
     def test_dataservice_rejects_a_contact_point_of_another_organization(self):
         contact_point = ContactPointFactory(organization=OrganizationFactory())
 
         with pytest.raises(ValidationError):
             DataserviceFactory(organization=OrganizationFactory(), contact_points=[contact_point])
+
+    def test_dataservice_rejects_a_contact_point_of_another_user(self):
+        contact_point = ContactPointFactory(owner=UserFactory())
+
+        with pytest.raises(ValidationError):
+            DataserviceFactory(owner=UserFactory(), contact_points=[contact_point])
 
     def test_own_contact_point_is_accepted(self):
         org = OrganizationFactory()
@@ -49,6 +61,19 @@ class ContactPointOwnershipTest(PytestOnlyDBTestCase):
         )
 
         assert contact_point.for_owner(org) == existing
+
+    def test_for_owner_skips_a_contact_point_owned_by_both(self):
+        """Nothing forbids a contact point carrying both fields, but it belongs to neither."""
+        org = OrganizationFactory()
+        both = ContactPointFactory(organization=org, owner=UserFactory())
+
+        contact_point = both.for_owner(org)
+
+        assert contact_point != both
+        assert contact_point.organization == org
+        assert contact_point.owner is None
+        # The whole point of `for_owner`: what it returns is acceptable to the objects it is for.
+        DatasetFactory(organization=org, contact_points=[contact_point])
 
 
 class ContactPointTest(PytestOnlyDBTestCase):

--- a/udata/tests/contact_point/test_contact_point_models.py
+++ b/udata/tests/contact_point/test_contact_point_models.py
@@ -49,6 +49,13 @@ class ContactPointOwnershipTest(PytestOnlyDBTestCase):
         DatasetFactory(organization=org, contact_points=[contact_point])
         DataserviceFactory(organization=org, contact_points=[contact_point])
 
+    def test_a_contact_point_cannot_change_owner(self):
+        contact_point = ContactPointFactory(organization=OrganizationFactory())
+
+        contact_point.organization = OrganizationFactory()
+        with pytest.raises(ValidationError):
+            contact_point.save()
+
     def test_for_owner_reuses_an_existing_equivalent(self):
         org = OrganizationFactory()
         contact_point = ContactPointFactory(owner=UserFactory())

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -139,6 +139,7 @@ class DatasetToRdfTest(PytestOnlyAPITestCase):
             email="hello@its.me",
             contact_form="https://data.support.com",
             role="contact",
+            organization=org,
         )
         remote_url = "https://somewhere.org/dataset"
         dataset = DatasetFactory(
@@ -198,6 +199,7 @@ class DatasetToRdfTest(PytestOnlyAPITestCase):
         contact = ContactPointFactory(
             name="Publisher Contact",
             role="publisher",
+            organization=org,
         )
         remote_url = "https://somewhere.org/dataset"
         dataset = DatasetFactory(

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -202,10 +202,8 @@ def assert500(response):
 
 def assert_command_ok(result):
     __tracebackhide__ = True
-    msg = "Command failed with exit code {0.exit_code} and output:\n{0.output}".format(result)
+    msg = f"Command failed with exit code {result.exit_code} and output:\n{result.output}"
     if result.exception:
-        # Appended after formatting: a traceback holds source lines, and any brace in them
-        # would be read as a format field.
         msg += "\n" + "".join(traceback.format_exception(result.exception))
     assert result.exit_code == 0, msg
 

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -202,10 +202,12 @@ def assert500(response):
 
 def assert_command_ok(result):
     __tracebackhide__ = True
-    msg = "Command failed with exit code {0.exit_code} and output:\n{0.output}"
+    msg = "Command failed with exit code {0.exit_code} and output:\n{0.output}".format(result)
     if result.exception:
-        msg += "".join(traceback.format_exception(result.exception))
-    assert result.exit_code == 0, msg.format(result)
+        # Appended after formatting: a traceback holds source lines, and any brace in them
+        # would be read as a format field.
+        msg += "\n" + "".join(traceback.format_exception(result.exception))
+    assert result.exit_code == 0, msg
 
 
 def assert_urls_equal(url1, url2):

--- a/udata/tests/helpers.py
+++ b/udata/tests/helpers.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -202,6 +203,8 @@ def assert500(response):
 def assert_command_ok(result):
     __tracebackhide__ = True
     msg = "Command failed with exit code {0.exit_code} and output:\n{0.output}"
+    if result.exception:
+        msg += "".join(traceback.format_exception(result.exception))
     assert result.exit_code == 0, msg.format(result)
 
 

--- a/udata/tests/test_contact_points_ownership_migration.py
+++ b/udata/tests/test_contact_points_ownership_migration.py
@@ -1,0 +1,137 @@
+from mongoengine.connection import get_db
+
+from udata.core.contact_point.factories import ContactPointFactory
+from udata.core.contact_point.models import ContactPoint
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.organization.factories import OrganizationFactory
+from udata.core.user.factories import UserFactory
+from udata.db import migrations
+from udata.tests.api import PytestOnlyDBTestCase
+
+MIGRATION = "2026-08-18-fix-contact-points-ownership.py"
+
+
+def point_at(document, contact_point):
+    """Make `document` reference a contact point its owner does not own.
+
+    Written straight to the collection: this is the state transfers used to leave behind, and
+    the models now reject it, so no factory can build it.
+    """
+    document.__class__.objects(id=document.id).update(contact_points=[contact_point.id])
+
+
+def contact_points_of(document):
+    return document.__class__.objects.get(id=document.id).contact_points
+
+
+def migrate():
+    migrations.get(MIGRATION).migrate(get_db())
+
+
+class ContactPointsOwnershipMigrationTest(PytestOnlyDBTestCase):
+    def test_dataset_of_an_organization_gets_a_contact_point_of_its_own(self):
+        org = OrganizationFactory()
+        stranger = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        dataset = DatasetFactory(organization=org)
+        point_at(dataset, stranger)
+
+        migrate()
+
+        fixed = contact_points_of(dataset)[0]
+        assert fixed.organization == org
+        assert fixed.owner is None
+        assert (fixed.name, fixed.email, fixed.role) == (
+            stranger.name,
+            stranger.email,
+            stranger.role,
+        )
+
+    def test_dataset_of_a_user_gets_a_contact_point_of_its_own(self):
+        owner = UserFactory()
+        stranger = ContactPointFactory(owner=UserFactory(), role="contact")
+        dataset = DatasetFactory(owner=owner)
+        point_at(dataset, stranger)
+
+        migrate()
+
+        fixed = contact_points_of(dataset)[0]
+        assert fixed.owner == owner
+        assert fixed.organization is None
+
+    def test_dataservice_is_fixed_too(self):
+        org = OrganizationFactory()
+        stranger = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        dataservice = DataserviceFactory(organization=org)
+        point_at(dataservice, stranger)
+
+        migrate()
+
+        assert contact_points_of(dataservice)[0].organization == org
+
+    def test_the_contact_point_is_left_to_whoever_owns_it(self):
+        """It is shared, so the objects already using it must keep it untouched."""
+        stranger_org = OrganizationFactory()
+        stranger = ContactPointFactory(organization=stranger_org, role="contact")
+        dataset = DatasetFactory(organization=OrganizationFactory())
+        point_at(dataset, stranger)
+
+        migrate()
+
+        stranger.reload()
+        assert stranger.organization == stranger_org
+
+    def test_an_existing_contact_point_of_the_owner_is_reused(self):
+        org = OrganizationFactory()
+        stranger = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        already_there = ContactPointFactory(
+            organization=org,
+            name=stranger.name,
+            email=stranger.email,
+            contact_form=stranger.contact_form,
+            role=stranger.role,
+        )
+        dataset = DatasetFactory(organization=org)
+        point_at(dataset, stranger)
+
+        migrate()
+
+        assert contact_points_of(dataset) == [already_there]
+        assert ContactPoint.objects.count() == 2
+
+    def test_a_consistent_object_is_left_alone(self):
+        org = OrganizationFactory()
+        contact_point = ContactPointFactory(organization=org, role="contact")
+        dataset = DatasetFactory(organization=org, contact_points=[contact_point])
+
+        migrate()
+
+        assert contact_points_of(dataset) == [contact_point]
+        assert ContactPoint.objects.count() == 1
+
+    def test_an_ownerless_object_is_left_for_a_human(self):
+        """Transfers do not produce those, so the migration reports them instead of guessing."""
+        stranger = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        ownerless = DatasetFactory()
+        point_at(ownerless, stranger)
+
+        migrate()
+
+        assert contact_points_of(ownerless) == [stranger]
+
+    def test_a_document_that_cannot_be_saved_does_not_stop_the_others(self):
+        """A legacy contact point can fail validation; the rest must still be fixed."""
+        broken = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        ContactPoint.objects(id=broken.id).update(unset__name=True)
+        doomed = DatasetFactory(organization=OrganizationFactory())
+        point_at(doomed, broken)
+
+        org = OrganizationFactory()
+        stranger = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        fixable = DatasetFactory(organization=org)
+        point_at(fixable, stranger)
+
+        migrate()
+
+        assert contact_points_of(fixable)[0].organization == org
+        assert contact_points_of(doomed) == [broken]

--- a/udata/tests/test_transfer.py
+++ b/udata/tests/test_transfer.py
@@ -1,11 +1,15 @@
 import pytest
 
 from udata.auth import PermissionDenied, login_user
+from udata.core.contact_point.factories import ContactPointFactory
+from udata.core.contact_point.models import ContactPoint
+from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.metrics import (
     update_org_metrics,  # noqa needed to register signals
 )
+from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import UserFactory
 from udata.core.user.metrics import (
     update_owner_metrics,  # noqa needed to register signals
@@ -174,6 +178,108 @@ class TransferAcceptTest(PytestOnlyDBTestCase):
         login_user(editor)
         with pytest.raises(PermissionDenied):
             accept_transfer(transfer)
+
+
+class TransferContactPointsTest(PytestOnlyDBTestCase):
+    def test_dataset_contact_points_follow_the_recipient_organization(self):
+        owner = UserFactory()
+        recipient = OrganizationFactory(members=[Member(user=owner, role="admin")])
+        contact_point = ContactPointFactory(owner=owner, role="contact")
+        subject = DatasetFactory(owner=owner, contact_points=[contact_point])
+        transfer = TransferFactory(owner=owner, recipient=recipient, subject=subject)
+
+        login_user(owner)
+        accept_transfer(transfer)
+
+        subject.reload()
+        assert len(subject.contact_points) == 1
+        moved = subject.contact_points[0]
+        assert moved.organization == recipient
+        assert moved.owner is None
+        assert (moved.name, moved.email, moved.role) == (
+            contact_point.name,
+            contact_point.email,
+            contact_point.role,
+        )
+
+    def test_dataset_contact_points_follow_the_recipient_user(self):
+        org = OrganizationFactory()
+        recipient = UserFactory()
+        contact_point = ContactPointFactory(organization=org, role="contact")
+        subject = DatasetFactory(organization=org, contact_points=[contact_point])
+        transfer = TransferFactory(owner=org, recipient=recipient, subject=subject)
+
+        login_user(recipient)
+        accept_transfer(transfer)
+
+        subject.reload()
+        moved = subject.contact_points[0]
+        assert moved.owner == recipient
+        assert moved.organization is None
+
+    def test_dataservice_contact_points_follow_the_recipient(self):
+        owner = UserFactory()
+        recipient = OrganizationFactory(members=[Member(user=owner, role="admin")])
+        contact_point = ContactPointFactory(owner=owner, role="contact")
+        subject = DataserviceFactory(owner=owner, contact_points=[contact_point])
+        transfer = TransferFactory(owner=owner, recipient=recipient, subject=subject)
+
+        login_user(owner)
+        accept_transfer(transfer)
+
+        subject.reload()
+        assert subject.contact_points[0].organization == recipient
+
+    def test_contact_point_is_copied_not_moved(self):
+        """A contact point is shared, so the datasets left behind must keep theirs."""
+        owner = UserFactory()
+        recipient = OrganizationFactory(members=[Member(user=owner, role="admin")])
+        contact_point = ContactPointFactory(owner=owner, role="contact")
+        staying = DatasetFactory(owner=owner, contact_points=[contact_point])
+        subject = DatasetFactory(owner=owner, contact_points=[contact_point])
+        transfer = TransferFactory(owner=owner, recipient=recipient, subject=subject)
+
+        login_user(owner)
+        accept_transfer(transfer)
+
+        staying.reload()
+        assert staying.contact_points == [contact_point]
+        contact_point.reload()
+        assert contact_point.owner == owner
+        assert contact_point.organization is None
+
+    def test_existing_contact_point_of_the_recipient_is_reused(self):
+        owner = UserFactory()
+        recipient = OrganizationFactory(members=[Member(user=owner, role="admin")])
+        contact_point = ContactPointFactory(owner=owner, role="contact")
+        already_there = ContactPointFactory(
+            organization=recipient,
+            role=contact_point.role,
+            name=contact_point.name,
+            email=contact_point.email,
+            contact_form=contact_point.contact_form,
+        )
+        subject = DatasetFactory(owner=owner, contact_points=[contact_point])
+        transfer = TransferFactory(owner=owner, recipient=recipient, subject=subject)
+
+        login_user(owner)
+        accept_transfer(transfer)
+
+        subject.reload()
+        assert subject.contact_points == [already_there]
+        assert ContactPoint.objects.count() == 2
+
+    def test_transfering_a_reuse_has_no_contact_points_to_move(self):
+        owner = UserFactory()
+        recipient = OrganizationFactory(members=[Member(user=owner, role="admin")])
+        subject = ReuseFactory(owner=owner)
+        transfer = TransferFactory(owner=owner, recipient=recipient, subject=subject)
+
+        login_user(owner)
+        accept_transfer(transfer)
+
+        subject.reload()
+        assert subject.organization == recipient
 
 
 class TransferNotificationsTest(PytestOnlyDBTestCase):

--- a/udata/tests/test_transfer.py
+++ b/udata/tests/test_transfer.py
@@ -1,4 +1,5 @@
 import pytest
+from mongoengine.errors import ValidationError
 
 from udata.auth import PermissionDenied, login_user
 from udata.core.contact_point.factories import ContactPointFactory
@@ -17,6 +18,7 @@ from udata.core.user.metrics import (
 from udata.features.notifications.models import Notification
 from udata.features.transfer.actions import accept_transfer, refuse_transfer, request_transfer
 from udata.features.transfer.factories import TransferFactory
+from udata.features.transfer.models import Transfer
 from udata.features.transfer.notifications import transfer_request_notifications
 from udata.models import Member
 from udata.tests.api import DBTestCase, PytestOnlyDBTestCase
@@ -280,6 +282,27 @@ class TransferContactPointsTest(PytestOnlyDBTestCase):
 
         subject.reload()
         assert subject.organization == recipient
+
+    def test_a_contact_point_that_cannot_be_carried_over_leaves_the_transfer_pending(self):
+        """The API refuses to respond twice to a transfer, so a failure here would leave it
+        accepted with the subject never transferred, and no way to retry."""
+        owner = UserFactory()
+        recipient = OrganizationFactory(members=[Member(user=owner, role="admin")])
+        contact_point = ContactPointFactory(owner=owner, role="contact")
+        subject = DatasetFactory(owner=owner, contact_points=[contact_point])
+        # A legacy contact point the model rejects, as `2024-12-05-contact-point-is-now-a-list`
+        # could leave behind: reachable only by writing straight to the collection.
+        ContactPoint.objects(id=contact_point.id).update(unset__name=True)
+        transfer = TransferFactory(owner=owner, recipient=recipient, subject=subject)
+
+        login_user(owner)
+        with pytest.raises(ValidationError):
+            accept_transfer(Transfer.objects.get(id=transfer.id))
+
+        transfer.reload()
+        assert transfer.status == "pending"
+        subject.reload()
+        assert subject.owner == owner
 
 
 class TransferNotificationsTest(PytestOnlyDBTestCase):


### PR DESCRIPTION
Contact point ownership was only checked in the v1 dataset form, so the v2 API,  harvesting and transfers could leave an object pointing at somebody else's contact  point. These objects are in a failing state during save.

On prod 8 objects are in this state (3 datasets, 5 dataservices), all coming from  transfers accepted between July 2025 and July 2026.