### PR TITLE
fix: return a 404 instead of a 500 for an unknown harvest job

### DIFF
--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -43,20 +43,6 @@ def list_sources(owner=None, deleted=False):
     return list(sources)
 
 
-def get_job(ident, *, with_items=True):
-    """Get an harvest job given its ID.
-
-    The heavy `data` blob is never serialized by the read endpoints, so it's
-    always excluded. `with_items=False` additionally drops the embedded items,
-    for routes that expose them only as a counters link and never load or
-    dereference them.
-    """
-    qs = HarvestJob.objects.exclude("data")
-    if not with_items:
-        qs = qs.exclude("items")
-    return qs.get(id=ident)
-
-
 def validate_source(source: HarvestSource, comment=None):
     """Validate a source for automatic harvesting"""
     source.validation.on = datetime.now(UTC)

--- a/udata/harvest/api.py
+++ b/udata/harvest/api.py
@@ -304,24 +304,22 @@ class JobsAPI(API):
         return qs.paginate(args["page"], args["page_size"])
 
 
-@ns.route("/job/<string:ident>/", endpoint="harvest_job")
+@ns.route("/job/<harvest_job_without_items:job>/", endpoint="harvest_job")
 class JobAPI(API):
     @api.doc("get_harvest_job")
     @api.marshal_with(HarvestJob.__read_fields__)
-    def get(self, ident):
+    def get(self, job: HarvestJob):
         """Get a single job given an ID"""
-        # Items are exposed as a counters link only, so don't load them.
-        return actions.get_job(ident, with_items=False)
+        return job
 
 
-@ns.route("/job/<string:ident>/items/", endpoint="harvest_job_items")
+@ns.route("/job/<harvest_job:job>/items/", endpoint="harvest_job_items")
 class JobItemsAPI(API):
     @api.doc("list_harvest_job_items")
     @api.expect(HarvestItem.__index_parser__)
     @api.marshal_with(HarvestItem.__page_fields__)
-    def get(self, ident):
+    def get(self, job: HarvestJob):
         """List the items of a given harvest job (paginated)"""
