### PR TITLE
fix: validate uploaded image content instead of the client-declared mimetype

### DIFF
--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -188,6 +188,9 @@ def parse_uploaded_image(field):
         image_format = Image.open(image).format
     except UnidentifiedImageError:
         image_format = None
+    # `Image.open` left the cursor right after the header it read. `field.save` may store
+    # the stream as-is (flask_storage only rewinds when it resizes or optimizes), which
+    # would silently truncate the stored file.
     image.seek(0)
     if image_format not in IMAGES_FORMATS:
         api.abort(400, "Unsupported image format")

--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -3,6 +3,7 @@ import os
 from datetime import UTC, datetime
 
 from flask import json
+from PIL import Image, UnidentifiedImageError
 from werkzeug.datastructures import FileStorage
 
 from udata.api import api, fields
@@ -11,7 +12,7 @@ from . import chunks, utils
 
 META = "meta.json"
 
-IMAGES_MIMETYPES = ("image/jpeg", "image/png", "image/webp")
+IMAGES_FORMATS = ("JPEG", "PNG", "WEBP")
 
 
 uploaded_image_fields = api.model(
@@ -28,7 +29,7 @@ chunk_status_fields = api.model("UploadStatus", {"success": fields.Boolean, "err
 
 
 image_parser = api.parser()
-image_parser.add_argument("file", type=FileStorage, location="files")
+image_parser.add_argument("file", type=FileStorage, location="files", required=True)
 image_parser.add_argument("bbox", type=str, location="form")
 
 
@@ -180,7 +181,15 @@ def parse_uploaded_image(field):
     args = image_parser.parse_args()
 
     image = args["file"]
-    if image.mimetype not in IMAGES_MIMETYPES:
+    # The mimetype is declared by the client and may not match the content at all
+    # (an SVG announced as `image/png` for instance): decode the file to know what
+    # it really is, otherwise Pillow raises further down and the request 500s.
+    try:
+        image_format = Image.open(image).format
+    except UnidentifiedImageError:
+        image_format = None
+    image.seek(0)
+    if image_format not in IMAGES_FORMATS:
         api.abort(400, "Unsupported image format")
     bbox = args.get("bbox", None)
     if bbox:

--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -188,6 +188,11 @@ def parse_uploaded_image(field):
         image_format = Image.open(image).format
     except UnidentifiedImageError:
         image_format = None
+    except Image.DecompressionBombError:
+        # A valid image whose header announces more pixels than Pillow accepts to decode.
+        # A few dozen bytes are enough to declare a huge size, so this must be refused
+        # here: every other decoding (resize, optimize, thumbnails) would raise too.
+        api.abort(400, "Image is too large")
     # `Image.open` left the cursor right after the header it read. `field.save` may store
     # the stream as-is (flask_storage only rewinds when it resizes or optimizes), which
     # would silently truncate the stored file.

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -86,6 +86,23 @@ class MeAPITest(APITestCase):
         )
         self.assert400(response)
 
+    def test_my_avatar_upload_rejects_lying_mimetype(self):
+        """It should reject a file whose content does not match its declared mimetype"""
+        self.login()
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
+        response = self.post(
+            url_for("api.my_avatar"),
+            {"file": (BytesIO(svg), "logo.svg", "image/png")},
+            json=False,
+        )
+        self.assert400(response)
+
+    def test_my_avatar_upload_without_file(self):
+        """It should reject an upload without any file"""
+        self.login()
+        response = self.post(url_for("api.my_avatar"), {}, json=False)
+        self.assert400(response)
+
     def test_update_profile(self):
         """It should update my profile from the API"""
         self.login()

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -1,3 +1,5 @@
+import struct
+import zlib
 from datetime import UTC, datetime, timedelta, timezone
 from io import BytesIO
 
@@ -113,6 +115,33 @@ class MeAPITest(APITestCase):
         response = self.post(
             url_for("api.my_avatar"),
             {"file": (BytesIO(svg), "logo.svg", "image/png")},
+            json=False,
+        )
+        self.assert400(response)
+
+    def test_my_avatar_upload_rejects_decompression_bomb(self):
+        """It should reject a valid image announcing more pixels than Pillow decodes"""
+        self.login()
+
+        def chunk(chunk_type, data):
+            return (
+                struct.pack(">I", len(data))
+                + chunk_type
+                + data
+                + struct.pack(">I", zlib.crc32(chunk_type + data))
+            )
+
+        # A 69 bytes PNG announcing 20000x20000 pixels: `Image.open` refuses it right
+        # after reading the header, before any decoding.
+        bomb = (
+            b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", 20000, 20000, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(b"\x00" * 100))
+            + chunk(b"IEND", b"")
+        )
+        response = self.post(
+            url_for("api.my_avatar"),
+            {"file": (BytesIO(bomb), "bomb.png")},
             json=False,
         )
         self.assert400(response)

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -76,6 +76,26 @@ class MeAPITest(APITestCase):
         user.reload()
         self.assertEqual(user.avatar.bbox, [10, 10, 40, 40])
 
+    def test_my_avatar_upload_stores_the_whole_file(self):
+        """It should store the complete file, not just what the format check left"""
+        # Without optimization and without a max size, flask_storage saves the stream
+        # from wherever its cursor is: any byte consumed by the format check would be
+        # missing from the stored avatar.
+        self.app.config["FS_IMAGES_OPTIMIZE"] = False
+        user = self.login()
+        image = create_test_image()
+        expected_size = len(image.getvalue())
+
+        response = self.post(
+            url_for("api.my_avatar"),
+            {"file": (image, "test.png")},
+            json=False,
+        )
+        self.assert200(response)
+
+        user.reload()
+        self.assertEqual(len(storages.avatars.read(user.avatar.filename)), expected_size)
+
     def test_my_avatar_upload_rejects_non_image(self):
         """It should reject a non-image file"""
         self.login()


### PR DESCRIPTION
Fix [UnidentifiedImageError](https://errors.data.gouv.fr/organizations/sentry/issues/300233/?referrer=alert_email&alert_type=email&alert_timestamp=1787307713153&alert_rule_id=10&notification_uuid=5c484318-4c9e-4f88-a8a3-3213e54a5952&environment=demo.data.gouv.fr) api.my_avatar
cannot identify image file <FileStorage: 'ch9.svg' ('image/png')>