### PR TITLE
fix: transfer api reference injection

### DIFF
--- a/udata/core/topic/models.py
+++ b/udata/core/topic/models.py
@@ -207,9 +207,13 @@ class Topic(Datetimed, Auditable, Linkable, Document[TopicQuerySet], Owned):
             **self._self_api_url_kwargs(**kwargs),
         )
 
-    @field(description="The topic API URI")
+    @field(description="Link to the API endpoint for this topic", show_as_ref=True)
     def uri(self):
         return self.self_api_url()
+
+    @field(description="Link to the udata web page for this topic", show_as_ref=True)
+    def page(self):
+        return self.self_web_url()
 
 
 post_save.connect(Topic.post_save, sender=Topic)

--- a/udata/features/transfer/api.py
+++ b/udata/features/transfer/api.py
@@ -5,6 +5,7 @@ from udata.api import API, api, base_reference, fields
 from udata.core.dataservices.models import Dataservice
 from udata.core.dataset.api_fields import dataset_ref_fields
 from udata.core.organization.models import Organization
+from udata.core.topic.models import Topic
 from udata.features.transfer.permissions import (
     TransferPermission,
     TransferResponsePermission,
@@ -13,7 +14,7 @@ from udata.models import Dataset, Reuse, User, db
 from udata.utils import id_or_404
 
 from .actions import accept_transfer, refuse_transfer, request_transfer
-from .models import TRANSFER_STATUS, Transfer
+from .models import TRANSFER_PERSONS, TRANSFER_STATUS, TRANSFERABLE_SUBJECTS, Transfer
 
 RESPONSE_TYPES = ["accept", "refuse"]
 
@@ -53,6 +54,7 @@ subject_mapping = {
     Dataservice: Dataservice.__ref_fields__,
     Dataset: dataset_ref_fields,
     Reuse: Reuse.__ref_fields__,
+    Topic: Topic.__ref_fields__,
 }
 
 transfer_fields = api.model(
@@ -98,7 +100,7 @@ requests_parser.add_argument(
     "subject", type=str, help="ID of dataset, dataservice, reuse…", location="args"
 )
 requests_parser.add_argument(
-    "subject_type", choices=["Dataset", "Reuse", "Dataservice"], type=str, help="", location="args"
+    "subject_type", choices=TRANSFERABLE_SUBJECTS, type=str, help="", location="args"
 )
 requests_parser.add_argument(
     "recipient", type=str, help="ID of user or organization", location="args"
@@ -112,31 +114,28 @@ requests_parser.add_argument(
 )
 
 
-def resolve_reference(field, specs, allowed_models):
+def resolve_reference(field, specs, choices):
     """Resolve a client-provided `{"class": …, "id": …}` pair into a document.
 
-    Both parts come straight from the request body: `db.resolve_model` resolves against
-    the whole document registry, so `class` is restricted to the classes this field
-    actually accepts, and `id` has to be an object id — anything else (a dict) reaches
-    MongoDB as a set of operators (`{"$regex": …}`) selecting an arbitrary document,
-    since MongoEngine only rejects those on an `ObjectId` primary key.
+    Both parts come straight from the request body, and both are checked before anything
+    reaches MongoDB. `class` is matched against the field's `choices` rather than resolved
+    against the whole document registry, because a generic reference only validates its
+    choices on save — long after the lookup below has run. And `id` has to be an object
+    id: a dict reaches MongoDB as a set of operators (`{"$regex": …}`) selecting an
+    arbitrary document, which MongoEngine rejects on an `ObjectId` primary key but not on
+    a `StringField` one.
     """
     if not isinstance(specs, dict):
         ns.abort(400, errors={field: "Expected an object with `class` and `id` keys"})
 
-    try:
-        model = db.resolve_model(specs)
-    except ValueError as e:
-        ns.abort(400, errors={field: str(e)})
-
-    if model not in allowed_models:
-        expected = ", ".join(sorted(allowed.__name__ for allowed in allowed_models))
-        ns.abort(400, errors={field: "`class` must be one of: {0}".format(expected)})
+    if specs.get("class") not in choices:
+        ns.abort(400, errors={field: "`class` must be one of: {0}".format(", ".join(choices))})
 
     object_id = specs.get("id")
     if not ObjectId.is_valid(object_id):
         ns.abort(400, errors={field: "`id` must be an identifier"})
 
+    model = db.resolve_model(specs)
     try:
         return model.objects.get(id=object_id)
     except model.DoesNotExist:
@@ -184,8 +183,8 @@ class TransferRequestsAPI(API):
         if not isinstance(data, dict):
             ns.abort(400, "Expected a JSON object")
 
-        subject = resolve_reference("subject", data.get("subject"), subject_mapping)
-        recipient = resolve_reference("recipient", data.get("recipient"), person_mapping)
+        subject = resolve_reference("subject", data.get("subject"), TRANSFERABLE_SUBJECTS)
+        recipient = resolve_reference("recipient", data.get("recipient"), TRANSFER_PERSONS)
 
         comment = data.get("comment")
 

--- a/udata/features/transfer/api.py
+++ b/udata/features/transfer/api.py
@@ -114,32 +114,35 @@ requests_parser.add_argument(
 )
 
 
-def resolve_reference(field, specs, choices):
-    """Resolve a client-provided `{"class": …, "id": …}` pair into a document.
+def resolve_reference(data, field_name, allowed_classes):
+    """Resolve the `{"class": …, "id": …}` reference held by `field_name` into a document.
 
     Both parts come straight from the request body, and both are checked before anything
-    reaches MongoDB. `class` is matched against the field's `choices` rather than resolved
+    reaches MongoDB. `class` is matched against `allowed_classes` rather than resolved
     against the whole document registry, because a generic reference only validates its
     choices on save — long after the lookup below has run. And `id` has to be an object
     id: a dict reaches MongoDB as a set of operators (`{"$regex": …}`) selecting an
     arbitrary document, which MongoEngine rejects on an `ObjectId` primary key but not on
     a `StringField` one.
     """
-    if not isinstance(specs, dict):
-        ns.abort(400, errors={field: "Expected an object with `class` and `id` keys"})
+    reference = data.get(field_name)
+    if not isinstance(reference, dict):
+        ns.abort(400, errors={field_name: "Expected an object with `class` and `id` keys"})
 
-    if specs.get("class") not in choices:
-        ns.abort(400, errors={field: "`class` must be one of: {0}".format(", ".join(choices))})
+    class_name = reference.get("class")
+    if class_name not in allowed_classes:
+        expected = ", ".join(allowed_classes)
+        ns.abort(400, errors={field_name: "`class` must be one of: {0}".format(expected)})
 
-    object_id = specs.get("id")
+    object_id = reference.get("id")
     if not ObjectId.is_valid(object_id):
-        ns.abort(400, errors={field: "`id` must be an identifier"})
+        ns.abort(400, errors={field_name: "`id` must be an identifier"})
 
-    model = db.resolve_model(specs)
+    model = db.resolve_model(class_name)
     try:
         return model.objects.get(id=object_id)
     except model.DoesNotExist:
-        ns.abort(400, errors={field: 'Unknown {0} id "{1}"'.format(field, object_id)})
+        ns.abort(400, errors={field_name: 'Unknown {0} id "{1}"'.format(field_name, object_id)})
 
 
 @ns.route("/", endpoint="transfers")
@@ -183,8 +186,8 @@ class TransferRequestsAPI(API):
         if not isinstance(data, dict):
             ns.abort(400, "Expected a JSON object")
 
-        subject = resolve_reference("subject", data.get("subject"), TRANSFERABLE_SUBJECTS)
-        recipient = resolve_reference("recipient", data.get("recipient"), TRANSFER_PERSONS)
+        subject = resolve_reference(data, "subject", TRANSFERABLE_SUBJECTS)
+        recipient = resolve_reference(data, "recipient", TRANSFER_PERSONS)
 
         comment = data.get("comment")
 

--- a/udata/features/transfer/api.py
+++ b/udata/features/transfer/api.py
@@ -112,6 +112,37 @@ requests_parser.add_argument(
 )
 
 
+def resolve_reference(field, specs, allowed_models):
+    """Resolve a client-provided `{"class": …, "id": …}` pair into a document.
+
+    Both parts come straight from the request body: `db.resolve_model` resolves against
+    the whole document registry, so `class` is restricted to the classes this field
+    actually accepts, and `id` has to be an object id — anything else (a dict) reaches
+    MongoDB as a set of operators (`{"$regex": …}`) selecting an arbitrary document,
+    since MongoEngine only rejects those on an `ObjectId` primary key.
+    """
+    if not isinstance(specs, dict):
+        ns.abort(400, errors={field: "Expected an object with `class` and `id` keys"})
+
+    try:
+        model = db.resolve_model(specs)
+    except ValueError as e:
+        ns.abort(400, errors={field: str(e)})
+
+    if model not in allowed_models:
+        expected = ", ".join(sorted(allowed.__name__ for allowed in allowed_models))
+        ns.abort(400, errors={field: "`class` must be one of: {0}".format(expected)})
+
+    object_id = specs.get("id")
+    if not ObjectId.is_valid(object_id):
+        ns.abort(400, errors={field: "`id` must be an identifier"})
+
+    try:
+        return model.objects.get(id=object_id)
+    except model.DoesNotExist:
+        ns.abort(400, errors={field: 'Unknown {0} id "{1}"'.format(field, object_id)})
+
+
 @ns.route("/", endpoint="transfers")
 class TransferRequestsAPI(API):
     @api.doc("list_transfers")
@@ -150,22 +181,11 @@ class TransferRequestsAPI(API):
     def post(self):
         """Initiate transfer request"""
         data = request.json
+        if not isinstance(data, dict):
+            ns.abort(400, "Expected a JSON object")
 
-        subject_model = db.resolve_model(data["subject"])
-        subject_id = data["subject"]["id"]
-        try:
-            subject = subject_model.objects.get(id=subject_id)
-        except subject_model.DoesNotExist:
-            msg = 'Unkown subject id "{0}"'.format(subject_id)
-            ns.abort(400, errors={"subject": msg})
-
-        recipient_model = db.resolve_model(data["recipient"])
-        recipient_id = data["recipient"]["id"]
-        try:
-            recipient = recipient_model.objects.get(id=recipient_id)
-        except recipient_model.DoesNotExist:
-            msg = 'Unkown recipient id "{0}"'.format(recipient_id)
-            ns.abort(400, errors={"recipient": msg})
+        subject = resolve_reference("subject", data.get("subject"), subject_mapping)
+        recipient = resolve_reference("recipient", data.get("recipient"), person_mapping)
 
         comment = data.get("comment")
 

--- a/udata/features/transfer/models.py
+++ b/udata/features/transfer/models.py
@@ -19,12 +19,19 @@ TRANSFER_STATUS = {
     "refused": _("Refused"),
 }
 
+# Class names rather than the classes themselves, to keep this module free of imports from
+# every transferable model. These lists are the single source of truth for what a transfer
+# accepts: the API reads them back to reject a class before it queries with it, because a
+# generic reference is only validated on save, long after that lookup ran.
+TRANSFERABLE_SUBJECTS = ["Dataset", "Reuse", "Dataservice", "Topic"]
+TRANSFER_PERSONS = ["User", "Organization"]
+
 
 class Transfer(Document):
     user = ReferenceField("User")
-    owner = GenericReferenceField(required=True)
-    recipient = GenericReferenceField(required=True)
-    subject = GenericReferenceField(required=True)
+    owner = GenericReferenceField(required=True, choices=TRANSFER_PERSONS)
+    recipient = GenericReferenceField(required=True, choices=TRANSFER_PERSONS)
+    subject = GenericReferenceField(required=True, choices=TRANSFERABLE_SUBJECTS)
     comment = StringField()
     status = StringField(choices=list(TRANSFER_STATUS), default="pending")
 

--- a/udata/features/transfer/notifications.py
+++ b/udata/features/transfer/notifications.py
@@ -5,35 +5,37 @@ from mongoengine import EmbeddedDocument
 from mongoengine.fields import GenericReferenceField
 
 from udata.api_fields import field, generate_fields
-from udata.core.dataservices.models import Dataservice
-from udata.core.dataset.models import Dataset
 from udata.core.organization.models import Organization
-from udata.core.reuse.models import Reuse
 from udata.core.user.models import User
 from udata.features.notifications.actions import notifier
 from udata.models import Transfer
+
+from .models import TRANSFER_PERSONS, TRANSFERABLE_SUBJECTS
 
 log = logging.getLogger(__name__)
 
 
 @generate_fields()
 class TransferRequestNotificationDetails(EmbeddedDocument):
+    # Same choices as `Transfer` itself: a notification describes a transfer, so anything
+    # transferable must be notifiable. Listing them again here silently dropped the
+    # notification of every transfer of a class added on one side only.
     transfer_owner = field(
-        GenericReferenceField(choices=(User, Organization), required=True),
+        GenericReferenceField(choices=TRANSFER_PERSONS, required=True),
         readonly=True,
         auditable=False,
         allow_null=True,
         filterable={},
     )
     transfer_recipient = field(
-        GenericReferenceField(choices=(User, Organization), required=True),
+        GenericReferenceField(choices=TRANSFER_PERSONS, required=True),
         readonly=True,
         auditable=False,
         allow_null=True,
         filterable={},
     )
     transfer_subject = field(
-        GenericReferenceField(choices=(Dataset, Dataservice, Reuse), required=True),
+        GenericReferenceField(choices=TRANSFERABLE_SUBJECTS, required=True),
         readonly=True,
         auditable=False,
         allow_null=True,

--- a/udata/features/transfer/permissions.py
+++ b/udata/features/transfer/permissions.py
@@ -7,19 +7,29 @@ class TransferPermission(Permission):
     """Permissions to transfer an object assets"""
 
     def __init__(self, subject):
+        # No need at all when nobody owns the subject: purging an organization only deletes
+        # the organization, and `Owned.organization` nullifies itself, leaving its datasets
+        # behind with neither an owner nor an organization. Such a subject has nobody
+        # entitled to give it away, which is what an empty permission means (sysadmins
+        # excepted, as everywhere else).
+        needs = []
         if subject.organization:
-            need = OrganizationAdminNeed(subject.organization.id)
+            needs.append(OrganizationAdminNeed(subject.organization.id))
         elif subject.owner:
-            need = UserNeed(subject.owner.fs_uniquifier)
-        super(TransferPermission, self).__init__(need)
+            needs.append(UserNeed(subject.owner.fs_uniquifier))
+        super().__init__(*needs)
 
 
 class TransferResponsePermission(Permission):
     """Permissions to transfer an object assets"""
 
     def __init__(self, transfer):
+        # Same as above: `Transfer.recipient` is a choice-less generic reference, so
+        # transfers pointing at something that is neither a user nor an organization can
+        # already sit in the database. Nobody can respond to those.
+        needs = []
         if isinstance(transfer.recipient, Organization):
-            need = OrganizationAdminNeed(transfer.recipient.id)
+            needs.append(OrganizationAdminNeed(transfer.recipient.id))
         elif isinstance(transfer.recipient, User):
-            need = UserNeed(transfer.recipient.fs_uniquifier)
-        super(TransferResponsePermission, self).__init__(need)
+            needs.append(UserNeed(transfer.recipient.fs_uniquifier))
+        super().__init__(*needs)

--- a/udata/migrations/2026-09-07-drop-transfers-with-unsupported-classes.py
+++ b/udata/migrations/2026-09-07-drop-transfers-with-unsupported-classes.py
@@ -1,0 +1,46 @@
+"""
+Until `Transfer` got `choices` on its generic references, the transfer API resolved the
+`class` sent in the request body against the whole document registry. Transfers pointing
+at a class a transfer means nothing for could therefore be created, and they are not just
+dead rows: the listing endpoint marshals its whole result set with a `Polymorph` field,
+which raises on the first unknown class — so a single one of them makes every transfer of
+its recipient unreadable.
+
+They cannot be repaired (there is no sensible class to move them to) and none of them can
+ever be accepted, so they are removed.
+"""
+
+import logging
+
+from udata.features.transfer.models import TRANSFER_PERSONS, TRANSFERABLE_SUBJECTS, Transfer
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info("Dropping transfers whose subject, recipient or owner is not transferable")
+
+    unsupported = Transfer.objects(
+        __raw__={
+            "$or": [
+                {"subject._cls": {"$nin": TRANSFERABLE_SUBJECTS}},
+                {"recipient._cls": {"$nin": TRANSFER_PERSONS}},
+                {"owner._cls": {"$nin": TRANSFER_PERSONS}},
+            ]
+        }
+    )
+
+    for transfer in unsupported.no_dereference():
+        # `to_mongo` rather than the attributes: the referenced document may itself be
+        # gone, and dereferencing it would raise instead of logging what we are removing.
+        raw = transfer.to_mongo()
+        log.info(
+            "Dropping transfer %s (subject=%s, recipient=%s, owner=%s, status=%s)",
+            transfer.id,
+            raw.get("subject", {}).get("_cls"),
+            raw.get("recipient", {}).get("_cls"),
+            raw.get("owner", {}).get("_cls"),
+            raw.get("status"),
+        )
+
+    log.info("Dropped %s transfer(s)", unsupported.delete())

--- a/udata/tests/api/test_transfer_api.py
+++ b/udata/tests/api/test_transfer_api.py
@@ -4,6 +4,7 @@ from flask import url_for
 from udata.core.dataset.factories import DatasetFactory, LicenseFactory
 from udata.core.dataset.models import Dataset
 from udata.core.organization.factories import OrganizationFactory
+from udata.core.topic.factories import TopicFactory
 from udata.core.user.factories import UserFactory
 from udata.core.user.models import User
 from udata.utils import faker
@@ -251,6 +252,32 @@ class TransferAPITest(APITestCase):
 
         self.assert400(response)
         self.assertIn("subject", response.json["errors"])
+
+    def test_request_topic_transfer(self):
+        """Topics are owned like datasets, and transferring one is supported."""
+        user = self.login()
+        recipient_org = OrganizationFactory()
+        topic = TopicFactory(owner=user)
+
+        response = self.post(
+            url_for("api.transfers"),
+            {
+                "subject": {"class": "Topic", "id": str(topic.id)},
+                "recipient": {"class": "Organization", "id": str(recipient_org.id)},
+                "comment": faker.sentence(),
+            },
+        )
+        self.assert201(response)
+        self.assertEqual(response.json["subject"]["class"], "Topic")
+        self.assertEqual(response.json["subject"]["id"], str(topic.id))
+
+        # The listing marshals the subject with a `Polymorph`, which raises on a class it
+        # does not know about — so reading the transfer back is a distinct guarantee.
+        response = self.get(url_for("api.transfers", subject=str(topic.id)))
+        self.assert200(response)
+        self.assertEqual(len(response.json), 1)
+        self.assertEqual(response.json[0]["subject"]["name"], topic.name)
+        self.assertEqual(response.json[0]["subject"]["page"], topic.self_web_url())
 
     def test_400_on_recipient_class_outside_persons(self):
         user = self.login()

--- a/udata/tests/api/test_transfer_api.py
+++ b/udata/tests/api/test_transfer_api.py
@@ -253,6 +253,54 @@ class TransferAPITest(APITestCase):
         self.assert400(response)
         self.assertIn("subject", response.json["errors"])
 
+    def test_400_on_subject_class_that_resolves_to_a_single_document(self):
+        """Same hole as above, one step further: the lookup succeeds and the crash moves.
+
+        With an id matching exactly one licence, `objects.get()` returns it and the
+        request reaches `TransferPermission`, which reads `subject.organization` — an
+        attribute a `License` simply does not have. Rejecting the class is the only thing
+        that covers this: a licence is not an `Owned`, so no amount of care inside the
+        permission would help.
+        """
+        self.login()
+        recipient = UserFactory()
+        license = LicenseFactory()
+
+        response = self.post(
+            url_for("api.transfers"),
+            {
+                "subject": {"class": "License", "id": license.id},
+                "recipient": {"class": "User", "id": str(recipient.id)},
+                "comment": faker.sentence(),
+            },
+        )
+
+        self.assert400(response)
+        self.assertIn("subject", response.json["errors"])
+
+    def test_403_on_a_subject_nobody_owns(self):
+        """Purging an organization leaves its datasets behind with no owner at all.
+
+        Such a dataset is a perfectly regular `Dataset`, so it goes through the class and
+        id checks untouched and reaches the permission, which finds nobody entitled to
+        give it away. That has to be a refusal, not a crash.
+        """
+        self.login()
+        orphan = DatasetFactory()
+        self.assertIsNone(orphan.owner)
+        self.assertIsNone(orphan.organization)
+
+        response = self.post(
+            url_for("api.transfers"),
+            {
+                "subject": {"class": "Dataset", "id": str(orphan.id)},
+                "recipient": {"class": "User", "id": str(UserFactory().id)},
+                "comment": faker.sentence(),
+            },
+        )
+
+        self.assert403(response)
+
     def test_request_topic_transfer(self):
         """Topics are owned like datasets, and transferring one is supported."""
         user = self.login()

--- a/udata/tests/api/test_transfer_api.py
+++ b/udata/tests/api/test_transfer_api.py
@@ -1,7 +1,7 @@
 from bson import ObjectId
 from flask import url_for
 
-from udata.core.dataset.factories import DatasetFactory
+from udata.core.dataset.factories import DatasetFactory, LicenseFactory
 from udata.core.dataset.models import Dataset
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.user.factories import UserFactory
@@ -230,6 +230,77 @@ class TransferAPITest(APITestCase):
         data = response.json
 
         self.assertIn("recipient", data["errors"])
+
+    def test_400_on_subject_class_outside_transferable_types(self):
+        """`db.resolve_model` resolves any registered document, a `License` included."""
+        self.login()
+        recipient = UserFactory()
+        LicenseFactory(id="other-at")
+        LicenseFactory(id="other-open")
+
+        response = self.post(
+            url_for("api.transfers"),
+            {
+                # A `StringField` primary key lets the operators through untouched, so
+                # this used to query the licenses and blow up on the second match.
+                "subject": {"class": "License", "id": {"$regex": "^other-"}},
+                "recipient": {"class": "User", "id": str(recipient.id)},
+                "comment": faker.sentence(),
+            },
+        )
+
+        self.assert400(response)
+        self.assertIn("subject", response.json["errors"])
+
+    def test_400_on_recipient_class_outside_persons(self):
+        user = self.login()
+        dataset = DatasetFactory(owner=user)
+
+        response = self.post(
+            url_for("api.transfers"),
+            {
+                "subject": {"class": "Dataset", "id": str(dataset.id)},
+                "recipient": {"class": "Dataset", "id": str(dataset.id)},
+                "comment": faker.sentence(),
+            },
+        )
+
+        self.assert400(response)
+        self.assertIn("recipient", response.json["errors"])
+
+    def test_400_on_mongo_operators_as_subject_id(self):
+        user = self.login()
+        DatasetFactory(owner=user)
+        recipient = UserFactory()
+
+        response = self.post(
+            url_for("api.transfers"),
+            {
+                "subject": {"class": "Dataset", "id": {"$ne": None}},
+                "recipient": {"class": "User", "id": str(recipient.id)},
+                "comment": faker.sentence(),
+            },
+        )
+
+        self.assert400(response)
+        self.assertIn("subject", response.json["errors"])
+
+    def test_400_on_malformed_subject_reference(self):
+        self.login()
+        recipient = UserFactory()
+
+        for subject in ("Dataset", {"class": "Dataset"}, {"class": "Dataset", "id": "not-an-id"}):
+            response = self.post(
+                url_for("api.transfers"),
+                {
+                    "subject": subject,
+                    "recipient": {"class": "User", "id": str(recipient.id)},
+                    "comment": faker.sentence(),
+                },
+            )
+
+            self.assert400(response)
+            self.assertIn("subject", response.json["errors"])
 
     def test_cannot_accept_or_refuse_transfer_after_accepting_or_refusing(self):
         user = self.login()

--- a/udata/tests/test_transfer.py
+++ b/udata/tests/test_transfer.py
@@ -5,7 +5,7 @@ from udata.auth import PermissionDenied, login_user
 from udata.core.contact_point.factories import ContactPointFactory
 from udata.core.contact_point.models import ContactPoint
 from udata.core.dataservices.factories import DataserviceFactory
-from udata.core.dataset.factories import DatasetFactory
+from udata.core.dataset.factories import DatasetFactory, LicenseFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.organization.metrics import (
     update_org_metrics,  # noqa needed to register signals
@@ -96,6 +96,17 @@ class TransferStartTest(PytestOnlyDBTestCase):
         with pytest.raises(ValueError):
             self.assert_transfer_started(dataset, user, user, comment)
 
+    def test_request_transfer_of_an_orphaned_subject(self):
+        # Purging an organization deletes it and leaves its datasets behind, with the
+        # `organization` reference nullified and no owner to fall back on.
+        dataset = DatasetFactory()
+        assert dataset.owner is None
+        assert dataset.organization is None
+
+        login_user(UserFactory())
+        with pytest.raises(PermissionDenied):
+            request_transfer(dataset, UserFactory(), faker.sentence())
+
     def test_request_transfer_to_same_organization(self):
         user = UserFactory()
         member = Member(user=user, role="admin")
@@ -178,6 +189,17 @@ class TransferAcceptTest(PytestOnlyDBTestCase):
         transfer = TransferFactory(owner=owner, recipient=org, subject=subject)
 
         login_user(editor)
+        with pytest.raises(PermissionDenied):
+            accept_transfer(transfer)
+
+    def test_nobody_can_accept_a_transfer_whose_recipient_is_not_a_person(self):
+        # `Transfer.recipient` is a choice-less generic reference, so the API used to let
+        # any document class through and such transfers may already sit in the database.
+        owner = UserFactory()
+        subject = DatasetFactory(owner=owner)
+        transfer = TransferFactory(owner=owner, recipient=LicenseFactory(), subject=subject)
+
+        login_user(owner)
         with pytest.raises(PermissionDenied):
             accept_transfer(transfer)
 

--- a/udata/tests/test_transfer.py
+++ b/udata/tests/test_transfer.py
@@ -11,6 +11,7 @@ from udata.core.organization.metrics import (
     update_org_metrics,  # noqa needed to register signals
 )
 from udata.core.reuse.factories import ReuseFactory
+from udata.core.topic.factories import TopicFactory
 from udata.core.user.factories import UserFactory
 from udata.core.user.metrics import (
     update_owner_metrics,  # noqa needed to register signals
@@ -18,7 +19,7 @@ from udata.core.user.metrics import (
 from udata.features.notifications.models import Notification
 from udata.features.transfer.actions import accept_transfer, refuse_transfer, request_transfer
 from udata.features.transfer.factories import TransferFactory
-from udata.features.transfer.models import Transfer
+from udata.features.transfer.models import TRANSFERABLE_SUBJECTS, Transfer
 from udata.features.transfer.notifications import transfer_request_notifications
 from udata.models import Member
 from udata.tests.api import DBTestCase, PytestOnlyDBTestCase
@@ -404,6 +405,31 @@ class TransferRequestNotificationTest(DBTestCase):
         assert notification.details.transfer_recipient == recipient
         assert notification.details.transfer_subject == dataset
         assert_equal_dates(notification.created_at, transfer.created)
+
+    def test_notification_created_for_every_transferable_subject(self):
+        """A notification describes a transfer, so it must accept every transferable class.
+
+        `on_transfer_created` swallows and logs its exceptions, so a subject the details
+        refuse costs the recipient its notification without failing the transfer — the
+        absence of the notification is the only observable symptom.
+        """
+        owner = UserFactory()
+        subjects = {
+            "Dataset": DatasetFactory(owner=owner),
+            "Reuse": ReuseFactory(owner=owner),
+            "Dataservice": DataserviceFactory(owner=owner),
+            "Topic": TopicFactory(owner=owner),
+        }
+        assert sorted(subjects) == sorted(TRANSFERABLE_SUBJECTS)
+
+        login_user(owner)
+        for class_name, subject in subjects.items():
+            recipient = UserFactory()
+            request_transfer(subject, recipient, faker.sentence())
+
+            notifications = Notification.objects(user=recipient)
+            assert len(notifications) == 1, f"no notification for a {class_name} transfer"
+            assert notifications[0].details.transfer_subject == subject
 
     def test_notification_created_for_org_admins_only(self):
         """Notifications are created for all admin users of recipient org, not editors"""

--- a/udata/tests/test_transfer.py
+++ b/udata/tests/test_transfer.py
@@ -193,11 +193,18 @@ class TransferAcceptTest(PytestOnlyDBTestCase):
             accept_transfer(transfer)
 
     def test_nobody_can_accept_a_transfer_whose_recipient_is_not_a_person(self):
-        # `Transfer.recipient` is a choice-less generic reference, so the API used to let
-        # any document class through and such transfers may already sit in the database.
+        # `Transfer.recipient` only got its `choices` once such transfers had already been
+        # created, so the row is written past validation to reproduce a legacy one rather
+        # than a shape the model still accepts.
         owner = UserFactory()
         subject = DatasetFactory(owner=owner)
-        transfer = TransferFactory(owner=owner, recipient=LicenseFactory(), subject=subject)
+        transfer = TransferFactory(owner=owner, recipient=UserFactory(), subject=subject)
+        Transfer.objects(id=transfer.id).update_one(
+            __raw__={
+                "$set": {"recipient": {"_cls": "License", "_ref": LicenseFactory().to_dbref()}}
+            }
+        )
+        transfer.reload()
 
         login_user(owner)
         with pytest.raises(PermissionDenied):


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/301567/ and https://errors.data.gouv.fr/organizations/sentry/issues/301560

MultipleObjectsReturned api.transfers
2 or more items returned, instead of 1

AttributeError api.transfers
'License' object has no attribute 'organization'

Also fix https://errors.data.gouv.fr/organizations/sentry/issues/301890/
Error creating notification for admin user 6a9e59fb93ec631ffa38e226 and recipient 6a9e59fb93ec631.. api.transfers