### PR TITLE
fix: handle HEAD requests on the OAuth authorize endpoint

### DIFF
--- a/udata/api/oauth2.py
+++ b/udata/api/oauth2.py
@@ -334,21 +334,7 @@ def client_info(*args, **kwargs):
 @blueprint.route("/authorize", methods=["GET", "POST"])
 @login_required
 def authorize(*args, **kwargs):
-    if request.method == "GET":
-        try:
-            grant = oauth.get_consent_grant(end_user=current_user)
-        except OAuth2Error as error:
-            return error.error
-        # Bypass authorization screen for internal clients
-        # It's not used right now…
-        if grant.client.internal:
-            return oauth.create_authorization_response(grant_user=current_user)
-
-        if wants_json():
-            return jsonify({"client": {"name": grant.client.name}, "scopes": ["default"]})
-
-        return render_template("api/oauth_authorize.html", grant=grant)
-    elif request.method == "POST":
+    if request.method == "POST":
         accept = "accept" in request.form
         decline = "decline" in request.form
         if accept and not decline:
@@ -356,6 +342,23 @@ def authorize(*args, **kwargs):
         else:
             grant_user = None
         return oauth.create_authorization_response(grant_user=grant_user)
+
+    # GET, and HEAD which Flask routes here too since it always adds HEAD
+    # alongside GET. RFC 9110 §9.3.2 requires HEAD to behave like GET, minus
+    # the response body, which Werkzeug strips for us.
+    try:
+        grant = oauth.get_consent_grant(end_user=current_user)
+    except OAuth2Error as error:
+        return error.error
+    # Bypass authorization screen for internal clients
+    # It's not used right now…
+    if grant.client.internal:
+        return oauth.create_authorization_response(grant_user=current_user)
+
+    if wants_json():
+        return jsonify({"client": {"name": grant.client.name}, "scopes": ["default"]})
+
+    return render_template("api/oauth_authorize.html", grant=grant)
 
 
 @blueprint.route("/error")

--- a/udata/tests/api/test_auth_api.py
+++ b/udata/tests/api/test_auth_api.py
@@ -193,6 +193,24 @@ class APIAuthTest(PytestOnlyAPITestCase):
         assert200(response)
         assert response.json == {"success": True}
 
+    def test_authorization_head(self, oauth):
+        """Should answer HEAD requests, which Flask routes alongside GET"""
+        self.login()
+
+        response = self.client.head(
+            url_for(
+                "oauth.authorize",
+                response_type="code",
+                client_id=oauth.client_id,
+                redirect_uri=oauth.default_redirect_uri,
+                code_challenge=create_s256_code_challenge(generate_token(48)),
+                code_challenge_method="S256",
+            )
+        )
+
+        assert200(response)
+        assert response.data == b""
+
     def test_authorization_decline(self, oauth):
         """Should redirect to the redirect_uri on authorization denied"""
         self.login()


### PR DESCRIPTION
[TypeError](https://errors.data.gouv.fr/organizations/sentry/issues/300275/?referrer=alert_email&alert_type=email&alert_timestamp=1787354156400&alert_rule_id=10&notification_uuid=16deb27f-17c4-40e5-941f-a0196c8e0b70&environment=data.gouv.fr) oauth.authorize
> The view function for 'oauth.authorize' did not return a valid response. The function either returned None or ended without a return statement.