### PR TITLE
fix: make the contact point name optional instead of an empty string

### DIFF
--- a/udata/core/contact_point/models.py
+++ b/udata/core/contact_point/models.py
@@ -30,7 +30,7 @@ MASK_FIELDS = ("id", "name", "email", "contact_form", "role")
 
 @generate_fields(page_mask=",".join(MASK_FIELDS))
 class ContactPoint(Document, Owned):
-    name = field(StringField(max_length=255, required=True), checks=[check_no_urls])
+    name = field(StringField(max_length=255), checks=[check_no_urls])
     email = field(StringField(max_length=255), checks=[check_is_email])
     contact_form = field(URLField())
     role = field(StringField(required=True, choices=list(CONTACT_ROLES)))
@@ -38,6 +38,10 @@ class ContactPoint(Document, Owned):
     meta = {"queryset_class": OwnedQuerySet}
 
     def validate(self, clean=True):
+        # The name is optional, but a contact point holding nothing but a role names nobody
+        # and reaches nobody.
+        if not self.name and not self.email and not self.contact_form:
+            raise ValidationError(_("A contact point requires a name, an email or a contact form"))
         if self.role == "contact" and not self.email and not self.contact_form:
             raise ValidationError(
                 _("At least an email or a contact form is required for a contact point")

--- a/udata/migrations/2026-08-21-clean-nameless-contact-points.py
+++ b/udata/migrations/2026-08-21-clean-nameless-contact-points.py
@@ -1,0 +1,42 @@
+"""
+Harvesting used to name a contact point after its `foaf:Agent` or `vcard:Kind`, falling back to
+an empty string when neither carried a name. `ContactPoint.name` is now optional, so the empty
+string has to become an absent value: it is the same thing said in two ways, and only one of
+them is falsy everywhere.
+
+Those without a name also have no email and no contact form when they come from an agent that
+carried nothing at all, which harvesting stopped creating in #3862. Nobody can be reached
+through them and they render as an empty line under the datasets referencing them, so they are
+removed rather than normalized.
+
+Written against the collections rather than the models: this is a bulk rewrite of two fields,
+and loading every document through the ORM to save it back would only add ways to fail.
+"""
+
+import logging
+
+log = logging.getLogger(__name__)
+
+NO_INFORMATION = {"name": None, "email": None, "contact_form": None}
+
+
+def migrate(db):
+    normalized = db.contact_point.update_many({"name": ""}, {"$unset": {"name": ""}}).modified_count
+    log.info(f"{normalized} contact points had an empty name instead of no name.")
+
+    unreachable = [
+        contact_point["_id"] for contact_point in db.contact_point.find(NO_INFORMATION, {"_id": 1})
+    ]
+    if not unreachable:
+        log.info("No contact point left without any way to reach it.")
+        return
+
+    for collection in (db.dataset, db.dataservice):
+        detached = collection.update_many(
+            {"contact_points": {"$in": unreachable}},
+            {"$pull": {"contact_points": {"$in": unreachable}}},
+        ).modified_count
+        log.info(f"{detached} {collection.name}s no longer reference an unreachable contact point.")
+
+    removed = db.contact_point.delete_many({"_id": {"$in": unreachable}}).deleted_count
+    log.info(f"{removed} contact points removed, holding nothing but a role.")

--- a/udata/migrations/2026-08-21-clean-nameless-contact-points.py
+++ b/udata/migrations/2026-08-21-clean-nameless-contact-points.py
@@ -1,15 +1,20 @@
 """
 Harvesting used to name a contact point after its `foaf:Agent` or `vcard:Kind`, falling back to
-an empty string when neither carried a name. `ContactPoint.name` is now optional, so the empty
-string has to become an absent value: it is the same thing said in two ways, and only one of
-them is falsy everywhere.
+an empty string when neither carried a name, and to read an address out of a bare `mailto:`,
+which left an empty string too. Both now yield an absent value, so the empty strings already in
+base have to become absent as well: it is the same thing said in two ways, and only one of them
+is falsy everywhere.
 
-Those without a name also have no email and no contact form when they come from an agent that
-carried nothing at all, which harvesting stopped creating in #3862. Nobody can be reached
-through them and they render as an empty line under the datasets referencing them, so they are
-removed rather than normalized.
+Normalizing the emails is also what keeps harvesting from duplicating them. It looks a contact
+point up by its exact fields before creating one, and an empty string never matches the absent
+value now extracted.
 
-Written against the collections rather than the models: this is a bulk rewrite of two fields,
+Contact points without a name also have no email and no contact form when they come from an
+agent that carried nothing at all, which harvesting stopped creating in #3862. Nobody can be
+reached through them and they render as an empty line under the datasets referencing them, so
+they are removed rather than normalized.
+
+Written against the collections rather than the models: this is a bulk rewrite of a few fields,
 and loading every document through the ORM to save it back would only add ways to fail.
 """
 
@@ -21,8 +26,11 @@ NO_INFORMATION = {"name": None, "email": None, "contact_form": None}
 
 
 def migrate(db):
-    normalized = db.contact_point.update_many({"name": ""}, {"$unset": {"name": ""}}).modified_count
-    log.info(f"{normalized} contact points had an empty name instead of no name.")
+    for field in ("name", "email"):
+        normalized = db.contact_point.update_many(
+            {field: ""}, {"$unset": {field: ""}}
+        ).modified_count
+        log.info(f"{normalized} contact points had an empty {field} instead of no {field}.")
 
     unreachable = [
         contact_point["_id"] for contact_point in db.contact_point.find(NO_INFORMATION, {"_id": 1})

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -394,10 +394,10 @@ def themes_from_rdf(rdf):
     return sorted({normalize_tag(tag) for tag in tags if normalize_tag(tag)})
 
 
-def contact_point_name(agent_name: str | None, org_name: str | None) -> str:
+def contact_point_name(agent_name: str | None, org_name: str | None) -> str | None:
     if agent_name and org_name:
         return f"{agent_name} ({org_name})"
-    return agent_name or org_name or ""
+    return agent_name or org_name or None
 
 
 def contact_points_from_rdf(
@@ -535,7 +535,8 @@ def contact_points_to_rdf(contacts, graph=None):
                 node.set(VCARD.hasURL, URIRef(contact.contact_form))
         else:
             node.set(RDF.type, FOAF.Agent)
-            node.set(FOAF.name, Literal(contact.name))
+            if contact.name:
+                node.set(FOAF.name, Literal(contact.name))
             if contact.email:
                 node.set(FOAF.mbox, URIRef(f"mailto:{contact.email}"))
             if contact.contact_form:

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -400,6 +400,11 @@ def contact_point_name(agent_name: str | None, org_name: str | None) -> str | No
     return agent_name or org_name or None
 
 
+def contact_point_email(mbox: str | None) -> str | None:
+    """A `mailto:` with nothing behind it announces an address it does not carry."""
+    return (mbox or "").removeprefix("mailto:").strip() or None
+
+
 def contact_points_from_rdf(
     resource: RdfResource,
     predicate: URIRef,
@@ -470,8 +475,7 @@ def contact_point_from_vcard(obj: RdfResource) -> tuple[str | None, str | None, 
             else None
         ),
     )
-    email = rdf_value(obj, VCARD.hasEmail) or rdf_value(obj, VCARD.email) or None
-    email = email.replace("mailto:", "").strip() if email else None
+    email = contact_point_email(rdf_value(obj, VCARD.hasEmail) or rdf_value(obj, VCARD.email))
     contact_form = (
         rdf_value(obj, VCARD.hasURL)
         or rdf_value(obj, VCARD.url)
@@ -500,8 +504,7 @@ def contact_point_from_foaf(obj: RdfResource) -> tuple[str | None, str | None, s
             None,
         )
         email = rdf_value(obj, FOAF.mbox)
-    email = email.replace("mailto:", "").strip() if email else None
-    return name, email, None
+    return name, contact_point_email(email), None
 
 
 def contact_points_to_rdf(contacts, graph=None):

--- a/udata/tests/api/test_contact_points.py
+++ b/udata/tests/api/test_contact_points.py
@@ -137,6 +137,23 @@ class ContactPointAPITest(APITestCase):
         )
         assert ContactPoint.objects.count() == 0
 
+    def test_contact_point_api_create_without_a_name(self):
+        self.login()
+        data = {"email": faker.email(), "role": "creator"}
+        response = self.post(url_for("api.contact_points"), data=data)
+        assert201(response)
+        assert ContactPoint.objects.first().name is None
+
+    def test_contact_point_missing_every_information(self):
+        self.login()
+        data = {"role": "creator"}
+        response = self.post(url_for("api.contact_points"), data=data)
+        assert400(response)
+        assert response.json["message"] == _(
+            "A contact point requires a name, an email or a contact form"
+        )
+        assert ContactPoint.objects.count() == 0
+
     def test_contact_point_missing_role(self):
         self.login()
         data = {"name": faker.word(), "email": faker.email()}

--- a/udata/tests/contact_point/test_contact_point_models.py
+++ b/udata/tests/contact_point/test_contact_point_models.py
@@ -14,6 +14,19 @@ class ContactPointTest(PytestOnlyDBTestCase):
         # The ContactPointFactory provides a contact_form by default, so the following should not raise.
         ContactPointFactory(role="contact", email=None)
 
+    def test_a_contact_point_does_not_need_a_name(self):
+        """Harvested agents often carry an email and no name at all."""
+        contact_point = ContactPointFactory(name=None, role="contact")
+
+        assert contact_point.name is None
+
+    def test_a_contact_point_needs_a_name_an_email_or_a_contact_form(self):
+        with pytest.raises(ValidationError):
+            ContactPointFactory(name=None, email=None, contact_form=None, role="creator")
+
+        ContactPointFactory(name=None, contact_form=None, role="creator")
+        ContactPointFactory(email=None, contact_form=None, role="creator")
+
     def test_validate_other_role_doesnt_need_an_email_or_contact_form(self):
         ContactPointFactory(role="creator", email=None, contact_form=None)
         ContactPointFactory(role="publisher", email=None, contact_form=None)

--- a/udata/tests/contact_point/test_contact_point_models.py
+++ b/udata/tests/contact_point/test_contact_point_models.py
@@ -14,19 +14,15 @@ class ContactPointTest(PytestOnlyDBTestCase):
         # The ContactPointFactory provides a contact_form by default, so the following should not raise.
         ContactPointFactory(role="contact", email=None)
 
-    def test_a_contact_point_does_not_need_a_name(self):
-        """Harvested agents often carry an email and no name at all."""
-        contact_point = ContactPointFactory(name=None, role="contact")
-
-        assert contact_point.name is None
-
-    def test_a_contact_point_needs_a_name_an_email_or_a_contact_form(self):
+    def test_a_contact_point_without_a_name_needs_an_email_or_a_contact_form(self):
         with pytest.raises(ValidationError):
-            ContactPointFactory(name=None, email=None, contact_form=None, role="creator")
+            ContactPointFactory(role="creator", name=None, email=None, contact_form=None)
 
-        ContactPointFactory(name=None, contact_form=None, role="creator")
-        ContactPointFactory(email=None, contact_form=None, role="creator")
+        ContactPointFactory(role="creator", name=None, email="me@example.org", contact_form=None)
+        ContactPointFactory(
+            role="creator", name=None, email=None, contact_form="https://example.org"
+        )
 
     def test_validate_other_role_doesnt_need_an_email_or_contact_form(self):
-        ContactPointFactory(role="creator", email=None, contact_form=None)
-        ContactPointFactory(role="publisher", email=None, contact_form=None)
+        ContactPointFactory(role="creator", name="Someone", email=None, contact_form=None)
+        ContactPointFactory(role="publisher", name="Someone", email=None, contact_form=None)

--- a/udata/tests/test_nameless_contact_points_migration.py
+++ b/udata/tests/test_nameless_contact_points_migration.py
@@ -1,4 +1,6 @@
 from mongoengine.connection import get_db
+from rdflib import BNode, Graph, Literal
+from rdflib.resource import Resource as RdfResource
 
 from udata.core.contact_point.factories import ContactPointFactory
 from udata.core.contact_point.models import ContactPoint
@@ -6,6 +8,7 @@ from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.db import migrations
+from udata.rdf import DCT, FOAF, RDF, contact_points_from_rdf
 from udata.tests.api import PytestOnlyDBTestCase
 
 MIGRATION = "2026-08-21-clean-nameless-contact-points.py"
@@ -28,6 +31,23 @@ def migrate():
     migrations.get(MIGRATION).migrate(get_db())
 
 
+def harvest(organization, name, mbox):
+    """Harvest a `foaf:Agent` as a rights holder of a dataset, as a DCAT catalog exposes one."""
+    graph = Graph()
+    agent = BNode()
+    graph.add((agent, RDF.type, FOAF.Agent))
+    graph.add((agent, FOAF.name, Literal(name)))
+    graph.add((agent, FOAF.mbox, Literal(mbox)))
+    dataset = BNode()
+    graph.add((dataset, DCT.rightsHolder, agent))
+
+    return list(
+        contact_points_from_rdf(
+            RdfResource(graph, dataset), DCT.rightsHolder, "rightsHolder", organization
+        )
+    )
+
+
 class NamelessContactPointsMigrationTest(PytestOnlyDBTestCase):
     def test_an_empty_name_becomes_no_name(self):
         contact_point = ContactPointFactory(organization=OrganizationFactory(), role="contact")
@@ -38,6 +58,31 @@ class NamelessContactPointsMigrationTest(PytestOnlyDBTestCase):
         contact_point.reload()
         assert contact_point.name is None
         assert contact_point.email
+
+    def test_an_empty_email_becomes_no_email(self):
+        contact_point = ContactPointFactory(organization=OrganizationFactory(), role="creator")
+        strip(contact_point, email="")
+
+        migrate()
+
+        contact_point.reload()
+        assert contact_point.email is None
+        assert contact_point.name
+
+    def test_a_normalized_contact_point_is_reused_by_harvesting(self):
+        """Why the empty emails are normalized: harvesting looks a contact point up by its exact
+        fields before creating one, and an empty string never matches the absent value it now
+        extracts from a bare `mailto:`."""
+        org = OrganizationFactory()
+        harvested = ContactPointFactory(
+            organization=org, role="rightsHolder", name="MNHN", contact_form=None
+        )
+        strip(harvested, email="")
+
+        migrate()
+
+        assert harvest(org, name="MNHN", mbox="mailto:") == [harvested]
+        assert ContactPoint.objects.count() == 1
 
     def test_a_contact_point_nobody_can_reach_is_removed(self):
         org = OrganizationFactory()

--- a/udata/tests/test_nameless_contact_points_migration.py
+++ b/udata/tests/test_nameless_contact_points_migration.py
@@ -1,0 +1,97 @@
+from mongoengine.connection import get_db
+
+from udata.core.contact_point.factories import ContactPointFactory
+from udata.core.contact_point.models import ContactPoint
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataset.factories import DatasetFactory
+from udata.core.organization.factories import OrganizationFactory
+from udata.db import migrations
+from udata.tests.api import PytestOnlyDBTestCase
+
+MIGRATION = "2026-08-21-clean-nameless-contact-points.py"
+
+
+def strip(contact_point, **fields):
+    """Empty the given fields of a contact point, as harvesting used to leave them.
+
+    Written as a raw `$set`: an empty name is precisely what the model now refuses to say,
+    and mongoengine turns a `None` into an `$unset` rather than storing it.
+    """
+    ContactPoint.objects(id=contact_point.id).update(__raw__={"$set": fields})
+
+
+def contact_points_of(document):
+    return document.__class__.objects.get(id=document.id).contact_points
+
+
+def migrate():
+    migrations.get(MIGRATION).migrate(get_db())
+
+
+class NamelessContactPointsMigrationTest(PytestOnlyDBTestCase):
+    def test_an_empty_name_becomes_no_name(self):
+        contact_point = ContactPointFactory(organization=OrganizationFactory(), role="contact")
+        strip(contact_point, name="")
+
+        migrate()
+
+        contact_point.reload()
+        assert contact_point.name is None
+        assert contact_point.email
+
+    def test_a_contact_point_nobody_can_reach_is_removed(self):
+        org = OrganizationFactory()
+        unreachable = ContactPointFactory(organization=org, role="creator")
+        strip(unreachable, name="", email=None, contact_form=None)
+        dataset = DatasetFactory(organization=org, contact_points=[unreachable])
+
+        migrate()
+
+        assert contact_points_of(dataset) == []
+        assert ContactPoint.objects.count() == 0
+
+    def test_a_dataservice_is_cleaned_too(self):
+        org = OrganizationFactory()
+        unreachable = ContactPointFactory(organization=org, role="creator")
+        strip(unreachable, name="", email=None, contact_form=None)
+        dataservice = DataserviceFactory(organization=org, contact_points=[unreachable])
+
+        migrate()
+
+        assert contact_points_of(dataservice) == []
+
+    def test_the_other_contact_points_of_a_dataset_are_kept(self):
+        org = OrganizationFactory()
+        unreachable = ContactPointFactory(organization=org, role="creator")
+        strip(unreachable, name="", email=None, contact_form=None)
+        kept = ContactPointFactory(organization=org, role="contact")
+        dataset = DatasetFactory(organization=org, contact_points=[unreachable, kept])
+
+        migrate()
+
+        assert contact_points_of(dataset) == [kept]
+
+    def test_a_nameless_contact_point_with_an_email_is_kept(self):
+        """It has no name but it can still be reached, and the front falls back to the email."""
+        org = OrganizationFactory()
+        contact_point = ContactPointFactory(organization=org, role="creator")
+        strip(contact_point, name="", contact_form=None)
+        dataset = DatasetFactory(organization=org, contact_points=[contact_point])
+
+        migrate()
+
+        assert contact_points_of(dataset) == [contact_point]
+        contact_point.reload()
+        assert contact_point.name is None
+
+    def test_a_named_contact_point_is_left_alone(self):
+        org = OrganizationFactory()
+        contact_point = ContactPointFactory(organization=org, role="contact")
+        dataset = DatasetFactory(organization=org, contact_points=[contact_point])
+        name = contact_point.name
+
+        migrate()
+
+        assert contact_points_of(dataset) == [contact_point]
+        contact_point.reload()
+        assert contact_point.name == name

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -286,7 +286,7 @@ class ContactFromRdfTest(PytestOnlyDBTestCase):
 
         # Expected name can be a mix of user and org info...
         expected_name = (
-            f"{user_name} ({org_name})" if user_name and org_name else user_name or org_name or ""
+            f"{user_name} ({org_name})" if user_name and org_name else user_name or org_name
         )
         # ...but other info can't be mixed, so it's either all user or all org
         if user_info:
@@ -360,7 +360,7 @@ class ContactFromRdfTest(PytestOnlyDBTestCase):
 
         # All expected info can come from either user or org, via member/memberOf
         expected_name = (
-            f"{user_name} ({org_name})" if user_name and org_name else user_name or org_name or ""
+            f"{user_name} ({org_name})" if user_name and org_name else user_name or org_name
         )
         expected_email = user_email or org_email
 

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -479,6 +479,20 @@ class ContactFromRdfTest(PytestOnlyDBTestCase):
 
     @pytest.mark.parametrize(
         "property",
+        [VCARD.hasEmail, VCARD.email],
+        ids=lambda u: vocabulary_key(u, VCARD),
+    )
+    def test_contact_point_from_vcard_email_announced_but_missing(self, property):
+        g = Graph()
+        contact = BNode()
+        g.add((contact, property, Literal("mailto:")))
+
+        _, email, _ = contact_point_from_vcard(RdfResource(g, contact))
+
+        assert email is None
+
+    @pytest.mark.parametrize(
+        "property",
         [VCARD.hasURL, VCARD.url, VCARD.hasUrl],
         ids=lambda u: vocabulary_key(u, VCARD),
     )
@@ -542,6 +556,17 @@ class ContactFromRdfTest(PytestOnlyDBTestCase):
         _, email, _ = contact_point_from_foaf(RdfResource(g, contact))
 
         assert email == expected_email
+
+    def test_contact_point_from_foaf_email_announced_but_missing(self):
+        g = Graph()
+        contact = BNode()
+        g.add((contact, FOAF.name, Literal("foo")))
+        g.add((contact, FOAF.mbox, Literal("mailto:")))
+
+        name, email, _ = contact_point_from_foaf(RdfResource(g, contact))
+
+        assert name == "foo"
+        assert email is None
 
     def test_contact_point_from_foaf_org_missing(self):
         expected_name = "foo"

--- a/udata/tests/test_rdf.py
+++ b/udata/tests/test_rdf.py
@@ -118,6 +118,17 @@ class ContactToRdfTest:
             # Default predicate is "contact"
             assert predicate == DCAT.contactPoint
 
+    @pytest.mark.parametrize("role", ["contact", "creator"], ids=["vcard", "foaf"])
+    def test_contact_points_to_rdf_without_a_name(self, role):
+        contact = ContactPoint(email="hello@its.me", role=role)
+
+        contact_rdfs = contact_points_to_rdf([contact], None)
+
+        for contact_point, _predicate in contact_rdfs:
+            assert contact_point.value(VCARD.fn) is None
+            assert contact_point.value(FOAF.name) is None
+            assert contact_point.value(VCARD.hasEmail) or contact_point.value(FOAF.mbox)
+
     @pytest.mark.parametrize("role,predicate", AGENT_ROLE_TO_RDF_PREDICATE.items())
     def test_contact_points_to_rdf_roles(self, role, predicate):
         contact = ContactPoint(


### PR DESCRIPTION
`ContactPoint.name` was `required=True`, but mongoengine only rejects `None`: an empty
string goes through (`mongoengine/base/document.py:415-431`). Harvesting created those,
`contact_point_name` falling back to `""` when neither the agent nor its organization
had a name.

In production 294 contact points have an empty name, and none has a null one. 190 of
them still carry an email or a contact form, so they can be reached and the front
already falls back to those (`ContactPoint.vue`, `ContactPointSelect.vue`): making the
name optional keeps them working as they are. The 104 others hold nothing but a role,
and the 563 datasets referencing them show an empty contact line, so the migration
detaches and deletes them.

A contact point now requires a name, an email or a contact form, whatever its role.
#3862 stopped harvesting from creating the empty ones on August 12th, this covers the
other write paths.

Needs `name: string | null` in the contact point type on the cdata side.