-        job = actions.get_job(ident)
         args = HarvestItem.__index_parser__.parse_args()
         # Items are embedded documents on the job, so the auto-generated
         # apply_sort_filters (which calls queryset.filter) does not apply here.

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -413,7 +413,7 @@ class HarvestJob(Document):
     items = field(
         ListField(EmbeddedDocumentField(HarvestItem)),
         readonly=True,
-        href=lambda o: url_for("api.harvest_job_items", ident=o.id),
+        href=lambda o: url_for("api.harvest_job_items", job=o.id),
         href_total=lambda o: o.items_total,
         href_extra=lambda o: {
             "by_status": o.items_by_status,

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -27,7 +27,6 @@ from ..models import (
     VALIDATION_ACCEPTED,
     VALIDATION_REFUSED,
     HarvestError,
-    HarvestItem,
     HarvestJob,
     HarvestSource,
 )
@@ -221,33 +220,6 @@ class HarvestActionsTest(MockBackendsMixin, PytestOnlyDBTestCase):
         # each dataset deletion, but the final count must still be accurate.
         org.reload()
         assert org.metrics["datasets"] == 0
-
-    def test_get_job_by_id(self):
-        job = HarvestJobFactory()
-        assert actions.get_job(str(job.id)) == job
-
-    def test_get_job_by_objectid(self):
-        job = HarvestJobFactory()
-        assert actions.get_job(job.id) == job
-
-    def test_get_job_never_loads_data_blob(self):
-        """The heavy `data` blob is never serialized by the read endpoints, so
-        `get_job` must always exclude it from the query — with or without items —
-        to avoid loading it for nothing (it dominates the document size)."""
-        job = HarvestJobFactory(
-            data={"raw": "a very heavy blob"},
-            items=[HarvestItem(remote_id="1"), HarvestItem(remote_id="2")],
-        )
-
-        with_items = actions.get_job(job.id)
-        without_items = actions.get_job(job.id, with_items=False)
-
-        # Excluded from the projection: the field falls back to its default.
-        assert with_items.data == {}
-        assert without_items.data == {}
-        # `with_items` still loads the items, `with_items=False` drops them too.
-        assert len(with_items.items) == 2
-        assert without_items.items == []
 
     def test_schedule(self):
         source = HarvestSourceFactory()

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -2,7 +2,8 @@ import logging
 from datetime import UTC, datetime
 
 import pytest
-from flask import url_for
+from bson import ObjectId
+from flask import current_app, url_for
 from mongoengine.connection import get_db
 from mongoengine.context_managers import query_counter
 from pytest_mock import MockerFixture
@@ -14,6 +15,7 @@ from udata.core.user.factories import AdminFactory, UserFactory
 from udata.db import migrations
 from udata.harvest.backends import get_enabled_backends
 from udata.models import Member, PeriodicTask
+from udata.routing import HarvestJobConverter, HarvestJobWithoutItemsConverter
 from udata.tests.api import PytestOnlyAPITestCase
 from udata.tests.helpers import (
     argvalues,
@@ -922,6 +924,39 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         source.reload()
         assert source.periodic_task is not None
 
+    def test_get_unknown_job(self):
+        """An unknown job ID is a 404, on the job and on its items subresource.
+
+        Regression test: the raw `DoesNotExist` used to bubble up as a 500.
+        """
+        unknown = str(ObjectId())
+
+        assert404(self.get(url_for("api.harvest_job", job=unknown)))
+        assert404(self.get(url_for("api.harvest_job_items", job=unknown)))
+
+    def test_get_job_with_a_malformed_id(self):
+        """A malformed ID designates no resource either: 404, not a validation error."""
+        assert404(self.get(url_for("api.harvest_job", job="not-an-object-id")))
+        assert404(self.get(url_for("api.harvest_job_items", job="not-an-object-id")))
+
+    def test_job_converters_never_load_the_data_blob(self):
+        """The heavy `data` blob is never serialized by the read endpoints, so both
+        converters exclude it from the query — it dominates the document size."""
+        job = HarvestJobFactory(
+            data={"raw": "a very heavy blob"},
+            items=[HarvestItem(remote_id="1"), HarvestItem(remote_id="2")],
+        )
+
+        with_items = HarvestJobConverter(current_app.url_map).to_python(str(job.id))
+        without_items = HarvestJobWithoutItemsConverter(current_app.url_map).to_python(str(job.id))
+
+        # Excluded from the projection: the field falls back to its default.
+        assert with_items.data == {}
+        assert without_items.data == {}
+        # Only the items subresource route loads them.
+        assert len(with_items.items) == 2
+        assert without_items.items == []
+
     def test_get_job_error_details_hidden_from_non_admin(self):
         """Error `details` (stack traces / internal info) must only be exposed to admins.
 
@@ -932,13 +967,13 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
             errors=[HarvestError(message="oops", details="secret stack trace")],
         )
 
-        response = self.get(url_for("api.harvest_job", ident=str(job.id)))
+        response = self.get(url_for("api.harvest_job", job=job))
         assert200(response)
         assert response.json["errors"][0]["message"] == "oops"
         assert response.json["errors"][0]["details"] is None
 
         self.login(AdminFactory())
-        response = self.get(url_for("api.harvest_job", ident=str(job.id)))
+        response = self.get(url_for("api.harvest_job", job=job))
         assert200(response)
         assert response.json["errors"][0]["details"] == "secret stack trace"
 
@@ -951,7 +986,7 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         source = HarvestSourceFactory()
         job = HarvestJobFactory(source=source)
 
-        response = self.get(url_for("api.harvest_job", ident=str(job.id)))
+        response = self.get(url_for("api.harvest_job", job=job))
         assert200(response)
         assert response.json["source"] == {
             "id": str(source.id),
@@ -967,7 +1002,7 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
                 HarvestItem(dataset=DatasetFactory(), remote_url="https://my.remote.example.com"),
             ],
         )
-        response = self.get(url_for("api.harvest_job", ident=str(job.id)))
+        response = self.get(url_for("api.harvest_job", job=job))
         assert200(response)
         items_link = response.json["items"]
         assert items_link["rel"] == "subsection"
@@ -1053,7 +1088,7 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
             ]
             job = HarvestJobFactory(items=items)
             with query_counter() as counter:
-                response = self.get(url_for("api.harvest_job", ident=str(job.id)))
+                response = self.get(url_for("api.harvest_job", job=job))
                 assert200(response)
                 assert response.json["items"]["total"] == 5
                 assert response.json["items"]["by_type"]["dataset"] == (5 if with_refs else 0)
@@ -1102,7 +1137,7 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
                 HarvestItem(dataset=DatasetFactory(), remote_url="https://my.remote.example.com"),
             ],
         )
-        response = self.get(url_for("api.harvest_job_items", ident=str(job.id)))
+        response = self.get(url_for("api.harvest_job_items", job=job))
         assert200(response)
         assert response.json["total"] == 3
         assert len(response.json["data"]) == 3
@@ -1150,9 +1185,7 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
     def test_list_items_paginated(self):
         """Items endpoint paginates with page/page_size"""
         job = HarvestJobFactory(items=[HarvestItem() for _ in range(5)])
-        response = self.get(
-            url_for("api.harvest_job_items", ident=str(job.id), page=2, page_size=2)
-        )
+        response = self.get(url_for("api.harvest_job_items", job=job, page=2, page_size=2))
         assert200(response)
         assert response.json["total"] == 5
         assert response.json["page"] == 2
@@ -1163,17 +1196,17 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         """Items endpoint exposes next_page/previous_page URLs at the right places"""
         job = HarvestJobFactory(items=[HarvestItem() for _ in range(5)])
 
-        first = self.get(url_for("api.harvest_job_items", ident=str(job.id), page=1, page_size=2))
+        first = self.get(url_for("api.harvest_job_items", job=job, page=1, page_size=2))
         assert200(first)
         assert first.json["previous_page"] is None
         assert "page=2" in first.json["next_page"]
 
-        middle = self.get(url_for("api.harvest_job_items", ident=str(job.id), page=2, page_size=2))
+        middle = self.get(url_for("api.harvest_job_items", job=job, page=2, page_size=2))
         assert200(middle)
         assert "page=1" in middle.json["previous_page"]
         assert "page=3" in middle.json["next_page"]
 
-        last = self.get(url_for("api.harvest_job_items", ident=str(job.id), page=3, page_size=2))
+        last = self.get(url_for("api.harvest_job_items", job=job, page=3, page_size=2))
         assert200(last)
         assert "page=2" in last.json["previous_page"]
         assert last.json["next_page"] is None
@@ -1182,9 +1215,7 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         """Requesting a page beyond the last one returns 404 (Pagination aborts
         when a non-first page holds no item)."""
         job = HarvestJobFactory(items=[HarvestItem() for _ in range(5)])
-        response = self.get(
-            url_for("api.harvest_job_items", ident=str(job.id), page=4, page_size=2)
-        )
+        response = self.get(url_for("api.harvest_job_items", job=job, page=4, page_size=2))
         assert404(response)
 
     def test_list_items_filtered_by_status(self):
@@ -1197,19 +1228,19 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
                 HarvestItem(status="skipped"),
             ],
         )
-        response = self.get(url_for("api.harvest_job_items", ident=str(job.id), status="done"))
+        response = self.get(url_for("api.harvest_job_items", job=job, status="done"))
         assert200(response)
         assert response.json["total"] == 2
         assert {item["status"] for item in response.json["data"]} == {"done"}
 
-        response = self.get(url_for("api.harvest_job_items", ident=str(job.id), status="failed"))
+        response = self.get(url_for("api.harvest_job_items", job=job, status="failed"))
         assert200(response)
         assert response.json["total"] == 1
 
     def test_list_items_filtered_by_unknown_status(self):
         """Status filter rejects unknown values"""
         job = HarvestJobFactory(items=[HarvestItem()])
-        response = self.get(url_for("api.harvest_job_items", ident=str(job.id), status="bogus"))
+        response = self.get(url_for("api.harvest_job_items", job=job, status="bogus"))
         assert400(response)
 
     def test_get_source_permissions_as_anonymous(self):

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -14,7 +14,7 @@ from udata.core.dataservices.models import Dataservice
 from udata.core.spatial.models import GeoZone
 from udata.core.visualizations.models import Chart
 from udata.features.notifications.models import Notification
-from udata.harvest.models import HarvestSource
+from udata.harvest.models import HarvestJob, HarvestSource
 from udata.mongo.slug_fields import SlugField
 from udata.uris import cdata_url, homepage_url
 
@@ -138,6 +138,23 @@ class HarvestSourceConverter(ModelConverter):
     model = HarvestSource
 
 
+class HarvestJobConverter(ModelConverter):
+    model = HarvestJob
+
+    def get_excludes(self):
+        # The heavy `data` blob is never serialized by the read endpoints.
+        return ["data"]
+
+
+class HarvestJobWithoutItemsConverter(ModelConverter):
+    model = HarvestJob
+
+    def get_excludes(self):
+        # For routes exposing the items as a counters link only: they never
+        # load nor dereference them.
+        return ["data", "items"]
+
+
 class CommunityResourceConverter(ModelConverter):
     model = models.CommunityResource
 
@@ -253,6 +270,8 @@ def init_app(app):
     app.url_map.converters["dataset_without_resources"] = DatasetWithoutResourcesConverter
     app.url_map.converters["dataservice"] = DataserviceConverter
     app.url_map.converters["harvest_source"] = HarvestSourceConverter
+    app.url_map.converters["harvest_job"] = HarvestJobConverter
+    app.url_map.converters["harvest_job_without_items"] = HarvestJobWithoutItemsConverter
     app.url_map.converters["crid"] = CommunityResourceConverter
     app.url_map.converters["org"] = OrganizationConverter
     app.url_map.converters["reuse"] = ReuseConverter


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/301570

DoesNotExist  api.harvest_job_items
HarvestJob matching query does not exist.