### PR TITLE
fix: retry save when a concurrent writer takes the computed slug

### DIFF
--- a/udata/mongo/document.py
+++ b/udata/mongo/document.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar, Generic
 
+from mongoengine.errors import NotUniqueError
 from typing_extensions import TypeVar
 
 from udata.flask_mongoengine.document import Document
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
 QS = TypeVar("QS", bound=UDataQuerySet, default=UDataQuerySet)
 
 log = logging.getLogger(__name__)
+
+MAX_SLUG_SAVE_ATTEMPTS = 5
 
 
 def serialize(value):
@@ -51,6 +54,29 @@ class UDataDocument(Document, Generic[QS]):
     objects: QS
     DoesNotExist: ClassVar[type[Exception]]
     id: "ObjectId"
+
+    def save(self, *args, **kwargs):
+        # A SlugField picks a free suffix by querying the collection, which leaves a window
+        # for a concurrent writer to insert that very slug before we do. No client-side check
+        # can close that window, so replay the save instead: the pre_save signal will look
+        # for the next free suffix, this time against the slug the other writer just took.
+        # Imported here because `slug_fields` is built on top of this module.
+        from .slug_fields import conflicting_slug_fields, reset_slug
+
+        for attempt in range(MAX_SLUG_SAVE_ATTEMPTS):
+            try:
+                return super().save(*args, **kwargs)
+            except NotUniqueError as error:
+                conflicting = conflicting_slug_fields(self, error)
+                if not conflicting or attempt == MAX_SLUG_SAVE_ATTEMPTS - 1:
+                    raise
+                for field in conflicting:
+                    log.info(
+                        "Slug %s was taken concurrently on %s, regenerating it",
+                        getattr(self, field.db_field),
+                        self.__class__.__name__,
+                    )
+                    reset_slug(self, field)
 
     def to_dict(self, exclude=None):
         id_field = self._meta["id_field"]

--- a/udata/mongo/slug_fields.py
+++ b/udata/mongo/slug_fields.py
@@ -126,6 +126,30 @@ class SlugFollow(UDataDocument):
     }
 
 
+def conflicting_slug_fields(instance, error):
+    """
+    The slug fields whose unique index rejected a save with the given NotUniqueError.
+
+    MongoEngine replaces pymongo's DuplicateKeyError by its own exception, but Python
+    keeps the original as the exception context, and it names the offending index keys.
+    """
+    duplicate_key_error = error.__cause__ or error.__context__
+    key_pattern = (getattr(duplicate_key_error, "details", None) or {}).get("keyPattern") or {}
+    return [
+        field
+        for field in instance._fields.values()
+        if isinstance(field, SlugField) and field.populate_from and field.db_field in key_pattern
+    ]
+
+
+def reset_slug(instance, field):
+    """
+    Reset a slug to the plain slugified source value, dropping any uniqueness suffix,
+    so that the next `populate_slug` looks for a free suffix again.
+    """
+    setattr(instance, field.db_field, field.slugify(getattr(instance, field.populate_from)))
+
+
 def populate_slug(instance, field):
     """
     Populate a slug field if needed.

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -1,5 +1,6 @@
 from copy import copy
 from datetime import UTC, date, datetime, timedelta
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -23,7 +24,7 @@ from udata.mongo import build_test_config, db, validate_config
 from udata.mongo.datetime_fields import DateField, DateRange, Datetimed
 from udata.mongo.document import UDataDocument as Document
 from udata.mongo.extras_fields import ExtrasField
-from udata.mongo.slug_fields import SlugField
+from udata.mongo.slug_fields import SlugField, populate_slug
 from udata.mongo.url_field import URLField
 from udata.mongo.uuid_fields import AutoUUIDField
 from udata.settings import Defaults
@@ -235,6 +236,27 @@ class SlugFieldTest(PytestOnlyDBTestCase):
         assert obj.slug == "a-slug"
         obj.save()
         assert obj.slug == "a-slug"
+
+    def test_populate_when_slug_is_taken_between_populate_and_insert(self):
+        """SlugField should pick another suffix when a concurrent writer took the computed one"""
+        SlugTester.objects.create(title="A Title")
+
+        computed_slugs = []
+
+        def take_computed_slug(instance, field):
+            slug = populate_slug(instance, field)
+            # Only steal the slug of the first save, not of the steal itself nor of the retry.
+            if not computed_slugs:
+                computed_slugs.append(slug)
+                SlugTester.objects.create(title="A Title")
+            return slug
+
+        with patch("udata.mongo.slug_fields.populate_slug", take_computed_slug):
+            obj = SlugTester.objects.create(title="A Title")
+
+        assert computed_slugs == ["a-title-1"]
+        assert obj.slug == "a-title-2"
+        assert SlugTester.objects.count() == 3
 
     def test_work_accross_inheritance(self):
         """SlugField should ensure uniqueness accross inheritance"""


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/301000

NotUniqueError  api.datasets
Tried to save duplicate unique keys (E11000 duplicate key error collection: udata.dataset index: slug_1 dup key: { slug: "donnees-essentielles-des-marches-publics-region-auvergne-rhone-alpes-1936" }, full error: {'index': 0, 'cod

Useful for https://www.data.gouv.fr/organizations/region-auvergne-rhone-alpes/search?q=Donn%C3%A9es+essentielles&type=datasets&sort=-last_update which upload multiple datasets with the same title sometimes 21 times in a few minutes.

