### PR TITLE
fix: run field checks on creation even when the value equals the field default

### DIFF
--- a/udata/api_fields.py
+++ b/udata/api_fields.py
@@ -73,7 +73,7 @@ def required_if(**conditions):
                     field=field,
                 )
 
-    check.run_even_if_missing = True
+    check.always_run = True
     return check
 
 
@@ -1081,20 +1081,28 @@ def patch(obj: _T, request) -> _T:
                         message=f"'{value}' is not a valid choice. Valid choices: {valid_choices}",
                     )
 
-            # Run checks if value is modified.
-            # We run checks here (before setattr) to compare old vs new value.
-            checks = info.get("checks", [])
-            if is_value_modified(getattr(obj, key), value):
-                for check in checks:
+            # An unchanged value normally skips its checks, so that resending an object
+            # as-is stays idempotent: `only_creation` must not reject a PUT that echoes
+            # back the owner it was given, nor `check_url_does_not_exists` a reuse that
+            # keeps its own URL. Two cases have no such old value to be idempotent with:
+            #  - a creation, where the "old" value is just the field default. Writing the
+            #    default is still a caller-supplied value and must be validated.
+            #  - an `always_run` check, which validates the resulting state rather than
+            #    the write itself, and so cannot be escaped by leaving a field out or by
+            #    resending it unchanged.
+            modified = is_value_modified(getattr(obj, key), value)
+            for check in info.get("checks", []):
+                if obj._created or modified or getattr(check, "always_run", False):
                     # Pass the API key so error messages match the payload the caller sent.
                     run_check(check, value, api_key, obj, data)
 
             setattr(obj, key, value)
 
-    # Run checks marked with `run_even_if_missing` on fields not in request.
-    # Some checks (like `required_if`) need to run even when their field is absent
-    # from the request, because they validate cross-field constraints based on
-    # other fields in the request (e.g. "page_id is required if body_type is blocs").
+    # Run `always_run` checks on fields absent from the request (the ones present
+    # already ran in the loop above). Some checks (like `required_if`) validate a
+    # cross-field constraint on the resulting object rather than on the value being
+    # written (e.g. "page_id is required if body_type is blocs"), so leaving the
+    # field out of the payload must not be a way to escape them.
     for key, _, info in get_fields(obj.__class__):
         api_key = info.get("rename") or key
         if api_key in data:
@@ -1103,7 +1111,7 @@ def patch(obj: _T, request) -> _T:
         value = getattr(obj, key, None)
 
         for check in checks:
-            if not getattr(check, "run_even_if_missing", False):
+            if not getattr(check, "always_run", False):
                 continue
             run_check(check, value, api_key, obj, data)
 

--- a/udata/core/owned.py
+++ b/udata/core/owned.py
@@ -80,6 +80,11 @@ def check_organization_is_valid_for_current_user(organization, **_kwargs):
     from udata.auth import current_user
     from udata.models import Organization
 
+    # An explicit null clears the producer, like `check_owner_is_current_user` above:
+    # there is no organization to look up, let alone to check permissions on.
+    if not organization:
+        return
+
     org = Organization.objects(id=organization.id).first()
     if org is None:
         raise FieldValidationError(_("Unknown organization"), field="organization")

--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -42,7 +42,7 @@ def check_title_or_element_required(value, obj, data, **_kwargs):
         )
 
 
-check_title_or_element_required.run_even_if_missing = True
+check_title_or_element_required.always_run = True
 
 
 class TopicQuerySet(OwnedQuerySet):

--- a/udata/harvest/models.py
+++ b/udata/harvest/models.py
@@ -248,11 +248,11 @@ def check_config_matches_backend(_value, data, obj, **_kwargs):
             )
 
 
-# Both must run even when their field is absent from the payload: an update can
-# change the backend without resending the config (and the other way around),
-# and a stored backend that is no longer enabled must keep being rejected.
-check_backend_is_enabled.run_even_if_missing = True
-check_config_matches_backend.run_even_if_missing = True
+# Both must run whatever the payload does with their field: an update can change the
+# backend without resending the config (and the other way around), and a stored backend
+# that is no longer enabled must keep being rejected.
+check_backend_is_enabled.always_run = True
+check_config_matches_backend.always_run = True
 
 
 @generate_fields(searchable=True)

--- a/udata/harvest/tests/test_api.py
+++ b/udata/harvest/tests/test_api.py
@@ -662,6 +662,18 @@ class HarvestAPITest(MockBackendsMixin, PytestOnlyAPITestCase):
         source.reload()
         assert source.validation.state == VALIDATION_PENDING
 
