### PR TITLE
fix: require a subject on reports instead of crashing while marshalling a subject-less one

### DIFF
--- a/udata/core/reports/models.py
+++ b/udata/core/reports/models.py
@@ -4,7 +4,7 @@ from bson import DBRef
 from flask import url_for
 from flask_login import current_user
 from flask_restx import inputs
-from mongoengine import DO_NOTHING, NULLIFY, Q, signals
+from mongoengine import NULLIFY, Q, signals
 from mongoengine.fields import (
     DateTimeField,
     DictField,
@@ -71,9 +71,7 @@ class Report(Document[ReportQuerySet]):
 
     # Here we use the lazy version of `GenericReferenceField` because we could point to a
     # non existant model (if it was deleted we want to keep the report data).
-    subject = field(
-        GenericLazyReferenceField(reverse_delete_rule=DO_NOTHING, choices=REPORTABLE_MODELS)
-    )
+    subject = field(GenericLazyReferenceField(choices=REPORTABLE_MODELS, required=True))
 
     subject_deleted_at = field(
         DateTimeField(),

--- a/udata/tests/api/test_reports_api.py
+++ b/udata/tests/api/test_reports_api.py
@@ -580,3 +580,16 @@ class ReportsAPITest(APITestCase):
 
         report.reload()
         self.assertEqual(report.callbacks, {})
+
+
+class ReportsSubjectRequiredAPITest(APITestCase):
+    def test_reports_api_create_without_subject(self):
+        response = self.post(
+            url_for("api.reports"),
+            {
+                "message": "This is spammy",
+                "reason": REASON_SPAM,
+            },
+        )
+        self.assert400(response)
+        self.assertEqual(Report.objects.count(), 0)


### PR DESCRIPTION
Fix [AttributeError](https://errors.data.gouv.fr/organizations/sentry/issues/300235/?referrer=alert_email&alert_type=email&alert_timestamp=1787309668421&alert_rule_id=10&notification_uuid=e4d52d6f-c6cb-49f1-ba48-e27a6e4c276c&environment=demo.data.gouv.fr) api.reports
'NoneType' object has no attribute 'document_type'

Only one instance in demo (removed it with `udata shell`), nothing in production 

```
>>> from udata.core.reports.models import Report; Report._get_collection().count_documents({"subject": None})
1
>>> list(Report._get_collection().find({"subject": None}, {"reason": 1, "reported_at": 1, "message": 1, "by": 1}))
[{'_id': ObjectId('6a882e62f076c44095087dd4'), 'reason': 'others', 'reported_at': datetime.datetime(2026, 8, 21, 10, 54, 26, 552000)}]
>>> from udata.core.reports.models import Report; Report._get_collection().delete_one({"subject": None})
DeleteResult({'n': 1, 'ok': 1.0}, acknowledged=True)
>>> from udata.core.reports.models import Report; Report._get_collection().count_documents({"subject": None})
0
```