### PR TITLE
fix: fix dangling orgs refs

### DIFF
--- a/udata/api/fields.py
+++ b/udata/api/fields.py
@@ -19,7 +19,7 @@ from flask_restx.fields import Integer as Integer
 from flask_restx.fields import List as List
 from flask_restx.fields import MarshallingError as MarshallingError
 from flask_restx.fields import MinMaxMixin as MinMaxMixin
-from flask_restx.fields import Nested as Nested
+from flask_restx.fields import Nested as RestxNested
 from flask_restx.fields import NumberMixin as NumberMixin
 from flask_restx.fields import Polymorph as Polymorph
 from flask_restx.fields import Raw as Raw
@@ -27,10 +27,32 @@ from flask_restx.fields import String as String
 from flask_restx.fields import StringMixin as StringMixin
 from flask_restx.fields import Url as Url
 from flask_restx.fields import Wildcard as Wildcard
+from mongoengine.errors import DoesNotExist
 
 from udata.utils import multi_to_dict
 
 log = logging.getLogger(__name__)
+
+
+class Nested(RestxNested):
+    """Like flask-restx Nested, but missing DB references serialize as null.
+
+    Accessing a MongoEngine ``ReferenceField`` whose target was deleted raises
+    ``DoesNotExist``. Without this, a single dangling org/user ref turns a list
+    endpoint into a 500.
+    """
+
+    def output(self, key, obj, ordered=False, **kwargs):
+        try:
+            return super().output(key, obj, ordered=ordered, **kwargs)
+        except DoesNotExist:
+            log.warning(
+                "Missing referenced document while marshalling %s.%s",
+                type(obj).__name__,
+                key,
+            )
+            return None
+
 
 # Extract Flask's url_for() reserved arguments dynamically to filter from user-provided query params
 URL_FOR_RESERVED_ARGS = {

--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -367,7 +367,8 @@ def convert_db_to_field(key, field, info) -> tuple[Callable | None, Callable | N
         else:
 
             def constructor_read(**kwargs):
-                return restx_fields.Nested(nested_fields, **kwargs)
+                # udata Nested: dangling refs → null (DATAGOUV-36F0)
+                return custom_restx_fields.Nested(nested_fields, **kwargs)
 
         write_params["description"] = "ID of the reference"
         constructor_write = restx_fields.String

--- a/udata/core/discussions/permissions.py
+++ b/udata/core/discussions/permissions.py
@@ -1,3 +1,5 @@
+from mongoengine.errors import DoesNotExist
+
 from udata.auth import Permission, UserNeed
 from udata.core.dataset.permissions import OwnablePermission
 from udata.core.organization.permissions import (
@@ -19,9 +21,14 @@ class DiscussionAuthorPermission(Permission):
     def __init__(self, discussion: Discussion):
         needs = []
 
-        if discussion.organization:
-            needs.append(OrganizationAdminNeed(discussion.organization.id))
-            needs.append(OrganizationEditorNeed(discussion.organization.id))
+        try:
+            organization = discussion.organization
+        except DoesNotExist:
+            organization = None
+
+        if organization:
+            needs.append(OrganizationAdminNeed(organization.id))
+            needs.append(OrganizationEditorNeed(organization.id))
         else:
             needs.append(UserNeed(discussion.user.fs_uniquifier))
 
@@ -32,9 +39,14 @@ class DiscussionMessagePermission(Permission):
     def __init__(self, message: Message):
         needs = []
 
-        if message.posted_by_organization:
-            needs.append(OrganizationAdminNeed(message.posted_by_organization.id))
-            needs.append(OrganizationEditorNeed(message.posted_by_organization.id))
+        try:
+            organization = message.posted_by_organization
+        except DoesNotExist:
+            organization = None
+
+        if organization:
+            needs.append(OrganizationAdminNeed(organization.id))
+            needs.append(OrganizationEditorNeed(organization.id))
         else:
             needs.append(UserNeed(message.posted_by.fs_uniquifier))
 

--- a/udata/tests/api/test_fields.py
+++ b/udata/tests/api/test_fields.py
@@ -1,6 +1,9 @@
 from datetime import UTC, date, datetime
 
-from udata.api.fields import ISODateTime
+from flask_restx import marshal
+from mongoengine.errors import DoesNotExist
+
+from udata.api.fields import ISODateTime, Nested, String
 from udata.core.dataset.factories import DatasetFactory
 
 from . import APITestCase
@@ -46,3 +49,14 @@ class FieldTest(APITestCase):
 
         result = ISODateTime().format(date_date)
         self.assertEqual(result, date_date.isoformat())
+
+
+class NestedMissingRefTest:
+    def test_missing_reference_serializes_as_null(self):
+        class MissingOrg:
+            @property
+            def organization(self):
+                raise DoesNotExist("gone")
+
+        model = {"organization": Nested({"id": String()}, allow_null=True)}
+        assert marshal(MissingOrg(), model) == {"organization": None}

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -944,10 +944,9 @@ class DiscussionsTest(APITestCase):
     def test_get_discussion_with_deleted_organization(self):
         """A deleted org ref must not 500 on discussion read or list.
 
-        DATAGOUV-36F0: GET /api/1/discussions/?sort=-created&page=10 with
-        X-Fields data{created,subject,discussion},next_page raised
-        DoesNotExist while dereferencing a missing Organization DBRef on
-        Message.posted_by_organization.
+        Sentry DATAGOUV-36F0: GET /api/1/discussions/<id>/ (and the list
+        endpoint) raised DoesNotExist when Message.posted_by_organization
+        pointed at a missing Organization.
         """
         dataset = DatasetFactory()
         user = UserFactory()

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -941,6 +941,52 @@ class DiscussionsTest(APITestCase):
         self.assertEqual(data["url"], discussion.self_api_url())
         self.assertEqual(data["self_web_url"], discussion.self_web_url())
 
+    def test_get_discussion_with_deleted_organization(self):
+        """A deleted org ref must not 500 on discussion read or list.
+
+        Production: GET /api/1/discussions/?sort=-created&page=10 returned 500
+        because one thread still pointed at a removed organization.
+        """
+        dataset = DatasetFactory()
+        user = UserFactory()
+        org = OrganizationFactory()
+        message = Message(
+            content="hello",
+            posted_by=user,
+            posted_by_organization=org,
+        )
+        discussion = Discussion.objects.create(
+            subject=dataset,
+            user=user,
+            organization=org,
+            title="Avancement du projet",
+            discussion=[message],
+        )
+        org.delete()
+        discussion.reload()
+
+        response = self.get(url_for("api.discussion", id=discussion.id))
+        self.assert200(response)
+        data = response.json
+        self.assertIsNone(data["organization"])
+        self.assertEqual(data["user"]["id"], str(user.id))
+        self.assertEqual(data["title"], "Avancement du projet")
+        self.assertIsNone(data["discussion"][0]["posted_by_organization"])
+        self.assertEqual(data["discussion"][0]["posted_by"]["id"], str(user.id))
+        self.assertEqual(data["permissions"]["delete"], False)
+        self.assertEqual(data["permissions"]["edit"], False)
+        self.assertEqual(data["discussion"][0]["permissions"]["delete"], False)
+
+        response = self.get(
+            url_for("api.discussions", sort="-created"),
+            headers={"X-Fields": "data{created,subject,discussion},next_page"},
+        )
+        self.assert200(response)
+        self.assertEqual(len(response.json["data"]), 1)
+        listed = response.json["data"][0]
+        self.assertEqual(listed["subject"]["id"], str(dataset.id))
+        self.assertIsNone(listed["discussion"][0]["posted_by_organization"])
+
     @pytest.mark.options(SPAM_WORDS=["spam"])
     def test_add_comment_to_discussion(self):
         dataset = Dataset.objects.create(title="Test dataset")

--- a/udata/tests/test_discussions.py
+++ b/udata/tests/test_discussions.py
@@ -944,8 +944,10 @@ class DiscussionsTest(APITestCase):
     def test_get_discussion_with_deleted_organization(self):
         """A deleted org ref must not 500 on discussion read or list.
 
-        Production: GET /api/1/discussions/?sort=-created&page=10 returned 500
-        because one thread still pointed at a removed organization.
+        DATAGOUV-36F0: GET /api/1/discussions/?sort=-created&page=10 with
+        X-Fields data{created,subject,discussion},next_page raised
+        DoesNotExist while dereferencing a missing Organization DBRef on
+        Message.posted_by_organization.
         """
         dataset = DatasetFactory()
         user = UserFactory()
@@ -963,7 +965,6 @@ class DiscussionsTest(APITestCase):
             discussion=[message],
         )
         org.delete()
-        discussion.reload()
 
         response = self.get(url_for("api.discussion", id=discussion.id))
         self.assert200(response)


### PR DESCRIPTION
Fix [this Sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/301053/?project=12):

If a discussion still points to an organization that was deleted, listing discussions crashed with a 500.
The API now returns null for that missing organization instead of failing the whole page.

[Problem discovered and discussed here](https://matrix.to/#/!FMXpGlfBgjvMumrnPQ:agent.dinum.tchap.gouv.fr/$1nKzs1nHV27p2dB7Ju6_4d9Qe1_01OPFn1kx-0PsclU?via=agent.dinum.tchap.gouv.fr).
