### PR TITLE
fix(discussion): fix integrity on organization reference

### DIFF
--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 from bson import ObjectId
-from flask import current_app, url_for
+from flask import current_app, g, url_for
 from flask_login import current_user
 from flask_restx.inputs import boolean
 from mongoengine import EmbeddedDocument
@@ -366,7 +366,7 @@ class Discussion(SpamMixin, Linkable, Document):
         from udata.core.dataset.permissions import OwnablePermission
         from udata.core.owned import Owned
 
-        if not current_user or not current_user.is_authenticated:
+        if not current_user or not current_user.is_authenticated or not hasattr(g, "identity"):
             return False
 
         if not isinstance(self.subject, Owned):

--- a/udata/core/organization/tasks.py
+++ b/udata/core/organization/tasks.py
@@ -1,7 +1,7 @@
 from udata.core import storages
 from udata.core.badges.tasks import notify_new_badge
 from udata.features.notifications.models import Notification
-from udata.models import Activity, ContactPoint, Dataset, Follow, Transfer
+from udata.models import Activity, ContactPoint, Dataset, Discussion, Follow, Transfer
 from udata.search import reindex
 from udata.tasks import get_logger, job, task
 
@@ -24,6 +24,19 @@ def purge_organizations(self):
         log.info(f"Purging organization {organization}")
         # Remove followers
         Follow.objects(following=organization).delete()
+        # Remove discussions references
+        Discussion.objects(organization=organization).delete()
+        # Clear references to the organization in remaining discussions
+        for discussion in Discussion.objects(
+            discussion__posted_by_organization=organization
+        ).no_cache():
+            for message in discussion.discussion:
+                if message.posted_by_organization == organization:
+                    message.posted_by_organization = None
+            discussion.save()
+        for discussion in Discussion.objects(closed_by_organization=organization).no_cache():
+            discussion.closed_by_organization = None
+            discussion.save()
         # Remove activity
         Activity.objects(related_to=organization).delete()
         Activity.objects(organization=organization).delete()

--- a/udata/migrations/2026-09-02-discussion-integrity.py
+++ b/udata/migrations/2026-09-02-discussion-integrity.py
@@ -1,0 +1,55 @@
+"""
+Remove Discussion integrity problems
+"""
+
+import logging
+
+import mongoengine
+
+from udata.models import Discussion
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info("Processing Discussion references.")
+
+    # Delete discussions for orgs with reference errors
+    discussion_count = 0
+    discussions = Discussion.objects(organization__ne=None).no_cache().all()
+    for discussion in discussions:
+        try:
+            discussion.organization.id
+        except mongoengine.errors.DoesNotExist:
+            discussion_count += 1
+            discussion.delete()
+
+    # Unset posted_by_organization in messages for orgs with reference errors
+    message_count = 0
+    discussions = Discussion.objects(discussion__posted_by_organization__ne=None).no_cache().all()
+    for discussion in discussions:
+        modified = False
+        for message in discussion.discussion:
+            try:
+                message.posted_by_organization.id
+            except mongoengine.errors.DoesNotExist:
+                message_count += 1
+                message.posted_by_organization = None
+                modified = True
+        if modified:
+            discussion.save()
+
+    # Unset closed_by_organization for orgs with reference errors
+    closed_count = 0
+    discussions = Discussion.objects(closed_by_organization__ne=None).no_cache().all()
+    for discussion in discussions:
+        try:
+            discussion.closed_by_organization.id
+        except mongoengine.errors.DoesNotExist:
+            closed_count += 1
+            discussion.closed_by_organization = None
+            discussion.save()
+
+    log.info(f"Deleted {discussion_count} Discussion objects")
+    log.info(f"Unset {message_count} posted_by_organization in Discussion messages")
+    log.info(f"Unset {closed_count} closed_by_organization in Discussion objects")

--- a/udata/migrations/2026-09-02-discussion-integrity.py
+++ b/udata/migrations/2026-09-02-discussion-integrity.py
@@ -26,12 +26,17 @@ def migrate(db):
 
     # Unset posted_by_organization in messages for orgs with reference errors
     message_count = 0
-    discussions = Discussion.objects(discussion__posted_by_organization__ne=None).no_cache().all()
+    # `$elemMatch` and not `discussion__posted_by_organization__ne`: on a path through an array,
+    # `$ne` only matches threads where *every* message has an organization, which leaves out the
+    # common shape of a thread mixing messages posted on behalf of an organization and plain ones.
+    discussions = (
+        Discussion.objects(discussion__match={"posted_by_organization__ne": None}).no_cache().all()
+    )
     for discussion in discussions:
         modified = False
         for message in discussion.discussion:
             try:
-                message.posted_by_organization.id
+                message.posted_by_organization and message.posted_by_organization.id
             except mongoengine.errors.DoesNotExist:
                 message_count += 1
                 message.posted_by_organization = None

--- a/udata/tests/organization/test_organization_tasks.py
+++ b/udata/tests/organization/test_organization_tasks.py
@@ -3,9 +3,10 @@ from flask import url_for
 from udata.api.oauth2 import OAuth2Client
 from udata.core import storages
 from udata.core.dataset.factories import DatasetFactory, ResourceFactory
+from udata.core.discussions.factories import DiscussionFactory, MessageDiscussionFactory
 from udata.core.organization import tasks
 from udata.core.user.factories import AdminFactory
-from udata.models import ContactPoint, Dataset, Member, Organization, Transfer
+from udata.models import ContactPoint, Dataset, Discussion, Member, Organization, Transfer
 from udata.tests.api import APITestCase
 from udata.tests.helpers import create_test_image
 
