### PR TITLE
chore: support Flask-Caching 2.5.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,7 @@ Key settings for local development:
 - `SERVER_NAME = 'localhost:7000'`
 - `URLS_ALLOW_LOCAL = True`
 - `URLS_ALLOW_PRIVATE = True`
-- `CACHE_TYPE = 'null'`
+- `CACHE_TYPE = 'flask_caching.backends.NullCache'`
 - `FS_ROOT`: Path to file storage directory
 - `HARVESTER_BACKENDS`: List of enabled harvester backends
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -382,9 +382,9 @@ You can see the full options list in
 
 ### CACHE_TYPE
 
-**default**: `'flask_caching.backends.redis'`
+**default**: `'flask_caching.backends.RedisCache'`
 
-The cache type, which can be adjusted to your needs (_ex:_ `null`, `flask_caching.backends.memcached`)
+The cache type, which can be adjusted to your needs (_ex:_ `null`, `flask_caching.backends.MemcachedCache`)
 
 ### CACHE_KEY_PREFIX
 

--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -384,7 +384,7 @@ You can see the full options list in
 
 **default**: `'flask_caching.backends.RedisCache'`
 
-The cache type, which can be adjusted to your needs (_ex:_ `null`, `flask_caching.backends.MemcachedCache`)
+The cache type, which can be adjusted to your needs (_ex:_ `flask_caching.backends.NullCache`, `flask_caching.backends.MemcachedCache`)
 
 ### CACHE_KEY_PREFIX
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,7 +113,7 @@ DEBUG = True
 SEND_MAIL = False
 SERVER_NAME = 'dev.local:7000'
 CDATA_BASE_URL = 'http://dev.local:3000'
-CACHE_TYPE = 'flask_caching.backends.null'
+CACHE_TYPE = 'flask_caching.backends.NullCache'
 
 URLS_ALLOW_PRIVATE = True
 URLS_ALLOW_LOCAL = True

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -373,7 +373,7 @@ CELERY_RESULT_BACKEND = 'redis://localhost:6379'
 CELERY_TASK_RESULT_EXPIRES = 86400
 
 # We use Redis as caching backend but in a separate collection
-CACHE_TYPE = 'flask_caching.backends.redis'
+CACHE_TYPE = 'flask_caching.backends.RedisCache'
 CACHE_REDIS_URL = 'redis://localhost:6379/2'
 
 # The identity used to send mails

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -65,7 +65,7 @@ class Defaults(object):
     CELERY_TASK_ROUTES = "udata.tasks.router"
 
     CACHE_KEY_PREFIX = "udata-cache"
-    CACHE_TYPE = "flask_caching.backends.redis"
+    CACHE_TYPE = "flask_caching.backends.RedisCache"
 
     # Flask mail settings
 
@@ -707,7 +707,7 @@ class Testing(object):
     CELERY_TASK_EAGER_PROPAGATES = True
     TEST_WITH_PLUGINS = False
     HARVESTER_BACKENDS = ["factory"]
-    CACHE_TYPE = "flask_caching.backends.null"
+    CACHE_TYPE = "flask_caching.backends.NullCache"
     CACHE_NO_NULL_WARNING = True
     DEBUG_TOOLBAR = False
     SERVER_NAME = "local.test"
@@ -749,5 +749,5 @@ class Debug(Defaults):
         "flask_debugtoolbar.panels.logger.LoggingPanel",
         "flask_debugtoolbar.panels.profiler.ProfilerDebugPanel",
     )
-    CACHE_TYPE = "flask_caching.backends.null"
+    CACHE_TYPE = "flask_caching.backends.NullCache"
     CACHE_NO_NULL_WARNING = True

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -3175,8 +3175,16 @@ class DatasetSchemasAPITest(PytestOnlyAPITestCase):
     @pytest.mark.options(SCHEMA_CATALOG_URL="https://example.com/schemas")
     def test_dataset_schemas_api_list_error_w_cache(self, rmock, mocker):
         cache_mock_set = mocker.patch.object(cache, "set")
+        # Only serve the inner long-term cache key, so the outer @memoize layer
+        # does not short-circuit and the fallback logic is actually exercised.
         mocker.patch.object(
-            cache, "get", return_value=ResourceSchemaMockData.get_mock_data()["schemas"]
+            cache,
+            "get",
+            side_effect=lambda key: (
+                ResourceSchemaMockData.get_mock_data()["schemas"]
+                if key == "schema-catalog-objects"
+                else None
+            ),
         )
 
         # Fill cache

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -933,7 +933,7 @@ class ResourceSchemaTest(PytestOnlyDBTestCase):
 
         # fill cache
         rmock.get("https://example.com/schemas", json=ResourceSchemaMockData.get_mock_data())
