### PR TITLE
fix: reject invalid or out-of-bounds image crop boxes instead of 500ing

### DIFF
--- a/udata/core/storages/api.py
+++ b/udata/core/storages/api.py
@@ -176,6 +176,27 @@ def handle_upload(storage, prefix=None):
     return infos
 
 
+def parse_bbox(raw: str, image_size: tuple[int, int]) -> list[int]:
+    """Parse a crop box given by the client as `left,upper,right,lower` pixel coordinates"""
+    coordinates = raw.split(",")
+    if len(coordinates) != 4:
+        api.abort(400, "Invalid bounding box")
+    try:
+        # `float` accepts values that `int` then refuses, such as `nan` or `1e400`.
+        left, upper, right, lower = (int(float(coordinate)) for coordinate in coordinates)
+    except (ValueError, OverflowError):
+        api.abort(400, "Invalid bounding box")
+
+    width, height = image_size
+    # Pillow crops outside of the image instead of failing, padding the result: a box a
+    # few digits wider than the source is enough to allocate hundreds of megabytes, then
+    # to raise a decompression bomb error once past its pixel limit.
+    if not (0 <= left < right <= width and 0 <= upper < lower <= height):
+        api.abort(400, "Bounding box outside of the image")
+
+    return [left, upper, right, lower]
+
+
 def parse_uploaded_image(field):
     """Parse an uploaded image and save into a ImageField()"""
     args = image_parser.parse_args()
@@ -185,21 +206,21 @@ def parse_uploaded_image(field):
     # (an SVG announced as `image/png` for instance): decode the file to know what
     # it really is, otherwise Pillow raises further down and the request 500s.
     try:
-        image_format = Image.open(image).format
+        uploaded = Image.open(image)
     except UnidentifiedImageError:
-        image_format = None
+        api.abort(400, "Unsupported image format")
     except Image.DecompressionBombError:
         # A valid image whose header announces more pixels than Pillow accepts to decode.
         # A few dozen bytes are enough to declare a huge size, so this must be refused
         # here: every other decoding (resize, optimize, thumbnails) would raise too.
         api.abort(400, "Image is too large")
+    if uploaded.format not in IMAGES_FORMATS:
+        api.abort(400, "Unsupported image format")
+
+    bbox = parse_bbox(args["bbox"], uploaded.size) if args["bbox"] else None
+
     # `Image.open` left the cursor right after the header it read. `field.save` may store
     # the stream as-is (flask_storage only rewinds when it resizes or optimizes), which
     # would silently truncate the stored file.
     image.seek(0)
-    if image_format not in IMAGES_FORMATS:
-        api.abort(400, "Unsupported image format")
-    bbox = args.get("bbox", None)
-    if bbox:
-        bbox = [int(float(c)) for c in bbox.split(",")]
     field.save(image, bbox=bbox)

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -78,6 +78,33 @@ class MeAPITest(APITestCase):
         user.reload()
         self.assertEqual(user.avatar.bbox, [10, 10, 40, 40])
 
+    def test_my_avatar_upload_rejects_invalid_bbox(self):
+        """It should reject a bbox that is not four pixel coordinates"""
+        self.login()
+        for bbox in ("1e400,0,1,1", "nan,0,1,1", "a,b,c,d", "10,10,40", "10,10,40,40,40"):
+            with self.subTest(bbox=bbox):
+                response = self.post(
+                    url_for("api.my_avatar"),
+                    {"file": (create_test_image(), "test.png"), "bbox": bbox},
+                    json=False,
+                )
+                self.assert400(response)
+
+    def test_my_avatar_upload_rejects_bbox_outside_of_the_image(self):
+        """It should reject a bbox that does not fit in the uploaded image"""
+        # Pillow pads a crop reaching outside of the image instead of failing: cropping
+        # a 50x50 avatar to 20000x20000 allocates the whole padded surface.
+        self.login()
+        # `create_test_image` is 50x50: an empty and a reversed box are degenerate too.
+        for bbox in ("0,0,20000,20000", "-10,10,40,40", "10,10,10,40", "40,10,10,40"):
+            with self.subTest(bbox=bbox):
+                response = self.post(
+                    url_for("api.my_avatar"),
+                    {"file": (create_test_image(), "test.png"), "bbox": bbox},
+                    json=False,
+                )
+                self.assert400(response)
+
     def test_my_avatar_upload_stores_the_whole_file(self):
         """It should store the complete file, not just what the format check left"""
         # Without optimization and without a max size, flask_storage saves the stream


### PR DESCRIPTION
bbox is not used right now in cdata, only in old front (but we may want to add it back)

Fix https://errors.data.gouv.fr/organizations/sentry/issues/301565

OverflowError  api.visualization_image
Level: Error cannot convert float infinity to integer