### PR TITLE
fix: reject mongo operators and out-of-choices classes in API references instead of querying with them

### DIFF
--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -995,6 +995,19 @@ def patch(obj: _T, request) -> _T:
                     document_type = db.resolve_model(value["class"])
                 except ValueError as e:
                     raise FieldValidationError(message=str(e), field=key)
+                # `resolve_model` resolves against the whole document registry, so
+                # without this the client picks which collection the lookup below
+                # queries — MongoEngine only enforces `choices` at save() time, long
+                # after that query ran. A field without `choices` accepts them all,
+                # by design (e.g. `Transfer.subject`).
+                if (
+                    model_attribute.choices
+                    and document_type._class_name not in model_attribute.choices
+                ):
+                    raise FieldValidationError(
+                        message=f"Value must be one of {model_attribute.choices}",
+                        field=key,
+                    )
                 value = wrap_primary_key(
                     key,
                     model_attribute,
@@ -1133,6 +1146,15 @@ def wrap_primary_key(
 
     if isinstance(value, dict) and "id" in value:
         return wrap_primary_key(field_name, foreign_field, value["id"], document_type)
+
+    # `value` comes straight from the request body and goes straight into the query
+    # below, so anything but a scalar is a set of Mongo operators (`{"$ne": …}`) that
+    # selects an arbitrary document instead of the requested one. MongoEngine catches
+    # them only when the primary key is an `ObjectId`, whose `prepare_query_value`
+    # refuses the dict; on a `StringField` primary key (`License`, `GeoZone`…) the
+    # operators reach the database untouched.
+    if isinstance(value, (dict, list)):
+        raise FieldValidationError(field=field_name, message="Expected a reference id")
 
     document_type = document_type or foreign_field.document_type().__class__
     id_field_name = document_type._meta["id_field"]

--- a/udata/tests/api/test_reports_api.py
+++ b/udata/tests/api/test_reports_api.py
@@ -5,12 +5,13 @@ from flask import url_for
 
 from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
-from udata.core.dataset.models import Dataset
+from udata.core.dataset.models import Dataset, License
 from udata.core.discussions.factories import DiscussionFactory, MessageDiscussionFactory
 from udata.core.discussions.models import Discussion, Message
 from udata.core.reports.constants import (
     REASON_AUTO_SPAM,
     REASON_ILLEGAL_CONTENT,
+    REASON_OTHERS,
     REASON_SPAM,
     reports_reasons_translations,
 )
@@ -580,3 +581,35 @@ class ReportsAPITest(APITestCase):
 
         report.reload()
         self.assertEqual(report.callbacks, {})
+
+
+class ReportsSubjectClassAPITest(APITestCase):
+    def test_reports_api_create_with_a_non_reportable_subject_class(self):
+        """`class` is resolved against the whole document registry, so a class outside
+        `REPORTABLE_MODELS` must be rejected before its collection is queried."""
+        License(id="fr-lo", title="Licence Ouverte").save()
+
+        response = self.post(
+            url_for("api.reports"),
+            {
+                "reason": REASON_OTHERS,
+                "subject": {"class": "License", "id": "fr-lo"},
+            },
+        )
+        self.assert400(response)
+        self.assertEqual(Report.objects.count(), 0)
+
+    def test_reports_api_create_with_mongo_operators_as_subject_id(self):
+        """`License.id` being a `StringField`, the operators used to reach the database
+        and crash the query instead of being rejected as an invalid reference."""
+        License(id="fr-lo", title="Licence Ouverte").save()
+
+        response = self.post(
+            url_for("api.reports"),
+            {
+                "reason": REASON_OTHERS,
+                "subject": {"class": "License", "id": {"$where": "return true"}},
+            },
+        )
+        self.assert400(response)
+        self.assertEqual(Report.objects.count(), 0)

--- a/udata/tests/test_api_fields.py
+++ b/udata/tests/test_api_fields.py
@@ -22,6 +22,7 @@ from werkzeug.exceptions import BadRequest
 from udata.api import api
 from udata.api_fields import field, generate_fields, patch, patch_and_save
 from udata.core.dataset.api_fields import dataset_fields
+from udata.core.dataset.models import License
 from udata.core.organization import constants as org_constants
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.models import Organization
@@ -598,6 +599,16 @@ class GenericReferenceFieldTest(PytestOnlyDBTestCase):
             {"subject": {"class": "Organization", "id": str(organization.id)}},
         )
         assert obj.subject == organization
+
+    @pytest.mark.parametrize("operators", [{"$where": "return true"}, {"$ne": "nope"}, {"$gt": ""}])
+    def test_write_field_rejects_mongo_operators_as_id(self, operators: dict) -> None:
+        """An id made of Mongo operators would select an arbitrary document instead of
+        the requested one. MongoEngine catches it on an `ObjectId` primary key, but
+        `License.id` is a `StringField`, so the operators would reach the database."""
+        License(id="fr-lo", title="Licence Ouverte").save()
+
+        with pytest.raises(FieldValidationError):
+            patch(FakeWithGenericReference(), {"subject": {"class": "License", "id": operators}})
 
 
 class RenameFieldTest(PytestOnlyDBTestCase):


### PR DESCRIPTION
Fix [OperationFailure](https://errors.data.gouv.fr/organizations/sentry/issues/300236/)  `api.reports`

`$where cannot be applied to a field, full error: {'ok': 0.0, 'errmsg': '$where cannot be applied to a field', 'code': 2, 'codeName': 'BadValue'}`

Not really actionable today but we never know…