@@ -58,6 +59,17 @@ class OrganizationTasksTest(APITestCase):
             redirect_uris=["https://test.org/callback"],
         )
 
+        discussion = DiscussionFactory(subject=dataset, organization=org)
+        discussion_with_message = DiscussionFactory(
+            subject=dataset,
+            discussion=[
+                MessageDiscussionFactory(),
+                MessageDiscussionFactory(posted_by_organization=org),
+                MessageDiscussionFactory(posted_by_organization=org),
+            ],
+        )
+        discussion_closed_by_org = DiscussionFactory(subject=dataset, closed_by_organization=org)
+
         # Delete organization
         response = self.delete(url_for("api.organization", org=org))
         self.assert204(response)
@@ -78,6 +90,17 @@ class OrganizationTasksTest(APITestCase):
 
         dataset = Dataset.objects(id=dataset.id).first()
         self.assertIsNone(dataset.organization)
+
+        discussion = Discussion.objects(id=discussion.id).first()
+        self.assertIsNone(discussion)
+
+        discussion_with_message.reload()
+        self.assertEqual(len(discussion_with_message.discussion), 3)
+        self.assertIsNone(discussion_with_message.discussion[1].posted_by_organization)
+        self.assertIsNone(discussion_with_message.discussion[2].posted_by_organization)
+
+        discussion_closed_by_org.reload()
+        self.assertIsNone(discussion_closed_by_org.closed_by_organization)
 
         organization = Organization.objects(name="delete me").first()
         self.assertIsNone(organization)

--- a/udata/tests/test_discussion_integrity_migration.py
+++ b/udata/tests/test_discussion_integrity_migration.py
@@ -1,0 +1,103 @@
+from mongoengine.connection import get_db
+
+from udata.core.discussions.factories import DiscussionFactory, MessageDiscussionFactory
+from udata.core.discussions.models import Discussion
+from udata.core.organization.factories import OrganizationFactory
+from udata.db import migrations
+from udata.tests.api import PytestOnlyDBTestCase
+
+MIGRATION = "2026-09-02-discussion-integrity.py"
+
+
+def migrate():
+    migrations.get(MIGRATION).migrate(get_db())
+
+
+def reloaded(discussion):
+    """Reload the discussion, dereferencing organizations as the API does.
+
+    A dangling reference raises `DoesNotExist` on access, which is the 500 this migration
+    exists to make impossible.
+    """
+    return Discussion.objects.get(id=discussion.id)
+
+
+class DiscussionOrganizationTest(PytestOnlyDBTestCase):
+    def test_discussion_opened_on_behalf_of_a_deleted_organization_is_removed(self):
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(organization=org)
+        org.delete()
+
+        migrate()
+
+        assert Discussion.objects(id=discussion.id).first() is None
+
+    def test_discussion_of_a_live_organization_is_left_alone(self):
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(organization=org)
+
+        migrate()
+
+        assert reloaded(discussion).organization == org
+
+
+class MessagePostedByOrganizationTest(PytestOnlyDBTestCase):
+    def test_message_posted_on_behalf_of_a_deleted_organization_is_unset(self):
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(
+            discussion=[MessageDiscussionFactory(posted_by_organization=org)]
+        )
+        org.delete()
+
+        migrate()
+
+        assert reloaded(discussion).discussion[0].posted_by_organization is None
+
+    def test_thread_mixing_plain_and_on_behalf_messages_is_cleaned_too(self):
+        """The common shape: someone opens a thread, an organization member answers."""
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(
+            discussion=[
+                MessageDiscussionFactory(),
+                MessageDiscussionFactory(posted_by_organization=org),
+            ]
+        )
+        org.delete()
+
+        migrate()
+
+        messages = reloaded(discussion).discussion
+        assert messages[0].posted_by_organization is None
+        assert messages[1].posted_by_organization is None
+
+    def test_message_of_a_live_organization_is_left_alone(self):
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(
+            discussion=[
+                MessageDiscussionFactory(),
+                MessageDiscussionFactory(posted_by_organization=org),
+            ]
+        )
+
+        migrate()
+
+        assert reloaded(discussion).discussion[1].posted_by_organization == org
+
+
+class ClosedByOrganizationTest(PytestOnlyDBTestCase):
+    def test_closed_on_behalf_of_a_deleted_organization_is_unset(self):
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(closed_by_organization=org)
+        org.delete()
+
+        migrate()
+
+        assert reloaded(discussion).closed_by_organization is None
+
+    def test_closed_by_a_live_organization_is_left_alone(self):
+        org = OrganizationFactory()
+        discussion = DiscussionFactory(closed_by_organization=org)
+
+        migrate()
+
+        assert reloaded(discussion).closed_by_organization == org


### PR DESCRIPTION
Fix `Trying to dereference unknown document DBRef('organization', ObjectId('6a74a0726dfe7c1502ea806a'))` on a discussion with org reg integrity ([sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/301115/))

1. We add organization ref cleaning in discussions purge task.
2. We apply a migration that remove existing inconsistent discussions or refs. Locally, I have:
```
  │ Processing Discussion references.
  │ Deleted 1 Discussion objects
  │ Unset 0 posted_by_organization in Discussion messages
  │ Unset 0 closed_by_organization in Discussion objects
```

`posted_by` and `closed_by` are always set on top of organization infos and used as fallback after organization reference removal.

Replace https://github.com/opendatateam/udata/pull/3922