+    def test_reject_source_with_an_empty_comment_fails(self):
+        """An empty comment is no comment: it must be rejected like an absent one"""
+        self.login(AdminFactory())
+        source = HarvestSourceFactory()
+
+        data = {"state": VALIDATION_REFUSED, "comment": "  "}
+        response = self.post(url_for("api.validate_harvest_source", source=source), data)
+        assert400(response)
+
+        source.reload()
+        assert source.validation.state == VALIDATION_PENDING
+
     def test_validate_source_is_admin_only(self):
         """It should allow to validate a source if admin"""
         self.login()

--- a/udata/tests/api/test_organizations_api.py
+++ b/udata/tests/api/test_organizations_api.py
@@ -640,6 +640,21 @@ class MembershipAPITest(PytestOnlyAPITestCase):
         organization.reload()
         assert len(organization.requests) == 0
 
+    def test_request_membership_with_an_empty_comment(self):
+        """An empty comment is no comment: it must be rejected like an absent one,
+        otherwise the request is created and the notification mail crashes on it."""
+        organization = OrganizationFactory()
+        self.login()
+
+        for comment in ["", "   "]:
+            response = self.post(
+                url_for("api.request_membership", org=organization), {"comment": comment}
+            )
+            assert400(response)
+
+        organization.reload()
+        assert len(organization.requests) == 0
+
     def test_request_existing_pending_membership_do_not_duplicate_it(self):
         user = self.login()
         previous_request = MembershipRequest(user=user, comment="previous")

--- a/udata/tests/apiv2/test_topics.py
+++ b/udata/tests/apiv2/test_topics.py
@@ -1048,6 +1048,20 @@ class TopicElementsAPITest(APITestCase):
             "A topic element must have a title or an element."
         )
 
+    def test_add_element_with_explicitly_empty_fields(self):
+        """Spelling the fields out as empty must be rejected just like omitting them:
+        every value then equals its own default, which is not a reason to skip a check."""
+        owner = self.login()
+        topic = TopicFactory(owner=owner)
+        response = self.post(
+            url_for("apiv2.topic_elements", topic=topic), [{"title": "", "element": None}]
+        )
+        assert response.status_code == 400
+        assert response.json["errors"][0]["element"][0] == _(
+            "A topic element must have a title or an element."
+        )
+        assert TopicElement.objects(topic=topic).count() == 0
+
     def test_add_element_ignores_arbitrary_topic_in_payload(self):
         owner = self.login()
         topic = TopicFactory(owner=owner)

--- a/udata/tests/test_api_fields.py
+++ b/udata/tests/test_api_fields.py
@@ -93,11 +93,15 @@ class FakeEmbedded(EmbeddedDocument):
 
 
 @generate_fields()
-class FakeWithRequiredIf(EmbeddedDocument):
-    """Exercises `required_if`: `comment` is mandatory as soon as `kind` is a request."""
+class FakeWithRequiredIf(Document):
+    """Exercises `required_if`: `comment` is mandatory as soon as `kind` is a request.
+    A Document (not an EmbeddedDocument) so a test can persist one and patch it back
+    as an update, where `_created` is False."""
 
     kind = field(StringField(choices=["request", "invitation"], default="request"))
     comment = field(StringField(), checks=[required_if(kind="request")])
+
+    meta = {"collection": "fake_with_required_if_api_fields"}
 
 
 def check_is_set(value: str = "", field: str = "", **_kwargs) -> None:
@@ -582,6 +586,14 @@ class RequiredIfTest(PytestOnlyDBTestCase):
 
     def test_not_required_when_the_condition_is_not_met(self) -> None:
         assert patch(FakeWithRequiredIf(), {"kind": "invitation", "comment": ""}).comment is None
+
+    def test_unchanged_empty_value_is_rejected_on_update(self) -> None:
+        """What `always_run` buys over the creation case: on a stored object that
+        already breaks the constraint, echoing the offending value back must not be a
+        way through — an update has no `_created` to fall back on."""
+        stored = FakeWithRequiredIf.objects.create(kind="request", comment=None)
+        with pytest.raises(FieldValidationError):
+            patch(FakeWithRequiredIf.objects.get(pk=stored.pk), {"comment": ""})
 
 
 class ChecksOnCreationTest(PytestOnlyDBTestCase):