-        ResourceSchema.all()
+        ResourceSchema.all.uncached()
         assert cache_mock_set.called
 
         mocker.patch.object(
@@ -942,7 +942,7 @@ class ResourceSchemaTest(PytestOnlyDBTestCase):
         rmock.get("https://example.com/schemas", status_code=500)
         assert (
             ResourceSchemaMockData.get_all_schemas_from_mock_data(with_datapackage_info=False)
-            == ResourceSchema.all()
+            == ResourceSchema.all.uncached()
         )
         assert rmock.call_count == 2
 

--- a/uv.lock
+++ b/uv.lock
@@ -228,11 +228,11 @@ wheels = [
 
 [[package]]
 name = "cachelib"
-version = "0.14.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/a5/5eb041dbee71766704d44cf5dfb6950ab018be0fd02cd763ade09869e33c/cachelib-0.14.0.tar.gz", hash = "sha256:73fedcadd0ba818fb2bb9f3c7cd5fcc2a71e86286f1842f55f28d500faee17f1", size = 170320, upload-time = "2026-05-09T16:16:02.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/f4/b20875916b83f68775093554ce2544b12255396ba69abd93d8903cce0feb/cachelib-0.17.0.tar.gz", hash = "sha256:f3c7dc8d3c1132ab699681ffdf8a52d341d9425ac1401c538cf0b1d87b1677c8", size = 135529, upload-time = "2026-08-24T00:40:51.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0e/5493f2078dece836979f4e28e3b2066064a6d66691d4b0888efc7c62f702/cachelib-0.14.0-py3-none-any.whl", hash = "sha256:4671000b032baa8fac47ad19850f4f522785cee764b4e04c5cfe8955a18d67de", size = 22746, upload-time = "2026-05-09T16:16:01.68Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/9110494f2816d3f2907ac9a0a0a5387f34bc4fa9755721ad09f0a2c99e9b/cachelib-0.17.0-py3-none-any.whl", hash = "sha256:f83909b6f78741c3a5d76d292d13bf24964ffb13e00ea1d18f92e20599766ce0", size = 28221, upload-time = "2026-08-24T00:40:50.237Z" },
 ]
 
 [[package]]
@@ -733,15 +733,15 @@ wheels = [
 
 [[package]]
 name = "flask-caching"
-version = "2.4.1"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib" },
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/15/d2852e86419c6c1416cba00c177b2cf609b5c2935372933684f84111c631/flask_caching-2.4.1.tar.gz", hash = "sha256:ecef4ca80b9cb1fa01d461373a0fce441527cd57eecee1aa71c1f6d750d7ff77", size = 165380, upload-time = "2026-07-08T19:23:57.264Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/ce/a54552acb28bd0ac617703780e8f2344a4e5aee7a46936328fe7cf5b3a95/flask_caching-2.5.0.tar.gz", hash = "sha256:5a8779b54695f96e1b4a7a149dd8c6d863433ea66327cde4311ce7fd7b57391f", size = 218694, upload-time = "2026-08-24T18:52:01.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/e3/ad7572c7f00b1286f2fc2a387f01b62bb46b59c5f91536093eae57889adb/flask_caching-2.4.1-py3-none-any.whl", hash = "sha256:5f5555d610ec1f230c8200ae00c1c723ee562f657c22f896b806f4689513b952", size = 28977, upload-time = "2026-07-08T19:23:55.68Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/51/ce7bc1eb0787acef0fecd6dae3f9f45cf46da5c5a51da79efa1e0eb2724c/flask_caching-2.5.0-py3-none-any.whl", hash = "sha256:8e625acd99759171a428ceb9b669ba6743c11dd9b37ace4e0ea7a3ee34097ccd", size = 34976, upload-time = "2026-08-24T18:52:00.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support for lowercase `CACHE_TYPE` config has been dropped in flask-caching==2.5.0 (included in our pyproject constraints), it makes the entire application crash.
Pin 2.5.0 in uv.lock.
Use the backend class name, ie `CACHE_TYPE = "flask_caching.backends.RedisCache"`.

```
 - cachelib==0.14.0
 + cachelib==0.17.0
 - flask-caching==2.4.1
 + flask-caching==2.5.0
 ```