### PR TITLE
fix!: remove the unpaginated org discussions endpoints in favor of /discussions/?org=

### DIFF
--- a/udata/core/organization/api.py
+++ b/udata/core/organization/api.py
@@ -760,19 +760,6 @@ class OrgReusesAPI(API):
         return list(qs)
 
 
-@ns.route("/<org:org>/discussions/", endpoint="org_discussions")
-class OrgDiscussionsAPI(API):
-    @api.doc("list_organization_discussions")
-    @api.marshal_list_with(Discussion.__read_fields__)
-    def get(self, org):
-        """List organization discussions"""
-        reuses = Reuse.objects(organization=org).only("id")
-        datasets = Dataset.objects(organization=org).only("id")
-        subjects = list(reuses) + list(datasets)
-        qs = Discussion.objects(subject__in=subjects).order_by("-created")
-        return list(qs)
-
-
 @ns.route("/roles/", endpoint="org_roles")
 class OrgRolesAPI(API):
     @api.doc("org_roles")

--- a/udata/core/user/api.py
+++ b/udata/core/user/api.py
@@ -11,8 +11,6 @@ from udata.auth import admin_permission
 from udata.core.api_token.api import apitoken_created_fields
 from udata.core.api_token.models import ApiToken, parse_future_datetime
 from udata.core.dataset.api_fields import community_resource_fields, dataset_fields
-from udata.core.discussions.actions import discussions_for
-from udata.core.discussions.models import Discussion
 from udata.core.followers.api import FollowAPI
 from udata.core.legal.mails import add_send_legal_notice_argument, send_legal_notice_on_deletion
 from udata.core.organization.api_fields import pending_invitation_fields
@@ -205,23 +203,6 @@ class MyOrgReusesAPI(API):
         if q:
             reuses = reuses.filter(title__icontains=q)
         return list(reuses)
-
-
-@me.route("/org_discussions/", endpoint="my_org_discussions")
-class MyOrgDiscussionsAPI(API):
-    @api.secure
-    @api.doc("my_org_discussions")
-    @api.expect(filter_parser)
-    @api.marshal_list_with(Discussion.__read_fields__)
-    def get(self):
-        """List all discussions related to my organizations."""
-        q = filter_parser.parse_args().get("q")
-        discussions = discussions_for(current_user._get_current_object())
-        discussions = discussions.order_by("-created")
-        if q:
-            decoded = q
-            discussions = discussions.filter(title__icontains=decoded)
-        return list(discussions)
 
 
 @me.route("/api_tokens/", endpoint="my_api_tokens")

--- a/udata/tests/api/test_me_api.py
+++ b/udata/tests/api/test_me_api.py
@@ -14,7 +14,7 @@ from udata.core.organization.factories import OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import UserFactory
 from udata.i18n import _
-from udata.models import Discussion, Follow, Member, User
+from udata.models import Follow, Member, User
 from udata.tests.helpers import capture_mails, create_test_image
 from udata.utils import faker
 
@@ -327,56 +327,6 @@ class MeAPITest(APITestCase):
         response = self.get(url_for("api.my_org_reuses", q="foô"))
         self.assert200(response)
         self.assertEqual(len(response.json), len(reuses) + len(org_reuses))
-
-    def test_my_org_discussions(self):
-        user = self.login()
-        member = Member(user=user, role="editor")
-        organization = OrganizationFactory(members=[member])
-        reuse = ReuseFactory(owner=user)
-        org_reuse = ReuseFactory(organization=organization)
-        dataset = DatasetFactory(owner=user)
-        org_dataset = DatasetFactory(organization=organization)
-
-        discussions = [
-            Discussion.objects.create(subject=dataset, title="", user=user),
-            Discussion.objects.create(subject=org_dataset, title="", user=user),
-            Discussion.objects.create(subject=reuse, title="", user=user),
-            Discussion.objects.create(subject=org_reuse, title="", user=user),
-        ]
-
-        # Should not be listed
-        Discussion.objects.create(subject=DatasetFactory(), title="", user=user)
-        Discussion.objects.create(subject=ReuseFactory(), title="", user=user)
-
-        response = self.get(url_for("api.my_org_discussions"))
-        self.assert200(response)
-        self.assertEqual(len(response.json), len(discussions))
-
-    def test_my_org_discussions_with_search(self):
-        user = self.login()
-        member = Member(user=user, role="editor")
-        organization = OrganizationFactory(members=[member])
-        reuse = ReuseFactory(owner=user)
-        org_reuse = ReuseFactory(organization=organization)
-        dataset = DatasetFactory(owner=user)
-        org_dataset = DatasetFactory(organization=organization)
-
-        discussions = [
-            Discussion.objects.create(subject=dataset, title="foô", user=user),
-            Discussion.objects.create(subject=org_reuse, title="foô", user=user),
-        ]
-
-        # Should not be listed.
-        (Discussion.objects.create(subject=reuse, title="", user=user),)
-        (Discussion.objects.create(subject=org_dataset, title="", user=user),)
-
-        # Should really not be listed.
-        Discussion.objects.create(subject=DatasetFactory(), title="foô", user=user)
-        Discussion.objects.create(subject=ReuseFactory(), title="foô", user=user)
-
-        response = self.get(url_for("api.my_org_discussions", q="foô"))
-        self.assert200(response)
-        self.assertEqual(len(response.json), len(discussions))
 
     def test_my_reuses_401(self):
         response = self.get(url_for("api.my_reuses"))

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -23,7 +23,7 @@ from udata.core.reuse.factories import ReuseFactory
 from udata.core.user.factories import AdminFactory, UserFactory
 from udata.features.notifications.models import Notification
 from udata.i18n import _
-from udata.models import Discussion, Follow, Member, MembershipRequest, Organization
+from udata.models import Follow, Member, MembershipRequest, Organization
 from udata.tests.api import PytestOnlyAPITestCase
 from udata.tests.helpers import (
     assert200,
@@ -1626,28 +1626,6 @@ class OrganizationReusesAPITest(PytestOnlyAPITestCase):
 
         assert200(response)
         assert len(response.json) == len(reuses)
-
-
-class OrganizationDiscussionsAPITest(PytestOnlyAPITestCase):
-    def test_list_org_discussions(self):
-        """Should list organization discussions"""
-        user = UserFactory()
-        org = OrganizationFactory()
-        reuse = ReuseFactory(organization=org)
-        dataset = DatasetFactory(organization=org)
-        discussions = [
-            Discussion.objects.create(subject=dataset, title="", user=user),
-            Discussion.objects.create(subject=reuse, title="", user=user),
-        ]
-
-        response = self.get(url_for("api.org_discussions", org=org))
-
-        assert200(response)
-        assert len(response.json) == len(discussions)
-
-        discussions_ids = [str(d.id) for d in discussions]
-        for discussion in response.json:
-            assert discussion["id"] in discussions_ids
 
 
 class OrganizationBadgeAPITest(PytestOnlyAPITestCase):


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/300836

InvalidBSON  api.org_discussions (MemoryError hidden by pymongo)

Both are unpaginated and dereference `subject` once per discussion. On Météo-France, 488
discussions for 43 distinct datasets: 684 MB refetched per call, 500 or 502 after 12 to
17s. `/api/1/discussions/?org=<id>` returns the same list in 4s.

Over 118 days of HAProxy logs the org one got 43 requests (23 in 200, mostly scanners),
`/me/org_discussions/` got only 1 call.

`/me/org_discussions/` has no strict equivalent: it covered all my organizations plus my
own datasets and reuses in a single call, so it's now one `?org=` call per organization.