--- a/udata/tests/test_api_fields.py
+++ b/udata/tests/test_api_fields.py
@@ -20,7 +20,7 @@ from mongoengine.fields import (
 from werkzeug.exceptions import BadRequest
 
 from udata.api import api
-from udata.api_fields import field, generate_fields, patch, patch_and_save
+from udata.api_fields import field, generate_fields, patch, patch_and_save, required_if
 from udata.core.dataset.api_fields import dataset_fields
 from udata.core.dataset.models import License
 from udata.core.organization import constants as org_constants
@@ -90,6 +90,26 @@ class FakeEmbedded(EmbeddedDocument):
     status = field(
         StringField(choices=[("active", "Active"), ("inactive", "Inactive")]),
     )
+
+
+@generate_fields()
+class FakeWithRequiredIf(EmbeddedDocument):
+    """Exercises `required_if`: `comment` is mandatory as soon as `kind` is a request."""
+
+    kind = field(StringField(choices=["request", "invitation"], default="request"))
+    comment = field(StringField(), checks=[required_if(kind="request")])
+
+
+def check_is_set(value: str = "", field: str = "", **_kwargs) -> None:
+    """A plain check (not `always_run`) that rejects the field's own default, so a test
+    can tell whether a creation writing that default still goes through its checks."""
+    if not value:
+        raise FieldValidationError("Value is required", field=field)
+
+
+@generate_fields()
+class FakeWithDefaultRejectingCheck(EmbeddedDocument):
+    kind = field(StringField(), checks=[check_is_set])
 
 
 @generate_fields(
@@ -542,6 +562,51 @@ class PatchChoicesValidationTest(PytestOnlyDBTestCase):
         """An explicit null on a choices field must not raise."""
         embedded = patch(FakeEmbedded(), {"status": None})
         assert embedded.status is None
+
+
+class RequiredIfTest(PytestOnlyDBTestCase):
+    def test_absent_field_is_rejected(self) -> None:
+        with pytest.raises(FieldValidationError):
+            patch(FakeWithRequiredIf(), {})
+
+    def test_empty_value_is_rejected(self) -> None:
+        """A blank string is blanked to None by patch(), which on a field already
+        holding None leaves the value unmodified. The check must run all the same,
+        otherwise `{"comment": ""}` is a way to bypass the constraint entirely."""
+        for value in ["", "   ", None]:
+            with pytest.raises(FieldValidationError):
+                patch(FakeWithRequiredIf(), {"comment": value})
+
+    def test_value_is_accepted(self) -> None:
+        assert patch(FakeWithRequiredIf(), {"comment": "a reason"}).comment == "a reason"
+
+    def test_not_required_when_the_condition_is_not_met(self) -> None:
+        assert patch(FakeWithRequiredIf(), {"kind": "invitation", "comment": ""}).comment is None
+
+
+class ChecksOnCreationTest(PytestOnlyDBTestCase):
+    """An unchanged value skips its checks so that resending an object as-is stays
+    idempotent. A creation has no previous value to be idempotent with — only a field
+    default — so writing that default must still be validated."""
+
+    def test_default_value_is_checked_on_creation(self) -> None:
+        for value in ["", "   ", None]:
+            with pytest.raises(FieldValidationError):
+                patch(FakeWithDefaultRejectingCheck(), {"kind": value})
+
+    def test_valid_value_is_accepted_on_creation(self) -> None:
+        assert patch(FakeWithDefaultRejectingCheck(), {"kind": "a value"}).kind == "a value"
+
+    def test_unchanged_value_is_not_rechecked_on_update(self) -> None:
+        """A check that rejects the value already stored (uniqueness, immutability)
+        must not fire on an update that merely echoes it back."""
+        stored = FakeWithRename.objects.create(label=FORBIDDEN_VALUE)
+        patch(FakeWithRename.objects.get(pk=stored.pk), {"name": FORBIDDEN_VALUE})
+
+    def test_changed_value_is_still_checked_on_update(self) -> None:
+        stored = FakeWithRename.objects.create(label="a fine label")
+        with pytest.raises(FieldValidationError):
+            patch(FakeWithRename.objects.get(pk=stored.pk), {"name": FORBIDDEN_VALUE})
 
 
 class PatchBlankStringTest(PytestOnlyDBTestCase):


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/301403

TypeError udata.core.organization.tasks.notify_membership_request
object of type 'NoneType' has no len()

Since None was the "comment" default it wasn't check at the creation and it was failing later during the mail construction