### PR TITLE
fix: make /organizations/<org>/datasets/ an alias of /datasets/?organization=<org>

### DIFF
--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -312,6 +312,21 @@ community_parser.add_argument(
 
 common_doc = {"params": {"dataset": "The dataset ID or slug"}}
 
+
+def list_visible_datasets(args):
+    """Paginate the datasets visible to the current user, filtered by `args`.
+
+    Shared by `/datasets/` and `/organizations/<org>/datasets/` so both expose
+    the exact same visibility rules and filters.
+    """
+    datasets = Dataset.objects.visible_by_user(
+        current_user, mongoengine.Q(private__ne=True, archived=None, deleted=None)
+    )
+    datasets = dataset_parser.parse_filters(datasets, args)
+    sort = args["sort"] or ("$text_score" if args["q"] else None) or DEFAULT_SORTING
+    return datasets.order_by(sort).paginate(args["page"], args["page_size"])
+
+
 # Build catalog_parser from DatasetApiParser parser with a default page_size of 100
 catalog_parser = DatasetApiParser().parser
 catalog_parser.replace_argument(
@@ -328,13 +343,7 @@ class DatasetListAPI(API):
     @api.marshal_with(dataset_page_fields)
     def get(self):
         """List or search all datasets"""
-        args = dataset_parser.parse()
-        datasets = Dataset.objects.visible_by_user(
-            current_user, mongoengine.Q(private__ne=True, archived=None, deleted=None)
-        )
-        datasets = dataset_parser.parse_filters(datasets, args)
-        sort = args["sort"] or ("$text_score" if args["q"] else None) or DEFAULT_SORTING
-        return datasets.order_by(sort).paginate(args["page"], args["page_size"])
+        return list_visible_datasets(dataset_parser.parse())
 
     @api.secure
     @api.doc("create_dataset", responses={400: "Validation error"})

--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -14,7 +14,12 @@ from udata.core.contact_point.models import ContactPoint
 from udata.core.dataservices.csv import DataserviceCsvAdapter
 from udata.core.dataservices.models import Dataservice
 from udata.core.dataservices.search import parse_dataservice_filters
-from udata.core.dataset.api import DatasetApiParser, catalog_parser
+from udata.core.dataset.api import (
+    DatasetApiParser,
+    catalog_parser,
+    dataset_parser,
+    list_visible_datasets,
+)
 from udata.core.dataset.api_fields import dataset_page_fields
 from udata.core.dataset.csv import DatasetCsvAdapter, ResourcesCsvAdapter
 from udata.core.dataset.models import Dataset
@@ -731,21 +736,20 @@ class AvatarAPI(API):
         return {"image": org.logo}
 
 
-dataset_parser = DatasetApiParser()
-
-
 @ns.route("/<org:org>/datasets/", endpoint="org_datasets")
 class OrgDatasetsAPI(API):
     @api.doc("list_organization_datasets")
     @api.expect(dataset_parser.parser)
     @api.marshal_with(dataset_page_fields)
     def get(self, org):
-        """List organization datasets (including private ones when member)"""
+        """List organization datasets (including private ones when member)
+
+        Alias of `/datasets/?organization=<org>`: same visibility rules, same filters.
+        """
         args = dataset_parser.parse()
-        qs = Dataset.objects.owned_by(org)
-        if not org.permissions["private"].can():
-            qs = qs(private__ne=True)
-        return qs.order_by(args["sort"]).paginate(args["page"], args["page_size"])
+        # The organization from the path always wins over a query string one.
+        args["organization"] = str(org.id)
+        return list_visible_datasets(args)
 
 
 @ns.route("/<org:org>/reuses/", endpoint="org_reuses")

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -1592,6 +1592,68 @@ class OrganizationDatasetsAPITest(PytestOnlyAPITestCase):
         assert200(response)
         assert len(response.json["data"]) == 2
 
+    def test_list_org_datasets_hide_archived_and_deleted(self):
+        """Should not include archived nor deleted datasets when not member"""
+        org = OrganizationFactory()
+        datasets = DatasetFactory.create_batch(3, organization=org)
+        DatasetFactory.create_batch(2, organization=org, archived=datetime.now(UTC))
+        DatasetFactory.create_batch(2, organization=org, deleted=datetime.now(UTC))
+
+        response = self.get(url_for("api.org_datasets", org=org))
+
+        assert200(response)
+        assert {d["id"] for d in response.json["data"]} == {str(d.id) for d in datasets}
+
+    def test_list_org_datasets_include_archived_and_deleted_when_member(self):
+        """Should include archived and deleted datasets when member"""
+        user = self.login()
+        org = OrganizationFactory(members=[Member(user=user, role="editor")])
+        datasets = DatasetFactory.create_batch(2, organization=org)
+        datasets += DatasetFactory.create_batch(1, organization=org, archived=datetime.now(UTC))
+        datasets += DatasetFactory.create_batch(1, organization=org, deleted=datetime.now(UTC))
+
+        response = self.get(url_for("api.org_datasets", org=org))
+
+        assert200(response)
+        assert {d["id"] for d in response.json["data"]} == {str(d.id) for d in datasets}
+
+    def test_list_org_datasets_applies_filters(self):
+        """Should apply the filters advertised by the dataset parser"""
+        org = OrganizationFactory()
+        DatasetFactory(organization=org, tags=["health"])
+        DatasetFactory(organization=org, tags=["energy"])
+
+        response = self.get(url_for("api.org_datasets", org=org, tag="health"))
+
+        assert200(response)
+        assert len(response.json["data"]) == 1
+
+    def test_list_org_datasets_ignores_other_organization_arg(self):
+        """The organization from the path should win over the query string one"""
+        org = OrganizationFactory()
+        other_org = OrganizationFactory()
+        datasets = DatasetFactory.create_batch(2, organization=org)
+        DatasetFactory.create_batch(3, organization=other_org)
+
+        response = self.get(url_for("api.org_datasets", org=org, organization=str(other_org.id)))
+
+        assert200(response)
+        assert {d["id"] for d in response.json["data"]} == {str(d.id) for d in datasets}
+
+    def test_list_org_datasets_matches_dataset_list_endpoint(self):
+        """Should be an alias of /datasets/?organization=<org>"""
+        org = OrganizationFactory()
+        DatasetFactory.create_batch(3, organization=org)
+        DatasetFactory.create_batch(2, organization=org, archived=datetime.now(UTC))
+        DatasetFactory.create_batch(1, organization=OrganizationFactory())
+
+        org_response = self.get(url_for("api.org_datasets", org=org))
+        list_response = self.get(url_for("api.datasets", organization=str(org.id)))
+
+        assert200(org_response)
+        assert200(list_response)
+        assert org_response.json["data"] == list_response.json["data"]
+
 
 class OrganizationReusesAPITest(PytestOnlyAPITestCase):
     def test_list_org_reuses(self):


### PR DESCRIPTION
`/organizations/<org>/datasets` was declaring `dataset_parser.parser` but didn't look into any of the filters (except sort and pagination…)

I think it should be the same as `/datasets?organization=<org>` but it removes the archived and deleted from the response, it's technically a breaking change…